### PR TITLE
Remove mention of gitter.im

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,10 +10,5 @@ coverage:
         if_no_uploads: error
         if_not_found: success
         if_ci_failed: failure
-  notify:
-    gitter:
-      default:
-        url: "https://webhooks.gitter.im/e/42136d49f4c9c5fd2611"
-        threshold: 1%
 
 comment: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,10 +97,3 @@ deploy:
 
 notifications:
     email: false
-    webhooks:
-        # Integration for Gitter
-        urls:
-            - https://webhooks.gitter.im/e/648c8355310c2ef3df4f
-        on_success: change  # options: [always|never|change] default: always
-        on_failure: always  # options: [always|never|change] default: always
-        on_start: never     # options: [always|never|change] default: always

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,7 @@ PyGMT
     A Python interface for the Generic Mapping Tools
 
 `Documentation (development version) <https://www.pygmt.org/dev>`__ |
-`Contact <https://gitter.im/GenericMappingTools/pygmt>`__ |
-`Forum <https://forum.generic-mapping-tools.org>`__
+`Contact <https://forum.generic-mapping-tools.org>`__ |
 
 .. image:: http://img.shields.io/pypi/v/pygmt.svg?style=flat-square
     :alt: Latest version on PyPI
@@ -25,9 +24,6 @@ PyGMT
 .. image:: https://img.shields.io/pypi/pyversions/pygmt.svg?style=flat-square
     :alt: Compatible Python versions.
     :target: https://pypi.python.org/pypi/pygmt
-.. image:: https://img.shields.io/gitter/room/GenericMappingTools/pygmt.svg?style=flat-square
-    :alt: Chat room on Gitter
-    :target: https://gitter.im/GenericMappingTools/pygmt
 .. image:: https://img.shields.io/discourse/status?label=forum&server=https%3A%2F%2Fforum.generic-mapping-tools.org%2F&style=flat-square
     :alt: Discourse forum
     :target: https://forum.generic-mapping-tools.org

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -144,7 +144,7 @@ html_context = {
         ),
         (
             '<i class="fa fa-comment fa-fw"></i> Contact',
-            "https://gitter.im/GenericMappingTools/pygmt",
+            "https://forum.generic-mapping-tools.org",
         ),
         (
             '<i class="fa fa-github fa-fw"></i> Source Code',


### PR DESCRIPTION
**Description of proposed changes**

Following up from #404, I noticed some old gitter webhooks that still points to the old [gmt-python gitter chatroom](https://gitter.im/GenericMappingTools/gmt-python) :man_facepalming:.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This PR will basically revert the gitter.im webhook integrations added in #36, and other instances of gitter. Questions should now be redirected to https://forum.generic-mapping-tools.org. New users trying to join the gitter chatroom will see this welcome message:

![gitter welcome message telling them to go to https://forum.generic-mapping-tools.org](https://user-images.githubusercontent.com/23487320/77606730-3ccec380-6f7d-11ea-8000-c50e5dc18e8d.png)

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
