### PR TITLE
Proj classes

### DIFF
--- a/pygmt/projection.py
+++ b/pygmt/projection.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python
+
+"""
+Contains the projections supported by GMT, and the necessary mechanisms
+to create a projection and output a valid GMT projection string.
+
+>>> from pygmt import projection
+>>> proj = projection.LambertAzimuthalEqualArea(lon0=30, lat0=-20, horizon=60, width="8i")
+>>> proj
+LambertAzimuthalEqualArea(lon0=30, lat0=-20, horizon=60, width='8i')
+>>> print(proj)
+A30/-20/60/8i
+"""
+
+from enum import Enum
+import attr
+
+
+class Supported(Enum):
+
+    """
+    The supported projections and their GMT code.
+    """
+
+    UNDEFINED = ""
+    LAMBERT_AZIMUTH_EQUAL_AREA = "A"  # DONE
+    ALBERS_CONIC_EQUAL_AREA = "B"  # DONE
+    CASSINI_CYLINDRICAL = "C"  # DONE
+    CYLINDRICAL_STEROGRAPHIC = "JCyl_stere/"  # includes `/` according to https://docs.generic-mapping-tools.org/latest/proj_codes.html  # DONE
+    EQUIDISTANT_CONIC = "JD"  # DONE
+    AZIMUTHAL_EQUIDISTANT = "E"  # DONE
+    AZIMUTHAL_GNOMIC = "F"  # DONE
+    AZIMUTHAL_ORTHOGRAPHIC = "G"  # DONE
+    GENERAL_PERSPECTIVE = "G"  # DONE
+    HAMMER_EQUAL_AREA = "H"
+    SINUSOIDAL_EQUAL_AREA = "I"
+    MILLER_CYLINDRICAL = "J"
+    ECKERT_IV_EQUAL_AREA = "Kf"
+    ECKERT_VI_EQUAL_AREA = "Ks"
+    LAMBERT_CONIC_CONFORMAL = "L"
+    MERCATOR_CYLINDRICAL = "M"  # DONE
+    ROBINSON = "N"
+    OBLIQUE_MERCATOR_1 = "Oa"
+    OBLIQUE_MERCATOR_2 = "Ob"
+    OBLIQUE_MERCATOR_3 = "Oc"
+    POLAR = "P"
+    POLYCONIC = "Poly"
+    EQUIDISTANT_CYLINDRICAL = "Q"
+    WINKEL_TRIPEL = "R"
+    GENERAL_STEREOGRAPHIC = "S"  # DONE
+    TRANSVERSE_MERCATOR = "T"
+    UNIVERSAL_TRANSVERSE_MERCATOR = "U"
+    VAN_DER_GRINTEN = "V"
+    MOLLWEIDE = "W"
+    LINEAR = "X"
+    CYLINDRICAL_EQUAL_AREA = "Y"  # DONE
+
+
+@attr.s()
+class _Projection:
+
+    """
+    Base class for all projections.
+    """
+
+    # private; we don't want the user to care or know about
+    _fmt: str = attr.ib(init=False, repr=False, default="{_code}")
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.UNDEFINED.value)
+
+    def __str__(self):
+        exclude = attr.fields(self.__class__)._fmt
+        kwargs = attr.asdict(self, filter=attr.filters.exclude(exclude))
+        return self._fmt.format(**kwargs)
+
+
+@attr.s(kw_only=True)
+class _Azimuthal(_Projection):
+
+    """
+    Base class for azimuthal projections.
+    """
+
+    lon0: float = attr.ib()
+    lat0: float = attr.ib()
+    horizon: float = attr.ib(default=90)
+    width: str = attr.ib()
+
+    # private; we don't want the user to care or know about
+    _fmt: str = attr.ib(init=False, repr=False,
+                        default="{_code}{lon0}/{lat0}/{horizon}/{width}")
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.UNDEFINED.value)
+
+    @horizon.validator
+    def check_horizon(self, attribute, value):
+        """
+        Validate the horizon attribute.
+        """
+        if value > 180:
+            raise ValueError("horizon must be less than or equal to 180")
+
+
+@attr.s(kw_only=True)
+class _Cylindrical(_Projection):
+
+    """
+    Base class for cylindrical projections.
+    """
+
+    lon0: float = attr.ib()
+    lat0: float = attr.ib()
+    width: str = attr.ib()
+
+    # private; we don't want the user to care or know about
+    _fmt: str = attr.ib(init=False, repr=False,
+                        default="{_code}{lon0}/{lat0}/{wdith}")
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.UNDEFINED.value)
+
+@attr.s(kw_only=True)
+class _Conic:
+
+    """
+    Base class for conic projections.
+    """
+
+    lon0: float = attr.ib()
+    lat0: float = attr.ib()
+    lat1: float = attr.ib()
+    lat2: float = attr.ib()
+    width: float = attr.ib()
+
+    # private; we don't want the user to care or know about
+    _fmt: str = attr.ib(init=False, repr=False,
+                        default="{_code}{lon0}/{lat0}/{lat1}/{lat2}/{width}")
+
+
+@attr.s(frozen=True)
+class LambertAzimuthalEqualArea(_Azimuthal):
+
+    """
+    Definition for the lambert azimuthal equal area projection.
+    """
+
+    # private; we don't want the user to care or know about
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.LAMBERT_AZIMUTH_EQUAL_AREA.value)
+
+
+@attr.s(frozen=True)
+class AzimuthalEquidistant(_Azimuthal):
+
+    """
+    Definition for the azimuthal equidistant projection.
+    """
+
+    horizon: float = attr.ib(default=180, kw_only=True)
+
+    # private; we don't want the user to care or know about
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.AZIMUTHAL_EQUIDISTANT.value)
+
+
+@attr.s(frozen=True)
+class AzimuthalGnomic(_Azimuthal):
+
+    """
+    Definition for the azimuthal gnomic projection.
+    """
+
+    horizon: float = attr.ib(default=60, kw_only=True)
+
+    # private; we don't want the user to care or know about
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.AZIMUTHAL_EQUIDISTANT.value)
+
+    @horizon.validator
+    def check_horizon(self, attribute, value):
+        """
+        Validate the horizon attribute.
+        """
+        if value >= 90:
+            raise ValueError("horizon must be less than 90")
+
+
+@attr.s(frozen=True)
+class AzimuthalOrthographic(_Azimuthal):
+
+    """
+    Definition for the azimuthal orthographic projection.
+    """
+
+    horizon: float = attr.ib(default=60, kw_only=True)
+
+    # private; we don't want the user to care or know about
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.AZIMUTHAL_EQUIDISTANT.value)
+
+    @horizon.validator
+    def check_horizon(self, attribute, value):
+        """
+        Validate the horizon attribute.
+        """
+        if value > 90:
+            raise ValueError("horizon must be less than or equal to 90")
+
+
+@attr.s(frozen=True, kw_only=True)
+class GeneralPerspective(_Projection):
+
+    """
+    Definition for the azimuthal general perspective projection.
+    """
+
+    lon0: float = attr.ib()
+    lat0: float = attr.ib()
+    altitude: float = attr.ib()
+    azimuth: float = attr.ib()
+    tilt: float = attr.ib()
+    twist: float = attr.ib()
+    Width: float = attr.ib()
+    Height: float = attr.ib()
+    width: float = attr.ib()
+
+    # private; we don't want the user to care or know about
+    _fmt: str = attr.ib(init=False, repr=False,
+                        default=("{_code}{lon0}/{lat0}/{altitude}/{azimuth}/"
+                                 "{tilt}/{twist}/{Width}/{Height}/{width}"))
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.GENERAL_PERSPECTIVE.value)
+
+
+@attr.s(frozen=True)
+class GeneralSterographic(_Azimuthal):
+
+    """
+    Definition for the azimuthal general sterographic projection.
+    """
+
+    horizon: float = attr.ib(default=90, kw_only=True)
+
+    # private; we don't want the user to care or know about
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.GENERAL_STEREOGRAPHIC.value)
+
+    @horizon.validator
+    def check_horizon(self, attribute, value):
+        """
+        Validate the horizon attribute.
+        """
+        if value >= 180:
+            raise ValueError("horizon must be less than 180")
+
+
+@attr.s(frozen=True, kw_only=True)
+class AlbersConicEqualArea(_Conic):
+
+    """
+    Definition for the albers conic equal area projection.
+    """
+
+    # private; we don't want the user to care or know about
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.ALBERS_CONIC_EQUAL_AREA.value)
+
+
+@attr.s(frozen=True, kw_only=True)
+class EquidistantConic(_Conic):
+
+    """
+    Definition for the equidistant conic projection.
+    """
+
+    # private; we don't want the user to care or know about
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.EQUIDISTANT_CONIC)
+
+
+@attr.s(frozen=True)
+class CassiniCylindrical(_Cylindrical):
+
+    # private; we don't want the user to care or know about
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.CASSINI_CYLINDRICAL.value)
+
+
+@attr.s(frozen=True)
+class MercatorCylindrical(_Cylindrical):
+
+    lon0: float = attr.ib(default=180, kw_only=True)
+    lat0: float = attr.ib(default=0, kw_only=True)
+
+    # private; we don't want the user to care or know about
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.MERCATOR_CYLINDRICAL.value)
+
+
+@attr.s(frozen=True)
+class CylindricalStereographic(_Cylindrical):
+
+    lon0: float = attr.ib(default=180, kw_only=True)
+    lat0: float = attr.ib(default=0, kw_only=True)
+
+    # private; we don't want the user to care or know about
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.CYLINDRICAL_STEROGRAPHIC.value)
+
+
+@attr.s(frozen=True)
+class CylindricalEqualArea(_Cylindrical):
+
+    # private; we don't want the user to care or know about
+    _code: str = attr.ib(init=False, repr=False,
+                         default=Supported.CYLINDRICAL_EQUAL_AREA.value)

