### PR TITLE
WIP: Let get_clib_path find the path to the gmt shared library on Windows

### DIFF
--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -71,7 +71,7 @@ def get_clib_path(env):
         The path to the libgmt shared library.
 
     """
-    libname = ".".join(["libgmt", clib_extension()])
+    libname = clib_name()
     if env is None:
         env = os.environ
     if "GMT_LIBRARY_PATH" in env:
@@ -81,37 +81,41 @@ def get_clib_path(env):
     return libpath
 
 
-def clib_extension(os_name=None):
+def clib_name(os_name=None, is_64bit=None):
     """
-    Return the extension for the shared library for the current OS.
+    Return the name of GMT's shared library for the current OS.
 
-    .. warning::
-
-        Currently only works for macOS and Linux.
-
-    Returns
-    -------
+    Parameters
+    ----------
     os_name : str or None
         The operating system name as given by ``sys.platform``
         (the default if None).
 
     Returns
     -------
-    ext : str
-        The extension ('.so', '.dylib', etc).
+    libname : str
+        The name of GMT's shared library.
 
     """
     if os_name is None:
         os_name = sys.platform
-    # Set the shared library extension in a platform independent way
+
+    if is_64bit is None:
+        is_64bit = sys.maxsize > 2 ** 32
+
     if os_name.startswith("linux"):
-        lib_ext = "so"
+        libname = "libgmt.so"
     elif os_name == "darwin":
         # Darwin is macOS
-        lib_ext = "dylib"
+        libname = "libgmt.dylib"
+    elif os_name == "win32":
+        if is_64bit:
+            libname = "gmt_w64.dll"
+        else:
+            libname = "gmt_w32.dll"
     else:
         raise GMTOSError('Operating system "{}" not supported.'.format(sys.platform))
-    return lib_ext
+    return libname
 
 
 def check_libgmt(libgmt):

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -14,7 +14,7 @@ import pytest
 
 from .. import clib
 from ..clib.session import FAMILIES, VIAS
-from ..clib.loading import clib_extension, load_libgmt, check_libgmt, get_clib_path
+from ..clib.loading import clib_name, load_libgmt, check_libgmt, get_clib_path
 from ..clib.conversion import dataarray_to_matrix
 from ..exceptions import (
     GMTCLibError,
@@ -107,13 +107,15 @@ def test_check_libgmt():
         check_libgmt(dict())
 
 
-def test_clib_extension():
-    "Make sure we get the correct extension for different OS names"
+def test_clib_name():
+    "Make sure we get the correct library name for different OS names"
     for linux in ["linux", "linux2", "linux3"]:
-        assert clib_extension(linux) == "so"
-    assert clib_extension("darwin") == "dylib"
+        assert clib_name(linux) == "libgmt.so"
+    assert clib_name("darwin") == "libgmt.dylib"
+    assert clib_name("win32", True) == "gmt_w64.dll"
+    assert clib_name("win32", False) == "gmt_w32.dll"
     with pytest.raises(GMTOSError):
-        clib_extension("meh")
+        clib_name("meh")
 
 
 def test_getitem():


### PR DESCRIPTION
**Description of proposed changes**
The name of the shared library is `gmt_w64.dll` for 64-bit Windows, and `gmt_w32.dll` for 32-bit Windows, and the library is located in `C:\programs\gmt6\bin` by default. This PR changes `get_clib_path` so that it can return the correct library name for Windows.

I've tried to install pygmt on Windows and run the test. The GMT6 binary is the one provided by Joaquim. 

The tests give 19 failures. Most of the failures are due to different image size, which may be caused by slightly different ghostscript (the version I use is 9.22). Other failures seems related to the slightly different behaviors of Python packages for different system, and permission issues. See the attached log for details. [pytest.log](https://github.com/GenericMappingTools/pygmt/files/2797717/pytest.log) 

Although currently we don't have CI tests on Windows, I think we can at least merge this PR into master, so that Windows users can have a try and help us find bugs on Windows.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #46 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
