### PR TITLE
Allow load_earth_relief() to load pixel or gridline registered data

### DIFF
--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -31,8 +31,9 @@ def load_earth_relief(resolution="01d", registration=None):
 
     registration : str
         Grid registration type. Either ``pixel`` for pixel registration or
-        ``gridline`` for gridline registration. Default is ``None``, which
-        returns a pixel registered grid.
+        ``gridline`` for gridline registration. Default is ``None``, where
+        a pixel-registered grid is returned unless only the
+        gridline-registered grid is available.
 
     Returns
     -------
@@ -44,19 +45,19 @@ def load_earth_relief(resolution="01d", registration=None):
     _is_valid_resolution(resolution)
 
     if registration in ("pixel", "gridline", None):
-        _registration = ""  # If None, let GMT decide on Pixel/Gridline type
+        reg = ""  # If None, let GMT decide on Pixel/Gridline type
         with clib.Session() as lib:
-            if registration is not None and Version(lib.info["version"]) >= Version(
-                "6.1.0"
-            ):
-                _registration = f"_{registration[0]}"
+            if registration and Version(lib.info["version"]) >= Version("6.1.0"):
+                reg = f"_{registration[0]}"
     else:
         raise GMTInvalidInput(
             f"Invalid grid registration: {registration}, should be either "
-            "'pixel', 'gridline' or None. Default is None for pixel registration."
+            "'pixel', 'gridline' or None. Default is None, where a "
+            "pixel-registered grid is returned unless only the "
+            "gridline-registered grid is available."
         )
 
-    fname = which(f"@earth_relief_{resolution}{_registration}", download="u")
+    fname = which(f"@earth_relief_{resolution}{reg}", download="u")
     grid = xr.open_dataarray(fname)
     # Add some metadata to the grid
     grid.name = "elevation"

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -32,8 +32,8 @@ def load_earth_relief(resolution="01d", pixel_reg=None):
     pixel_reg : bool
         Grid registration type. Either ``True`` for pixel registration or
         ``False`` for gridline registration. Default is ``None``, which returns
-        a pixel registered grid for GMT 6.1 or newer, and a gridline registered
-        grid for GMT 6.0.
+        a pixel registered grid for GMT 6.1 or newer. Only a gridline
+        registered grid is possible for GMT 6.0.
 
     Returns
     -------

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -49,6 +49,12 @@ def load_earth_relief(resolution="01d", registration=None):
         with clib.Session() as lib:
             if registration and Version(lib.info["version"]) >= Version("6.1.0"):
                 reg = f"_{registration[0]}"
