### PR TITLE
Allow passing in list to 'region' argument in surface

### DIFF
--- a/pygmt/gridding.py
+++ b/pygmt/gridding.py
@@ -6,17 +6,19 @@ import xarray as xr
 from .clib import Session
 from .helpers import (
     build_arg_string,
-    fmt_docstring,
-    GMTTempFile,
-    use_alias,
     data_kind,
     dummy_context,
+    fmt_docstring,
+    GMTTempFile,
+    kwargs_to_strings,
+    use_alias,
 )
 from .exceptions import GMTInvalidInput
 
 
 @fmt_docstring
 @use_alias(I="spacing", R="region", G="outfile")
+@kwargs_to_strings(R="sequence")
 def surface(x=None, y=None, z=None, data=None, **kwargs):
     """
     Grids table data using adjustable tension continuous curvature splines.

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -21,7 +21,7 @@ def test_surface_input_file():
     Run surface by passing in a filename
     """
     fname = which("@tut_ship.xyz", download="c")
-    output = surface(data=fname, spacing="5m", region="245/255/20/30")
+    output = surface(data=fname, spacing="5m", region=[245, 255, 20, 30])
     assert isinstance(output, xr.Dataset)
     return output
 
@@ -32,7 +32,7 @@ def test_surface_input_data_array():
     """
     ship_data = load_sample_bathymetry()
     data = ship_data.values  # convert pandas.DataFrame to numpy.ndarray
-    output = surface(data=data, spacing="5m", region="245/255/20/30")
+    output = surface(data=data, spacing="5m", region=[245, 255, 20, 30])
     assert isinstance(output, xr.Dataset)
     return output
 
@@ -47,7 +47,7 @@ def test_surface_input_xyz():
         y=ship_data.latitude,
         z=ship_data.bathymetry,
         spacing="5m",
-        region="245/255/20/30",
+        region=[245, 255, 20, 30],
     )
     assert isinstance(output, xr.Dataset)
     return output
@@ -63,7 +63,7 @@ def test_surface_input_xy_no_z():
             x=ship_data.longitude,
             y=ship_data.latitude,
             spacing="5m",
-            region="245/255/20/30",
+            region=[245, 255, 20, 30],
         )
 
 
@@ -75,7 +75,7 @@ def test_surface_wrong_kind_of_input():
     data = ship_data.bathymetry.to_xarray()  # convert pandas.Series to xarray.DataArray
     assert data_kind(data) == "grid"
     with pytest.raises(GMTInvalidInput):
-        surface(data=data, spacing="5m", region="245/255/20/30")
+        surface(data=data, spacing="5m", region=[245, 255, 20, 30])
 
 
 def test_surface_with_outfile_param():
@@ -86,7 +86,7 @@ def test_surface_with_outfile_param():
     data = ship_data.values  # convert pandas.DataFrame to numpy.ndarray
     try:
         output = surface(
-            data=data, spacing="5m", region="245/255/20/30", outfile=TEMP_GRID
+            data=data, spacing="5m", region=[245, 255, 20, 30], outfile=TEMP_GRID
         )
         assert output is None  # check that output is None since outfile is set
         assert os.path.exists(path=TEMP_GRID)  # check that outfile exists at path
@@ -104,7 +104,7 @@ def test_surface_short_aliases():
     ship_data = load_sample_bathymetry()
     data = ship_data.values  # convert pandas.DataFrame to numpy.ndarray
     try:
-        output = surface(data=data, I="5m", R="245/255/20/30", G=TEMP_GRID)
+        output = surface(data=data, I="5m", R=[245, 255, 20, 30], G=TEMP_GRID)
         assert output is None  # check that output is None since outfile is set
         assert os.path.exists(path=TEMP_GRID)  # check that outfile exists at path
         grid = xr.open_dataset(TEMP_GRID)


### PR DESCRIPTION
**Description of proposed changes**

Allows users to pass in a Python list to region (e.g. `region=[245, 255, 20, 30]`) instead of having to do `region="245/255/20/30"` in the [`surface`](https://www.pygmt.org/dev/api/generated/pygmt.surface.html) module.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #347 


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [x] If adding new functionality, add an example to docstrings or tutorials.
