### PR TITLE
Quickfix Zeit Now miniconda installer link to anaconda.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build:miniconda": "curl -o ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash ~/miniconda.sh -b -p $HOME/miniconda",
+    "build:miniconda": "curl -o ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash ~/miniconda.sh -b -p $HOME/miniconda",
     "build:pygmt": "conda env create -f environment.yml && source activate pygmt && conda install -c conda-forge -y gmt==6.0.0 && make install",
     "build:docs": "source activate pygmt && cd doc && make all && mv _build/html ../public",
     "build": "export PATH=$HOME/miniconda/bin:$PATH && npm run build:miniconda && npm run build:pygmt && npm run build:docs"


### PR DESCRIPTION
**Description of proposed changes**

Resolve broken Continuous Documentation by changing miniconda installer URL from https://repo.continuum.io to https://repo.anaconda.com, because `curl` was not redirecting properly.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Also reported at https://github.com/MolSSI/cookiecutter-cms/issues/103.

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
