### PR TITLE
Set GMT_COMPATIBILITY to 6 when pygmt session starts

### DIFF
--- a/pygmt/session_management.py
+++ b/pygmt/session_management.py
@@ -15,6 +15,7 @@ def begin():
     prefix = "pygmt-session"
     with Session() as lib:
         lib.call_module("begin", prefix)
+        # pygmt relies on GMT modern mode with GMT_COMPATIBILITY at version 6
         lib.call_module("set", "GMT_COMPATIBILITY 6")
 
 

--- a/pygmt/session_management.py
+++ b/pygmt/session_management.py
@@ -15,6 +15,7 @@ def begin():
     prefix = "pygmt-session"
     with Session() as lib:
         lib.call_module("begin", prefix)
+        lib.call_module("set", "GMT_COMPATIBILITY 6")
 
 
 def end():

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -48,7 +48,5 @@ def test_gmt_compat_6_is_applied(capsys):
             lib.call_module("set", "GMT_COMPATIBILITY 6")
         end()
         begin()  # Restart the global session
-        assert os.path.exists("gmt.conf")
-        os.remove("gmt.conf")
         assert os.path.exists("pygmt-session.pdf")
         os.remove("pygmt-session.pdf")

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -20,3 +20,35 @@ def test_begin_end():
     begin()  # Restart the global session
     assert os.path.exists("pygmt-session.pdf")
     os.remove("pygmt-session.pdf")
+
+
+def test_gmt_compat_6_is_applied(capsys):
+    """
+    Ensure that users with old gmt.conf files won't get pygmt-session [ERROR]:
+    GMT_COMPATIBILITY: Expects values from 6 to 6; reset to 6.
+    """
+    end()  # Kill the global session
+    try:
+        with Session() as lib:
+            # pretend that gmt.conf has GMT_COMPATIBILITY = 5
+            lib.call_module("gmtset", "GMT_COMPATIBILITY 5")
+        begin()
+        with Session() as lib:
+            lib.call_module("basemap", "-R10/70/-3/8 -JX4i/3i -Ba")
+            out, err = capsys.readouterr()  # capture stdout and stderr
+            assert out == ""
+            assert err != (
+                "pygmt-session [ERROR]: GMT_COMPATIBILITY:"
+                " Expects values from 6 to 6; reset to 6.\n"
+            )
+            assert err == ""  # double check that there are no other errors
+    finally:
+        with Session() as lib:
+            # revert gmt.conf back to GMT_COMPATIBILITY = 6
+            lib.call_module("set", "GMT_COMPATIBILITY 6")
+        end()
+        begin()  # Restart the global session
+        assert os.path.exists("gmt.conf")
+        os.remove("gmt.conf")
+        assert os.path.exists("pygmt-session.pdf")
+        os.remove("pygmt-session.pdf")


### PR DESCRIPTION
**Description of proposed changes**

To prevent users getting "pygmt-session [ERROR]: GMT_COMPATIBILITY: Expects values from 6 to 6; reset to 6". Overrides [GMT_COMPATIBILITY](https://docs.generic-mapping-tools.org/6.0/gmt.conf.html#gmt-miscellaneous-parameters) setting in users `gmt.conf` file.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #428, #365


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
