### PR TITLE
Add show_versions() function for printing debugging information used in issue reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,5 +22,8 @@ PASTE ERROR MESSAGE HERE
 
 **System information**
 
-Please post the output of `python -c "import pygmt; pygmt.show_versions()"`:
+Please paste the output of `python -c "import pygmt; pygmt.show_versions()"`:
 
+```
+PASTE THE OUTPUT HERE
+```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,16 +22,5 @@ PASTE ERROR MESSAGE HERE
 
 **System information**
 
-* Operating system:
-* Python installation (Anaconda, system, ETS):
-* Version of GMT:
-* Version of Python:
-* Version of this package:
-* If using conda, paste the output of `conda list` below:
+Please post the output of `python -c "import pygmt; pygmt.show_versions()"`:
 
-<details>
-<summary>output of conda list</summary>
-<pre>
-PASTE OUTPUT OF CONDA LIST HERE
-</pre>
-</details>

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test:
 	# Run a tmp folder to make sure the tests are run on the installed version
 	mkdir -p $(TESTDIR)
 	@echo ""
-	@cd $(TESTDIR); python -c "import $(PROJECT); $(PROJECT).print_clib_info()"
+	@cd $(TESTDIR); python -c "import $(PROJECT); $(PROJECT).show_versions()"
 	@echo ""
 	cd $(TESTDIR); pytest $(PYTEST_ARGS) $(PROJECT)
 	cp $(TESTDIR)/.coverage* .

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -92,6 +92,7 @@ Miscellaneous
     which
     test
     print_clib_info
+    show_versions
 
 
 .. automodule:: pygmt.datasets

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -117,7 +117,7 @@ well (be sure to have your conda env activated)::
 Test your installation by running the following inside a Python interpreter::
 
     import pygmt
-    pygmt.print_clib_info()
+    pygmt.show_versions()
     pygmt.test()
 
 

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -7,9 +7,6 @@
 # session will be closed when the current Python process terminates. Thus, the
 # Python API does not expose the `gmt begin` and `gmt end` commands.
 
-import sys
-import platform
-import importlib
 import atexit as _atexit
 
 from ._version import get_versions as _get_versions
@@ -55,6 +52,9 @@ def show_versions():
     """
     Print useful debugging information for issue reports.
     """
+    import sys
+    import platform
+    import importlib
 
     def _get_module_version(module):
         """Get version information of a Python module."""

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -73,7 +73,7 @@ def show_versions():
             return None
 
     def _get_ghostscript_version():
-        """Check ghostscript version."""
+        """Get ghostscript version."""
         os_name = sys.platform
         if os_name.startswith("linux") or os_name == "darwin":
             cmds = ["gs"]
@@ -110,7 +110,7 @@ def show_versions():
     print("Dependency information:")
     for modname in deps:
         print(f"  {modname}: {_get_module_version(modname)}")
-    print("  ghostscript:", _get_ghostscript_version())
+    print(f"  ghostscript: {_get_ghostscript_version()}")
 
     print_clib_info()
 

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -92,6 +92,16 @@ def show_versions():
                 continue
         return None
 
