### PR TITLE
Fix several failures due to updates of earth relief data

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -111,7 +111,7 @@ class Session:
     ...             )
     ...             # Read the contents of the temp file before it's deleted.
     ...             print(fout.read().strip())
-    -180 180 -90 90 -8592.14453125 5558.79248047 1 1 361 181
+    -180 180 -90 90 -8592.5 5559 1 1 361 181
     """
 
     # The minimum version of GMT required
@@ -1225,7 +1225,7 @@ class Session:
         >>> print(data.lat.values.min(), data.lat.values.max())
         -90.0 90.0
         >>> print(data.values.min(), data.values.max())
-        -8592.145 5558.7925
+        -8592.5 5559.0
         >>> with Session() as ses:
         ...     with ses.virtualfile_from_grid(data) as fin:
         ...         # Send the output to a file so that we can read it
@@ -1233,7 +1233,7 @@ class Session:
         ...             args = '{} -L0 -Cn ->{}'.format(fin, fout.name)
         ...             ses.call_module('grdinfo', args)
         ...             print(fout.read().strip())
-        -180 180 -90 90 -8592.14453125 5558.79248047 1 1 361 181
+        -180 180 -90 90 -8592.5 5559 1 1 361 181
         >>> # The output is: w e s n z0 z1 dx dy n_columns n_rows
 
         """

--- a/pygmt/tests/test_datasets.py
+++ b/pygmt/tests/test_datasets.py
@@ -74,8 +74,8 @@ def test_earth_relief_01d():
     assert data.shape == (181, 361)
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -8592.144531)
-    npt.assert_allclose(data.max(), 5558.79248)
+    npt.assert_allclose(data.min(), -8592.5)
+    npt.assert_allclose(data.max(), 5559.0)
 
 
 def test_earth_relief_30m():
@@ -84,5 +84,5 @@ def test_earth_relief_30m():
     assert data.shape == (361, 721)
     npt.assert_allclose(data.lat, np.arange(-90, 90.5, 0.5))
     npt.assert_allclose(data.lon, np.arange(-180, 180.5, 0.5))
-    npt.assert_allclose(data.min(), -9460.310547)
-    npt.assert_allclose(data.max(), 5887.60791)
+    npt.assert_allclose(data.min(), -9460.5)
+    npt.assert_allclose(data.max(), 5887.5)

--- a/pygmt/tests/test_grdinfo.py
+++ b/pygmt/tests/test_grdinfo.py
@@ -13,13 +13,13 @@ def test_grdinfo():
     "Make sure grd info works as expected"
     grid = load_earth_relief()
     result = grdinfo(grid, L=0, C="n")
-    assert result.strip() == "-180 180 -90 90 -8592.14453125 5558.79248047 1 1 361 181"
+    assert result.strip() == "-180 180 -90 90 -8592.5 5559 1 1 361 181"
 
 
 def test_grdinfo_file():
     "Test grdinfo with file input"
     result = grdinfo("@earth_relief_01d", L=0, C="n")
-    assert result.strip() == "-180 180 -90 90 -8592.14465255 5558.79248047 1 1 361 181"
+    assert result.strip() == "-180 180 -90 90 -8592.5 5559 1 1 361 181"
 
 
 def test_grdinfo_fails():

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -28,7 +28,7 @@ def test_grdtrack_input_dataframe_and_dataarray():
     output = grdtrack(points=dataframe, grid=dataarray, newcolname="bathymetry")
     assert isinstance(output, pd.DataFrame)
     assert output.columns.to_list() == ["longitude", "latitude", "bathymetry"]
-    npt.assert_allclose(output.iloc[0], [-110.9536, -42.2489, -2797.497251])
+    npt.assert_allclose(output.iloc[0], [-110.9536, -42.2489, -2797.394987])
 
     return output
 
@@ -46,7 +46,7 @@ def test_grdtrack_input_csvfile_and_dataarray():
         assert os.path.exists(path=TEMP_TRACK)  # check that outfile exists at path
 
         track = pd.read_csv(TEMP_TRACK, sep="\t", header=None, comment=">")
-        npt.assert_allclose(track.iloc[0], [-110.9536, -42.2489, -2797.497251])
+        npt.assert_allclose(track.iloc[0], [-110.9536, -42.2489, -2797.394987])
     finally:
         os.remove(path=TEMP_TRACK)
 
@@ -63,7 +63,7 @@ def test_grdtrack_input_dataframe_and_ncfile():
     output = grdtrack(points=dataframe, grid=ncfile, newcolname="bathymetry")
     assert isinstance(output, pd.DataFrame)
     assert output.columns.to_list() == ["longitude", "latitude", "bathymetry"]
-    npt.assert_allclose(output.iloc[0], [-32.2971, 37.4118, -1686.878079])
+    npt.assert_allclose(output.iloc[0], [-32.2971, 37.4118, -1686.748899])
 
     return output
 
@@ -81,7 +81,7 @@ def test_grdtrack_input_csvfile_and_ncfile():
         assert os.path.exists(path=TEMP_TRACK)  # check that outfile exists at path
 
         track = pd.read_csv(TEMP_TRACK, sep="\t", header=None, comment=">")
-        npt.assert_allclose(track.iloc[0], [-32.2971, 37.4118, -1686.878079])
+        npt.assert_allclose(track.iloc[0], [-32.2971, 37.4118, -1686.748899])
     finally:
         os.remove(path=TEMP_TRACK)
 


### PR DESCRIPTION
**Description of proposed changes**

Update some numbers due to the recent changes in GMT earth relief data.

Partially address #451.

Note: For unknown reasons, the caches of the Azure Pipelines expire and there is always a cache miss. 
Each CI job will download the data files from the GMT data server. 

It seems the long-time internet connection issue in Azure Pipelines is gone, and all files are downloaded without timeouts.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
