### PR TITLE
Fix more gmt and GMT/Python to PyGMT

### DIFF
--- a/doc/CNAME
+++ b/doc/CNAME
@@ -1,1 +1,1 @@
-www.gmtpython.xyz
+www.pygmt.org

--- a/doc/_static/gmt-python-banner.svg
+++ b/doc/_static/gmt-python-banner.svg
@@ -13388,7 +13388,7 @@
            y="931.54108"
            x="22.286631"
            id="tspan37645-6"
-           sodipodi:role="line">GMT/Python</tspan></text>
+           sodipodi:role="line">PyGMT</tspan></text>
     </g>
   </g>
   <style

--- a/doc/_static/gmt-python-logo.svg
+++ b/doc/_static/gmt-python-logo.svg
@@ -27323,7 +27323,7 @@ NIZelwa/7oMAAAAASUVORK5CYII=
          id="tspan37645-6"
          x="22.286631"
          y="931.54108"
-         style="font-size:101.49938202px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#333333;font-family:Gentium Book Basic;-inkscape-font-specification:Gentium Book Basic">GMT/Python</tspan></text>
+         style="font-size:101.49938202px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#333333;font-family:Gentium Book Basic;-inkscape-font-specification:Gentium Book Basic">PyGMT</tspan></text>
   </g>
   <style
      id="style4"

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -72,7 +72,7 @@ Miscellaneous
 Datasets
 --------
 
-GMT/Python provides access to GMT's datasets through the :mod:`pygmt.datasets` package.
+PyGMT provides access to GMT's datasets through the :mod:`pygmt.datasets` package.
 These functions will download the datasets automatically the first time they are used
 and store them in the GMT cache folder.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -95,7 +95,7 @@ well (be sure to have your conda env activated)::
 
 Test your installation by running the following inside a Python interpreter::
 
-    import gmt
+    import pygmt
     pygmt.test()
 
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -17,7 +17,7 @@ Installing
 Which Python?
 -------------
 
-You'll need **Python 3.6 or greater** to run GMT/Python.
+You'll need **Python 3.6 or greater** to run PyGMT.
 
 We recommend using the `Anaconda <http://continuum.io/downloads#all>`__ Python
 distribution to ensure you have all dependencies installed and the ``conda``
@@ -31,17 +31,17 @@ Which GMT?
 
 You'll need the latest development version available from
 `the GitHub repository <https://github.com/GenericMappingTools/gmt>`__.
-GMT/Python is based on GMT 6, **which has not yet been officially released**.
+PyGMT is based on GMT 6, **which has not yet been officially released**.
 
 We need the very latest GMT since there are many changes being made to GMT itself in
-response to the development of GMT/Python, mainly the new
+response to the development of PyGMT, mainly the new
 `modern execution mode <http://gmt.soest.hawaii.edu/projects/gmt/wiki/Modernization>`__.
 
 
 Dependencies
 ------------
 
-GMT/Python requires the following libraries:
+PyGMT requires the following libraries:
 
 * `numpy <http://www.numpy.org/>`__
 * `pandas <https://pandas.pydata.org/>`__
@@ -56,7 +56,7 @@ The following are optional (but recommended) dependencies:
 Installing GMT
 --------------
 
-Unfortunately, you'll have to build GMT from source in order to get GMT/Python working.
+Unfortunately, you'll have to build GMT from source in order to get PyGMT working.
 Please follow the instructions at http://gmt.soest.hawaii.edu/projects/gmt/wiki/BuildingGMT
 
 .. note::
@@ -67,11 +67,11 @@ Please follow the instructions at http://gmt.soest.hawaii.edu/projects/gmt/wiki/
    packages available again. Please bear with us.
 
 
-Installing GMT/Python
+Installing PyGMT
 ---------------------
 
 Now that you have GMT installed and your conda environment activated,
-use ``pip`` to install the latest source of GMT/Python from Github::
+use ``pip`` to install the latest source of PyGMT from Github::
 
     pip install https://github.com/GenericMappingTools/pygmt/archive/master.zip
 
