### PR TITLE
Quickfix plot docstring to have label (l)

### DIFF
--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -181,8 +181,6 @@ class BasePlotting:
             Do not draw contours with less than `cut` number of points.
         S : string or int
             Resample smoothing factor.
-        l : str
-            Add a legend entry for the symbol or line being plotted.
         {J}
         {R}
         {B}
@@ -311,8 +309,8 @@ class BasePlotting:
             quoted lines).
         {W}
         {U}
-
-
+        l : str
+            Add a legend entry for the symbol or line being plotted.
         """
         kwargs = self._preprocess(**kwargs)
 

--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -45,8 +45,8 @@ def test_legend_entries():
         pen="faint",
         l="Apples",
     )
-    fig.plot(data="@Table_5_11.txt", pen="1.5p,gray", l='"My lines"')
-    fig.plot(data="@Table_5_11.txt", style="t0.15i", color="orange", l="Oranges")
+    fig.plot(data="@Table_5_11.txt", pen="1.5p,gray", label='"My lines"')
+    fig.plot(data="@Table_5_11.txt", style="t0.15i", color="orange", label="Oranges")
 
     fig.legend(position="JTR+jTR")
 


### PR DESCRIPTION
**Description of proposed changes**

The code that sets `label` as an alias for `l` in `plot` is in the right place, but the docstring was accidentally placed under `grdcontour` instead of `plot`.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Note to future self/contributor: Wait for https://github.com/GenericMappingTools/gmt/pull/1838 to actually use `-l` in `grdcontour` and `contour`.

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
