### PR TITLE
Upgrade the minimum required gmt version to 6.0.0rc5

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
   variables:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
-    CONDA_INSTALL_EXTRA: "codecov gmt=6.0.0rc4"
+    CONDA_INSTALL_EXTRA: "codecov gmt=6.0.0rc5"
     CONDA_EXTRA_CHANNEL: "conda-forge/label/dev"
 
   strategy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
         # The file with the listed requirements to be installed by conda
         - CONDA_REQUIREMENTS=requirements.txt
         - CONDA_REQUIREMENTS_DEV=requirements-dev.txt
-        - CONDA_INSTALL_EXTRA="codecov twine gmt=6.0.0rc4"
+        - CONDA_INSTALL_EXTRA="codecov twine gmt=6.0.0rc5"
         # Enable the development channel so we can get GMT 6.0.0 before it's released
         - CONDA_EXTRA_CHANNEL=conda-forge/label/dev
         # These variables control which actions are performed in a build

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build:miniconda": "curl -o ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash ~/miniconda.sh -b -p $HOME/miniconda",
-    "build:pygmt": "conda env create -f environment.yml && source activate pygmt && conda install -c conda-forge -c conda-forge/label/dev -y gmt==6.0.0rc4 && make install",
+    "build:pygmt": "conda env create -f environment.yml && source activate pygmt && conda install -c conda-forge -c conda-forge/label/dev -y gmt==6.0.0rc5 && make install",
     "build:docs": "source activate pygmt && cd doc && make all && mv _build/html ../public",
     "build": "export PATH=$HOME/miniconda/bin:$PATH && npm run build:miniconda && npm run build:pygmt && npm run build:docs"
   }

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -73,7 +73,7 @@ class Session:
     library in the directory specified by it.
 
     A ``GMTVersionError`` exception will be raised if the GMT shared library reports a
-    version < 6.0.0rc4.
+    version < 6.0.0rc5.
 
     The ``session_pointer`` attribute holds a ctypes pointer to the currently open
     session.
@@ -111,7 +111,7 @@ class Session:
     """
 
     # The minimum version of GMT required
-    required_version = "6.0.0rc4"
+    required_version = "6.0.0rc5"
 
     @property
     def session_pointer(self):

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -791,7 +791,7 @@ def test_get_default():
     with clib.Session() as lib:
         assert lib.get_default("API_GRID_LAYOUT") in ["rows", "columns"]
         assert int(lib.get_default("API_CORES")) >= 1
-        assert Version(lib.get_default("API_VERSION")) >= Version("6.0.0rc4")
+        assert Version(lib.get_default("API_VERSION")) >= Version("6.0.0rc5")
 
 
 def test_get_default_fails():


### PR DESCRIPTION
**Description of proposed changes**

Upgrade the minimum required gmt version to 6.0.0rc5, which is the last release candidate before 6.0.0.

**Reminders**

- [X] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
