### PR TITLE
Add netCDF4 as a dependency and install netcdf4

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -55,6 +55,7 @@ PyGMT requires the following libraries:
 * `numpy <http://www.numpy.org/>`__
 * `pandas <https://pandas.pydata.org/>`__
 * `xarray <http://xarray.pydata.org/>`__
+* `netCDF4 <https://github.com/Unidata/netcdf4-python>`__
 * `packaging <https://pypi.org/project/packaging/>`__
 
 The following are optional (but recommended) dependencies:

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -55,12 +55,12 @@ PyGMT requires the following libraries:
 * `numpy <http://www.numpy.org/>`__
 * `pandas <https://pandas.pydata.org/>`__
 * `xarray <http://xarray.pydata.org/>`__
-* `netCDF4 <https://github.com/Unidata/netcdf4-python>`__
 * `packaging <https://pypi.org/project/packaging/>`__
 
 The following are optional (but recommended) dependencies:
 
 * `IPython <https://ipython.org/>`__: For embedding the figures in Jupyter notebooks.
+* `netCDF4 <https://github.com/Unidata/netcdf4-python>`__: For reading netCDF4 data via `xarray <http://xarray.pydata.org/>`__
 
 
 Installing GMT and other dependencies
@@ -80,7 +80,7 @@ First, we must configure conda to get packages from the
 Now we can create a new conda environment with Python and all our dependencies installed
 (we'll call it ``pygmt`` but you can change it to whatever you want)::
 
-     conda create --name pygmt python=3.6 pip numpy pandas xarray netcdf4 packaging gmt=6.0.0
+     conda create --name pygmt python=3.6 pip numpy pandas xarray packaging gmt=6.0.0
 
 Activate the environment by running::
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -80,7 +80,7 @@ First, we must configure conda to get packages from the
 Now we can create a new conda environment with Python and all our dependencies installed
 (we'll call it ``pygmt`` but you can change it to whatever you want)::
 
-     conda create --name pygmt python=3.6 pip numpy pandas xarray packaging gmt=6.0.0
+     conda create --name pygmt python=3.6 pip numpy pandas xarray netcdf4 packaging gmt=6.0.0
 
 Activate the environment by running::
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -55,12 +55,12 @@ PyGMT requires the following libraries:
 * `numpy <http://www.numpy.org/>`__
 * `pandas <https://pandas.pydata.org/>`__
 * `xarray <http://xarray.pydata.org/>`__
+* `netCDF4 <https://github.com/Unidata/netcdf4-python>`__
 * `packaging <https://pypi.org/project/packaging/>`__
 
 The following are optional (but recommended) dependencies:
 
 * `IPython <https://ipython.org/>`__: For embedding the figures in Jupyter notebooks.
-* `netCDF4 <https://github.com/Unidata/netcdf4-python>`__: For reading netCDF4 data via `xarray <http://xarray.pydata.org/>`__
 
 
 Installing GMT and other dependencies
@@ -80,7 +80,7 @@ First, we must configure conda to get packages from the
 Now we can create a new conda environment with Python and all our dependencies installed
 (we'll call it ``pygmt`` but you can change it to whatever you want)::
 
-     conda create --name pygmt python=3.6 pip numpy pandas xarray packaging gmt=6.0.0
+     conda create --name pygmt python=3.6 pip numpy pandas xarray netcdf4 packaging gmt=6.0.0
 
 Activate the environment by running::
 


### PR DESCRIPTION
**Description of proposed changes**

xarray needs the netCDF4 package for reading (perhaps also writing) netCDF files. However, netCDF4 isn't installed by default since it's an optional dependency of xarray. Although pygmt doesn't import netCDF4 package explicitely, some features won't work without the package.

See #239 for past discussions.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.