--- a/pygmt/projection.py
+++ b/pygmt/projection.py
@@ -65,8 +65,7 @@ class _Projection:
 
     # private; we don't want the user to care or know about
     _fmt: str = attr.ib(init=False, repr=False, default="{_code}")
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.UNDEFINED.value)
+    _code: str = attr.ib(init=False, repr=False, default=Supported.UNDEFINED.value)
 
     def __str__(self):
         exclude = attr.fields(self.__class__)._fmt
@@ -98,10 +97,10 @@ class _Azimuthal(_Projection):
     width: str = attr.ib()
 
     # private; we don't want the user to care or know about
-    _fmt: str = attr.ib(init=False, repr=False,
-                        default="{_code}{lon0}/{lat0}/{horizon}/{width}")
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.UNDEFINED.value)
+    _fmt: str = attr.ib(
+        init=False, repr=False, default="{_code}{lon0}/{lat0}/{horizon}/{width}"
+    )
+    _code: str = attr.ib(init=False, repr=False, default=Supported.UNDEFINED.value)
 
     @horizon.validator
     def check_horizon(self, attribute, value):
@@ -133,10 +132,8 @@ class _Cylindrical(_Projection):
     width: str = attr.ib()
 
     # private; we don't want the user to care or know about
-    _fmt: str = attr.ib(init=False, repr=False,
-                        default="{_code}{lon0}/{lat0}/{wdith}")
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.UNDEFINED.value)
+    _fmt: str = attr.ib(init=False, repr=False, default="{_code}{lon0}/{lat0}/{wdith}")
+    _code: str = attr.ib(init=False, repr=False, default=Supported.UNDEFINED.value)
 
 
 @attr.s(kw_only=True)
