### PR TITLE
Use sphinx<=1.8.5 temporarily to avoid style errors introduced in sphinx 2.x

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
     - black
     - pylint
     - flake8
-    - sphinx
+    - sphinx<=1.8.5
     - sphinx_rtd_theme
     - sphinx-gallery
     - nbsphinx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ coverage
 black
 pylint
 flake8
-sphinx
+sphinx<=1.8.5
 sphinx_rtd_theme
 sphinx-gallery
 nbsphinx


### PR DESCRIPTION
**Description of proposed changes**
Use sphinx<=1.8.5.

Fixes #305.