### PR TITLE
Improve how PyGMT finds the GMT library

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -163,8 +163,6 @@ jobs:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
     CONDA_INSTALL_EXTRA: "codecov gmt=6.0.0"
-    # ctypes.CDLL cannot find conda's libraries
-    GMT_LIBRARY_PATH: 'C:\Miniconda\envs\testing\Library\bin'
 
   strategy:
     matrix:

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -51,7 +51,7 @@ def load_libgmt():
     return libgmt
 
 
-def clib_name(os_name):
+def clib_names(os_name):
     """
     Return the name of GMT's shared library for the current OS.
 
@@ -62,20 +62,20 @@ def clib_name(os_name):
 
     Returns
     -------
-    libname : list of str
+    libnames : list of str
         List of possible names of GMT's shared library.
 
     """
     if os_name.startswith("linux"):
-        libname = ["libgmt.so"]
+        libnames = ["libgmt.so"]
     elif os_name == "darwin":
         # Darwin is macOS
-        libname = ["libgmt.dylib"]
+        libnames = ["libgmt.dylib"]
     elif os_name == "win32":
-        libname = ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
+        libnames = ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
     else:
         raise GMTOSError('Operating system "{}" not supported.'.format(sys.platform))
-    return libname
+    return libnames
 
 
 def clib_full_names(env=None):
@@ -96,7 +96,7 @@ def clib_full_names(env=None):
     """
     if env is None:
         env = os.environ
-    libnames = clib_name(os_name=sys.platform)  # e.g. libgmt.so, libgmt.dylib, gmt.dll
+    libnames = clib_names(os_name=sys.platform)  # e.g. libgmt.so, libgmt.dylib, gmt.dll
     libpath = env.get("GMT_LIBRARY_PATH", "")  # e.g. $HOME/miniconda/envs/pygmt/lib
 
     lib_fullnames = [os.path.join(libpath, libname) for libname in libnames]

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -11,7 +11,7 @@ import ctypes
 from ..exceptions import GMTOSError, GMTCLibError, GMTCLibNotFoundError
 
 
-def load_libgmt(env=None):
+def load_libgmt():
     """
     Find and load ``libgmt`` as a :py:class:`ctypes.CDLL`.
 
@@ -37,14 +37,11 @@ def load_libgmt(env=None):
         couldn't access the functions).
 
     """
-    if env is None:
-        env = os.environ
-    libnames = clib_name(os_name=sys.platform)
-    libpath = env.get("GMT_LIBRARY_PATH", "")
+    lib_fullnames = clib_full_names()
     error = True
-    for libname in libnames:
+    for libname in lib_fullnames:
         try:
-            libgmt = ctypes.CDLL(os.path.join(libpath, libname))
+            libgmt = ctypes.CDLL(libname)
             check_libgmt(libgmt)
             error = False
             break
@@ -52,7 +49,7 @@ def load_libgmt(env=None):
             error = err
     if error:
         raise GMTCLibNotFoundError(
-            "Error loading the GMT shared library '{}':".format(", ".join(libnames))
+            "Error loading the GMT shared library '{}':".format(", ".join(lib_fullnames))
         )
     return libgmt
 
@@ -82,6 +79,16 @@ def clib_name(os_name):
     else:
         raise GMTOSError('Operating system "{}" not supported.'.format(sys.platform))
     return libname
+
+
+def clib_full_names(env=None):
+    if env is None:
+        env = os.environ
+    libnames = clib_name(os_name=sys.platform)
+    libpath = env.get("GMT_LIBRARY_PATH", "")
+
+    lib_fullnames = [os.path.join(libpath, libname) for libname in libnames]
+    return lib_fullnames
 
 
 def check_libgmt(libgmt):

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -20,12 +20,6 @@ def load_libgmt():
     the environment variable ``GMT_LIBRARY_PATH``. If it's not set, will let
     ctypes try to find the library.
 
-    Parameters
-    ----------
-    env : dict or None
-        A dictionary containing the environment variables. If ``None``, will
-        default to ``os.environ``.
-
     Returns
     -------
     :py:class:`ctypes.CDLL` object
@@ -50,7 +44,9 @@ def load_libgmt():
             error = err
     if error:
         raise GMTCLibNotFoundError(
-            "Error loading the GMT shared library '{}':".format(", ".join(lib_fullnames))
+            "Error loading the GMT shared library '{}':".format(
+                ", ".join(lib_fullnames)
+            )
         )
     return libgmt
 
@@ -83,15 +79,29 @@ def clib_name(os_name):
 
 
 def clib_full_names(env=None):
+    """
+    Return the full path of GMT's shared library for the current OS.
+
+    Parameters
+    ----------
+    env : dict or None
+        A dictionary containing the environment variables. If ``None``, will
+        default to ``os.environ``.
+
+    Returns
+    -------
+    lib_fullnames: list of str
+        List of possible full names of GMT's shared library.
+
+    """
     if env is None:
         env = os.environ
     libnames = clib_name(os_name=sys.platform)
     libpath = env.get("GMT_LIBRARY_PATH", "")
 
     lib_fullnames = [os.path.join(libpath, libname) for libname in libnames]
-
     # Search for DLLs in PATH if GMT_LIBRARY_PATH is not defined [Windows only]
-    if sys.platform == "win32" and not libpath:
+    if not libpath and sys.platform == "win32":
         for libname in libnames:
             libfullpath = find_library(libname)
             if libfullpath:

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -96,8 +96,8 @@ def clib_full_names(env=None):
     """
     if env is None:
         env = os.environ