@@ -166,8 +163,9 @@ class _Conic:
     width: float = attr.ib()
 
     # private; we don't want the user to care or know about
-    _fmt: str = attr.ib(init=False, repr=False,
-                        default="{_code}{lon0}/{lat0}/{lat1}/{lat2}/{width}")
+    _fmt: str = attr.ib(
+        init=False, repr=False, default="{_code}{lon0}/{lat0}/{lat1}/{lat2}/{width}"
+    )
 
 
 @attr.s(frozen=True)
@@ -189,8 +187,9 @@ class LambertAzimuthalEqualArea(_Azimuthal):
     """
 
     # private; we don't want the user to care or know about
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.LAMBERT_AZIMUTH_EQUAL_AREA.value)
+    _code: str = attr.ib(
+        init=False, repr=False, default=Supported.LAMBERT_AZIMUTH_EQUAL_AREA.value
+    )
 
 
 @attr.s(frozen=True)
@@ -214,8 +213,9 @@ class AzimuthalEquidistant(_Azimuthal):
     horizon: float = attr.ib(default=180, kw_only=True)
 
     # private; we don't want the user to care or know about
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.AZIMUTHAL_EQUIDISTANT.value)
+    _code: str = attr.ib(
+        init=False, repr=False, default=Supported.AZIMUTHAL_EQUIDISTANT.value
+    )
 
 
 @attr.s(frozen=True)
@@ -239,8 +239,9 @@ class AzimuthalGnomic(_Azimuthal):
     horizon: float = attr.ib(default=60, kw_only=True)
 
     # private; we don't want the user to care or know about
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.AZIMUTHAL_GNOMIC.value)
+    _code: str = attr.ib(
+        init=False, repr=False, default=Supported.AZIMUTHAL_GNOMIC.value
+    )
 
     @horizon.validator
     def check_horizon(self, attribute, value):
@@ -272,8 +273,9 @@ class AzimuthalOrthographic(_Azimuthal):
     horizon: float = attr.ib(default=90)
 
     # private; we don't want the user to care or know about
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.AZIMUTHAL_ORTHOGRAPHIC.value)
+    _code: str = attr.ib(
+        init=False, repr=False, default=Supported.AZIMUTHAL_ORTHOGRAPHIC.value
+    )
 
     @horizon.validator
     def check_horizon(self, attribute, value):
@@ -323,10 +325,14 @@ class GeneralPerspective(_Projection):
     width: float = attr.ib()
 
     # private; we don't want the user to care or know about
-    _fmt: str = attr.ib(init=False, repr=False,
-                        default="{_code}{lon0}/{lat0}/{altitude}/{azimuth}/{tilt}/{twist}/{viewport_width}/{viewport_height}/{width}")
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.GENERAL_PERSPECTIVE.value)
+    _fmt: str = attr.ib(
+        init=False,
+        repr=False,
+        default="{_code}{lon0}/{lat0}/{altitude}/{azimuth}/{tilt}/{twist}/{viewport_width}/{viewport_height}/{width}",
+    )
+    _code: str = attr.ib(
+        init=False, repr=False, default=Supported.GENERAL_PERSPECTIVE.value
+    )
 
 
 @attr.s(frozen=True)
@@ -350,8 +356,9 @@ class GeneralSterographic(_Azimuthal):
     horizon: float = attr.ib(default=90, kw_only=True)
 
     # private; we don't want the user to care or know about
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.GENERAL_STEREOGRAPHIC.value)
+    _code: str = attr.ib(
+        init=False, repr=False, default=Supported.GENERAL_STEREOGRAPHIC.value
+    )
 
     @horizon.validator
     def check_horizon(self, attribute, value):
@@ -383,8 +390,9 @@ class AlbersConicEqualArea(_Conic):
     """
 
     # private; we don't want the user to care or know about
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.ALBERS_CONIC_EQUAL_AREA.value)
+    _code: str = attr.ib(
+        init=False, repr=False, default=Supported.ALBERS_CONIC_EQUAL_AREA.value
+    )
 
 
 @attr.s(frozen=True, kw_only=True)
