### PR TITLE
Temporarily expect failures for some grdcontour and grdview tests

### DIFF
--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -2,11 +2,12 @@
 Test Figure.grdcontour
 """
 import os
+from packaging.version import Version
 
 import numpy as np
 import pytest
 
-from .. import Figure
+from .. import Figure, clib
 from ..exceptions import GMTInvalidInput
 from ..datasets import load_earth_relief
 
@@ -14,7 +15,14 @@ from ..datasets import load_earth_relief
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 TEST_CONTOUR_FILE = os.path.join(TEST_DATA_DIR, "contours.txt")
 
+with clib.Session() as lib:
+    gmt_version = Version(lib.info["version"])
 
+
+@pytest.mark.xfail(
+    condition=gmt_version < Version("6.1.0"),
+    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
+)
 @pytest.mark.mpl_image_compare
 def test_grdcontour():
     """Plot a contour image using an xarray grid
@@ -26,6 +34,10 @@ def test_grdcontour():
     return fig
 
 
+@pytest.mark.xfail(
+    condition=gmt_version < Version("6.1.0"),
+    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
+)
 @pytest.mark.mpl_image_compare
 def test_grdcontour_labels():
     """Plot a contour image using a xarray grid
@@ -44,6 +56,10 @@ def test_grdcontour_labels():
     return fig
 
 
+@pytest.mark.xfail(
+    condition=gmt_version < Version("6.1.0"),
+    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
+)
 @pytest.mark.mpl_image_compare
 def test_grdcontour_slice():
     "Plot an contour image using an xarray grid that has been sliced"
@@ -68,6 +84,10 @@ def test_grdcontour_file():
     return fig
 
 
+@pytest.mark.xfail(
+    condition=gmt_version < Version("6.1.0"),
+    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
+)
 @pytest.mark.mpl_image_compare
 def test_grdcontour_interval_file_full_opts():
     """ Plot based on external contour level file """

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -3,11 +3,15 @@
 Tests grdview
 """
 import pytest
+from packaging.version import Version
 
-from .. import Figure, which
+from .. import Figure, clib, which
 from ..datasets import load_earth_relief
 from ..exceptions import GMTInvalidInput
 from ..helpers import data_kind
+
+with clib.Session() as lib:
+    gmt_version = Version(lib.info["version"])
 
 
 @pytest.fixture(scope="module")
@@ -62,6 +66,10 @@ def test_grdview_with_perspective(grid):
     return fig
 
 
+@pytest.mark.xfail(
+    condition=gmt_version < Version("6.1.0"),
+    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
+)
 @pytest.mark.mpl_image_compare
 def test_grdview_with_perspective_and_zscale(grid):
     """
@@ -74,6 +82,10 @@ def test_grdview_with_perspective_and_zscale(grid):
     return fig
 
 
+@pytest.mark.xfail(
+    condition=gmt_version < Version("6.1.0"),
+    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
+)
 @pytest.mark.mpl_image_compare
 def test_grdview_with_perspective_and_zsize(grid):
     """
@@ -97,6 +109,10 @@ def test_grdview_with_cmap_for_image_plot(grid):
     return fig
 
 
+@pytest.mark.xfail(
+    condition=gmt_version < Version("6.1.0"),
+    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
+)
 @pytest.mark.mpl_image_compare
 def test_grdview_with_cmap_for_surface_monochrome_plot(grid):
     """
@@ -108,6 +124,10 @@ def test_grdview_with_cmap_for_surface_monochrome_plot(grid):
     return fig
 
 
+@pytest.mark.xfail(
+    condition=gmt_version < Version("6.1.0"),
+    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
+)
 @pytest.mark.mpl_image_compare
 def test_grdview_with_cmap_for_perspective_surface_plot(grid):
     """
@@ -116,11 +136,15 @@ def test_grdview_with_cmap_for_perspective_surface_plot(grid):
     """
     fig = Figure()
     fig.grdview(
-        grid=grid, cmap="oleron", surftype="s", perspective=[225, 30], zscale=0.005,
+        grid=grid, cmap="oleron", surftype="s", perspective=[225, 30], zscale=0.005
     )
     return fig
 
 
+@pytest.mark.xfail(
+    condition=gmt_version < Version("6.1.0"),
+    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
+)
 @pytest.mark.mpl_image_compare
 def test_grdview_on_a_plane(grid):
     """
@@ -132,6 +156,10 @@ def test_grdview_on_a_plane(grid):
     return fig
 
 
+@pytest.mark.xfail(
+    condition=gmt_version < Version("6.1.0"),
+    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
+)
 @pytest.mark.mpl_image_compare
 def test_grdview_on_a_plane_with_colored_frontal_facade(grid):
     """
@@ -143,6 +171,10 @@ def test_grdview_on_a_plane_with_colored_frontal_facade(grid):
     return fig
 
 
+@pytest.mark.xfail(
+    condition=gmt_version < Version("6.1.0"),
+    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
+)
 @pytest.mark.mpl_image_compare
 def test_grdview_with_perspective_and_zaxis_frame(grid):
     """
@@ -154,6 +186,10 @@ def test_grdview_with_perspective_and_zaxis_frame(grid):
     return fig
 
 
+@pytest.mark.xfail(
+    condition=gmt_version < Version("6.1.0"),
+    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
+)
 @pytest.mark.mpl_image_compare
 def test_grdview_surface_plot_styled_with_contourpen(grid):
     """
@@ -176,6 +212,10 @@ def test_grdview_surface_mesh_plot_styled_with_meshpen(grid):
     return fig
 
 
+@pytest.mark.xfail(
+    condition=gmt_version < Version("6.1.0"),
+    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
+)
 @pytest.mark.mpl_image_compare
 def test_grdview_on_a_plane_styled_with_facadepen(grid):
     """


### PR DESCRIPTION
**Description of proposed changes**

Until GMT 6.1.0 is released and we can update the baseline png images properly, use `pytest.mark.xfail` to temporarily bypass 13 test failures on `grdcontour` and `grdview`. Refer to https://docs.pytest.org/en/stable/skipping.html for pytest documentation on xfail/skipping tests.

This should allow us to merge PRs a bit more confidently by re-enabling the "Required" CI tests that were disabled. Note that the tests will fail when run on GMT master (i.e. GMT 6.1.0), and once we set a hard requirement on GMT 6.1.0 or newer, this workaround can be removed.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Partially addresses #451, see also #498

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
