### PR TITLE
Let PyGMT work with the conda GMT package on Windows

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -162,7 +162,11 @@ jobs:
   variables:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
-    CONDA_INSTALL_EXTRA: "codecov"
+    CONDA_INSTALL_EXTRA: "codecov gmt=6.0.0"
+    # ctypes.CDLL cannot find conda's libraries
+    GMT_LIBRARY_PATH: 'C:\Miniconda\envs\testing\Library\bin'
+    # Due to potential bug in GMT, we have to set GMT_SHAREDIR manually
+    GMT_SHAREDIR: 'C:\Miniconda\envs\testing\Library\share\gmt'
 
   strategy:
     matrix:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -182,12 +182,6 @@ jobs:
 
   steps:
 
-  # Install ghostscript separately since there is no Windows conda-forge package for it.
-  - bash: |
-      set -x -e
-      choco install ghostscript
-    displayName: Install ghostscript via chocolatey
-
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -155,7 +155,6 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Windows'
-  condition: False
 
   pool:
     vmImage: 'vs2017-win2016'

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -41,17 +41,18 @@ def load_libgmt(env=None):
         env = os.environ
     libnames = clib_name(os_name=sys.platform)
     libpath = env.get("GMT_LIBRARY_PATH", "")
-    error = False
+    error = True
     for libname in libnames:
         try:
             libgmt = ctypes.CDLL(os.path.join(libpath, libname))
             check_libgmt(libgmt)
+            error = False
             break
         except OSError as err:
             error = err
     if error:
         raise GMTCLibNotFoundError(
-            "Error loading the GMT shared library '{}':".format(libname)
+            "Error loading the GMT shared library '{}':".format(", ".join(libnames))
         )
     return libgmt
 

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -37,85 +37,46 @@ def load_libgmt(env=None):
         couldn't access the functions).
 
     """
-    libpath = get_clib_path(env)
-    try:
-        libgmt = ctypes.CDLL(libpath)
-        check_libgmt(libgmt)
-    except OSError as err:
-        msg = "\n".join(
-            [
-                "Error loading the GMT shared library '{}':".format(libpath),
-                "{}".format(str(err)),
-            ]
+    if env is None:
+        env = os.environ
+    libnames = clib_name(os_name=sys.platform)
+    libpath = env.get("GMT_LIBRARY_PATH", "")
+    error = False
+    for libname in libnames:
+        try:
+            libgmt = ctypes.CDLL(os.path.join(libpath, libname))
+            check_libgmt(libgmt)
+        except OSError as err:
+            error = err
+    if error:
+        raise GMTCLibNotFoundError(
+            "Error loading the GMT shared library '{}':".format(libname)
         )
-        raise GMTCLibNotFoundError(msg)
     return libgmt
 
 
-def get_clib_path(env=None):
-    """
-    Get the path to the libgmt shared library.
-
-    Determine the file name and extension and append to the path set by
-    ``GMT_LIBRARY_PATH``, if any.
-
-    Parameters
-    ----------
-    env : dict or None
-        A dictionary containing the environment variables. If ``None``, will
-        default to ``os.environ``.
-
-    Returns
-    -------
-    libpath : str
-        The path to the libgmt shared library.
-
-    """
-    libname = clib_name()
-    if env is None:
-        env = os.environ
-    if "GMT_LIBRARY_PATH" in env:
-        libpath = os.path.join(env["GMT_LIBRARY_PATH"], libname)
-    else:
-        libpath = libname
-    return libpath
-
-
-def clib_name(os_name=None, is_64bit=None):
+def clib_name(os_name):
     """
     Return the name of GMT's shared library for the current OS.
 
     Parameters
     ----------
-    os_name : str or None
-        The operating system name as given by ``sys.platform``
-        (the default if None).
-    is_64bit : bool or None
-        Whether or not the OS is 64bit. Only used if the OS is ``win32``. If
-        None, will determine automatically.
+    os_name : str
+        The operating system name as given by ``sys.platform``.
 
     Returns
     -------