@@ -408,8 +416,7 @@ class EquidistantConic(_Conic):
     """
 
     # private; we don't want the user to care or know about
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.EQUIDISTANT_CONIC)
+    _code: str = attr.ib(init=False, repr=False, default=Supported.EQUIDISTANT_CONIC)
 
 
 @attr.s(frozen=True)
@@ -429,8 +436,9 @@ class CassiniCylindrical(_Cylindrical):
     """
 
     # private; we don't want the user to care or know about
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.CASSINI_CYLINDRICAL.value)
+    _code: str = attr.ib(
+        init=False, repr=False, default=Supported.CASSINI_CYLINDRICAL.value
+    )
 
 
 @attr.s(frozen=True)
@@ -453,8 +461,9 @@ class MercatorCylindrical(_Cylindrical):
     lat0: float = attr.ib(default=0, kw_only=True)
 
     # private; we don't want the user to care or know about
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.MERCATOR_CYLINDRICAL.value)
+    _code: str = attr.ib(
+        init=False, repr=False, default=Supported.MERCATOR_CYLINDRICAL.value
+    )
 
 
 @attr.s(frozen=True)
@@ -477,8 +486,9 @@ class CylindricalStereographic(_Cylindrical):
     lat0: float = attr.ib(default=0, kw_only=True)
 
     # private; we don't want the user to care or know about
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.CYLINDRICAL_STEROGRAPHIC.value)
+    _code: str = attr.ib(
+        init=False, repr=False, default=Supported.CYLINDRICAL_STEROGRAPHIC.value
+    )
 
 
 @attr.s(frozen=True)
