### PR TITLE
Remove the variable GMT_SHAREDIR from CI settings

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -165,8 +165,6 @@ jobs:
     CONDA_INSTALL_EXTRA: "codecov gmt=6.0.0"
     # ctypes.CDLL cannot find conda's libraries
     GMT_LIBRARY_PATH: 'C:\Miniconda\envs\testing\Library\bin'
-    # Due to potential bug in GMT, we have to set GMT_SHAREDIR manually
-    GMT_SHAREDIR: 'C:\Miniconda\envs\testing\Library\share\gmt'
 
   strategy:
     matrix:


### PR DESCRIPTION
**Description of proposed changes**

The variable GMT_SHAREDIR was needed due to a GMT 6.0.0 bug. See https://github.com/GenericMappingTools/gmt/issues/3353 for the bug report, and https://github.com/GenericMappingTools/gmt/pull/3361 for the fix.

The conda GMT package was rebuilt in https://github.com/conda-forge/gmt-feedstock/pull/94, in which the patch was applied to GMT 6.0.0.

Now PyGMT should work well with no need to add the variable GMT_SHAREDIR.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [X] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