-    libname : str
-        The name of GMT's shared library.
+    libname : list of str
+        List of possible names of GMT's shared library.
 
     """
-    if os_name is None:
-        os_name = sys.platform
-
-    if is_64bit is None:
-        is_64bit = sys.maxsize > 2 ** 32
-
     if os_name.startswith("linux"):
-        libname = "libgmt.so"
+        libname = ["libgmt.so"]
     elif os_name == "darwin":
         # Darwin is macOS
-        libname = "libgmt.dylib"
+        libname = ["libgmt.dylib"]
     elif os_name == "win32":
-        if is_64bit:
-            libname = "gmt_w64.dll"
-        else:
-            libname = "gmt_w32.dll"
+        libname = ["gmt.lib", "gmt_w64.dll", "gmt_w32.dll"]
     else:
         raise GMTOSError('Operating system "{}" not supported.'.format(sys.platform))
     return libname

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -46,6 +46,7 @@ def load_libgmt(env=None):
         try:
             libgmt = ctypes.CDLL(os.path.join(libpath, libname))
             check_libgmt(libgmt)
+            break
         except OSError as err:
             error = err
     if error:

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -76,7 +76,7 @@ def clib_name(os_name):
         # Darwin is macOS
         libname = ["libgmt.dylib"]
     elif os_name == "win32":
-        libname = ["gmt.lib", "gmt_w64.dll", "gmt_w32.dll"]
+        libname = ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
     else:
         raise GMTOSError('Operating system "{}" not supported.'.format(sys.platform))
     return libname

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -52,7 +52,7 @@ def load_libgmt(env=None):
     return libgmt
 
 
-def get_clib_path(env):
+def get_clib_path(env=None):
     """
     Get the path to the libgmt shared library.
 

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -14,12 +14,9 @@ import pytest
 
 from .. import clib
 from ..clib.session import FAMILIES, VIAS