@@ -498,5 +508,6 @@ class CylindricalEqualArea(_Cylindrical):
     """
 
     # private; we don't want the user to care or know about
-    _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.CYLINDRICAL_EQUAL_AREA.value)
+    _code: str = attr.ib(
+        init=False, repr=False, default=Supported.CYLINDRICAL_EQUAL_AREA.value
+    )

--- a/pygmt/projection.py
+++ b/pygmt/projection.py
@@ -79,6 +79,17 @@ class _Azimuthal(_Projection):
 
     """
     Base class for azimuthal projections.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre.
+    lat0 : float
+        The latitude of the projection centre.
+    horizon : float
+        The max distance to the projection centre in degrees. Default is 90.
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
     """
 
     lon0: float = attr.ib()
@@ -106,6 +117,15 @@ class _Cylindrical(_Projection):
 
     """
     Base class for cylindrical projections.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre.
+    lat0 : float
+        The latitude of the projection centre.
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
     """
 
     lon0: float = attr.ib()
@@ -118,11 +138,25 @@ class _Cylindrical(_Projection):
     _code: str = attr.ib(init=False, repr=False,
                          default=Supported.UNDEFINED.value)
 
+
 @attr.s(kw_only=True)
 class _Conic:
 
     """
     Base class for conic projections.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre.
+    lat0 : float
+        The latitude of the projection centre.
+    lat1 : float
+        The first standard parallel.
+    lat2 : float
+        The second standard parallel.
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
     """
 
     lon0: float = attr.ib()
@@ -140,7 +174,18 @@ class _Conic:
 class LambertAzimuthalEqualArea(_Azimuthal):
 
     """
-    Definition for the lambert azimuthal equal area projection.
+    Class definition for the lambert azimuthal equal area projection.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre.
+    lat0 : float
+        The latitude of the projection centre.
+    horizon : float
+        The max distance to the projection centre in degrees. Default is 90.
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
     """
 
     # private; we don't want the user to care or know about
@@ -152,7 +197,18 @@ class LambertAzimuthalEqualArea(_Azimuthal):
 class AzimuthalEquidistant(_Azimuthal):
 
     """
-    Definition for the azimuthal equidistant projection.
+    Class definition for the azimuthal equidistant projection.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre.
+    lat0 : float
+        The latitude of the projection centre.
+    horizon : float
+        The max distance to the projection centre in degrees. Default is 180.
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
     """
 
     horizon: float = attr.ib(default=180, kw_only=True)
@@ -166,14 +222,25 @@ class AzimuthalEquidistant(_Azimuthal):
 class AzimuthalGnomic(_Azimuthal):
 
     """
