### PR TITLE
More informative metadata when loading earth_relief grids

### DIFF
--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -37,19 +37,12 @@ def load_earth_relief(resolution="01d"):
     """
     _is_valid_resolution(resolution)
     fname = which("@earth_relief_{}".format(resolution), download="u")
-    grid = xr.open_dataarray(fname)
+    grid = xr.open_dataset(fname).to_array(name="elevation").squeeze(drop=True)
     # Add some metadata to the grid
-    grid.name = "elevation"
     grid.attrs["long_name"] = "elevation relative to the geoid"
     grid.attrs["units"] = "meters"
     grid.attrs["vertical_datum"] = "EMG96"
     grid.attrs["horizontal_datum"] = "WGS84"
-    # Remove the actual range because it gets outdated when indexing the grid,
-    # which causes problems when exporting it to netCDF for usage on the
-    # command-line.
-    grid.attrs.pop("actual_range")
-    for coord in grid.coords:
-        grid[coord].attrs.pop("actual_range")
     return grid
 
 

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -37,12 +37,21 @@ def load_earth_relief(resolution="01d"):
     """
     _is_valid_resolution(resolution)
     fname = which("@earth_relief_{}".format(resolution), download="u")
-    grid = xr.open_dataset(fname).to_array(name="elevation").squeeze(drop=True)
+    _dataset = xr.open_dataset(fname)
+    grid = _dataset.z
+    grid.attrs.update(_dataset.attrs)  # add dataset atttributes to dataarray
     # Add some metadata to the grid
+    grid.name = "elevation"
     grid.attrs["long_name"] = "elevation relative to the geoid"
     grid.attrs["units"] = "meters"
     grid.attrs["vertical_datum"] = "EMG96"
     grid.attrs["horizontal_datum"] = "WGS84"
+    # Remove the actual range because it gets outdated when indexing the grid,
+    # which causes problems when exporting it to netCDF for usage on the
+    # command-line.
+    grid.attrs.pop("actual_range")
+    for coord in grid.coords:
+        grid[coord].attrs.pop("actual_range")
     return grid
 
 

--- a/pygmt/tests/test_datasets.py
+++ b/pygmt/tests/test_datasets.py
@@ -1,6 +1,7 @@
 """
 Test basic functionality for loading datasets.
 """
+import os
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -71,7 +72,9 @@ def test_earth_relief_fails():
 def test_earth_relief_01d():
     "Test some properties of the earth relief 01d data"
     data = load_earth_relief(resolution="01d")
-    assert data.attrs["node_offset"] == 1  # pixel registration
+    # assert data.attrs["node_offset"] == 1  # pixel registration
+    assert data.attrs["Conventions"] == "CF-1.7"
+    assert os.path.basename(data.encoding["source"]) == "earth_relief_01d.grd"
     assert data.shape == (181, 361)
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
@@ -82,7 +85,9 @@ def test_earth_relief_01d():
 def test_earth_relief_30m():
     "Test some properties of the earth relief 30m data"
     data = load_earth_relief(resolution="30m")
-    assert data.attrs["node_offset"] == 1  # pixel registration
+    # assert data.attrs["node_offset"] == 1  # pixel registration
+    assert data.attrs["Conventions"] == "CF-1.7"
+    assert os.path.basename(data.encoding["source"]) == "earth_relief_30m.grd"
     assert data.shape == (361, 721)
     npt.assert_allclose(data.lat, np.arange(-90, 90.5, 0.5))
     npt.assert_allclose(data.lon, np.arange(-180, 180.5, 0.5))

--- a/pygmt/tests/test_datasets.py
+++ b/pygmt/tests/test_datasets.py
@@ -71,6 +71,7 @@ def test_earth_relief_fails():
 def test_earth_relief_01d():
     "Test some properties of the earth relief 01d data"
     data = load_earth_relief(resolution="01d")
+    assert data.attrs["node_offset"] == 1  # pixel registration
     assert data.shape == (181, 361)
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
@@ -81,6 +82,7 @@ def test_earth_relief_01d():
 def test_earth_relief_30m():
     "Test some properties of the earth relief 30m data"
     data = load_earth_relief(resolution="30m")