@@ -87,7 +87,7 @@ This will allow you to use the ``gmt`` library from Python.
 Testing your install
 --------------------
 
-GMT/Python ships with a full test suite.
+PyGMT ships with a full test suite.
 You can run our tests after you install it but you will need a few extra dependencies as
 well (be sure to have your conda env activated)::
 
@@ -102,15 +102,15 @@ Test your installation by running the following inside a Python interpreter::
 Finding the GMT shared library
 ------------------------------
 
-Sometimes, GMT/Python will be unable to find the correct version of the GMT shared
+Sometimes, PyGMT will be unable to find the correct version of the GMT shared
 library.
 This can happen if you have multiple versions of GMT installed.
 
-You can tell GMT/Python exactly where to look for ``libgmt`` by setting the
+You can tell PyGMT exactly where to look for ``libgmt`` by setting the
 ``GMT_LIBRARY_PATH`` environment variable.
 This should be set to the directory where ``libgmt.so`` (or ``.dylib``) is found.
 **Only use this as a last resort**.
-Setting the path in this way means that GMT/Python will not be able to easily find the
+Setting the path in this way means that PyGMT will not be able to easily find the
 correct ``libgmt`` when you're changing conda environments.
 
 If you installed GMT using conda and the instructions above, place the following in your

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -96,7 +96,7 @@ well (be sure to have your conda env activated)::
 Test your installation by running the following inside a Python interpreter::
 
     import gmt
-    gmt.test()
+    pygmt.test()
 
 
 Finding the GMT shared library

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -68,7 +68,7 @@ Please follow the instructions at http://gmt.soest.hawaii.edu/projects/gmt/wiki/
 
 
 Installing PyGMT
----------------------
+----------------
 
 Now that you have GMT installed and your conda environment activated,
 use ``pip`` to install the latest source of PyGMT from Github::

--- a/doc/sphinxext.rst
+++ b/doc/sphinxext.rst
@@ -3,7 +3,7 @@
 Sphinx Extension
 ================
 
-We provide a `Sphinx <http://www.sphinx-doc.org/>`__ extension for including GMT/Python
+We provide a `Sphinx <http://www.sphinx-doc.org/>`__ extension for including PyGMT
 figures in your documentation. The extension defines the ``gmt-plot`` directive that
 will take execute the given code and insert the generated figure into the document.
 

--- a/doc/tutorials/first-steps.ipynb
+++ b/doc/tutorials/first-steps.ipynb
@@ -4,10 +4,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# First Steps with GMT/Python\n",
+    "# First Steps with PyGMT\n",
     "\n",
     "\n",
-    "This tutorial will get you started with the basic usage of GMT/Python.\n",
+    "This tutorial will get you started with the basic usage of PyGMT.\n",
     "Some of the examples shown here are from the [GMT Tutorial](http://gmt.soest.hawaii.edu/doc/latest/GMT_Tutorial.html#session-one).\n",
     "\n",
     "## Loading the library\n",
@@ -31,7 +31,7 @@
    "source": [
     "## Our first map\n",
     "\n",
-    "All figure generation in GMT/Python is handled by the `gmt.Figure` class. \n",
+    "All figure generation in PyGMT is handled by the `gmt.Figure` class. \n",
     "It has methods to add layers to your figure, like a basemap, coastlines, and data."
    ]
   },
@@ -110,7 +110,7 @@
     "\n",
     "You'll probably have noticed several things that are different from classic command-line GMT.\n",
     "Many of these changes reflect the new GMT [modern execution mode](http://gmt.soest.hawaii.edu/projects/gmt/wiki/Modernization) that will be part of the future 6.0 release.\n",
-    "A few are GMT/Python exclusive (like the long argument names).\n",
+    "A few are PyGMT exclusive (like the long argument names).\n",
     "\n",
     "1. The name of method is `coast` instead of `pscoast`. As a general rule, all `ps*` modules had their `ps` removed. The exceptions are: `psxy == plot`, `psxyz == plot3d`, and `psscale == colorbar`.\n",
     "2. The arguments don't use the GMT 1-letter syntax (R, J, B, etc). Those are still available as aliases and the methods will accept them (see below). \n",