-    Definition for the azimuthal gnomic projection.
+    Class definition for the azimuthal gnomic projection.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre.
+    lat0 : float
+        The latitude of the projection centre.
+    horizon : float
+        The max distance to the projection centre in degrees. Default is 60.
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
     """
 
     horizon: float = attr.ib(default=60, kw_only=True)
 
     # private; we don't want the user to care or know about
     _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.AZIMUTHAL_EQUIDISTANT.value)
+                         default=Supported.AZIMUTHAL_GNOMIC.value)
 
     @horizon.validator
     def check_horizon(self, attribute, value):
@@ -188,14 +255,25 @@ class AzimuthalGnomic(_Azimuthal):
 class AzimuthalOrthographic(_Azimuthal):
 
     """
-    Definition for the azimuthal orthographic projection.
+    Class definition for the azimuthal orthographic projection.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre.
+    lat0 : float
+        The latitude of the projection centre.
+    horizon : float
+        The max distance to the projection centre in degrees. Default is 90.
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
     """
 
-    horizon: float = attr.ib(default=60, kw_only=True)
+    horizon: float = attr.ib(default=90)
 
     # private; we don't want the user to care or know about
     _code: str = attr.ib(init=False, repr=False,
-                         default=Supported.AZIMUTHAL_EQUIDISTANT.value)
+                         default=Supported.AZIMUTHAL_ORTHOGRAPHIC.value)
 
     @horizon.validator
     def check_horizon(self, attribute, value):
@@ -210,7 +288,28 @@ class AzimuthalOrthographic(_Azimuthal):
 class GeneralPerspective(_Projection):
 
     """
-    Definition for the azimuthal general perspective projection.
+    Class definition for the azimuthal general perspective projection.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre (in degrees).
+    lat0 : float
+        The latitude of the projection centre (in degrees).
+    altitude : float
+        The height in km of the viewpoint above local sea level.
+    azimuth : float
+        The direction (in degrees) in which you are looking is specified, measured clockwise from north.
+    tilt : float
+        The viewing angle relative to zenith (in degrees).
+    twist : float
+        The clockwise rotation of the image (in degrees).
+    viewport_width : float
+        The width of the viewing angle (in degrees).
+    viewport_height : float
+        The height of the viewing angle (in degrees).
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
     """
 
     lon0: float = attr.ib()
@@ -225,8 +324,7 @@ class GeneralPerspective(_Projection):
 
     # private; we don't want the user to care or know about
     _fmt: str = attr.ib(init=False, repr=False,
-                        default=("{_code}{lon0}/{lat0}/{altitude}/{azimuth}/"
-                                 "{tilt}/{twist}/{Width}/{Height}/{width}"))
+                        default="{_code}{lon0}/{lat0}/{altitude}/{azimuth}/{tilt}/{twist}/{viewport_width}/{viewport_height}/{width}")
     _code: str = attr.ib(init=False, repr=False,
                          default=Supported.GENERAL_PERSPECTIVE.value)
 
@@ -235,7 +333,18 @@ class GeneralPerspective(_Projection):
 class GeneralSterographic(_Azimuthal):
 
     """
-    Definition for the azimuthal general sterographic projection.
+    Class definition for the azimuthal general sterographic projection.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre.
+    lat0 : float
+        The latitude of the projection centre.
+    horizon : float
+        The max distance to the projection centre in degrees. Default is 90.
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
     """
 
     horizon: float = attr.ib(default=90, kw_only=True)
@@ -257,7 +366,20 @@ class GeneralSterographic(_Azimuthal):
 class AlbersConicEqualArea(_Conic):
 
     """
-    Definition for the albers conic equal area projection.
+    Class definition for the albers conic equal area projection.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre.
+    lat0 : float
+        The latitude of the projection centre.
+    lat1 : float
+        The first standard parallel.
+    lat2 : float
+        The second standard parallel.
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
     """
 
     # private; we don't want the user to care or know about
@@ -269,7 +391,20 @@ class AlbersConicEqualArea(_Conic):
 class EquidistantConic(_Conic):
 
     """
