### PR TITLE
Fix the wrong example in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,8 +310,7 @@ returning the `pygmt.Figure` object:
 def test_my_plotting_case():
     "Test that my plotting function works"
     fig = Figure()
-    fig.psbasemap(region=[0, 360, -90, 90], projection='W7i', frame=True,
-                  portrait=True)
+    fig.basemap(region=[0, 360, -90, 90], projection='W7i', frame=True)
     return fig
 ```
 


### PR DESCRIPTION
**Description of proposed changes**

- `psbasemap` should be `basemap`
- `portrait` is not a valid argument

**Reminders**

- [X] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.