### PR TITLE
Redirect www.pygmt.org to latest, instead of dev

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv="Refresh" content="0;url=dev/"/>
+<meta http-equiv="Refresh" content="0;url=latest/"/>


### PR DESCRIPTION
**Description of proposed changes**

We now already have a formal release, https://www.pygmt.org/ now is redirected to https://www.pygmt.org/latest.

Address https://github.com/GenericMappingTools/pygmt/issues/418#issuecomment-623148149