-from ..clib.loading import clib_name, load_libgmt, check_libgmt, get_clib_path
 from ..clib.conversion import dataarray_to_matrix
 from ..exceptions import (
     GMTCLibError,
-    GMTOSError,
-    GMTCLibNotFoundError,
     GMTCLibNoSessionError,
     GMTInvalidInput,
     GMTVersionError,
@@ -68,54 +65,6 @@ def mock(session, func, returns=None, mock_func=None):
     yield
 
     setattr(session, "get_libgmt_func", get_libgmt_func)
-
-
-def test_load_libgmt():
-    "Test that loading libgmt works and doesn't crash."
-    load_libgmt()
-
-
-def test_load_libgmt_fail():
-    "Test that loading fails when given a bad library path."
-    env = {"GMT_LIBRARY_PATH": "not/a/real/path"}
-    with pytest.raises(GMTCLibNotFoundError):
-        load_libgmt(env=env)
-
-
-def test_get_clib_path():
-    "Test that the correct path is found when setting GMT_LIBRARY_PATH."
-    # Get the real path to the library first
-    with clib.Session() as lib:
-        libpath = lib.info["library path"]
-    libdir = os.path.dirname(libpath)
-    # Assign it to the environment variable but keep a backup value to restore
-    # later
-    env = {"GMT_LIBRARY_PATH": libdir}
-
-    # Check that the path is determined correctly
-    path_used = get_clib_path(env=env)
-    assert os.path.samefile(path_used, libpath)
-    assert os.path.dirname(path_used) == libdir
-
-    # Check that loading libgmt works
-    load_libgmt(env=env)
-
-
-def test_check_libgmt():
-    "Make sure check_libgmt fails when given a bogus library"
-    with pytest.raises(GMTCLibError):
-        check_libgmt(dict())
-
-
-def test_clib_name():
-    "Make sure we get the correct library name for different OS names"
-    for linux in ["linux", "linux2", "linux3"]:
-        assert clib_name(linux) == "libgmt.so"
-    assert clib_name("darwin") == "libgmt.dylib"
-    assert clib_name("win32", is_64bit=True) == "gmt_w64.dll"
-    assert clib_name("win32", is_64bit=False) == "gmt_w32.dll"
-    with pytest.raises(GMTOSError):
-        clib_name("meh")
 
 
 def test_getitem():

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -1,0 +1,58 @@
+"""
+Test the functions that load libgmt
+"""
+import os
+
+import pytest
+
+from ..clib.loading import clib_name, load_libgmt, check_libgmt, get_clib_path
+from .. import clib
+from ..exceptions import GMTCLibError, GMTOSError, GMTCLibNotFoundError
+
+
+def test_load_libgmt():
+    "Test that loading libgmt works and doesn't crash."
+    load_libgmt()
+
+
+def test_load_libgmt_fail():
+    "Test that loading fails when given a bad library path."
+    env = {"GMT_LIBRARY_PATH": "not/a/real/path"}
+    with pytest.raises(GMTCLibNotFoundError):
+        load_libgmt(env=env)
+
+
+def test_get_clib_path():
+    "Test that the correct path is found when setting GMT_LIBRARY_PATH."
+    # Get the real path to the library first
+    with clib.Session() as lib:
+        libpath = lib.info["library path"]
+    libdir = os.path.dirname(libpath)
+    # Assign it to the environment variable but keep a backup value to restore
+    # later
+    env = {"GMT_LIBRARY_PATH": libdir}
+
+    # Check that the path is determined correctly
+    path_used = get_clib_path(env=env)
+    assert os.path.samefile(path_used, libpath)
+    assert os.path.dirname(path_used) == libdir
+
+    # Check that loading libgmt works
+    load_libgmt(env=env)
+
+
+def test_check_libgmt():
+    "Make sure check_libgmt fails when given a bogus library"
+    with pytest.raises(GMTCLibError):
+        check_libgmt(dict())
+
+
+def test_clib_name():
+    "Make sure we get the correct library name for different OS names"
+    for linux in ["linux", "linux2", "linux3"]:
+        assert clib_name(linux) == "libgmt.so"
+    assert clib_name("darwin") == "libgmt.dylib"
+    assert clib_name("win32", is_64bit=True) == "gmt_w64.dll"
+    assert clib_name("win32", is_64bit=False) == "gmt_w32.dll"
+    with pytest.raises(GMTOSError):
+        clib_name("meh")

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -30,6 +30,6 @@ def test_clib_name():
     for linux in ["linux", "linux2", "linux3"]:
         assert clib_name(linux) == ["libgmt.so"]
     assert clib_name("darwin") == ["libgmt.dylib"]
-    assert clib_name("win32") == ["gmt.lib", "gmt_w64.dll", "gmt_w32.dll"]
+    assert clib_name("win32") == ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
     with pytest.raises(GMTOSError):
         clib_name("meh")

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -1,18 +1,21 @@
 """
 Test the functions that load libgmt
 """
-import os
-
 import pytest
 
-from ..clib.loading import clib_name, load_libgmt, check_libgmt, get_clib_path
-from .. import clib
+from ..clib.loading import clib_name, load_libgmt, check_libgmt
 from ..exceptions import GMTCLibError, GMTOSError, GMTCLibNotFoundError
+
+
+def test_check_libgmt():
+    "Make sure check_libgmt fails when given a bogus library"
+    with pytest.raises(GMTCLibError):
+        check_libgmt(dict())
 
 
 def test_load_libgmt():
     "Test that loading libgmt works and doesn't crash."
-    load_libgmt()
+    check_libgmt(load_libgmt())
 
 
 def test_load_libgmt_fail():
@@ -22,37 +25,11 @@ def test_load_libgmt_fail():
         load_libgmt(env=env)
 
 
-def test_get_clib_path():
-    "Test that the correct path is found when setting GMT_LIBRARY_PATH."
-    # Get the real path to the library first
-    with clib.Session() as lib:
-        libpath = lib.info["library path"]
-    libdir = os.path.dirname(libpath)
-    # Assign it to the environment variable but keep a backup value to restore
-    # later
-    env = {"GMT_LIBRARY_PATH": libdir}
-
-    # Check that the path is determined correctly
-    path_used = get_clib_path(env=env)
-    assert os.path.samefile(path_used, libpath)
-    assert os.path.dirname(path_used) == libdir
-
-    # Check that loading libgmt works
-    load_libgmt(env=env)
-
-
-def test_check_libgmt():
-    "Make sure check_libgmt fails when given a bogus library"
-    with pytest.raises(GMTCLibError):
-        check_libgmt(dict())
-
-
 def test_clib_name():
     "Make sure we get the correct library name for different OS names"
     for linux in ["linux", "linux2", "linux3"]:
-        assert clib_name(linux) == "libgmt.so"
-    assert clib_name("darwin") == "libgmt.dylib"
-    assert clib_name("win32", is_64bit=True) == "gmt_w64.dll"
-    assert clib_name("win32", is_64bit=False) == "gmt_w32.dll"
+        assert clib_name(linux) == ["libgmt.so"]
+    assert clib_name("darwin") == ["libgmt.dylib"]
+    assert clib_name("win32") == ["gmt.lib", "gmt_w64.dll", "gmt_w32.dll"]
     with pytest.raises(GMTOSError):
         clib_name("meh")

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -90,8 +90,8 @@ def test_surface_with_outfile_param():
         )
         assert output is None  # check that output is None since outfile is set
         assert os.path.exists(path=TEMP_GRID)  # check that outfile exists at path