+            elif registration == "pixel" and Version(lib.info["version"]) < Version(
+                "6.1.0"
+            ):
+                raise GMTInvalidInput(
+                    "Pixel registration is only available for GMT>=6.1.0"
+                )
     else:
         raise GMTInvalidInput(
             f"Invalid grid registration: {registration}, should be either "

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -46,7 +46,7 @@ def load_earth_relief(resolution="01d", pixel_reg=None):
 
     if not pixel_reg:
         registration = ""  # If None, let GMT decide on Pixel/Gridline type
-        # TODO simplify this if-then once PyGMT no longer depends on GMT 6.0
+        # Simplify this if-then clause once PyGMT no longer depends on GMT 6.0
         if pixel_reg is False:
             with clib.Session() as lib:
                 if Version(lib.info["version"]) >= Version("6.1.0"):

--- a/pygmt/tests/test_datasets.py
+++ b/pygmt/tests/test_datasets.py
@@ -70,7 +70,7 @@ def test_earth_relief_fails():
 # Only test 01d and 30m to avoid downloading large datasets in CI
 def test_earth_relief_01d():
     "Test some properties of the earth relief 01d data"
-    data = load_earth_relief(resolution="01d", pixel_reg=False)
+    data = load_earth_relief(resolution="01d", registration="gridline")
     assert data.shape == (181, 361)
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
@@ -80,9 +80,15 @@ def test_earth_relief_01d():
 
 def test_earth_relief_30m():
     "Test some properties of the earth relief 30m data"
-    data = load_earth_relief(resolution="30m", pixel_reg=False)
+    data = load_earth_relief(resolution="30m", registration="gridline")
     assert data.shape == (361, 721)
     npt.assert_allclose(data.lat, np.arange(-90, 90.5, 0.5))
     npt.assert_allclose(data.lon, np.arange(-180, 180.5, 0.5))
     npt.assert_allclose(data.min(), -9460.5)
     npt.assert_allclose(data.max(), 5887.5)
+
+
+def test_earth_relief_incorrect_registration():
+    "Test loading earth relief with incorrect registration type"
+    with pytest.raises(GMTInvalidInput):
+        load_earth_relief(registration="improper_type")

--- a/pygmt/tests/test_datasets.py
+++ b/pygmt/tests/test_datasets.py
@@ -70,7 +70,7 @@ def test_earth_relief_fails():
 # Only test 01d and 30m to avoid downloading large datasets in CI
 def test_earth_relief_01d():
     "Test some properties of the earth relief 01d data"
-    data = load_earth_relief(resolution="01d")
+    data = load_earth_relief(resolution="01d", pixel_reg=False)
     assert data.shape == (181, 361)
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
@@ -80,7 +80,7 @@ def test_earth_relief_01d():
 
 def test_earth_relief_30m():
     "Test some properties of the earth relief 30m data"
-    data = load_earth_relief(resolution="30m")
+    data = load_earth_relief(resolution="30m", pixel_reg=False)
     assert data.shape == (361, 721)
     npt.assert_allclose(data.lat, np.arange(-90, 90.5, 0.5))
     npt.assert_allclose(data.lon, np.arange(-180, 180.5, 0.5))

--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -19,8 +19,8 @@ with clib.Session() as lib:
     gmt_version = Version(lib.info["version"])
 
 
-@pytest.fixture(scope="module")
-def grid():
+@pytest.fixture(scope="module", name="grid")
+def fixture_grid():
     "Load the grid data from the sample earth_relief file"
     return load_earth_relief(pixel_reg=False)
 

--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -22,7 +22,7 @@ with clib.Session() as lib:
 @pytest.fixture(scope="module", name="grid")
 def fixture_grid():
     "Load the grid data from the sample earth_relief file"
-    return load_earth_relief(pixel_reg=False)
+    return load_earth_relief(registration="gridline")
 
 
 @pytest.mark.xfail(

--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -19,16 +19,21 @@ with clib.Session() as lib:
     gmt_version = Version(lib.info["version"])
 
 
+@pytest.fixture(scope="module")
+def grid():
+    "Load the grid data from the sample earth_relief file"
+    return load_earth_relief(pixel_reg=False)
+
+
 @pytest.mark.xfail(
     condition=gmt_version < Version("6.1.0"),
     reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
 )
 @pytest.mark.mpl_image_compare
-def test_grdcontour():
+def test_grdcontour(grid):
     """Plot a contour image using an xarray grid
     with fixed contour interval
     """
-    grid = load_earth_relief()
     fig = Figure()
     fig.grdcontour(grid, interval="1000", projection="W0/6i")
     return fig
@@ -39,11 +44,10 @@ def test_grdcontour():
     reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
 )
 @pytest.mark.mpl_image_compare
-def test_grdcontour_labels():
+def test_grdcontour_labels(grid):
     """Plot a contour image using a xarray grid
     with contour labels and alternate colors
     """
-    grid = load_earth_relief()
     fig = Figure()
     fig.grdcontour(
         grid,
@@ -61,11 +65,11 @@ def test_grdcontour_labels():
     reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
 )
 @pytest.mark.mpl_image_compare
-def test_grdcontour_slice():
+def test_grdcontour_slice(grid):
     "Plot an contour image using an xarray grid that has been sliced"
-    grid = load_earth_relief().sel(lat=slice(-30, 30))
+    grid_ = grid.sel(lat=slice(-30, 30))
     fig = Figure()
-    fig.grdcontour(grid, interval="1000", projection="M6i")
+    fig.grdcontour(grid_, interval="1000", projection="M6i")
     return fig
 
 

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -9,8 +9,8 @@ from ..exceptions import GMTInvalidInput
 from ..datasets import load_earth_relief
 
 
-@pytest.fixture(scope="module")
-def grid():
+@pytest.fixture(scope="module", name="grid")
+def fixture_grid():
     "Load the grid data from the sample earth_relief file"
     return load_earth_relief(pixel_reg=False)
 

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -9,21 +9,26 @@ from ..exceptions import GMTInvalidInput
 from ..datasets import load_earth_relief
 
 
+@pytest.fixture(scope="module")
+def grid():
+    "Load the grid data from the sample earth_relief file"
+    return load_earth_relief(pixel_reg=False)
+
+
 @pytest.mark.mpl_image_compare
-def test_grdimage():
+def test_grdimage(grid):
     "Plot an image using an xarray grid"
-    grid = load_earth_relief()
     fig = Figure()
     fig.grdimage(grid, cmap="earth", projection="W0/6i")
     return fig
 
 
 @pytest.mark.mpl_image_compare
-def test_grdimage_slice():
+def test_grdimage_slice(grid):
     "Plot an image using an xarray grid that has been sliced"
-    grid = load_earth_relief().sel(lat=slice(-30, 30))
+    grid_ = grid.sel(lat=slice(-30, 30))
     fig = Figure()
-    fig.grdimage(grid, cmap="earth", projection="M6i")
+    fig.grdimage(grid_, cmap="earth", projection="M6i")
     return fig
 
 

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -12,7 +12,7 @@ from ..datasets import load_earth_relief
 @pytest.fixture(scope="module", name="grid")
 def fixture_grid():
     "Load the grid data from the sample earth_relief file"
-    return load_earth_relief(pixel_reg=False)
+    return load_earth_relief(registration="gridline")
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_grdinfo.py
+++ b/pygmt/tests/test_grdinfo.py
@@ -11,7 +11,7 @@ from ..exceptions import GMTInvalidInput
 
 def test_grdinfo():
     "Make sure grd info works as expected"
-    grid = load_earth_relief(pixel_reg=False)
+    grid = load_earth_relief(registration="gridline")
     result = grdinfo(grid, L=0, C="n")
     assert result.strip() == "-180 180 -90 90 -8592.5 5559 1 1 361 181"
 

--- a/pygmt/tests/test_grdinfo.py
+++ b/pygmt/tests/test_grdinfo.py
@@ -11,7 +11,7 @@ from ..exceptions import GMTInvalidInput
 
 def test_grdinfo():
     "Make sure grd info works as expected"
-    grid = load_earth_relief()
+    grid = load_earth_relief(pixel_reg=False)
     result = grdinfo(grid, L=0, C="n")
     assert result.strip() == "-180 180 -90 90 -8592.5 5559 1 1 361 181"
 

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -20,7 +20,7 @@ TEMP_TRACK = os.path.join(TEST_DATA_DIR, "tmp_track.txt")
 @pytest.fixture(scope="module", name="dataarray")
 def fixture_dataarray():
     "Load the grid data from the sample earth_relief file"
-    return load_earth_relief(pixel_reg=False).sel(
+    return load_earth_relief(registration="gridline").sel(
         lat=slice(-49, -42), lon=slice(-118, -107)
     )
 

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -17,8 +17,8 @@ TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 TEMP_TRACK = os.path.join(TEST_DATA_DIR, "tmp_track.txt")
 
 
-@pytest.fixture(scope="module")
-def dataarray():
+@pytest.fixture(scope="module", name="dataarray")
+def fixture_dataarray():
     "Load the grid data from the sample earth_relief file"
     return load_earth_relief(pixel_reg=False).sel(
         lat=slice(-49, -42), lon=slice(-118, -107)

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -16,7 +16,7 @@ with clib.Session() as lib:
 @pytest.fixture(scope="module", name="grid")
 def fixture_grid():
     "Load the grid data from the sample earth_relief file"
-    return load_earth_relief(pixel_reg=False).sel(
+    return load_earth_relief(registration="gridline").sel(
         lat=slice(-49, -42), lon=slice(-118, -107)
     )
 

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -1,4 +1,3 @@
-# pylint: disable=redefined-outer-name
 """
 Tests grdview
 """
@@ -14,8 +13,8 @@ with clib.Session() as lib:
     gmt_version = Version(lib.info["version"])
 
 
-@pytest.fixture(scope="module")
-def grid():
+@pytest.fixture(scope="module", name="grid")
+def fixture_grid():
     "Load the grid data from the sample earth_relief file"
     return load_earth_relief(pixel_reg=False).sel(
         lat=slice(-49, -42), lon=slice(-118, -107)

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -17,7 +17,9 @@ with clib.Session() as lib:
 @pytest.fixture(scope="module")
 def grid():
     "Load the grid data from the sample earth_relief file"
-    return load_earth_relief().sel(lat=slice(-49, -42), lon=slice(-118, -107))
+    return load_earth_relief(pixel_reg=False).sel(
+        lat=slice(-49, -42), lon=slice(-118, -107)
+    )
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_makecpt.py
+++ b/pygmt/tests/test_makecpt.py
@@ -31,7 +31,7 @@ def region():
 @pytest.fixture(scope="module")
 def grid():
     "Load the grid data from the sample earth_relief file"
-    return load_earth_relief()
+    return load_earth_relief(pixel_reg=False)
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_makecpt.py
+++ b/pygmt/tests/test_makecpt.py
@@ -1,4 +1,3 @@
-# pylint: disable=redefined-outer-name
 """
 Tests for makecpt
 """
@@ -16,20 +15,20 @@ TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 POINTS_DATA = os.path.join(TEST_DATA_DIR, "points.txt")
 
 
-@pytest.fixture(scope="module")
-def points():
+@pytest.fixture(scope="module", name="points")
+def fixture_points():
     "Load the points data from the test file"
     return np.loadtxt(POINTS_DATA)
 
 
-@pytest.fixture(scope="module")
-def region():
+@pytest.fixture(scope="module", name="region")
+def fixture_region():
     "The data region"
     return [10, 70, -5, 10]
 
 
-@pytest.fixture(scope="module")
-def grid():
+@pytest.fixture(scope="module", name="grid")
+def fixture_grid():
     "Load the grid data from the sample earth_relief file"
     return load_earth_relief(pixel_reg=False)
 

--- a/pygmt/tests/test_makecpt.py
+++ b/pygmt/tests/test_makecpt.py
@@ -30,7 +30,7 @@ def fixture_region():
 @pytest.fixture(scope="module", name="grid")
 def fixture_grid():
     "Load the grid data from the sample earth_relief file"
-    return load_earth_relief(pixel_reg=False)
+    return load_earth_relief(registration="gridline")
 
 
 @pytest.mark.mpl_image_compare


### PR DESCRIPTION
**Description of proposed changes**

Somewhat backward compatible way of retrieving the `earth_relief` grids using GMT 6.0 or GMT 6.1. Tests on GMT 6.0 should still pass as usual in this PR, but there should be fewer failures on GMT 6.1 (except those due to the cpt change).

TODO:
- [x] Modify earth_relief.py to allow for getting pixel/gridline earth_relief grids (80170245ac2e781468dd52166a993ce9866faefe) **53** test failures on GMT 6.1
- [x] Change unit tests to use `load_earth_relief(pixel_reg=False)` (9a7491059906c7c37f4c352e7abfb16908119f1e) **39** test failures on GMT 6.1

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes (partially) #489


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
