### PR TITLE
Continuous Documentation

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -61,6 +61,15 @@ repository to avoid duplicating work across multiple repositories.
 If you find any problems with the test setup and deployment, please create issues and
 submit pull requests to that repository.
 
+## Continuous Documentation
+
+We use the [Zeit Now for Github integration](https://zeit.co/github) to preview changes
+made to our documentation website every time we make a commit in a pull request.
+The integration service has a configuration file `now.json`, with a list of options to
+change the default behaviour at https://zeit.co/docs/configuration.
+The actual script `package.json` is used by Zeit Now to install the necessary packages,
+build the documentation, copy the files to a 'public' folder and deploy that to the web,
+see https://zeit.co/docs/v2/build-step/?query=package.json#defining-a-build-script.
 
 ## Making a Release
 

--- a/now.json
+++ b/now.json
@@ -1,0 +1,6 @@
+{
+  "github": {
+    "silent": true
+  },
+  "public": true
+}

--- a/now.json
+++ b/now.json
@@ -1,6 +1,4 @@
 {
-  // Zeit Now for Github configuration that override default settings
-  // Documentation can be found at https://zeit.co/docs/configuration
   "github": {
     "silent": true
   },

--- a/now.json
+++ b/now.json
@@ -1,4 +1,6 @@
 {
+  // Zeit Now for Github configuration that override default settings
+  // Documentation can be found at https://zeit.co/docs/configuration
   "github": {
     "silent": true
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,4 @@
 {
-  // Script to deploy documentation to Zeit Now static site host
-  // Documentation at https://zeit.co/docs/v2/build-step/?query=package.json#defining-a-build-script
   "scripts": {
     "build:miniconda": "curl -o ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash ~/miniconda.sh -b -p $HOME/miniconda",
     "build:pygmt": "conda env create -f environment.yml && source activate pygmt && conda install -c conda-forge -c conda-forge/label/dev -y gmt==6.0.0rc4 && make install",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  // Script to deploy documentation to Zeit Now static site host
+  // Documentation at https://zeit.co/docs/v2/build-step/?query=package.json#defining-a-build-script
   "scripts": {
     "build:miniconda": "curl -o ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash ~/miniconda.sh -b -p $HOME/miniconda",
     "build:pygmt": "conda env create -f environment.yml && source activate pygmt && conda install -c conda-forge -c conda-forge/label/dev -y gmt==6.0.0rc4 && make install",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "build:miniconda": "curl -o ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash ~/miniconda.sh -b -p $HOME/miniconda",
+    "build:pygmt": "conda env create -f environment.yml && source activate pygmt && conda install -c conda-forge -c conda-forge/label/dev -y gmt==6.0.0rc4 && make install",
+    "build:docs": "source activate pygmt && cd doc && make all && mv _build/html ../public",
+    "build": "export PATH=$HOME/miniconda/bin:$PATH && npm run build:miniconda && npm run build:pygmt && npm run build:docs"
+  }
+}


### PR DESCRIPTION
**Description of proposed changes**

Making it easier to preview documentation changes in Pull Requests via 'Continuous Documentation'. Currently deployed to serverless infrastructure on [Zeit Now](https://zeit.co/now).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Zeit Now is meant to be a zero-config/serverless, but that's for the javascript world. I've hacked the `package.json` to get `sphinx` and `pygmt` up and running to build the docs. The static files are then copied to a `public` folder where it gets deployed automatically to a url that looks like `pygmt-abcdef.now.sh`. You can see an example at https://pygmt-l8nmyn8mx.now.sh/.

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Merge after #343, Fixes #342

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
