### PR TITLE
Remove `choco install ghostscript` step in Windows build

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -159,7 +159,7 @@ jobs:
   variables:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
-    CONDA_INSTALL_EXTRA: "codecov"
+    CONDA_INSTALL_EXTRA: "codecov gmt=6.0.0"
 
   strategy:
     matrix:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -172,12 +172,6 @@ jobs:
 
   steps:
 
-  # Install ghostscript separately since there is no Windows conda-forge package for it.
-  - bash: |
-      set -x -e
-      choco install ghostscript
-    displayName: Install ghostscript via chocolatey
-
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
 

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -7,6 +7,7 @@ GMT_LIBRARY_PATH environment variable.
 import os
 import sys
 import ctypes
+import ctypes.util
 
 from ..exceptions import GMTOSError, GMTCLibError, GMTCLibNotFoundError
 
@@ -46,12 +47,14 @@ def load_libgmt(env=None):
         try:
             libgmt = ctypes.CDLL(os.path.join(libpath, libname))
             check_libgmt(libgmt)
+            error = False
             break
         except OSError as err:
             error = err
     if error:
         raise GMTCLibNotFoundError(
-            "Error loading the GMT shared library '{}':".format(libname)
+            f"Error loading the GMT shared library '{libname}' because of {error}, try "
+            f"set GMT_LIBRARY_PATH={os.path.dirname(ctypes.util.find_library('gmt'))}"
         )
     return libgmt
 
@@ -77,7 +80,7 @@ def clib_name(os_name):
         # Darwin is macOS
         libname = ["libgmt.dylib"]
     elif os_name == "win32":
-        libname = ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
+        libname = ["gmt_w32.dll", "gmt_w64.dll", "gmt.dll"]
     else:
         raise GMTOSError('Operating system "{}" not supported.'.format(sys.platform))
     return libname

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -30,6 +30,6 @@ def test_clib_name():
     for linux in ["linux", "linux2", "linux3"]:
         assert clib_name(linux) == ["libgmt.so"]
     assert clib_name("darwin") == ["libgmt.dylib"]
-    assert clib_name("win32") == ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
+    assert clib_name("win32") == ["gmt_w32.dll", "gmt_w64.dll", "gmt.dll"]
     with pytest.raises(GMTOSError):
         clib_name("meh")


### PR DESCRIPTION
**Description of proposed changes**

Might not work, but won't hurt to try. Testing conda-forge ghostscript package for Windows now available since 9 July 2019 at https://anaconda.org/conda-forge/ghostscript/files/modal/info/5d251a3fa77eb5638cb1574f.

Cross referencing https://github.com/conda-forge/gmt-feedstock/pull/73

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
