### PR TITLE
Enable Mac and Windows CI on Azure Pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,214 @@
+# Configuration for Azure Pipelines
+########################################################################################
+
+# Only build the master branch, tags, and PRs (on by default) to avoid building random
+# branches in the repository until a PR is opened.
+trigger:
+  branches:
+    include:
+    - master
+    - refs/tags/*
+
+
+jobs:
+
+# Linux
+########################################################################################
+- job:
+  displayName: 'Style Checks'
+
+  pool:
+    vmImage: 'ubuntu-16.04'
+
+  variables:
+    CONDA_INSTALL_EXTRA: "black flake8 pylint=2.2.2"
+    PYTHON: '3.7'
+
+  steps:
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.7'
+
+  - bash: echo "##vso[task.prependpath]/usr/share/miniconda/bin"
+    displayName: Add conda to PATH
+
+  # Get the Fatiando CI scripts
+  - bash: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
+    displayName: Fetch the Fatiando CI scripts
+
+  # Setup dependencies and build a conda environment
+  - bash: source continuous-integration/azure/setup-miniconda.sh
+    displayName: Setup Miniconda
+
+  # Show installed pkg information for postmortem diagnostic
+  - bash: |
+      set -x -e
+      source activate testing
+      conda list
+    displayName: List installed packages
+
+  # Check that the code passes format checks
+  - bash: |
+      set -x -e
+      source activate testing
+      make check
+    displayName: Formatting check (black and flake8)
+    condition: succeededOrFailed()
+
+  # Check that the code passes linting checks
+  - bash: |
+      set -x -e
+      source activate testing
+      make lint
+    displayName: Linting (pylint)
+    condition: succeededOrFailed()
+
+
+# Mac
+########################################################################################
+- job:
+  displayName: 'Mac'
+
+  pool:
+    vmImage: 'macOS-10.14'
+
+  variables:
+    CONDA_REQUIREMENTS: requirements.txt
+    CONDA_REQUIREMENTS_DEV: requirements-dev.txt
+    CONDA_INSTALL_EXTRA: "codecov"
+    CONDA_EXTRA_CHANNEL: "conda-forge/label/dev"
+
+  strategy:
+    matrix:
+      Python37:
+        python.version: '3.7'
+        PYTHON: '3.7'
+      Python36:
+        python.version: '3.6'
+        PYTHON: '3.6'
+
+  steps:
+
+  - bash: echo "##vso[task.prependpath]$CONDA/bin"
+    displayName: Add conda to PATH
+
+  # Get the Fatiando CI scripts
+  - bash: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
+    displayName: Fetch the Fatiando CI scripts
+
+  # Setup dependencies and build a conda environment
+  - bash: source continuous-integration/azure/setup-miniconda.sh
+    displayName: Setup Miniconda
+
+  # Show installed pkg information for postmortem diagnostic
+  - bash: |
+      set -x -e
+      source activate testing
+      conda list
+    displayName: List installed packages
+
+  # Install the package
+  - bash: |
+      set -x -e
+      source activate testing
+      python setup.py bdist_wheel
+      pip install dist/*
+    displayName: Install the package
+
+  # Run the tests
+  - bash: |
+      set -x -e
+      source activate testing
+      make test PYTEST_EXTRA="-r P"
+    displayName: Test
+
+  # Build the documentation
+  - bash: |
+      set -x -e
+      source activate testing
+      make -C doc clean all
+    displayName: Build the documentation
+
+  # Upload test coverage if there were no failures
+  - bash: |
+      set -x -e
+      source activate testing
+      coverage xml
+      echo "Uploading coverage to Codecov"
+      codecov -e PYTHON AGENT_OS
+    env:
+      CODECOV_TOKEN: $(codecov.token)
+    condition: succeeded()
+    displayName: Upload coverage
+
+
+# Windows
+########################################################################################
+- job:
+  displayName: 'Windows'
+
+  pool:
+    vmImage: 'vs2017-win2016'
+
+  variables:
+    CONDA_REQUIREMENTS: requirements.txt
+    CONDA_REQUIREMENTS_DEV: requirements-dev.txt
+    CONDA_INSTALL_EXTRA: "codecov"
+    CONDA_EXTRA_CHANNEL: "conda-forge/label/dev"
+
+  strategy:
+    matrix:
+      Python37:
+        python.version: '3.7'
+        PYTHON: '3.7'
+      Python36:
+        python.version: '3.6'
+        PYTHON: '3.6'
+
+  steps:
+
+  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+    displayName: Add conda to PATH
+
+  # Get the Fatiando CI scripts
+  - script: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
+    displayName: Fetch the Fatiando CI scripts
+
+  # Setup dependencies and build a conda environment
+  - script: continuous-integration/azure/setup-miniconda.bat
+    displayName: Setup Miniconda
+
+  # Show installed pkg information for postmortem diagnostic
+  - bash: |
+      set -x -e
+      source activate testing
+      conda list
+    displayName: List installed packages
+
+  # Install the package that we want to test
+  - bash: |
+      set -x -e
+      source activate testing
+      python setup.py sdist --formats=zip
+      pip install dist/*
+    displayName: Install the package
+
+  # Run the tests
+  - bash: |
+      set -x -e
+      source activate testing
+      make test PYTEST_EXTRA="-r P"
+    displayName: Test
+
+  # Upload test coverage if there were no failures
+  - bash: |
+      set -x -e
+      source activate testing
+      coverage report -m
+      coverage xml
+      codecov -e PYTHON AGENT_OS
+    env:
+      CODECOV_TOKEN: $(codecov.token)
+    condition: succeeded()
+    displayName: Upload coverage

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -168,6 +168,12 @@ jobs:
 
   steps:
 
+  # Install ghostscript separately since there is no Windows conda-forge package for it.
+  - bash: |
+      set -x -e
+      choco install ghostscript
+    displayName: Install ghostscript via chocolatey
+
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,53 +26,24 @@ env:
         # The file with the listed requirements to be installed by conda
         - CONDA_REQUIREMENTS=requirements.txt
         - CONDA_REQUIREMENTS_DEV=requirements-dev.txt
+        - CONDA_INSTALL_EXTRA="codecov twine"
         # Enable the development channel so we can get GMT 6.0.0 before it's released
         - CONDA_EXTRA_CHANNEL=conda-forge/label/dev
         # These variables control which actions are performed in a build
-        - TEST=false
-        - CHECK=false
-        - BUILD_DOCS=false
-        - DEPLOY_DOCS=false
-        - DEPLOY_PYPI=false
+        - DEPLOY=false
 
 matrix:
     # Build under the following configurations
     include:
-        - name: "Style checks"
-          os: linux
-          env:
-              - PYTHON=3.7
-              - CHECK=true
-              - CONDA_INSTALL_EXTRA="black flake8 pylint=2.2.2"
-              - CONDA_REQUIREMENTS=""
-              - CONDA_REQUIREMENTS_DEV=""
         - name: "Linux - Python 3.7"
           os: linux
           env:
               - PYTHON=3.7
-              - TEST=true
-              - BUILD_DOCS=true
         - name: "Linux - Python 3.6 (deploy)"
           os: linux
           env:
               - PYTHON=3.6
-              - TEST=true
-              - BUILD_DOCS=true
-              - DEPLOY_DOCS=true
-              - DEPLOY_PYPI=true
-              - CONDA_INSTALL_EXTRA="twine"
-        - name: "Mac - Python 3.7"
-          os: osx
-          env:
-              - PYTHON=3.7
-              - TEST=true
-              - BUILD_DOCS=true
-        - name: "Mac - Python 3.6"
-          os: osx
-          env:
-              - PYTHON=3.6
-              - TEST=true
-              - BUILD_DOCS=true
+              - DEPLOY=true
 
 before_install:
     # Get the Fatiando CI scripts
@@ -89,29 +60,16 @@ install:
     - pip install dist/*
 
 script:
-    # Check code for style and lint for code quality
-    - if [ "$CHECK" == "true" ]; then
-        make check;
-        make lint;
-      fi
     # Run the test suite. Make pytest report any captured output on stdout or stderr.
-    - if [ "$TEST" == "true" ]; then
-          pip install codecov;
-          make test PYTEST_EXTRA="-r P";
-      fi
+    - make test PYTEST_EXTRA="-r P"
     # Build the documentation
-    - if [ "$BUILD_DOCS" == "true" ]; then
-        make -C doc all;
-      fi
+    - make -C doc all
 
 # Things to do if the build is successful
 after_success:
     # Upload coverage information
-    - if [ "$TEST" == "true" ]; then
-        coverage xml;
-        echo "Uploading coverage to Codecov";
-        codecov -e PYTHON;
-      fi
+    - coverage xml
+    - codecov -e PYTHON
 
 deploy:
     # Make a release on PyPI
@@ -119,21 +77,21 @@ deploy:
       script: continuous-integration/travis/deploy-pypi.sh
       on:
           tags: true
-          condition: '$DEPLOY_PYPI == "true"'
+          condition: '$DEPLOY == "true"'
     # Push the built HTML in doc/_build/html to the gh-pages branch
     - provider: script
       script: continuous-integration/travis/deploy-gh-pages.sh
       skip_cleanup: true
       on:
           branch: master
-          condition: '$DEPLOY_DOCS == "true"'
+          condition: '$DEPLOY == "true"'
     # Push HTML when building tags as well
     - provider: script
       script: continuous-integration/travis/deploy-gh-pages.sh
       skip_cleanup: true
       on:
           tags: true
-          condition: '$DEPLOY_DOCS == "true"'
+          condition: '$DEPLOY == "true"'
 
 notifications:
     email: false

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,9 @@ PyGMT
 .. image:: http://img.shields.io/travis/GenericMappingTools/pygmt/master.svg?style=flat-square&label=Linux|Mac
     :alt: Travis CI build status
     :target: https://travis-ci.org/GenericMappingTools/pygmt
+.. image:: https://img.shields.io/azure-devops/build/GenericMappingTools/7682ad4e-76bb-4775-849e-7c4f8dce4e1a/3/master.svg?label=Azure&style=flat-square
+    :alt: Azure Pipelines build status
+    :target: https://dev.azure.com/GenericMappingTools/PyGMT/_build
 .. image:: https://img.shields.io/codecov/c/github/GenericMappingTools/pygmt/master.svg?style=flat-square
     :alt: Test coverage status
     :target: https://codecov.io/gh/GenericMappingTools/pygmt


### PR DESCRIPTION
**Description of proposed changes**

Delegate the style checks and Mac builds to Azure instead of Travis (for speed).
Deployment still happens on Travis.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.