### PR TITLE
pandas.read_table is deprecated, use pandas.read_csv instead

### DIFF
--- a/pygmt/datasets/tutorial.py
+++ b/pygmt/datasets/tutorial.py
@@ -25,7 +25,7 @@ def load_japan_quakes():
 
     """
     fname = which("@tut_quakes.ngdc", download="c")
-    data = pd.read_table(fname, header=1, sep=r"\s+")
+    data = pd.read_csv(fname, header=1, sep=r"\s+")
     data.columns = [
         "year",
         "month",


### PR DESCRIPTION
`read_table` is deprecated since pandas 0.24. Use `read_csv` instead.

Fixes the FutureWarning:
```
FutureWarning: read_table is deprecated, use read_csv instead.
  data = pd.read_table(fname, header=1, sep=r"\s+")
```