### PR TITLE
Update GMT constant GMT_STR16 to GMT_VF_LEN for GMT API change in 6.1.0

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -987,7 +987,12 @@ class Session:
             valid_modifiers=["GMT_IS_REFERENCE", "GMT_IS_DUPLICATE"],
         )
 
-        buff = ctp.create_string_buffer(self["GMT_STR16"])
+        # The core GMT changes GMT_STR16 to GMT_VF_LEN in 6.1.0
+        # See https://github.com/GenericMappingTools/gmt/pull/2861
+        if Version(self.info["version"]) < Version("6.1.0"):
+            buff = ctp.create_string_buffer(self["GMT_STR16"])
+        else:
+            buff = ctp.create_string_buffer(self["GMT_VF_LEN"])
 
         status = c_open_virtualfile(
             self.session_pointer, family_int, geometry_int, direction_int, data, buff


### PR DESCRIPTION
**Description of proposed changes**

PyGMT fails with the latest GMT master branch with the following error message:
```
GMTCLibError: Constant 'GMT_STR16' doesn't exits in libgmt.
```

If you have the GMT master branch installed, you can reproduce the issue by
```
import pygmt
fig = pygmt.Figure()
fig.basemap(region='0/10/0/10', projection='X10c', frame=True)
fig.plot(x=5, y=5, style='c0.2c')
```

The error is caused by the recent change of the length of virtual file names
from `GMT_STR16` to `GMT_VF_LEN` in the core GMT
(see https://github.com/GenericMappingTools/gmt/pull/2861).

Changing `GMT_STR16` to `GMT_VF_LEN` is the easiest fix.
To keep compatibility with both GMT 6.0.0 and the upcomming 6.1.0,
this PR checks GMT version and use `GMT_STR16` for 6.0.0, otherwise
use `GMT_VF_LEN`.

**Reminders**

- [X] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.