### PR TITLE
Add sequence_space converter in kwargs_to_string

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -286,12 +286,7 @@ def kwargs_to_strings(convert_bools=True, **conversions):
             for arg, fmt in conversions.items():
                 if arg in kwargs:
                     value = kwargs[arg]
-                    issequence = fmt in (
-                        "sequence",
-                        "sequence_comma",
-                        "sequence_plus",
-                        "sequence_space",
-                    )
+                    issequence = fmt in separators
                     if issequence and is_nonstr_iter(value):
                         kwargs[arg] = separators[fmt].join(
                             "{}".format(item) for item in value

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -210,6 +210,7 @@ def kwargs_to_strings(convert_bools=True, **conversions):
       string
     * 'sequence_comma': transforms a sequence into a ``','`` separated string
     * 'sequence_plus': transforms a sequence into a ``'+'`` separated string
+    * 'sequence_space': transforms a sequence into a ``' '`` separated string
 
     Parameters
     ----------
@@ -224,7 +225,7 @@ def kwargs_to_strings(convert_bools=True, **conversions):
     Examples
     --------
 
-    >>> @kwargs_to_strings(R='sequence', i='sequence_comma')
+    >>> @kwargs_to_strings(R='sequence', i='sequence_comma', files='sequence_space')
     ... def module(*args, **kwargs):
     ...     "A module that prints the arguments it received"
     ...     print('{', end='')
@@ -245,13 +246,20 @@ def kwargs_to_strings(convert_bools=True, **conversions):
     {}
     >>> module(i=[1, 2])
     {'i': '1,2'}
+    >>> module(files=["data1.txt", "data2.txt"])
+    {'files': 'data1.txt data2.txt'}
     >>> # Other non-boolean arguments are passed along as they are
     >>> module(123, bla=(1, 2, 3), foo=True, A=False, i=(5, 6))
     {'bla': (1, 2, 3), 'foo': '', 'i': '5,6'}
     args: 123
 
     """
-    valid_conversions = ["sequence", "sequence_comma", "sequence_plus"]
+    valid_conversions = [
+        "sequence",
+        "sequence_comma",
+        "sequence_plus",
+        "sequence_space",
+    ]
 
     for arg, fmt in conversions.items():
         if fmt not in valid_conversions:
@@ -259,7 +267,12 @@ def kwargs_to_strings(convert_bools=True, **conversions):
                 "Invalid conversion type '{}' for argument '{}'.".format(fmt, arg)
             )
 
-    separators = {"sequence": "/", "sequence_comma": ",", "sequence_plus": "+"}
+    separators = {
+        "sequence": "/",
+        "sequence_comma": ",",
+        "sequence_plus": "+",
+        "sequence_space": " ",
+    }
 
     # Make the actual decorator function
     def converter(module_func):
@@ -273,7 +286,12 @@ def kwargs_to_strings(convert_bools=True, **conversions):
             for arg, fmt in conversions.items():
                 if arg in kwargs:
                     value = kwargs[arg]
-                    issequence = fmt in ("sequence", "sequence_comma", "sequence_plus")
+                    issequence = fmt in (
+                        "sequence",
+                        "sequence_comma",
+                        "sequence_plus",
+                        "sequence_space",
+                    )
                     if issequence and is_nonstr_iter(value):
                         kwargs[arg] = separators[fmt].join(
                             "{}".format(item) for item in value


### PR DESCRIPTION
**Description of proposed changes**

Introduce new 'sequence_space' converter for transforming a Python list or tuple into a space separated string. Useful in cases for e.g. when multiple file inputs can be passed into some module. 

For example:
```python
@kwargs_to_string(files="sequence_space")
def module(*args, **kwargs):
    ...

>>> module(files=["data1.txt", "data2.txt"]
{'files': 'data1.txt data2.txt'}
```

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #322

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [x] If adding new functionality, add an example to docstrings or tutorials.