-    Definition for the equidistant conic projection.
+    Class definition for the equidistant conic projection.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre.
+    lat0 : float
+        The latitude of the projection centre.
+    lat1 : float
+        The first standard parallel.
+    lat2 : float
+        The second standard parallel.
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
     """
 
     # private; we don't want the user to care or know about
@@ -280,6 +415,19 @@ class EquidistantConic(_Conic):
 @attr.s(frozen=True)
 class CassiniCylindrical(_Cylindrical):
 
+    """
+    Class definition for the cassini cylindrical projection.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre.
+    lat0 : float
+        The latitude of the projection centre.
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
+    """
+
     # private; we don't want the user to care or know about
     _code: str = attr.ib(init=False, repr=False,
                          default=Supported.CASSINI_CYLINDRICAL.value)
@@ -287,6 +435,19 @@ class CassiniCylindrical(_Cylindrical):
 
 @attr.s(frozen=True)
 class MercatorCylindrical(_Cylindrical):
+
+    """
+    Class definition for the cassini cylindrical projection.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre. Default is 180.
+    lat0 : float
+        The latitude of the projection centre. Default is 0.
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
+    """
 
     lon0: float = attr.ib(default=180, kw_only=True)
     lat0: float = attr.ib(default=0, kw_only=True)
@@ -299,6 +460,19 @@ class MercatorCylindrical(_Cylindrical):
 @attr.s(frozen=True)
 class CylindricalStereographic(_Cylindrical):
 
+    """
+    Class definition for the cassini cylindrical projection.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre. Default is 180.
+    lat0 : float
+        The latitude of the projection centre. Default is 0.
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
+    """
+
     lon0: float = attr.ib(default=180, kw_only=True)
     lat0: float = attr.ib(default=0, kw_only=True)
 
@@ -309,6 +483,19 @@ class CylindricalStereographic(_Cylindrical):
 
 @attr.s(frozen=True)
 class CylindricalEqualArea(_Cylindrical):
+
+    """
+    Class definition for the cassini cylindrical projection.
+
+    Parameters
+    ----------
+    lon0 : float
+        The longitude of the projection centre.
+    lat0 : float
+        The latitude of the projection centre.
+    width : str
+        The figure width. For example ``8i`` is 8 inches.
+    """
 
     # private; we don't want the user to care or know about
     _code: str = attr.ib(init=False, repr=False,


### PR DESCRIPTION
**WIP; Create Projection classes instead of strings**

This pull request is to address #356 and create projection classes instead of requiring the user to format their own strings which can be cumbersome and complicated.
The desired functionality was to enable tab completion enabling users to immediately see what projections are supported. It is also desirable for the classes to utilise the __str__ method to return a correctly formatted string supported by GMT.

An example of creating an lambert azimuthal equal area projection:
```python
>>> from pygmt import projection
>>> proj = projection.LambertAzimuthalEqualArea(lon0=30, lat0=-20, horizon=60, width="8i")
>>> proj
LambertAzimuthalEqualArea(lon0=30, lat0=-20, horizon=60, width='8i')
>>> print(proj)
A30/-20/60/8i
```

The supported projections are also defined via an [Enum](https://docs.python.org/3/library/enum.html).  These act as constants (change in one place only) and serve multiple purposes:
* defining and retrieving the projection name
* defining and retrieving the GMT code
* listing the supported projections
* easy boolean comparison of projection labels

All the classes are relying on [attrs](https://github.com/python-attrs/attrs) for simplicity in creation, whilst getting all the benefits that attrs provides such as an easier declaration of validators thus enabling parameter checks for invalid values.

Arguments need to be supplied as keywords (was simpler to define projections classes with mixtures of default values and None for parameters; the benefit is greater clarity to the user and avoiding mixups of incorrect parameter ordering).
The projection classes are also defined to be immutable, acting as a kind of config (this can be changed if desired). 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #356 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Finish including the other projections that GMT supports.