+    def _get_gmt_version():
+        """Get GMT version."""
+        try:
+            version = subprocess.check_output(
+                ["gmt", "--version"], universal_newlines=True
+            ).strip()
+            return version
+        except FileNotFoundError:
+            return None
+
     sys_info = {
         "python": sys.version.replace("\n", " "),
         "executable": sys.executable,
@@ -111,6 +121,7 @@ def show_versions():
     for modname in deps:
         print(f"  {modname}: {_get_module_version(modname)}")
     print(f"  ghostscript: {_get_ghostscript_version()}")
+    print(f"  gmt: {_get_gmt_version()}")
 
     print_clib_info()
 

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -85,7 +85,7 @@ def show_versions():
         for gs_cmd in cmds:
             try:
                 version = subprocess.check_output(
-                    [gs_cmd, "--version"], text=True
+                    [gs_cmd, "--version"], universal_newlines=True
                 ).strip()
                 return version
             except FileNotFoundError:

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -72,7 +72,6 @@ def show_versions():
         except ImportError:
             return None
 
-
     def _get_ghostscript_version():
         """Check ghostscript version."""
         os_name = sys.platform
@@ -92,7 +91,6 @@ def show_versions():
             except FileNotFoundError:
                 continue
         return None
-
 
     sys_info = {
         "python": sys.version.replace("\n", " "),

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -58,9 +58,7 @@ def show_versions():
     - Core dependency versions (Numpy, Pandas, Xarray, etc)
     - GMT library information
     """
-    
-    
-    """
+
     import sys
     import platform
     import importlib

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -57,12 +57,21 @@ def show_versions():
     import importlib
     import subprocess
 
-    def _get_module_version(module):
+    def _get_module_version(modname):
         """Get version information of a Python module."""
         try:
-            return module.__version__
-        except AttributeError:
-            return module.version
+            if modname in sys.modules:
+                module = sys.modules[modname]
+            else:
+                module = importlib.import_module(modname)
+
+            try:
+                return module.__version__
+            except AttributeError:
+                return module.version
+        except ImportError:
+            return None
+
 
     def _get_ghostscript_version():
         """Check ghostscript version."""
@@ -84,6 +93,7 @@ def show_versions():
                 continue
         return None
 
+
     sys_info = {
         "python": sys.version.replace("\n", " "),
         "executable": sys.executable,
@@ -91,16 +101,6 @@ def show_versions():
     }
 
     deps = ["numpy", "pandas", "xarray", "netCDF4", "packaging"]
-    deps_info = {}
-    for modname in deps:
-        try:
-            if modname in sys.modules:
-                mod = sys.modules[modname]
-            else:
-                mod = importlib.import_module(modname)
-            deps_info[modname] = _get_module_version(mod)
-        except ImportError:
-            deps_info[modname] = None
 
     print("PyGMT information:")
     print(f"  version: {__version__}")
@@ -110,8 +110,8 @@ def show_versions():
         print(f"  {k}: {v}")
 
     print("Dependency information:")
-    for k, v in deps_info.items():
-        print(f"  {k}: {v}")
+    for modname in deps:
+        print(f"  {modname}: {_get_module_version(modname)}")
     print("  ghostscript:", _get_ghostscript_version())
 
     print_clib_info()

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -50,7 +50,16 @@ def print_clib_info():
 
 def show_versions():
     """
-    Print useful debugging information for issue reports.
+    Prints various dependency versions useful when submitting bug reports. This
+    includes information about:
+
+    - PyGMT itself
+    - System information (Python version, Operating System)
+    - Core dependency versions (Numpy, Pandas, Xarray, etc)
+    - GMT library information
+    """
+    
+    
     """
     import sys
     import platform

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -128,7 +128,7 @@ def test(doctest=True, verbose=True, coverage=False, figures=True):
     """
     import pytest
 
-    print_clib_info()
+    show_versions()
 
     package = __name__
 

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -55,6 +55,7 @@ def show_versions():
     import sys
     import platform
     import importlib
+    import subprocess
 
     def _get_module_version(module):
         """Get version information of a Python module."""
@@ -62,6 +63,26 @@ def show_versions():
             return module.__version__
         except AttributeError:
             return module.version
+
+    def _get_ghostscript_version():
+        """Check ghostscript version."""
+        os_name = sys.platform
+        if os_name.startswith("linux") or os_name == "darwin":
+            cmds = ["gs"]
+        elif os_name == "win32":
+            cmds = ["gswin64c.exe", "gswin32c.exe"]
+        else:
+            return None
+
+        for gs_cmd in cmds:
+            try:
+                version = subprocess.check_output(
+                    [gs_cmd, "--version"], text=True
+                ).strip()
+                return version
+            except FileNotFoundError:
+                continue
+        return None
 
     sys_info = {
         "python": sys.version.replace("\n", " "),
@@ -91,6 +112,7 @@ def show_versions():
     print("Dependency information:")
     for k, v in deps_info.items():
         print(f"  {k}: {v}")
+    print("  ghostscript:", _get_ghostscript_version())
 
     print_clib_info()
 

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -61,7 +61,7 @@ def show_versions():
         try:
             return module.__version__
         except AttributeError:
-            return module.versio
+            return module.version
 
     sys_info = {
         "python": sys.version.replace("\n", " "),


### PR DESCRIPTION
**Description of proposed changes**

The `show_versions` function reports system information, package versions and GMT library information. The output looks like:
```
PyGMT information:
  version: v0.1.1+20.g4d11e8c.dirty
System information:
  python: 3.7.6 (default, Jan  8 2020, 13:42:34)  [Clang 4.0.1 (tags/RELEASE_401/final)]
  executable: /Users/seisman/.anaconda/bin/python
  machine: Darwin-19.4.0-x86_64-i386-64bit
Dependency information:
  numpy: 1.18.1
  pandas: 1.0.1
  xarray: 0.15.1
  netCDF4: 1.5.3
  packaging: 20.1
  ghostscript: 9.50
  gmt: 6.1.0_ddd829b_2020.05.29
GMT library information:
  binary dir: /Users/seisman/.anaconda/bin
  cores: 8
  grid layout: rows
  library path: /Users/seisman/local/GMT/lib/libgmt.dylib
  padding: 2
  plugin dir: /Users/seisman/local/GMT/lib/gmt/plugins
  share dir: /Users/seisman/local/GMT/share
  version: 6.1.0
```

TODO: 

- [x] Update the github issue template
- [x] Update the pygmt test instructions in the documentation
- [x] Replace `print_clib_info()` with `show_versions` in Makefile

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #460


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