-        grid = xr.open_dataarray(TEMP_GRID)
-        assert isinstance(grid, xr.DataArray)  # check that netcdf grid loaded properly
+        with xr.open_dataarray(TEMP_GRID) as grid:
+            assert isinstance(grid, xr.DataArray)  # ensure netcdf grid loads ok
     finally:
         os.remove(path=TEMP_GRID)
     return output
@@ -108,8 +108,8 @@ def test_surface_short_aliases():
         output = surface(data=data, I="5m", R=[245, 255, 20, 30], G=TEMP_GRID)
         assert output is None  # check that output is None since outfile is set
         assert os.path.exists(path=TEMP_GRID)  # check that outfile exists at path
-        grid = xr.open_dataarray(TEMP_GRID)
-        assert isinstance(grid, xr.DataArray)  # check that netcdf grid loaded properly
+        with xr.open_dataarray(TEMP_GRID) as grid:
+            assert isinstance(grid, xr.DataArray)  # ensure netcdf grid loads ok
     finally:
         os.remove(path=TEMP_GRID)
     return output


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes the PyGMT crash with the conda GMT package on Windows. It's a follow-up of RP #313. The commit history and the changed files in PR #313 is a little messy, so I cherry-picked 4 related commits from PR #313 and then work on top of it.

To make PyGMT work on Windows, users have to manually add two environmental variables:

- **GMT_LIBRARY_PATH**  `C:\Miniconda\envs\pygmt\Library\bin`
- **GMT_SHAREDIR** `C:\Miniconda\envs\pygmt\Library\share\gmt`

`ctypes.CDLL` cannot find the libraries provided by conda, possibly because conda doesn't add the library path into Windows' library search path. Thus, we have to add the **GMT_LIBRARY_PATH** variable to tell pygmt (i.e., ctypes.CDLL) where to find the gmt library file. 

GMT needs to know the path of its share directory to work. To determine the share directory, GMT checks a few environmental variables (GMT6_SHAREDIR, GMT5_SHAREDIR and GMT_SHARE). If none of them are defined, then GMT checks the variable GMT_SHARE_DIR which is set during building GMT. Since the conda GMT package was not built on users' computer, thus the GMT_SHARED_DIR directory doesn't exist at all. Then GMT tries to guess the share directory path based on the relative locations among the library, bin and share directories.
The guessing function works well on macOS and Linux, but not on Windows, and that function crashes.

PyGMT works well with the official GMT Windows installers, simply because the installers add the **GMT6_SHAREDIR** variable automatically. I believe it's a GMT bug, but we may need more time to find the exact crash location. Currently, the simplest workaround is adding the GMT_SHAREDIR variable manually.

**The Windows CI jobs now work well, except 11 failing tests. These failing tests will be addressed in other PRs.**

Fixes #46, #353. Closes #313.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
