### PR TITLE
Fix the gmt begin permission error in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,7 @@ matrix:
               - BUILD_DOCS=true
 
 before_install:
+    - mkdir -p "$HOME/.gmt/sessions"
     # Build and install GMT from the master branch
     - if [ "$TEST" == "true" ]; then
         bash helpers/build-gmt-master.sh;


### PR DESCRIPTION
**Description of proposed changes**

Try to fix the error in `gmt begin`.



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
