### PR TITLE
Quickfix min/max elevation for new SRTM15+V2 earth relief grids

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -107,8 +107,7 @@ class Session:
     ...             ses.call_module("grdinfo", "{} -C ->{}".format(fin, fout.name))
     ...             # Read the contents of the temp file before it's deleted.
     ...             print(fout.read().strip())
-    -180 180 -90 90 -8425 5551 1 1 361 181
-
+    -180 180 -90 90 -8596 5559 1 1 361 181
     """
 
     # The minimum version of GMT required
@@ -1188,7 +1187,7 @@ class Session:
         >>> print(data.lat.values.min(), data.lat.values.max())
         -90.0 90.0
         >>> print(data.values.min(), data.values.max())
-        -8425.0 5551.0
+        -8596.0 5559.0
         >>> with Session() as ses:
         ...     with ses.virtualfile_from_grid(data) as fin:
         ...         # Send the output to a file so that we can read it
@@ -1196,7 +1195,7 @@ class Session:
         ...             args = '{} -L0 -Cn ->{}'.format(fin, fout.name)
         ...             ses.call_module('grdinfo', args)
         ...             print(fout.read().strip())
-        -180 180 -90 90 -8425 5551 1 1 361 181
+        -180 180 -90 90 -8596 5559 1 1 361 181
         >>> # The output is: w e s n z0 z1 dx dy n_columns n_rows
 
         """

--- a/pygmt/tests/test_datasets.py
+++ b/pygmt/tests/test_datasets.py
@@ -62,8 +62,8 @@ def test_earth_relief_60():
     assert data.shape == (181, 361)
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -8425)
-    npt.assert_allclose(data.max(), 5551)
+    npt.assert_allclose(data.min(), -8596)
+    npt.assert_allclose(data.max(), 5559)
 
 
 def test_earth_relief_30():
@@ -72,5 +72,5 @@ def test_earth_relief_30():
     assert data.shape == (361, 721)
     npt.assert_allclose(data.lat, np.arange(-90, 90.5, 0.5))
     npt.assert_allclose(data.lon, np.arange(-180, 180.5, 0.5))
-    npt.assert_allclose(data.min(), -9214)
-    npt.assert_allclose(data.max(), 5859)
+    npt.assert_allclose(data.min(), -9458)
+    npt.assert_allclose(data.max(), 5888)

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -59,13 +59,13 @@ def test_grdinfo():
     "Make sure grd info works as expected"
     grid = load_earth_relief()
     result = grdinfo(grid, L=0, C="n")
-    assert result.strip() == "-180 180 -90 90 -8425 5551 1 1 361 181"
+    assert result.strip() == "-180 180 -90 90 -8596 5559 1 1 361 181"
 
 
 def test_grdinfo_file():
     "Test grdinfo with file input"
     result = grdinfo("@earth_relief_60m", L=0, C="n")
-    assert result.strip() == "-180 180 -90 90 -8425 5551 1 1 361 181"
+    assert result.strip() == "-180 180 -90 90 -8596 5559 1 1 361 181"
 
 
 def test_grdinfo_fails():


### PR DESCRIPTION
Upstream GMT has updated its earth relief grids (see https://github.com/GenericMappingTools/gmt/pull/1846) to use the new Global Bathymetry and Topography at 15 Arc Sec (SRTM15+V2) data by @btozer and others!

References:

- Tozer, B., Sandwell, D. T., Smith, W. H. F., Olson, C., Beale, J. R., & Wessel, P. (2019). Global Bathymetry and Topography at 15 Arc Sec: SRTM15+. Earth and Space Science. https://doi.org/10.1029/2019EA000658

**Description of proposed changes**

This pull request fixes the test failures by changing the minimum/maximum elevation values to that of the new earth relief grids.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [x] If adding new functionality, add an example to docstrings or tutorials.
