### PR TITLE
Fix the link to GMT documentation

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -149,7 +149,7 @@ Most calls to the C API happen through the :class:`pygmt.clib.Session` class.
 
     clib.Session
 
-`GMT modules <https://www.generic-mapping-tools.org/gmt/latest/quick_ref.html>`__ are executed through
+`GMT modules <https://docs.generic-mapping-tools.org/latest/modules.html>`__ are executed through
 the :meth:`~pygmt.clib.Session.call_module` method:
 
 .. autosummary::

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,8 +36,8 @@ napoleon_use_ivar = True
 # configure links to GMT docs
 extlinks = {
     "gmt-docs": (
-        "https://www.generic-mapping-tools.org/gmt/latest/%s",
-        "https://www.generic-mapping-tools.org/gmt/latest/",
+        "https://docs.generic-mapping-tools.org/latest/%s",
+        "https://docs.generic-mapping-tools.org/latest/",
     )
 }
 


### PR DESCRIPTION
**Description of proposed changes**

Fix the GMT documentation link from https://www.generic-mapping-tools.org/gmt/latest/
to https://docs.generic-mapping-tools.org/latest.