### PR TITLE
Bump minimum required GMT from 6.0.0rc5 to 6.0.0

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -76,8 +76,7 @@ jobs:
   variables:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
-    CONDA_INSTALL_EXTRA: "codecov gmt=6.0.0rc5"
-    CONDA_EXTRA_CHANNEL: "conda-forge/label/dev"
+    CONDA_INSTALL_EXTRA: "codecov gmt=6.0.0"
 
   strategy:
     matrix:
@@ -162,7 +161,6 @@ jobs:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
     CONDA_INSTALL_EXTRA: "codecov"
-    CONDA_EXTRA_CHANNEL: "conda-forge/label/dev"
 
   strategy:
     matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,7 @@ env:
         # The file with the listed requirements to be installed by conda
         - CONDA_REQUIREMENTS=requirements.txt
         - CONDA_REQUIREMENTS_DEV=requirements-dev.txt
-        - CONDA_INSTALL_EXTRA="codecov twine gmt=6.0.0rc5"
-        # Enable the development channel so we can get GMT 6.0.0 before it's released
-        - CONDA_EXTRA_CHANNEL=conda-forge/label/dev
+        - CONDA_INSTALL_EXTRA="codecov twine gmt=6.0.0"
         # These variables control which actions are performed in a build
         - DEPLOY=false
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ read it carefully.
 ## How Can I Talk to You?
 
 Discussion often happens in the issues and pull requests.
