### PR TITLE
Upgrade gmt from 6.0.0rc1 to 6.0.0rc4

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -19,7 +19,7 @@ Which Python?
 
 You'll need **Python 3.6 or greater** to run PyGMT.
 
-We recommend using the `Anaconda <http://continuum.io/downloads#all>`__ Python
+We recommend using the `Anaconda <https://www.anaconda.com/distribution>`__ Python
 distribution to ensure you have all dependencies installed and the ``conda``
 package manager available.
 Installing Anaconda does not require administrative rights to your computer and
@@ -29,14 +29,23 @@ doesn't interfere with any other Python installations in your system.
 Which GMT?
 ----------
 
-You'll need the latest development version available from
-`the GitHub repository <https://github.com/GenericMappingTools/gmt>`__.
-PyGMT is based on GMT 6, **which has not yet been officially released**.
+PyGMT requires GMT 6 as a minimum, which you can find the latest development version
+at `this GitHub repository <https://github.com/GenericMappingTools/gmt>`__.
 
 We need the very latest GMT since there are many changes being made to GMT itself in
 response to the development of PyGMT, mainly the new
-`modern execution mode <http://gmt.soest.hawaii.edu/projects/gmt/wiki/Modernization>`__.
+`modern execution mode <https://gmt.soest.hawaii.edu/projects/gmt/wiki/Modernization>`__.
 
+**GMT 6 has not been officially released yet**, but will be soon!
+In the meantime, GMT does provide compiled conda packages of their development version
+for Linux, Mac and Windows through
+`conda-forge <https://anaconda.org/conda-forge/gmt>`__.
+Advanced users can also
+`build GMT from source <https://github.com/GenericMappingTools/gmt/blob/master/BUILDING.md>`__
+instead, which is not so recommended but we would love to get feedback from anyone who
+tries.
+
+We recommend following the instructions further on to install GMT 6.
 
 Dependencies
 ------------
@@ -53,44 +62,38 @@ The following are optional (but recommended) dependencies:
 * `IPython <https://ipython.org/>`__: For embedding the figures in Jupyter notebooks.
 
 
-Installing GMT
---------------
+Installing GMT and other dependencies
+-------------------------------------
 
-Unfortunately, you'll have to build GMT from source in order to get PyGMT working.
-Please follow the `GMT Building Instructions <https://github.com/GenericMappingTools/gmt/blob/master/BUILDING.md>`__.
-
-For Windows users, you can also try to install the binaries of
-GMT development version, available from http://w3.ualg.pt/~jluis/mirone/downloads/gmt.html.
-Currently, we don't have tests running on Windows yet, so things might be broken.
-Please report any errors by `creating an issue on Github <https://github.com/GenericMappingTools/pygmt/issues>`__.
-
-.. note::
-
-   We used to maintain conda packages for the latest GMT. That caused many problems and
-   was very difficult to maintain updated. We have opted to not do that anymore so that
-   we can develop more quickly. Once GMT 6 is officially released, we'll have conda
-   packages available again. Please bear with us.
-
-Installing dependencies
------------------------
-
-Before installing PyGMT, we must install its dependencies.
+Before installing PyGMT, we must install GMT itself along with the other dependencies.
 The easiest way to do this is using the ``conda`` package manager.
 We recommend working in an isolated
