### PR TITLE
Allow text accepting "frame" as an argument

### DIFF
--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -675,7 +675,7 @@ class BasePlotting:
             lib.call_module("legend", arg_str)
 
     @fmt_docstring
-    @use_alias(R="region", J="projection")
+    @use_alias(R="region", J="projection", B="frame")
     @kwargs_to_strings(
         R="sequence",
         textfiles="sequence_space",


### PR DESCRIPTION
**Description of proposed changes**

`fig.text()` should accept "frame" as an argument.

**Reminders**

- [X] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
