### PR TITLE
Change load_earth_relief()'s default resolution to 01d

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -128,7 +128,7 @@ jobs:
   - bash: |
       set -x -e
       source activate testing
-      gmt which -Gu @earth_relief_10m @earth_relief_60m @ridge.txt @Table_5_11.txt @tut_bathy.nc @tut_quakes.ngdc @tut_ship.xyz
+      gmt which -Gu @earth_relief_10m @earth_relief_01d @ridge.txt @Table_5_11.txt @tut_bathy.nc @tut_quakes.ngdc @tut_ship.xyz
     displayName: Download remote data
     condition: ne(variables['CACHE_CACHEDATA_RESTORED'], true)
 
@@ -224,7 +224,7 @@ jobs:
   - bash: |
       set -x -e
       source activate testing
-      gmt which -Gu @earth_relief_10m @earth_relief_60m @ridge.txt @Table_5_11.txt @tut_bathy.nc @tut_quakes.ngdc @tut_ship.xyz
+      gmt which -Gu @earth_relief_10m @earth_relief_01d @ridge.txt @Table_5_11.txt @tut_bathy.nc @tut_quakes.ngdc @tut_ship.xyz
     displayName: Download remote data
     condition: ne(variables['CACHE_CACHEDATA_RESTORED'], true)
 

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -46,8 +46,8 @@ def dataarray_to_matrix(grid):
     --------
 
     >>> from pygmt.datasets import load_earth_relief
-    >>> # Use the global Earth relief grid with 1 degree spacing (60')
-    >>> grid = load_earth_relief(resolution='60m')
+    >>> # Use the global Earth relief grid with 1 degree spacing
+    >>> grid = load_earth_relief(resolution='01d')
     >>> matrix, region, inc = dataarray_to_matrix(grid)
     >>> print(region)
     [-180.0, 180.0, -90.0, 90.0]

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1210,7 +1210,7 @@ class Session:
 
         >>> from pygmt.datasets import load_earth_relief
         >>> from pygmt.helpers import GMTTempFile
-        >>> data = load_earth_relief(resolution='60m')
+        >>> data = load_earth_relief(resolution='01d')
         >>> print(data.shape)
         (181, 361)
         >>> print(data.lon.values.min(), data.lon.values.max())

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -24,9 +24,9 @@ def load_earth_relief(resolution="01d"):
     ----------
     resolution : str
         The grid resolution. The suffix ``d``, ``m`` and ``s`` stand for
-        arc-degree, arc-minute and arc-second. It can be ``'01d'``, ``'60m'``,
-        ``'30m'``, ``'10m'``, ``'05m'``, ``'02m'``, ``'01m'``, ``'30s'``
-        or ``'15s'``.
+        arc-degree, arc-minute and arc-second. It can be ``'01d'``, ``'30m'``,
+        ``'20m'``, ``'15m'``, ``'10m'``, ``'06m'``, ``'05m'``, ``'04m'``,
+        ``'03m'``, ``'02m'``, ``'01m'``, ``'30s'`` or ``'15s'``.
 
     Returns
     -------

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -85,9 +85,9 @@ def _is_valid_resolution(resolution):
     """
     valid_resolutions = ["01d"]
     valid_resolutions.extend(
-        ["{:02d}m".format(res) for res in [60, 30, 20, 15, 10, 6, 5, 4, 3, 2, 1]]
+        [f"{res:02d}m" for res in [60, 30, 20, 15, 10, 6, 5, 4, 3, 2, 1]]
     )
-    valid_resolutions.extend(["{:02d}s".format(res) for res in [30, 15]])
+    valid_resolutions.extend([f"{res:02d}s" for res in [30, 15]])
     if resolution not in valid_resolutions:
         raise GMTInvalidInput(
             "Invalid Earth relief resolution '{}'.".format(resolution)

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -8,7 +8,7 @@ from .. import which
 from ..exceptions import GMTInvalidInput
 
 
-def load_earth_relief(resolution="60m"):
+def load_earth_relief(resolution="01d"):
     """
     Load Earth relief grids (topography and bathymetry) in various resolutions.
 
@@ -23,9 +23,10 @@ def load_earth_relief(resolution="60m"):
     Parameters
     ----------
     resolution : str
-        The grid resolution. The suffix ``m`` and ``s`` stand for arc-minute
-        and arc-second. It can be ``'60m'``, ``'30m'``, ``'10m'``, ``'05m'``,
-        ``'02m'``, ``'01m'``, ``'30s'`` or ``'15s'``.
+        The grid resolution. The suffix ``d``, ``m`` and ``s`` stand for
+        arc-degree, arc-minute and arc-second. It can be ``'01d'``, ``'60m'``,
+        ``'30m'``, ``'10m'``, ``'05m'``, ``'02m'``, ``'01m'``, ``'30s'``
+        or ``'15s'``.
 
     Returns
     -------
@@ -69,6 +70,7 @@ def _is_valid_resolution(resolution):
     Examples
     --------
 
+    >>> _is_valid_resolution("01d")
     >>> _is_valid_resolution("60m")
     >>> _is_valid_resolution("5m")
     Traceback (most recent call last):
@@ -81,7 +83,10 @@ def _is_valid_resolution(resolution):
     pygmt.exceptions.GMTInvalidInput: Invalid Earth relief resolution '01s'.
 
     """
-    valid_resolutions = ["{:02d}m".format(res) for res in [60, 30, 10, 5, 2, 1]]
+    valid_resolutions = ["01d"]
+    valid_resolutions.extend(
+        ["{:02d}m".format(res) for res in [60, 30, 20, 15, 10, 6, 5, 4, 3, 2, 1]]
+    )
     valid_resolutions.extend(["{:02d}s".format(res) for res in [30, 15]])
     if resolution not in valid_resolutions:
         raise GMTInvalidInput(
@@ -120,7 +125,9 @@ def _shape_from_resolution(resolution):
     """
     _is_valid_resolution(resolution)
     unit = resolution[2]
