### PR TITLE
Fix the link of GMT building instructions

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -57,7 +57,7 @@ Installing GMT
 --------------
 
 Unfortunately, you'll have to build GMT from source in order to get PyGMT working.
-Please follow the instructions at http://gmt.soest.hawaii.edu/projects/gmt/wiki/BuildingGMT.
+Please follow the `GMT Building Instructions <https://github.com/GenericMappingTools/gmt/blob/master/BUILDING.md>`__.
 
 For Windows users, you can also try to install the binaries of
 GMT development version, available from http://w3.ualg.pt/~jluis/mirone/downloads/gmt.html.


### PR DESCRIPTION
The GMT building instruction `BUILDING.md` is better than the original one.