-    libnames = clib_name(os_name=sys.platform)
-    libpath = env.get("GMT_LIBRARY_PATH", "")
+    libnames = clib_name(os_name=sys.platform)  # e.g. libgmt.so, libgmt.dylib, gmt.dll
+    libpath = env.get("GMT_LIBRARY_PATH", "")  # e.g. $HOME/miniconda/envs/pygmt/lib
 
     lib_fullnames = [os.path.join(libpath, libname) for libname in libnames]
     # Search for DLLs in PATH if GMT_LIBRARY_PATH is not defined [Windows only]

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -7,6 +7,7 @@ through the GMT_LIBRARY_PATH environment variable.
 import os
 import sys
 import ctypes
+from ctypes.util import find_library
 
 from ..exceptions import GMTOSError, GMTCLibError, GMTCLibNotFoundError
 
@@ -88,6 +89,13 @@ def clib_full_names(env=None):
     libpath = env.get("GMT_LIBRARY_PATH", "")
 
     lib_fullnames = [os.path.join(libpath, libname) for libname in libnames]
+
+    # Search for DLLs in PATH if GMT_LIBRARY_PATH is not defined [Windows only]
+    if sys.platform == "win32" and not libpath:
+        for libname in libnames:
+            libfullpath = find_library(libname)
+            if libfullpath:
+                lib_fullnames.append(libfullpath)
     return lib_fullnames
 
 

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -1,6 +1,7 @@
 """
 Test the functions that load libgmt
 """
+import os
 import pytest
 
 from ..clib.loading import clib_name, load_libgmt, check_libgmt
@@ -16,6 +17,22 @@ def test_check_libgmt():
 def test_load_libgmt():
     "Test that loading libgmt works and doesn't crash."
     check_libgmt(load_libgmt())
+
+
+def test_load_libgmt_fail():
+    "Test that loading fails when given a bad library path."
+    # save the old value (if any) before setting a fake "GMT_LIBRARY_PATH"
+    old_gmt_library_path = os.environ.get("GMT_LIBRARY_PATH")
+
+    os.environ["GMT_LIBRARY_PATH"] = "/not/a/real/path"
+    with pytest.raises(GMTCLibNotFoundError):
+        load_libgmt()
+
+    # revert back to the original status (if any)
+    if old_gmt_library_path:
+        os.environ["GMT_LIBRARY_PATH"] = old_gmt_library_path
+    else:
+        del os.environ["GMT_LIBRARY_PATH"]
 
 
 def test_clib_name():

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -18,13 +18,6 @@ def test_load_libgmt():
     check_libgmt(load_libgmt())
 
 
-def test_load_libgmt_fail():
-    "Test that loading fails when given a bad library path."
-    env = {"GMT_LIBRARY_PATH": "not/a/real/path"}
-    with pytest.raises(GMTCLibNotFoundError):
-        load_libgmt(env=env)
-
-
 def test_clib_name():
     "Make sure we get the correct library name for different OS names"
     for linux in ["linux", "linux2", "linux3"]:
@@ -33,3 +26,4 @@ def test_clib_name():
     assert clib_name("win32") == ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
     with pytest.raises(GMTOSError):
         clib_name("meh")
+

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -26,4 +26,3 @@ def test_clib_name():
     assert clib_name("win32") == ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
     with pytest.raises(GMTOSError):
         clib_name("meh")
-

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -4,7 +4,7 @@ Test the functions that load libgmt
 import os
 import pytest
 
-from ..clib.loading import clib_name, load_libgmt, check_libgmt
+from ..clib.loading import clib_names, load_libgmt, check_libgmt
 from ..exceptions import GMTCLibError, GMTOSError, GMTCLibNotFoundError
 
 
@@ -35,11 +35,11 @@ def test_load_libgmt_fail():
         del os.environ["GMT_LIBRARY_PATH"]
 
 
-def test_clib_name():
+def test_clib_names():
     "Make sure we get the correct library name for different OS names"
     for linux in ["linux", "linux2", "linux3"]:
-        assert clib_name(linux) == ["libgmt.so"]
-    assert clib_name("darwin") == ["libgmt.dylib"]
-    assert clib_name("win32") == ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
+        assert clib_names(linux) == ["libgmt.so"]
+    assert clib_names("darwin") == ["libgmt.dylib"]
+    assert clib_names("win32") == ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
     with pytest.raises(GMTOSError):
-        clib_name("meh")
+        clib_names("meh")


### PR DESCRIPTION
**Description of proposed changes**

On Windows, ctypes can't find the gmt library in conda's path. The reason is still unclear to me. But ctypes provides a function [find_library](https://docs.python.org/3/library/ctypes.html#ctypes.util.find_library) which search DLLs in the system search path (i.e., the variable **PATH**). 

Thus, on Windows, if **GMT_LIBRARY_PATH** is not defined, we first call `find_library` to check if gmt.dll, gmt_w64 or gmt_w32 exists in one of the PATH. `find_library` returns its full path (e.g., `C:\Miniconda\envs\testing\Library\bin\gmt.dll`) if it's found, else returns None.

The new function `clib_full_names` returns the list of full names to the gmt library. When **GMT_LIBRARY_PATH** is not defined, it returns 
- macOS: `["libgmt.dylib"]` 
- Linux: `["libgmt.so"]`
- Windows: `["gmt.dll", "gmt_w64.dll", "gmt_w32.dll", "C:\Miniconda\envs\testing\Library\bin\gmt.dll"]`.

On Windows, the full path returned by `find_library` is placed at the end of the list, to better mimic the [library search order on Windows](https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order?redirectedfrom=MSDN#standard-search-order-for-desktop-applications).

With this PR merged, the variables **GMT_LIBRARY_PATH** is no longer required for Windows users.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