-    if unit == "m":
+    if unit == "d":
+        seconds = int(resolution[:2]) * 60 * 60
+    elif unit == "m":
         seconds = int(resolution[:2]) * 60
     elif unit == "s":
         seconds = int(resolution[:2])

--- a/pygmt/tests/test_datasets.py
+++ b/pygmt/tests/test_datasets.py
@@ -67,10 +67,10 @@ def test_earth_relief_fails():
             load_earth_relief(resolution=resolution)
 
 
-# Only test 60m and 30m to avoid downloading large datasets in CI
-def test_earth_relief_60():
-    "Test some properties of the earth relief 60m data"
-    data = load_earth_relief(resolution="60m")
+# Only test 01d and 30m to avoid downloading large datasets in CI
+def test_earth_relief_01d():
+    "Test some properties of the earth relief 01d data"
+    data = load_earth_relief(resolution="01d")
     assert data.shape == (181, 361)
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
@@ -78,7 +78,7 @@ def test_earth_relief_60():
     npt.assert_allclose(data.max(), 5558.79248)
 
 
-def test_earth_relief_30():
+def test_earth_relief_30m():
     "Test some properties of the earth relief 30m data"
     data = load_earth_relief(resolution="30m")
     assert data.shape == (361, 721)

--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -58,7 +58,7 @@ def test_grdcontour_file():
     "Plot a contour image using grid file input"
     fig = Figure()
     fig.grdcontour(
-        "@earth_relief_60m",
+        "@earth_relief_01d",
         interval="1000",
         limit="0",
         pen="0.5p,black",

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -32,7 +32,7 @@ def test_grdimage_file():
     "Plot an image using file input"
     fig = Figure()
     fig.grdimage(
-        "@earth_relief_60m",
+        "@earth_relief_01d",
         cmap="ocean",
         region=[-180, 180, -70, 70],
         projection="W0/10i",

--- a/pygmt/tests/test_grdinfo.py
+++ b/pygmt/tests/test_grdinfo.py
@@ -18,7 +18,7 @@ def test_grdinfo():
 
 def test_grdinfo_file():
     "Test grdinfo with file input"
-    result = grdinfo("@earth_relief_60m", L=0, C="n")
+    result = grdinfo("@earth_relief_01d", L=0, C="n")
     assert result.strip() == "-180 180 -90 90 -8592.14465255 5558.79248047 1 1 361 181"
 
 

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -58,7 +58,7 @@ def test_grdtrack_input_dataframe_and_ncfile():
     Run grdtrack by passing in a pandas.DataFrame and netcdf file as inputs
     """
     dataframe = load_ocean_ridge_points()
-    ncfile = which("@earth_relief_60m", download="c")
+    ncfile = which("@earth_relief_01d", download="c")
 
     output = grdtrack(points=dataframe, grid=ncfile, newcolname="bathymetry")
     assert isinstance(output, pd.DataFrame)
@@ -73,7 +73,7 @@ def test_grdtrack_input_csvfile_and_ncfile():
     Run grdtrack by passing in a csvfile and netcdf file as inputs
     """
     csvfile = which("@ridge.txt", download="c")
-    ncfile = which("@earth_relief_60m", download="c")
+    ncfile = which("@earth_relief_01d", download="c")
 
     try:
         output = grdtrack(points=csvfile, grid=ncfile, outfile=TEMP_TRACK)

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -31,7 +31,7 @@ def test_grdview_grid_file_with_region_subset():
     """
     Run grdview by passing in a grid filename, and cropping it to a region.
     """
-    gridfile = which("@earth_relief_60m", download="c")
+    gridfile = which("@earth_relief_01d", download="c")
 
     fig = Figure()
     fig.grdview(grid=gridfile, region=[-116, -109, -47, -44])


### PR DESCRIPTION
**Description of proposed changes**

In GMT 6.0.0, both `01d` and `60m` are valid resolutions of earth
relief data. It was called `60m` at the beginning, and was changed to `01d`
when GMT 6.0.0 was officially released. `60m` is still valid for backward
compatibility.

Run the following commands, and you will have the two data in the
current directory.
```
gmt which @earth_relief_60m -Gl
gmt which @earth_relief_01d -Gl
```
These two files have different file names but are identical:
```
$ md5sum earth_relief_01d.grd earth_relief_60m.grd
74a884c902015dda516d17605f317efe  earth_relief_01d.grd
74a884c902015dda516d17605f317efe  earth_relief_60m.grd
```

In the upcoming GMT 6.1.0, the resolution `60m` will be deprecated.
That's why we have many ~25 errors when testing PyGMT with the GMT master
branch, simply because GMT 6.1.0 can't download the `@earth_relief_60m`.

To make the transition to GMT 6.1.0 easier, here I change the default
earth relief resolution of `load_earth_relief()` function from `60m` to
`01d`. As the two grids are identical, the change in this PR won't break
anything.

Note that, currently there are ~43 failures due to the recent updates of
the GMT data server (#451), and we can't fix these failures easily due
to the grid registration issue (#476). Thus, I don't try to fix any
failures in this PR.

I also added some valid resolutions (e.g., 20m, 15m) which are missing. 

The test log files ([master.log](https://github.com/GenericMappingTools/pygmt/files/4817133/master.log) and [current-branch.log](https://github.com/GenericMappingTools/pygmt/files/4817135/current-branch.log)) of the master branch and this branch are the same.
Tests that fail in the master branch still fail in the same way in this branch.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