-`conda environment <https://conda.io/docs/user-guide/tasks/manage-environments.html>`__
+`conda environment <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__
 to avoid issues with competing versions of its dependencies.
 
-We can create a new conda environment with Python and all our dependencies installed
+First, we must configure conda to get packages from the
+`conda-forge channel <https://conda-forge.org/>`__ (the order is important)::
+
+    conda config --prepend channels conda-forge/label/dev
+    conda config --prepend channels conda-forge
+
+Now we can create a new conda environment with Python and all our dependencies installed
 (we'll call it ``pygmt`` but you can change it to whatever you want)::
 
-     conda create --name pygmt python=3.6 pip numpy pandas xarray packaging
+     conda create --name pygmt python=3.6 pip numpy pandas xarray packaging gmt=6.0.0rc*
 
 Activate the environment by running::
 
-    source activate pygmt
+    conda activate pygmt
 
-From now on, all commands will take place inside the environment and won't affect your
-default installation.
+From now on, all commands will take place inside the conda virtual environment and won't
+affect your default installation.
+
+.. note::
+
+    **Currently, this has only been tested to work on Linux and macOS.**
+    We don't have tests running on Windows yet, so things might be broken.
+    Please report any errors by `creating an issue on Github <https://github.com/GenericMappingTools/pygmt/issues>`__.
 
 Installing PyGMT
 ----------------

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -73,7 +73,7 @@ class Session:
     library in the directory specified by it.
 
     A ``GMTVersionError`` exception will be raised if the GMT shared library reports a
-    version < 6.0.0rc1.
+    version < 6.0.0rc4.
 
     The ``session_pointer`` attribute holds a ctypes pointer to the currently open
     session.
@@ -112,7 +112,7 @@ class Session:
     """
 
     # The minimum version of GMT required
-    required_version = "6.0.0rc1"
+    required_version = "6.0.0rc4"
 
     @property
     def session_pointer(self):
@@ -463,7 +463,7 @@ class Session:
         Parameters
         ----------
         module : str
-            Module name (``'pscoast'``, ``'psbasemap'``, etc).
+            Module name (``'coast'``, ``'basemap'``, etc).
         args : str
             String with the command line arguments that will be passed to the
             module (for example, ``'-R0/5/0/10 -JM'``).

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -791,7 +791,7 @@ def test_get_default():
     with clib.Session() as lib:
         assert lib.get_default("API_GRID_LAYOUT") in ["rows", "columns"]
         assert int(lib.get_default("API_CORES")) >= 1
-        assert Version(lib.get_default("API_VERSION")) >= Version("6.0.0rc1")
+        assert Version(lib.get_default("API_VERSION")) >= Version("6.0.0rc4")
 
 
 def test_get_default_fails():

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -19,7 +19,7 @@ def test_begin_end():
 
     begin()
     with Session() as lib:
-        lib.call_module("psbasemap", "-R10/70/-3/8 -JX4i/3i -Ba")
+        lib.call_module("basemap", "-R10/70/-3/8 -JX4i/3i -Ba")
     end()
 
     begin()  # Restart the global session

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -2,9 +2,11 @@
 Test the session management modules.
 """
 import os
+import pytest
 
 from ..session_management import begin, end
 from ..clib import Session
+from ..exceptions import GMTCLibError
 
 
 def test_begin_end():
@@ -12,11 +14,14 @@ def test_begin_end():
     Run a command inside a begin-end modern mode block.
     First, end the global session. When finished, restart it.
     """
-    end()  # Kill the global session
+    with pytest.raises(GMTCLibError, match="Module 'end' failed with status code 78:"):
+        end()  # Kill the global session first
+
     begin()
     with Session() as lib:
         lib.call_module("psbasemap", "-R10/70/-3/8 -JX4i/3i -Ba")
     end()
+
     begin()  # Restart the global session
     assert os.path.exists("pygmt-session.pdf")
     os.remove("pygmt-session.pdf")

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -2,11 +2,9 @@
 Test the session management modules.
 """
 import os
-import pytest
 
 from ..session_management import begin, end
 from ..clib import Session
-from ..exceptions import GMTCLibError
 
 
 def test_begin_end():
@@ -14,14 +12,11 @@ def test_begin_end():
     Run a command inside a begin-end modern mode block.
     First, end the global session. When finished, restart it.
     """
-    with pytest.raises(GMTCLibError, match="Module 'end' failed with status code 78:"):
-        end()  # Kill the global session first
-
+    end()  # Kill the global session
     begin()
     with Session() as lib:
         lib.call_module("basemap", "-R10/70/-3/8 -JX4i/3i -Ba")
     end()
-
     begin()  # Restart the global session
     assert os.path.exists("pygmt-session.pdf")
     os.remove("pygmt-session.pdf")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Requirements for installing with conda
-gmt=6.0.0rc1
+gmt=6.0.0rc4
 numpy
 pandas
 xarray


### PR DESCRIPTION
**Description of proposed changes**

Testing out the new *patched* GMT 6.0.0rc4 release (see upstream https://github.com/GenericMappingTools/gmt/issues/1471) for PyGMT, a step towards readying it for the GMT6 release coming soon. Full list of changes at https://github.com/GenericMappingTools/gmt/compare/6.0.0rc1...6.0.0rc4 in addition to the patch at https://github.com/conda-forge/gmt-feedstock/pull/85.

Builds upon #311. Might also be a good time to add GMT back to our conda installation (i.e. revert some aspects of https://github.com/GenericMappingTools/pygmt/pull/261).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Noticed some tests were breaking on my local instance when developing on `GMT 6.0.0rc4`, specifically `test_session_management.py` ~~and `test_sphinx_gallery.py`. Has something to do with modern/classic mode incompatibility, possibly because of https://github.com/GenericMappingTools/gmt/issues/1142~~. Tracking and resolving it here in this pull request.

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