--- a/doc/tutorials/first-steps.ipynb
+++ b/doc/tutorials/first-steps.ipynb
@@ -22,7 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import gmt"
+    "import pygmt"
    ]
   },
   {

--- a/doc/tutorials/first-steps.ipynb
+++ b/doc/tutorials/first-steps.ipynb
@@ -31,7 +31,7 @@
    "source": [
     "## Our first map\n",
     "\n",
-    "All figure generation in PyGMT is handled by the `gmt.Figure` class. \n",
+    "All figure generation in PyGMT is handled by the `pygmt.Figure` class. \n",
     "It has methods to add layers to your figure, like a basemap, coastlines, and data."
    ]
   },
@@ -39,7 +39,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We start a new figure by creating an instance of `gmt.Figure`:"
+    "We start a new figure by creating an instance of `pygmt.Figure`:"
    ]
   },
   {
@@ -48,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = gmt.Figure()"
+    "fig = pygmt.Figure()"
    ]
   },
   {
@@ -132,7 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig_alias = gmt.Figure()\n",
+    "fig_alias = pygmt.Figure()\n",
     "fig_alias.coast(R='-90/-70/0/20', J='M6i', G='gray', S=\"blue\", B=True)\n",
     "fig_alias.show()"
    ]

--- a/doc/tutorials/plot-data-points.ipynb
+++ b/doc/tutorials/plot-data-points.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Plotting data points\n",
     "\n",
-    "This tutorial will show you how to plot data points with GMT/Python.\n",
+    "This tutorial will show you how to plot data points with PyGMT.\n",
     "\n",
     "Start by importing the `gmt` Python package:"
    ]

