### PR TITLE
Wrap grdcut

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -72,6 +72,7 @@ Operations on grids:
 
     grdinfo
     grdtrack
+    grdcut
 
 GMT Defaults
 ------------

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -70,9 +70,9 @@ Operations on grids:
 .. autosummary::
     :toctree: generated
 
+    grdcut
     grdinfo
     grdtrack
-    grdcut
 
 GMT Defaults
 ------------

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -18,7 +18,7 @@ from .filtering import blockmedian
 from .gridding import surface
 from .sampling import grdtrack
 from .mathops import makecpt
-from .modules import config, info, grdinfo, which
+from .modules import config, info, grdinfo, grdcut, which
 from . import datasets
 
 

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -18,7 +18,8 @@ from .filtering import blockmedian
 from .gridding import surface
 from .sampling import grdtrack
 from .mathops import makecpt
-from .modules import config, info, grdinfo, grdcut, which
+from .modules import config, info, grdinfo, which
+from .gridops import grdcut
 from . import datasets
 
 

--- a/pygmt/gridops.py
+++ b/pygmt/gridops.py
@@ -1,0 +1,119 @@
+"""
+GMT modules for grid operations
+"""
+
+import xarray as xr
+
+
+from .clib import Session
+from .helpers import (
+    build_arg_string,
+    fmt_docstring,
+    kwargs_to_strings,
+    GMTTempFile,
+    use_alias,
+    data_kind,
+    dummy_context,
+)
+from .exceptions import GMTInvalidInput
+
+
+@fmt_docstring
+@use_alias(
+    G="outgrid",
+    R="region",
+    J="projection",
+    N="extend",
+    S="circ_subregion",
+    Z="z_subregion",
+)
+@kwargs_to_strings(R="sequence")
+def grdcut(grid, **kwargs):
+    """
+    Extract subregion from a grid.
+
+    Produce a new *outgrid* file which is a subregion of *grid*. The
+    subregion is specified with *region*; the specified range must not exceed
+    the range of *grid* (but see *extend*). If in doubt, run
+    :meth:`pygmt.grdinfo` to check range. Alternatively, define the subregion
+    indirectly via a range check on the node values or via distances from a
+    given point. Finally, you can give *projection* for oblique projections to
+    determine the corresponding rectangular *region* setting that will give a
+    grid that fully covers the oblique domain.
+
+    Full option list at :gmt-docs:`grdcut.html`
+
+    {aliases}
+
+    Parameters
+    ----------
+    grid : str
+        The name of the input grid file.
+    outgrid : str or None
+        The name of the output netCDF file with extension .nc to store the grid
+        in.
+    {J}
+    {R}
+    extend : bool or int or float
+        Allow grid to be extended if new *region* exceeds existing boundaries.
+        Give a value to initialize nodes outside current region.
+    circ_subregion : str
+        ``'lon/lat/radius[unit][+n]'``.
+        Specify an origin (*lon* and *lat*) and *radius*; append a distance
+        *unit* and we determine the corresponding rectangular region so that
+        all grid nodes on or inside the circle are contained in the subset.
+        If **+n** is appended we set all nodes outside the circle to NaN.
+    z_subregion : str
+        ``'[min/max][+n|N|r]'``.
+        Determine a new rectangular region so that all nodes outside this
+        region are also outside the given z-range [-inf/+inf]. To indicate no
+        limit on *min* or *max* only, specify a hyphen (-). Normally, any NaNs
+        encountered are simply skipped and not considered in the
+        range-decision. Append **+n** to consider a NaN to be outside the given
+        z-range. This means the new subset will be NaN-free. Alternatively,
+        append **+r** to consider NaNs to be within the data range. In this
+        case we stop shrinking the boundaries once a NaN is found [Default
+        simply skips NaNs when making the range decision]. Finally, if your
+        core subset grid is surrounded by rows and/or columns that are all
+        NaNs, append **+N** to strip off such columns before (optionally)
+        considering the range of the core subset for further reduction of the
+        area.
+
+    Returns
+    -------
+    ret: xarray.DataArray or None
+        Return type depends on whether the *outgrid* parameter is set:
+
+        - xarray.DataArray if *outgrid* is not set
+        - None if *outgrid* is set (grid output will be stored in *outgrid*)
+    """
+    kind = data_kind(grid)
+
+    with GMTTempFile(suffix=".nc") as tmpfile:
+        with Session() as lib:
+            if kind == "file":
+                file_context = dummy_context(grid)
+            elif kind == "grid":
+                raise NotImplementedError(
+                    "xarray.DataArray is not supported as the input grid yet!"
+                )
+                # file_context = lib.virtualfile_from_grid(grid)
+                # See https://github.com/GenericMappingTools/gmt/pull/3532
+                # for a feature request.
+            else:
+                raise GMTInvalidInput("Unrecognized data type: {}".format(type(grid)))
+
+            with file_context as infile:
+                if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
+                    kwargs.update({"G": tmpfile.name})
+                outgrid = kwargs["G"]
+                arg_str = " ".join([infile, build_arg_string(kwargs)])
+                lib.call_module("grdcut", arg_str)
+
+        if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
+            with xr.open_dataarray(outgrid) as dataarray:
+                result = dataarray.load()
+        else:
+            result = None  # if user sets an outgrid, return None
+
+        return result

