### PR TITLE
Register mpl_image_compare marker to remove PytestUnknownMarkWarning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,7 @@ tag_prefix = ''
 [flake8]
 ignore = E203, E266, E501, W503, F401, E741
 max-line-length = 88
+
+[tool:pytest]
+markers =
+    mpl_image_compare: compare generated plots with correct baseline version


### PR DESCRIPTION
**Description of proposed changes**

Supresses the annoying warning that @pytest.mark.mpl_image_compare emits when running `make test` because it isn't registered properly. 

Original warning was:

```bash
/home/.../envs/pygmt/lib/python3.7/site-packages/_pytest/mark/structures.py:324
  /home/.../envs/pygmt/lib/python3.7/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.mpl_image_compare - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This quickfix suppresses that warning until it is resolved upstream at https://github.com/matplotlib/pytest-mpl/issues/69. See also https://docs.pytest.org/en/latest/mark.html#raising-errors-on-unknown-marks

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Patches #78


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [x] If adding new functionality, add an example to docstrings or tutorials.