+    assert data.attrs["node_offset"] == 1  # pixel registration
     assert data.shape == (361, 721)
     npt.assert_allclose(data.lat, np.arange(-90, 90.5, 0.5))
     npt.assert_allclose(data.lon, np.arange(-180, 180.5, 0.5))


### PR DESCRIPTION
**Description of proposed changes**

Return a richer set of attributes when running `pygmt.datasets.load_earth_relief()`, to include all the NetCDF header info metadata such as a proper title, description (including the DOI) and GMT command history used to produce the grid. In particular, the `node_offset` attribute will be useful for #476. This PR will also be useful for #489.

Before (using `xr.open_dataarray(fname)`):

```python
<xarray.DataArray 'elevation' (lat: 180, lon: 360)>
array([[ 2999. ,  2997.5,  2995.5, ...,  3003.5,  3002.5,  3000.5],
       [ 3126.5,  3127. ,  3127. , ...,  3125. ,  3125.5,  3126. ],
       [ 3051. ,  3050.5,  3051.5, ...,  3058. ,  3056. ,  3053.5],
       ...,
       [-3888.5, -3884.5, -3885.5, ..., -3897.5, -3894. , -3890.5],
       [-3494.5, -3566. , -3612.5, ..., -3213.5, -3294. , -3402.5],
       [-3898.5, -3859. , -3812. , ..., -3982.5, -3966. , -3939.5]],
      dtype=float32)
Coordinates:
  * lon      (lon) float64 -179.5 -178.5 -177.5 -176.5 ... 177.5 178.5 179.5
  * lat      (lat) float64 -89.5 -88.5 -87.5 -86.5 -85.5 ... 86.5 87.5 88.5 89.5
Attributes:
    long_name:         elevation relative to the geoid
    units:             meters
    vertical_datum:    EMG96
    horizontal_datum:  WGS84
```

After (using `xr.open_dataset(fname).to_array(name="elevation").squeeze(drop=True)`):

```python
<xarray.DataArray 'elevation' (lat: 180, lon: 360)>
array([[ 2999. ,  2997.5,  2995.5, ...,  3003.5,  3002.5,  3000.5],
       [ 3126.5,  3127. ,  3127. , ...,  3125. ,  3125.5,  3126. ],
       [ 3051. ,  3050.5,  3051.5, ...,  3058. ,  3056. ,  3053.5],
       ...,
       [-3888.5, -3884.5, -3885.5, ..., -3897.5, -3894. , -3890.5],
       [-3494.5, -3566. , -3612.5, ..., -3213.5, -3294. , -3402.5],
       [-3898.5, -3859. , -3812. , ..., -3982.5, -3966. , -3939.5]],
      dtype=float32)
Coordinates:
  * lon      (lon) float64 -179.5 -178.5 -177.5 -176.5 ... 177.5 178.5 179.5
  * lat      (lat) float64 -89.5 -88.5 -87.5 -86.5 -85.5 ... 86.5 87.5 88.5 89.5
Attributes:
    Conventions:       CF-1.7
    history:           grdfilter SRTM15+V2.1.nc -Fg111.2 -D1 -I01d -rp -Gearth/earth_relief/earth_relief_01d_p.grd=ns+s0.5+o0 --IO_NC4_DEFLATION_LEVEL=9 --IO_NC4_CHUNK_SIZE=4096 --PROJ_ELLIPSOID=Sphere
    GMT_version:       6.1.0_e80cfbd_2020.05.28 [64-bit]
    node_offset:       1
    title:             Earth Relief at 01 arc degree
    description:       Obtained by Gaussian Cartesian filtering (111.2 km fullwidth) from SRTM15+V2.1.nc [Tozer et al., 2019; http://dx.doi.org/10.1029/2019EA000658]
    long_name:         elevation relative to the geoid
    units:             meters
    vertical_datum:    EMG96
    horizontal_datum:  WGS84
```


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