--- a/pygmt/modules.py
+++ b/pygmt/modules.py
@@ -1,14 +1,11 @@
 """
 Non-plot GMT modules.
 """
-import xarray as xr
-
 
 from .clib import Session
 from .helpers import (
     build_arg_string,
     fmt_docstring,
-    kwargs_to_strings,
     GMTTempFile,
     use_alias,
     data_kind,
@@ -149,107 +146,6 @@ def which(fname, **kwargs):
     if not path:
         raise FileNotFoundError("File '{}' not found.".format(fname))
     return path
-
-
-@fmt_docstring
-@use_alias(
-    G="outgrid",
-    R="region",
-    J="projection",
-    N="extend",
-    S="circ_subregion",
-    Z="z_subregion",
-)
-@kwargs_to_strings(R="sequence")
-def grdcut(grid, **kwargs):
-    """
-    Extract subregion from a grid.
-
-    Produce a new *outgrid* file which is a subregion of *grid*. The
-    subregion is specified with *region*; the specified range must not exceed
-    the range of *grid* (but see *extend*). If in doubt, run
-    :meth:`pygmt.grdinfo` to check range. Alternatively, define the subregion
-    indirectly via a range check on the node values or via distances from a
-    given point. Finally, you can give *projection* for oblique projections to
-    determine the corresponding rectangular *region* setting that will give a
-    grid that fully covers the oblique domain.
-
-    Full option list at :gmt-docs:`grdcut.html`
-
-    {aliases}
-
-    Parameters
-    ----------
-    grid : str
-        The name of the input grid file.
-    outgrid : str or None
-        The name of the output netCDF file with extension .nc to store the grid
-        in.
-    {J}
-    {R}
-    extend : bool or int or float
-        Allow grid to be extended if new *region* exceeds existing boundaries.
-        Give a value to initialize nodes outside current region.
-    circ_subregion : str
-        ``'lon/lat/radius[unit][+n]'``.
-        Specify an origin (*lon* and *lat*) and *radius*; append a distance
-        *unit* and we determine the corresponding rectangular region so that
-        all grid nodes on or inside the circle are contained in the subset.
-        If **+n** is appended we set all nodes outside the circle to NaN.
-    z_subregion : str
-        ``'[min/max][+n|N|r]'``.
-        Determine a new rectangular region so that all nodes outside this
-        region are also outside the given z-range [-inf/+inf]. To indicate no
-        limit on *min* or *max* only, specify a hyphen (-). Normally, any NaNs
-        encountered are simply skipped and not considered in the
-        range-decision. Append **+n** to consider a NaN to be outside the given
-        z-range. This means the new subset will be NaN-free. Alternatively,
-        append **+r** to consider NaNs to be within the data range. In this
-        case we stop shrinking the boundaries once a NaN is found [Default
-        simply skips NaNs when making the range decision]. Finally, if your
-        core subset grid is surrounded by rows and/or columns that are all
-        NaNs, append **+N** to strip off such columns before (optionally)
-        considering the range of the core subset for further reduction of the
-        area.
-
-    Returns
-    -------
-    ret: xarray.DataArray or None
-        Return type depends on whether the *outgrid* parameter is set:
-
-        - xarray.DataArray if *outgrid* is not set
-        - None if *outgrid* is set (grid output will be stored in *outgrid*)
-    """
-    kind = data_kind(grid)
-
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            if kind == "file":
-                file_context = dummy_context(grid)
-            elif kind == "grid":
-                raise NotImplementedError(
-                    "xarray.DataArray is not supported as the input grid yet!"
-                )
-                # file_context = lib.virtualfile_from_grid(grid)
-                # See https://github.com/GenericMappingTools/gmt/pull/3532
-                # for a feature request.
-            else:
-                raise GMTInvalidInput("Unrecognized data type: {}".format(type(grid)))
-
-            with file_context as infile:
-                if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
-                    kwargs.update({"G": tmpfile.name})
-                outgrid = kwargs["G"]
-                arg_str = " ".join([infile, build_arg_string(kwargs)])
-                lib.call_module("grdcut", arg_str)
-
-        if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
-            with xr.open_dataarray(outgrid) as dataarray:
-                result = dataarray.load()
-        else:
-            result = None  # if user sets an outgrid, return None
-
-        return result
 
 
 class config:  # pylint: disable=invalid-name

--- a/pygmt/modules.py
+++ b/pygmt/modules.py
@@ -1,10 +1,14 @@
 """
 Non-plot GMT modules.
 """
+import xarray as xr
+
+
 from .clib import Session
 from .helpers import (
     build_arg_string,
     fmt_docstring,
+    kwargs_to_strings,
     GMTTempFile,
     use_alias,
     data_kind,
@@ -145,6 +149,106 @@ def which(fname, **kwargs):
     if not path:
         raise FileNotFoundError("File '{}' not found.".format(fname))
     return path
+
+
+@fmt_docstring
+@use_alias(
+    G="outgrid",
+    R="region",
+    J="projection",
+    N="extend",
+    S="circ_subregion",
+    Z="z_subregion",
+)
+@kwargs_to_strings(R="sequence")
+def grdcut(ingrid, **kwargs):
+    """
+    Extract subregion from a grid.
+
+    Produce a new *outgrid* file which is a subregion of *ingrid*. The
+    subregion is specified with *region*; the specified range must not exceed
+    the range of *ingrid* (but see *extend*). If in doubt, run
+    :meth:`pygmt.grdinfo` to check range. Alternatively, define the subregion
+    indirectly via a range check on the node values or via distances from a
+    given point. Finally, you can give *projection* for oblique projections to
+    determine the corresponding rectangular *region* setting that will give a
+    grid that fully covers the oblique domain.
+
+    Full option list at :gmt-docs:`grdcut.html`
+
+    {aliases}
+
+    Parameters
+    ----------
+    ingrid : str
+        The name of the input grid file.
+    outgrid : str or None
+        The name of the output netCDF file with extension .nc to store the grid
+        in.
+    {J}
+    {R}
+    extend : bool or int or float
+        Allow grid to be extended if new *region* exceeds existing boundaries.
+        Give a value to initialize nodes outside current region.
+    circ_subregion : str
+        ``'lon/lat/radius[unit][+n]'``.
+        Specify an origin (*lon* and *lat*) and *radius*; append a distance
+        *unit* and we determine the corresponding rectangular region so that
+        all grid nodes on or inside the circle are contained in the subset.
+        If **+n** is appended we set all nodes outside the circle to NaN.
+    z_subregion :
+        ``'[min/max][+n|N|r]'``.
+        Determine a new rectangular region so that all nodes outside this
+        region are also outside the given z-range [-inf/+inf]. To indicate no
+        limit on *min* or *max* only, specify a hyphen (-). Normally, any NaNs
+        encountered are simply skipped and not considered in the
+        range-decision. Append **+n** to consider a NaN to be outside the given
+        z-range. This means the new subset will be NaN-free. Alternatively,
+        append **+r** to consider NaNs to be within the data range. In this
+        case we stop shrinking the boundaries once a NaN is found [Default
+        simply skips NaNs when making the range decision]. Finally, if your
+        core subset grid is surrounded by rows and/or columns that are all
+        NaNs, append **+N** to strip off such columns before (optionally)
+        considering the range of the core subset for further reduction of the
+        area.
+
+    Returns
+    -------
+    ret: xarray.DataArray or None
+        Return type depends on whether the *outgrid* parameter is set:
+
+        - xarray.DataArray if *outgrid* is not set
+        - None if *outgrid* is set (grid output will be stored in *outgrid*)
+    """
+    kind = data_kind(ingrid)
+
+    with GMTTempFile(suffix=".nc") as tmpfile:
+        with Session() as lib:
+            if kind == "file":
+                file_context = dummy_context(ingrid)
+            elif kind == "grid":
+                raise GMTInvalidInput(
+                    "xarray.DataArray is not supported as the input grid yet!"
+                )
+                # file_context = lib.virtualfile_from_grid(ingrid)
+                # See https://github.com/GenericMappingTools/gmt/pull/3532
+                # for a feature request.
+            else:
+                raise GMTInvalidInput("Unrecognized data type: {}".format(type(ingrid)))
+
+            with file_context as infile:
+                if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
+                    kwargs.update({"G": tmpfile.name})
+                outgrid = kwargs["G"]
+                arg_str = " ".join([infile, build_arg_string(kwargs)])
+                lib.call_module("grdcut", arg_str)
+
+        if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
+            result = xr.open_dataarray(outgrid)
+        else:
+            result = None  # if user sets an outgrid, return None
+
+        return result
 
 
 class config:  # pylint: disable=invalid-name

--- a/pygmt/modules.py
+++ b/pygmt/modules.py
@@ -244,7 +244,8 @@ def grdcut(grid, **kwargs):
                 lib.call_module("grdcut", arg_str)
 
         if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
-            result = xr.open_dataarray(outgrid)
+            with xr.open_dataarray(outgrid) as dataarray:
+                result = dataarray.load()
         else:
             result = None  # if user sets an outgrid, return None
 

--- a/pygmt/modules.py
+++ b/pygmt/modules.py
@@ -1,7 +1,6 @@
 """
 Non-plot GMT modules.
 """
-
 from .clib import Session
 from .helpers import (
     build_arg_string,

--- a/pygmt/modules.py
+++ b/pygmt/modules.py
@@ -227,7 +227,7 @@ def grdcut(grid, **kwargs):
             if kind == "file":
                 file_context = dummy_context(grid)
             elif kind == "grid":
-                raise GMTInvalidInput(
+                raise NotImplementedError(
                     "xarray.DataArray is not supported as the input grid yet!"
                 )
                 # file_context = lib.virtualfile_from_grid(grid)

--- a/pygmt/modules.py
+++ b/pygmt/modules.py
@@ -196,7 +196,7 @@ def grdcut(grid, **kwargs):
         *unit* and we determine the corresponding rectangular region so that
         all grid nodes on or inside the circle are contained in the subset.
         If **+n** is appended we set all nodes outside the circle to NaN.
-    z_subregion :
+    z_subregion : str
         ``'[min/max][+n|N|r]'``.
         Determine a new rectangular region so that all nodes outside this
         region are also outside the given z-range [-inf/+inf]. To indicate no

--- a/pygmt/modules.py
+++ b/pygmt/modules.py
@@ -161,13 +161,13 @@ def which(fname, **kwargs):
     Z="z_subregion",
 )
 @kwargs_to_strings(R="sequence")
-def grdcut(ingrid, **kwargs):
+def grdcut(grid, **kwargs):
     """
     Extract subregion from a grid.
 
-    Produce a new *outgrid* file which is a subregion of *ingrid*. The
+    Produce a new *outgrid* file which is a subregion of *grid*. The
     subregion is specified with *region*; the specified range must not exceed
-    the range of *ingrid* (but see *extend*). If in doubt, run
+    the range of *grid* (but see *extend*). If in doubt, run
     :meth:`pygmt.grdinfo` to check range. Alternatively, define the subregion
     indirectly via a range check on the node values or via distances from a
     given point. Finally, you can give *projection* for oblique projections to
@@ -180,7 +180,7 @@ def grdcut(ingrid, **kwargs):
 
     Parameters
     ----------
-    ingrid : str
+    grid : str
         The name of the input grid file.
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid
@@ -220,21 +220,21 @@ def grdcut(ingrid, **kwargs):
         - xarray.DataArray if *outgrid* is not set
         - None if *outgrid* is set (grid output will be stored in *outgrid*)
     """
-    kind = data_kind(ingrid)
+    kind = data_kind(grid)
 
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
             if kind == "file":
-                file_context = dummy_context(ingrid)
+                file_context = dummy_context(grid)
             elif kind == "grid":
                 raise GMTInvalidInput(
                     "xarray.DataArray is not supported as the input grid yet!"
                 )
-                # file_context = lib.virtualfile_from_grid(ingrid)
+                # file_context = lib.virtualfile_from_grid(grid)
                 # See https://github.com/GenericMappingTools/gmt/pull/3532
                 # for a feature request.
             else:
-                raise GMTInvalidInput("Unrecognized data type: {}".format(type(ingrid)))
+                raise GMTInvalidInput("Unrecognized data type: {}".format(type(grid)))
 
             with file_context as infile:
                 if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile

--- a/pygmt/tests/test_grdcut.py
+++ b/pygmt/tests/test_grdcut.py
@@ -53,7 +53,7 @@ def test_grdcut_dataarray_in_dataarray_out():
 
 def test_grdcut_dataarray_in_fail():
     "Make sure that grdcut fails correctly if DataArray is the input grid"
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(NotImplementedError):
         grid = load_earth_relief()
         grdcut(grid, region="0/180/0/90")
 

--- a/pygmt/tests/test_grdcut.py
+++ b/pygmt/tests/test_grdcut.py
@@ -1,0 +1,64 @@
+"""
+Tests for grdcut
+"""
+import os
+import numpy as np
+import pytest
+import xarray as xr
+
+from .. import grdcut, grdinfo
+from ..datasets import load_earth_relief
+from ..exceptions import GMTInvalidInput
+from ..helpers import GMTTempFile
+
+
+def test_grdcut_file_in_file_out():
+    "grduct an input grid file, and output to a grid file"
+    with GMTTempFile(suffix=".nc") as tmpfile:
+        result = grdcut("@earth_relief_01d", outgrid=tmpfile.name, region="0/180/0/90")
+        assert result is None  # return value is None
+        assert os.path.exists(path=tmpfile.name)  # check that outgrid exists
+        result = grdinfo(tmpfile.name, C=True)
+        assert result == "0 180 0 90 -8182 5651.5 1 1 180 90 1\n"
+
+
+def test_grdcut_file_in_dataarray_out():
+    "grdcut an input grid file, and output as DataArray"
+    outgrid = grdcut("@earth_relief_01d", region="0/180/0/90")
+    assert isinstance(outgrid, xr.DataArray)
+    # check information of the output grid
+    # the '@earth_relief_01d' is in pixel registration, so the grid range is
+    # not exactly 0/180/0/90
+    assert outgrid.coords["lat"].data.min() == 0.5
+    assert outgrid.coords["lat"].data.max() == 89.5
+    assert outgrid.coords["lon"].data.min() == 0.5
+    assert outgrid.coords["lon"].data.max() == 179.5
+    assert outgrid.data.min() == -8182.0
+    assert outgrid.data.max() == 5651.5
+    assert outgrid.sizes["lat"] == 90
+    assert outgrid.sizes["lon"] == 180
+
+
+def test_grdcut_dataarray_in_file_out():
+    "grdcut an input DataArray, and output to a grid file"
+    # Not supported yet.
+    # See https://github.com/GenericMappingTools/gmt/pull/3532
+
+
+def test_grdcut_dataarray_in_dataarray_out():
+    "grdcut an input DataArray, and output to a grid file"
+    # Not supported yet.
+    # See https://github.com/GenericMappingTools/gmt/pull/3532
+
+
+def test_grdcut_dataarray_in_fail():
+    "Make sure that grdcut fails correctly if DataArray is the input grid"
+    with pytest.raises(GMTInvalidInput):
+        grid = load_earth_relief()
+        grdcut(grid, region="0/180/0/90")
+
+
+def test_grdcut_fails():
+    "Check that grdcut fails correctly"
+    with pytest.raises(GMTInvalidInput):
+        grdcut(np.arange(10).reshape((5, 2)))

--- a/pygmt/tests/test_grdcut.py
+++ b/pygmt/tests/test_grdcut.py
@@ -19,7 +19,7 @@ def test_grdcut_file_in_file_out():
         assert result is None  # return value is None
         assert os.path.exists(path=tmpfile.name)  # check that outgrid exists
         result = grdinfo(tmpfile.name, C=True)
-        assert result == "0 180 0 90 -8182 5651.5 1 1 180 90\n"
+        assert result == "0 180 0 90 -8592.5 5559 1 1 181 91\n"
 
 
 def test_grdcut_file_in_dataarray_out():
@@ -29,14 +29,14 @@ def test_grdcut_file_in_dataarray_out():
     # check information of the output grid
     # the '@earth_relief_01d' is in pixel registration, so the grid range is
     # not exactly 0/180/0/90
-    assert outgrid.coords["lat"].data.min() == 0.5
-    assert outgrid.coords["lat"].data.max() == 89.5
-    assert outgrid.coords["lon"].data.min() == 0.5
-    assert outgrid.coords["lon"].data.max() == 179.5
-    assert outgrid.data.min() == -8182.0
-    assert outgrid.data.max() == 5651.5
-    assert outgrid.sizes["lat"] == 90
-    assert outgrid.sizes["lon"] == 180
+    assert outgrid.coords["lat"].data.min() == 0.0
+    assert outgrid.coords["lat"].data.max() == 90.0
+    assert outgrid.coords["lon"].data.min() == 0.0
+    assert outgrid.coords["lon"].data.max() == 180.0
+    assert outgrid.data.min() == -8592.5
+    assert outgrid.data.max() == 5559
+    assert outgrid.sizes["lat"] == 91
+    assert outgrid.sizes["lon"] == 181
 
 
 def test_grdcut_dataarray_in_file_out():

--- a/pygmt/tests/test_grdcut.py
+++ b/pygmt/tests/test_grdcut.py
@@ -19,7 +19,7 @@ def test_grdcut_file_in_file_out():
         assert result is None  # return value is None
         assert os.path.exists(path=tmpfile.name)  # check that outgrid exists
         result = grdinfo(tmpfile.name, C=True)
-        assert result == "0 180 0 90 -8182 5651.5 1 1 180 90 1\n"
+        assert result == "0 180 0 90 -8182 5651.5 1 1 180 90\n"
 
 
 def test_grdcut_file_in_dataarray_out():


### PR DESCRIPTION
**Description of proposed changes**

Wrap the `grdcut` function, which is the first step is to redesign 
the `load_earth_relief()` function (see #489).

Ideally it should take a grid file or a `xarray.DataArray` as input, and
store output as a grid file or return a `xarray.DataArray`.

Supported features:

- [X] input: grid file; output: grid file
- [X] input: grid file; output: `xarray.DataArray`
- [ ] input: `xarray.DataArray`; output: grid file
- [ ] input: `xarray.DataArray`; output: `xarray.DataArray`

Passing `xarray.DataArray` to `grdcut` is not implenmented in the
GMT 6.0.0. See https://github.com/GenericMappingTools/gmt/pull/3532 for
a feature request to the upstream GMT.

The long-form names of the grdcut function come from [GMT.jl](https://www.generic-mapping-tools.org/GMT.jl/latest/#GMT.grdcut), but they're open for better naming.

The implementation of the `grdcut()` function is very similar to the [`surface()` function](https://github.com/GenericMappingTools/pygmt/blob/516e799bb9753ed45b9e122b8ebb5fd446320866/pygmt/gridding.py#L22).

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