--- a/doc/tutorials/plot-data-points.ipynb
+++ b/doc/tutorials/plot-data-points.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import gmt"
+    "import pygmt"
    ]
   },
   {

--- a/doc/tutorials/plot-data-points.ipynb
+++ b/doc/tutorials/plot-data-points.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "## Cartesian plots\n",
     "\n",
-    "The `gmt.Figure` class has a `plot` method for displaying points and lines. Let's make a Cartesian x, y plot using some random data generated using numpy:"
+    "The `pygmt.Figure` class has a `plot` method for displaying points and lines. Let's make a Cartesian x, y plot using some random data generated using numpy:"
    ]
   },
   {
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = gmt.Figure()\n",
+    "fig = pygmt.Figure()\n",
     "# Create a 6x6 inch basemap using the data region\n",
     "fig.basemap(region=region, projection='X6i', frame=True)\n",
     "# Plot using triangles (i) of 0.3 cm\n",
@@ -89,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = gmt.Figure()\n",
+    "fig = pygmt.Figure()\n",
     "fig.basemap(region=region, projection='X6i', frame=True)\n",
     "fig.plot(x, y, style='ic', color='black', sizes=magnitude/10)\n",
     "fig.show()"
@@ -128,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = gmt.Figure()\n",
+    "fig = pygmt.Figure()\n",
     "fig.basemap(region=region, projection='X6i', frame=True)\n",
     "fig.plot(data='first-steps-data.txt', style='cc', color='red', \n",
     "         columns=[0, 1, '2s0.1'])\n",
@@ -143,7 +143,7 @@
     "\n",
     "GMT shines when plotting data on a map. We can use some **sample data** that is packaged with GMT to try this out. They can be accessed using special file names that begin with an `@` symbol, for example `@tut_quakes.ngdc`. You can supply these names as the `data` argument in `Figure.plot` and other plotting functions. If you don't have the files already, they are automatically downloaded by GMT and saved to a cache directory (usually `~/.gmt/cache`).\n",
     "\n",
-    "The `gmt.datasets` package allows easy access to these data files as Python data types. For example, we can access the sample dataset of tsunami generating earthquakes around Japan (`@tut_quakes.ngdc`) as a `pandas.DataFrame` using the `datasets.load_japan_quakes` function:"
+    "The `pygmt.datasets` package allows easy access to these data files as Python data types. For example, we can access the sample dataset of tsunami generating earthquakes around Japan (`@tut_quakes.ngdc`) as a `pandas.DataFrame` using the `datasets.load_japan_quakes` function:"
    ]
   },
   {
@@ -152,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from gmt.datasets import load_japan_quakes\n",
+    "from pygmt.datasets import load_japan_quakes\n",
     "\n",
     "quakes = load_japan_quakes()\n",
     "quakes.head()"
@@ -183,7 +183,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = gmt.Figure()\n",
+    "fig = pygmt.Figure()\n",
     "fig.coast(region=quakes_region, projection='M6i', frame=True, \n",
     "          land='black', water='skyblue')\n",
     "fig.plot(x=quakes.longitude, y=quakes.latitude, \n",
@@ -204,7 +204,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = gmt.Figure()\n",
+    "fig = pygmt.Figure()\n",
     "fig.coast(region=quakes_region, projection='M6i', frame=True, \n",
     "          land='black', water='skyblue')\n",
     "fig.plot(x=quakes.longitude, y=quakes.latitude, \n",
@@ -226,7 +226,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = gmt.Figure()\n",
+    "fig = pygmt.Figure()\n",
     "fig.coast(region=quakes_region, projection='M6i', frame=True, \n",
     "          land='black', water='skyblue')\n",
     "fig.plot(x=quakes.longitude, y=quakes.latitude, \n",
@@ -256,7 +256,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = gmt.Figure()\n",
+    "fig = pygmt.Figure()\n",
     "fig.coast(region=quakes_region, projection='X6id/6id', land='gray')\n",
     "fig.plot(x=quakes.longitude, y=quakes.latitude, \n",
     "         sizes=0.02*2**quakes.magnitude,\n",

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -30,7 +30,7 @@ class BasePlotting:
         insert special arguments into the kwargs or make any actions that are
         required before ``call_module``.
 
-        For example, the :class:`gmt.Figure` needs this to tell the GMT modules
+        For example, the :class:`pygmt.Figure` needs this to tell the GMT modules
         to plot to a specific figure.
 
         This is a dummy method that does nothing.

--- a/pygmt/clib/__init__.py
+++ b/pygmt/clib/__init__.py
@@ -1,7 +1,7 @@
 """
 Low-level wrapper for the GMT C API.
 
-The :class:`gmt.clib.Session` class wraps the GMT C shared library (``libgmt``)
+The :class:`pygmt.clib.Session` class wraps the GMT C shared library (``libgmt``)
 with a pythonic interface.
 Access to the C library is done through :py:mod:`ctypes`.
 

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -280,7 +280,7 @@ class Session:
         """
         Create a new GMT C API session.
 
-        This is required before most other methods of :class:`gmt.clib.Session` can be
+        This is required before most other methods of :class:`pygmt.clib.Session` can be
         called.
 
         .. warning::
@@ -293,7 +293,7 @@ class Session:
         is a :class:`ctypes.c_void_p` pointer. Sets the ``session_pointer`` attribute to
         this pointer.
 
-        Remember to terminate the current session using :meth:`gmt.clib.Session.destroy`
+        Remember to terminate the current session using :meth:`pygmt.clib.Session.destroy`
         before creating a new one.
 
         Parameters
@@ -607,7 +607,7 @@ class Session:
 
         The GMT C API takes certain defined constants, like ``'GMT_IS_GRID'``,
         that need to be validated and converted to integer values using
-        :meth:`gmt.clib.Session.__getitem__`.
+        :meth:`pygmt.clib.Session.__getitem__`.
 
         The constants can also take a modifier by appending another constant
         name, e.g. ``'GMT_IS_GRID|GMT_VIA_MATRIX'``. The two parts must be

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -29,11 +29,11 @@ class Figure(BasePlotting):
     A GMT figure to handle all plotting.
 
     Use the plotting methods of this class to add elements to the figure.  You
-    can preview the figure using :meth:`gmt.Figure.show` and save the figure to
-    a file using :meth:`gmt.Figure.savefig`.
+    can preview the figure using :meth:`pygmt.Figure.show` and save the figure to
+    a file using :meth:`pygmt.Figure.savefig`.
 
     Unlike traditional GMT figures, no figure file is generated until you call
-    :meth:`gmt.Figure.savefig` or :meth:`gmt.Figure.psconvert`.
+    :meth:`pygmt.Figure.savefig` or :meth:`pygmt.Figure.psconvert`.
 
     Examples
     --------
@@ -76,10 +76,10 @@ class Figure(BasePlotting):
 
         Unlike the command-line version (``gmt figure``), this method does not
         trigger the generation of a figure file. An explicit call to
-        :meth:`gmt.Figure.savefig` or :meth:`gmt.Figure.psconvert` must be made
+        :meth:`pygmt.Figure.savefig` or :meth:`pygmt.Figure.psconvert` must be made
         in order to get a file.
         """
-        # Passing format '-' tells gmt.end to not produce any files.
+        # Passing format '-' tells pygmt.end to not produce any files.
         fmt = "-"
         with Session() as lib:
             lib.call_module("figure", "{} {}".format(self._name, fmt))
@@ -111,7 +111,7 @@ class Figure(BasePlotting):
         PDF, PNG, PPM, SVG, TIFF) using GhostScript.
 
         If no input files are given, will convert the current active figure
-        (see :func:`gmt.figure`). In this case, an output name must be given
+        (see :func:`pygmt.figure`). In this case, an output name must be given
         using parameter *F*.
 
         {gmt_module_docs}

--- a/pygmt/session_management.py
+++ b/pygmt/session_management.py
@@ -8,7 +8,7 @@ def begin():
     """
     Initiate a new GMT modern mode session.
 
-    Used in combination with :func:`gmt.end`.
+    Used in combination with :func:`pygmt.end`.
 
     Only meant to be used once for creating the global session.
 
@@ -22,10 +22,10 @@ def end():
     """
     Terminate GMT modern mode session and optionally produce the figure files.
 
-    Called after :func:`gmt.begin` and all commands that you want included in a
+    Called after :func:`pygmt.begin` and all commands that you want included in a
     session. Will finalize any PostScript plots that were made in the
     background, convert them to the desired format (specified in
-    ``gmt.begin``), and bring the figures to the working directory.
+    ``pygmt.begin``), and bring the figures to the working directory.
 
     """
     with Session() as lib:

--- a/pygmt/sphinxext/__init__.py
+++ b/pygmt/sphinxext/__init__.py
@@ -1,3 +1,3 @@
 """
-Sphinx extensions for GMT/Python.
+Sphinx extensions for PyGMT.
 """

--- a/pygmt/sphinxext/gmtplot.py
+++ b/pygmt/sphinxext/gmtplot.py
@@ -5,7 +5,7 @@ example::
 
     .. gmt-plot::
 
-        import gmt
+        import pygmt
         fig = pygmt.Figure()
         fig.coast(region="g", projection="W0/10i", land="gray")
         fig.show()

--- a/pygmt/sphinxext/gmtplot.py
+++ b/pygmt/sphinxext/gmtplot.py
@@ -6,11 +6,11 @@ example::
     .. gmt-plot::
 
         import gmt
-        fig = gmt.Figure()
+        fig = pygmt.Figure()
         fig.coast(region="g", projection="W0/10i", land="gray")
         fig.show()
 
-The *last statement* of the code-block should contain a call to ``gmt.Figure.show``.
+The *last statement* of the code-block should contain a call to ``pygmt.Figure.show``.
 Anything printed to stdout will be captured and included between the figure and the
 code.
 

--- a/pygmt/tests/test_which.py
+++ b/pygmt/tests/test_which.py
@@ -1,5 +1,5 @@
 """
-Tests for gmt.which
+Tests for pygmt.which
 """
 import os
 


### PR DESCRIPTION
**Description of proposed changes**
Further renaming following #265.

- `GMT/Python` => `PyGMT`
- `import gmt` => `import pygmt`
- `gmt.*` => `pygmt.*`