### PR TITLE
Cache test data on Azure Pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -220,7 +220,7 @@ jobs:
   - task: Cache@2
     inputs:
       key: cachedata | 20200519
-      path: $(HOME)/.gmt
+      path: $(HOMEPATH)/.gmt
       cacheHitVar: CACHE_CACHEDATA_RESTORED
     displayName: Cache GMT remote data for testing
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -119,7 +119,7 @@ jobs:
   # Cache the ${HOME}/.gmt directory, for docs and testing
   - task: Cache@2
     inputs:
-      key: cachedata | 20200520
+      key: cachedata | 20200519
       path: $(HOME)/.gmt
       cacheHitVar: CACHE_CACHEDATA_RESTORED
     displayName: Cache GMT remote data for testing
@@ -128,7 +128,7 @@ jobs:
   - bash: |
       set -x -e
       source activate testing
-      gmt which -Gu @earth_relief_10m @earth_relief_60m @ridge.txt @Table_5_11.txt @tut_quakes.ngdc @tut_ship.xyz
+      gmt which -Gu @earth_relief_10m @earth_relief_60m @ridge.txt @Table_5_11.txt @tut_bathy.nc @tut_quakes.ngdc @tut_ship.xyz
     displayName: Download remote data
     condition: ne(variables['CACHE_CACHEDATA_RESTORED'], true)
 
@@ -219,7 +219,7 @@ jobs:
   # Cache the ${HOME}/.gmt directory, for docs and testing
   - task: Cache@2
     inputs:
-      key: cachedata | 20200520
+      key: cachedata | 20200519
       path: $(HOME)/.gmt
       cacheHitVar: CACHE_CACHEDATA_RESTORED
     displayName: Cache GMT remote data for testing
@@ -228,7 +228,7 @@ jobs:
   - bash: |
       set -x -e
       source activate testing
-      gmt which -Gu @earth_relief_10m @earth_relief_60m @ridge.txt @Table_5_11.txt @tut_quakes.ngdc @tut_ship.xyz
+      gmt which -Gu @earth_relief_10m @earth_relief_60m @ridge.txt @Table_5_11.txt @tut_bathy.nc @tut_quakes.ngdc @tut_ship.xyz
     displayName: Download remote data
     condition: ne(variables['CACHE_CACHEDATA_RESTORED'], true)
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -127,6 +127,7 @@ jobs:
   # Download remote files, if not already cached
   - bash: |
       set -x -e
+      source activate testing
       $(gmt --show-sharedir)/tools/gmt_getremote.sh cache
       gmt which -Gu @earth_relief_10m @earth_relief_60m @ridge.txt @Table_5_11.txt @tut_quakes.ngdc @tut_ship.xyz
     displayName: Download remote data
@@ -227,6 +228,7 @@ jobs:
   # Download remote files, if not already cached
   - bash: |
       set -x -e
+      source activate testing
       $(gmt --show-sharedir)/tools/gmt_getremote.sh cache
       gmt which -Gu @earth_relief_10m @earth_relief_60m @ridge.txt @Table_5_11.txt @tut_quakes.ngdc @tut_ship.xyz
     displayName: Download remote data

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -116,6 +116,22 @@ jobs:
       conda list
     displayName: List installed packages
 
+  # Cache the ${HOME}/.gmt directory, for docs and testing
+  - task: Cache@2
+    inputs:
+      key: cachedata | 20200520
+      path: $(HOME)/.gmt
+      cacheHitVar: CACHE_CACHEDATA_RESTORED
+    displayName: Cache GMT remote data for testing
+
+  # Download remote files, if not already cached
+  - bash: |
+      set -x -e
+      $(gmt --show-sharedir)/tools/gmt_getremote.sh cache
+      gmt which -Gu @earth_relief_10m @earth_relief_60m @ridge.txt @Table_5_11.txt @tut_quakes.ngdc @tut_ship.xyz
+    displayName: Download remote data
+    condition: ne(variables['CACHE_CACHEDATA_RESTORED'], true)
+
   # Install the package
   - bash: |
       set -x -e
@@ -199,6 +215,22 @@ jobs:
       source activate testing
       conda list
     displayName: List installed packages
+
+  # Cache the ${HOME}/.gmt directory, for docs and testing
+  - task: Cache@2
+    inputs:
+      key: cachedata | 20200520
+      path: $(HOME)/.gmt
+      cacheHitVar: CACHE_CACHEDATA_RESTORED
+    displayName: Cache GMT remote data for testing
+
+  # Download remote files, if not already cached
+  - bash: |
+      set -x -e
+      $(gmt --show-sharedir)/tools/gmt_getremote.sh cache
+      gmt which -Gu @earth_relief_10m @earth_relief_60m @ridge.txt @Table_5_11.txt @tut_quakes.ngdc @tut_ship.xyz
+    displayName: Download remote data
+    condition: ne(variables['CACHE_CACHEDATA_RESTORED'], true)
 
   # Install the package that we want to test
   - bash: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -128,7 +128,6 @@ jobs:
   - bash: |
       set -x -e
       source activate testing
-      $(gmt --show-sharedir)/tools/gmt_getremote.sh cache
       gmt which -Gu @earth_relief_10m @earth_relief_60m @ridge.txt @Table_5_11.txt @tut_quakes.ngdc @tut_ship.xyz
     displayName: Download remote data
     condition: ne(variables['CACHE_CACHEDATA_RESTORED'], true)
@@ -229,7 +228,6 @@ jobs:
   - bash: |
       set -x -e
       source activate testing
-      $(gmt --show-sharedir)/tools/gmt_getremote.sh cache
       gmt which -Gu @earth_relief_10m @earth_relief_60m @ridge.txt @Table_5_11.txt @tut_quakes.ngdc @tut_ship.xyz
     displayName: Download remote data
     condition: ne(variables['CACHE_CACHEDATA_RESTORED'], true)


### PR DESCRIPTION
**Description of proposed changes**

Windows builds on Azure Pipelines can't seem to fetch GMT data from http://oceania.generic-mapping-tools.org/, as mentioned in https://github.com/GenericMappingTools/pygmt/pull/434#issuecomment-630647330. This Pull Request mimics the upstream GMT one at https://github.com/GenericMappingTools/gmt/pull/3056.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Files we are caching includes:
- @earth_relief_10m
- @earth_relief_60m
- @ridge.txt
- @Table_5_11.txt
- @tut_quakes.ngdc
- @tut_ship.xyz.

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
