### PR TITLE
Use extlinks for linking GMT docs, and get rid of gmt_module_docs decorator

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -128,7 +128,7 @@ Most calls to the C API happen through the :class:`pygmt.clib.Session` class.
 
     clib.Session
 
-`GMT modules <http://gmt.soest.hawaii.edu/doc/latest/#man-pages>`__ are executed through
+`GMT modules <https://www.generic-mapping-tools.org/gmt/latest/quick_ref.html>`__ are executed through
 the :meth:`~pygmt.clib.Session.call_module` method:
 
 .. autosummary::

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,6 +30,14 @@ autosummary_generate = False
 
 numpydoc_class_members_toctree = False
 
+# configure links to GMT docs
+extlinks = {
+    "gmt-docs": (
+        "https://www.generic-mapping-tools.org/gmt/latest/%s",
+        "https://www.generic-mapping-tools.org/gmt/latest/",
+    )
+}
+
 # intersphinx configuration
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -84,7 +84,7 @@ class BasePlotting:
 
         A map projection must be supplied.
 
-        {gmt_module_docs}
+        Full option list at :gmt-docs:`coast.html`
 
         {aliases}
 

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -146,7 +146,7 @@ class BasePlotting:
 
         Takes a grid file name or an xarray.DataArray object as input.
 
-        {gmt_module_docs}
+        Full option list at :gmt-docs:`grdcontour.html`
 
         {aliases}
 
@@ -209,7 +209,7 @@ class BasePlotting:
 
         Takes a grid file name or an xarray.DataArray object as input.
 
-        {gmt_module_docs}
+        Full option list at :gmt-docs:`grdimage.html`
 
         {aliases}
 
@@ -268,7 +268,7 @@ class BasePlotting:
         is drawn or not. If a symbol is selected, *G* and *W* determines the
         fill and outline/no outline, respectively.
 
-        {gmt_module_docs}
+        Full option list at :gmt-docs:`plot.html`
 
         {aliases}
 
@@ -369,7 +369,7 @@ class BasePlotting:
 
         [TODO: Insert more documentation]
 
-        {gmt_module_docs}
+        Full option list at :gmt-docs:`contour.html`
 
         {aliases}
 
@@ -436,7 +436,7 @@ class BasePlotting:
 
         At least one of the options *B*, *L*, or *T* must be specified.
 
-        {gmt_module_docs}
+        Full option list at :gmt-docs:`basemap.html`
 
         {aliases}
 
@@ -475,7 +475,7 @@ class BasePlotting:
         Use various options to change this and to place a transparent or
         opaque rectangular map panel behind the GMT logo.
 
-        {gmt_module_docs}
+        Full option list at :gmt-docs:`logo.html`
 
         {aliases}
 
@@ -507,7 +507,7 @@ class BasePlotting:
 
         Reads an Encapsulated PostScript file or a raster image file and plots it on a map.
 
-        {gmt_module_docs}
+        Full option list at :gmt-docs:`image.html`
 
         {aliases}
 

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -118,7 +118,7 @@ class Figure(BasePlotting):
         (see :func:`pygmt.figure`). In this case, an output name must be given
         using parameter *F*.
 
-        {gmt_module_docs}
+        Full option list at :gmt-docs:`psconvert.html`
 
         {aliases}
 
@@ -297,7 +297,7 @@ class Figure(BasePlotting):
         to the fixed lower left corner of the page, or prepend **r** [Default] to
         move the origin relative to its current location.
 
-        Detailed usage at http://gmt.soest.hawaii.edu/doc/latest/GMT_Docs.html#plot-positioning-and-layout-the-x-y-options
+        Detailed usage at :gmt-docs:`GMT_Docs.html#plot-positioning-and-layout-the-x-y-options`
 
         Parameters
         ----------

--- a/pygmt/gridding.py
+++ b/pygmt/gridding.py
@@ -32,7 +32,7 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
 
     Must provide either *data* or *x*, *y*, and *z*.
 
-    {gmt_module_docs}
+    Full option list at :gmt-docs:`surface.html`
 
     Parameters
     ----------

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -12,8 +12,6 @@ from .utils import is_nonstr_iter
 from ..exceptions import GMTInvalidInput
 
 
-GMT_DOCS = "http://gmt.soest.hawaii.edu/doc/latest"
-
 COMMON_OPTIONS = {
     "R": """\
         R : str or list
@@ -55,8 +53,6 @@ def fmt_docstring(module_func):
 
     Use any of these placeholders in your docstring to have them substituted:
 
-    * ``{gmt_module_docs}``: link to the GMT docs for that module. Assumes that
-      the name of the GMT module is the same as the function name.
     * ``{aliases}``: Insert a section listing the parameter aliases defined by
       decorator ``use_alias``.
 
@@ -90,8 +86,6 @@ def fmt_docstring(module_func):
     ...     '''
     ...     My nice module.
     ...
-    ...     {gmt_module_docs}
-    ...
     ...     Parameters
     ...     ----------
     ...     {R}
@@ -103,8 +97,6 @@ def fmt_docstring(module_func):
     >>> print(gmtinfo.__doc__)
     <BLANKLINE>
     My nice module.
-    <BLANKLINE>
-    Full option list at http://gmt.soest.hawaii.edu/doc/latest/gmtinfo.html
     <BLANKLINE>
     Parameters
     ----------
@@ -124,10 +116,6 @@ def fmt_docstring(module_func):
 
     """
     filler_text = {}
-
-    url = "{}/{}.html".format(GMT_DOCS, module_func.__name__)
-    text = "Full option list at"
-    filler_text["gmt_module_docs"] = " ".join([text, url])
 
     if hasattr(module_func, "aliases"):
         aliases = ["**Aliases:**\n"]

--- a/pygmt/modules.py
+++ b/pygmt/modules.py
@@ -20,7 +20,7 @@ def grdinfo(grid, **kwargs):
 
     Can read the grid from a file or given as an xarray.DataArray grid.
 
-    {gmt_module_docs}
+    Full option list at :gmt-docs:`grdinfo.html`
 
     Parameters
     ----------
@@ -65,7 +65,7 @@ def info(fname, **kwargs):
     increments provided. The *T* option will provide a *-Tzmin/zmax/dz* string
     for makecpt.
 
-    {gmt_module_docs}
+    Full option list at :gmt-docs:`gmtinfo.html`
 
     Parameters
     ----------
@@ -109,7 +109,7 @@ def which(fname, **kwargs):
     to set the desired behavior. If *download* is not used (or False), the file
     will not be found.
 
-    {gmt_module_docs}
+    Full option list at :gmt-docs:`gmtwhich.html`
 
     {aliases}
 


### PR DESCRIPTION
**Description of proposed changes**

In this PR, I use [extlinks](https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html) to insert links to GMT documentation, instead of the gmt_module_docs decorator.
```
:gmt-docs:`coast.html`
```
will be rendered as https://www.generic-mapping-tools.org/gmt/latest/coast.html.

It's more flexible than the decorator and it can link to any GMT documentations. Thus, we can get rid of the gmt_module_docs decorator.

The only side-effect I know is that `help(pygmt.Figure.coast)` in interactive mode shows the raw RST string, rather then the link to GMT site.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
