### PR TITLE
Update fatiando continuous integration scripts from 1.1.1 to 1.2.0

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
     displayName: Add conda to PATH
 
   # Get the Fatiando CI scripts
-  - bash: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
+  - bash: git clone --branch=1.2.0 --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts
 
   # Setup dependencies and build a conda environment
@@ -94,7 +94,7 @@ jobs:
     displayName: Add conda to PATH
 
   # Get the Fatiando CI scripts
-  - bash: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
+  - bash: git clone --branch=1.2.0 --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts
 
   # Setup dependencies and build a conda environment
@@ -179,7 +179,7 @@ jobs:
     displayName: Add conda to PATH
 
   # Get the Fatiando CI scripts
-  - script: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
+  - script: git clone --branch=1.2.0 --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts
 
   # Setup dependencies and build a conda environment

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -97,6 +97,12 @@ jobs:
   - bash: git clone --branch=1.2.0 --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts
 
+  # On Hosted macOS, the agent user doesn't have ownership of Miniconda's installation
+  # directory. We need to take ownership if we want to update conda or install packages
+  # globally.
+  - bash: sudo chown -R $USER $CONDA
+    displayName: Take ownership of conda installation
+
   # Setup dependencies and build a conda environment
   - bash: source continuous-integration/azure/setup-miniconda.sh
     displayName: Setup Miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
 
 before_install:
     # Get the Fatiando CI scripts
-    - git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
+    - git clone --branch=1.2.0 --depth=1 https://github.com/fatiando/continuous-integration.git
     # Download and install miniconda and setup dependencies
     # Need to source the script to set the PATH variable globaly
     - source continuous-integration/travis/setup-miniconda.sh


### PR DESCRIPTION
**Description of proposed changes**

Fixes randomly failing Mac builds. See release notes at https://github.com/fatiando/continuous-integration/releases/tag/1.2.0.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
