### PR TITLE
Re-caching GMT remote files

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -119,7 +119,7 @@ jobs:
   # Cache the ${HOME}/.gmt directory, for docs and testing
   - task: Cache@2
     inputs:
-      key: cachedata | 20200524
+      key: cachedata | 20200626
       path: $(HOME)/.gmt
       cacheHitVar: CACHE_CACHEDATA_RESTORED
     displayName: Cache GMT remote data for testing
@@ -215,7 +215,7 @@ jobs:
   # Cache the ${HOME}/.gmt directory, for docs and testing
   - task: Cache@2
     inputs:
-      key: cachedata | 20200524
+      key: cachedata | 20200626
       path: $(HOMEPATH)/.gmt
       cacheHitVar: CACHE_CACHEDATA_RESTORED
     displayName: Cache GMT remote data for testing


### PR DESCRIPTION
**Description of proposed changes**

The earth relief data for GMT 6.0.0 was just changed back to gridline registration. It means that GMT<=6.0.0 uses gridline-registered earth relief data, while GMT>=6.1.0 will uses pixel-registered earth relief data by default.

Related to #451.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
