### PR TITLE
Add instructions to view the test coverage reports locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ MANIFEST
 .ipynb_checkpoints/
 .vscode/
 tmp-test-dir-with-unique-name/
+htmlcov
 build/
 dist/
 doc/_build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,7 +303,8 @@ Run the tests and calculate test coverage using:
     make test
 
 The coverage report will let you know which lines of code are touched by the tests.
-**Strive to get 100% coverage for the lines you changed.**
+If all the tests pass, you can view the coverage reports by opening `htmlcov/index.html`
+in your browser. **Strive to get 100% coverage for the lines you changed.**
 It's OK if you can't or don't know how to test something.
 Leave a comment in the PR and we'll help you out.
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 	@cd $(TESTDIR); python -c "import $(PROJECT); $(PROJECT).show_versions()"
 	@echo ""
 	cd $(TESTDIR); pytest $(PYTEST_ARGS) $(PROJECT)
-	cp $(TESTDIR)/.coverage* .
+	cp $(TESTDIR)/.coverage* . && coverage html
 	rm -r $(TESTDIR)
 
 format:
@@ -43,6 +43,6 @@ lint:
 clean:
 	find . -name "*.pyc" -exec rm -v {} \;
 	find . -name "*~" -exec rm -v {} \;
-	rm -rvf build dist MANIFEST *.egg-info __pycache__ .coverage .cache
+	rm -rvf build dist MANIFEST *.egg-info __pycache__ .coverage .cache htmlcov
 	rm -rvf $(TESTDIR)
 	rm -rvf baseline


### PR DESCRIPTION
**Description of proposed changes**

After tests, run `coverage html` to generate coverage reports in HTML format.
The coverage reports is located in the `htmlcov` directory by default.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #463


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