-In addition, there is a [Gitter chatroom](https://gitter.im/GenericMappingTools/pygmt)
+In addition, there is a [Discourse forum](https://forum.generic-mapping-tools.org)
 for the project where you can ask questions.
 
 

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,8 @@ PyGMT
     A Python interface for the Generic Mapping Tools
 
 `Documentation (development version) <https://www.pygmt.org/dev>`__ |
-`Contact <https://gitter.im/GenericMappingTools/pygmt>`__
+`Contact <https://gitter.im/GenericMappingTools/pygmt>`__ |
+`Forum <https://forum.generic-mapping-tools.org>`__ `
 
 .. image:: http://img.shields.io/pypi/v/pygmt.svg?style=flat-square
     :alt: Latest version on PyPI
@@ -27,6 +28,9 @@ PyGMT
 .. image:: https://img.shields.io/gitter/room/GenericMappingTools/pygmt.svg?style=flat-square
     :alt: Chat room on Gitter
     :target: https://gitter.im/GenericMappingTools/pygmt
+.. image:: https://img.shields.io/discourse/status?label=forum&server=https%3A%2F%2Fforum.generic-mapping-tools.org%2F&style=flat-square
+    :alt: Discourse forum
+    :target: https://forum.generic-mapping-tools.org
 
 
 .. placeholder-for-doc-index
@@ -43,8 +47,7 @@ ideas and implement new features. **This is NOT a finished product.**
 We welcome any feedback and ideas!
 Let us know by submitting
 `issues on Github <https://github.com/GenericMappingTools/pygmt/issues>`__
-or send us a message on our
-`Gitter chatroom <https://gitter.im/GenericMappingTools/pygmt>`__.
+or by posting on our `Discourse forum <https://forum.generic-mapping-tools.org>`__.
 
 About
 -----
@@ -77,7 +80,7 @@ Contacting Us
   <https://github.com/GenericMappingTools/pygmt>`__. Feel free to `open an issue
   <https://github.com/GenericMappingTools/pygmt/issues/new>`__ or comment on any
   open issue or pull request.
-* We have a `chat room on Gitter <https://gitter.im/GenericMappingTools/pygmt>`__
+* We have a `Discourse forum <https://forum.generic-mapping-tools.org>`__
   where you can ask questions and leave comments.
 * This project is released with a `Contributor Code of Conduct
   <https://github.com/GenericMappingTools/pygmt/blob/master/CODE_OF_CONDUCT.md>`__.

--- a/README.rst
+++ b/README.rst
@@ -54,10 +54,9 @@ publication quality maps and figures. It provides a Pythonic interface for the
 `Generic Mapping Tools (GMT) <https://github.com/GenericMappingTools/gmt>`__, a
 command-line program widely used in the Earth Sciences.
 
-We rely heavily on new features currently being implemented in GMT. In particular, a new
-*modern execution mode* that greatly simplifies figure creation. **These features are
-not available in the 5.4 version of GMT**. They will be part of the future 6.0 release
-of GMT predicted for early 2019.
+We rely heavily on new features that have been implemented in GMT 6.0. In particular,
+a new *modern execution mode* that greatly simplifies figure creation. **These features
+are not available in the 5.4 version of GMT**.
 
 
 Project goals

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -29,16 +29,15 @@ doesn't interfere with any other Python installations in your system.
 Which GMT?
 ----------
 
-PyGMT requires GMT 6 as a minimum, which you can find the latest development version
-at `this GitHub repository <https://github.com/GenericMappingTools/gmt>`__.
+PyGMT requires Generic Mapping Tools (GMT) version 6 as a minimum, which is the latest
+released version that can be found at
+`this website <https://www.generic-mapping-tools.org>`__.
 
 We need the very latest GMT since there are many changes being made to GMT itself in
 response to the development of PyGMT, mainly the new
 `modern execution mode <https://gmt.soest.hawaii.edu/projects/gmt/wiki/Modernization>`__.
 
-**GMT 6 has not been officially released yet**, but will be soon!
-In the meantime, GMT does provide compiled conda packages of their development version
-for Linux, Mac and Windows through
+Compiled conda packages of GMT for Linux, Mac and Windows are provided through
 `conda-forge <https://anaconda.org/conda-forge/gmt>`__.
 Advanced users can also
 `build GMT from source <https://github.com/GenericMappingTools/gmt/blob/master/BUILDING.md>`__
@@ -72,15 +71,14 @@ We recommend working in an isolated
 to avoid issues with competing versions of its dependencies.
 
 First, we must configure conda to get packages from the
-`conda-forge channel <https://conda-forge.org/>`__ (the order is important)::
+`conda-forge channel <https://conda-forge.org/>`__::
 
-    conda config --prepend channels conda-forge/label/dev
     conda config --prepend channels conda-forge
 
 Now we can create a new conda environment with Python and all our dependencies installed
 (we'll call it ``pygmt`` but you can change it to whatever you want)::
 
-     conda create --name pygmt python=3.6 pip numpy pandas xarray packaging gmt=6.0.0rc*
+     conda create --name pygmt python=3.6 pip numpy pandas xarray packaging gmt=6.0.0
 
 Activate the environment by running::
 
@@ -139,5 +137,5 @@ You can tell PyGMT exactly where to look for ``libgmt`` by setting the
 This should be set to the directory where ``libgmt.so``, ``libgmt.dylib`` or ``gmt.dll``
 can be found for Linux, MacOS and Windows respectively.
 e.g. in a terminal run::
-   
+
    export GMT_LIBRARY_PATH=$HOME/anaconda3/envs/pygmt/lib

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -10,8 +10,7 @@ Installing
     We welcome any feedback and ideas!
     Let us know by submitting
     `issues on Github <https://github.com/GenericMappingTools/pygmt/issues>`__
-    or send us a message on our
-    `Gitter chatroom <https://gitter.im/GenericMappingTools/pygmt>`__.
+    or by posting on our `Discourse forum <https://forum.generic-mapping-tools.org>`__.
 
 
 Which Python?

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@ name: pygmt
 channels:
     - conda-forge
     - defaults
-    - conda-forge/label/dev
 dependencies:
     - python=3.7
     - pip

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build:miniconda": "curl -o ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash ~/miniconda.sh -b -p $HOME/miniconda",
-    "build:pygmt": "conda env create -f environment.yml && source activate pygmt && conda install -c conda-forge -c conda-forge/label/dev -y gmt==6.0.0rc5 && make install",
+    "build:pygmt": "conda env create -f environment.yml && source activate pygmt && conda install -c conda-forge -y gmt==6.0.0 && make install",
     "build:docs": "source activate pygmt && cd doc && make all && mv _build/html ../public",
     "build": "export PATH=$HOME/miniconda/bin:$PATH && npm run build:miniconda && npm run build:pygmt && npm run build:docs"
   }

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -73,7 +73,7 @@ class Session:
     library in the directory specified by it.
 
     A ``GMTVersionError`` exception will be raised if the GMT shared library reports a
-    version < 6.0.0rc5.
+    version < 6.0.0.
 
     The ``session_pointer`` attribute holds a ctypes pointer to the currently open
     session.
@@ -111,7 +111,7 @@ class Session:
     """
 
     # The minimum version of GMT required
-    required_version = "6.0.0rc5"
+    required_version = "6.0.0"
 
     @property
     def session_pointer(self):

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -791,7 +791,7 @@ def test_get_default():
     with clib.Session() as lib:
         assert lib.get_default("API_GRID_LAYOUT") in ["rows", "columns"]
         assert int(lib.get_default("API_CORES")) >= 1
-        assert Version(lib.get_default("API_VERSION")) >= Version("6.0.0rc5")
+        assert Version(lib.get_default("API_VERSION")) >= Version("6.0.0")
 
 
 def test_get_default_fails():


### PR DESCRIPTION
**Description of proposed changes**

GMT6 is finally released, so we can simplify our conda installation steps and update the documentation accordingly.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

TODO:
- [x] Use GMT 6.0.0 from the main conda-forge channel in our CI scripts and config files
- [x] Update documentation to indicate GMT6 is released!
- [x] Mention new [GMT Community Forum](https://forum.generic-mapping-tools.org/)

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #362, Supersedes #351 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
