### PR TITLE
Upgrade the CI scripts to 1.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,7 @@ before_install:
       fi
     - cd "$TRAVIS_BUILD_DIR"
     # Get the Fatiando CI scripts
-    - git clone --branch=1.0.0 --depth=1 https://github.com/fatiando/continuous-integration.git
+    - git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
     # Download and install miniconda and setup dependencies
     # Need to source the script to set the PATH variable globaly
     - source continuous-integration/travis/setup-miniconda.sh


### PR DESCRIPTION
Fixes failures on linux because of missing conda dependencies taken from
the defaults channel.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
