### PR TITLE
Let pytest generate both HTML and XML coverage reports

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -69,7 +69,6 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac'
-  condition: False
 
   pool:
     vmImage: 'macOS-10.14'
@@ -159,7 +158,6 @@ jobs:
   - bash: |
       set -x -e
       source activate testing
-      coverage xml
       echo "Uploading coverage to Codecov"
       codecov -e PYTHON AGENT_OS
     env:
@@ -172,7 +170,6 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Windows'
-  condition: False
 
   pool:
     vmImage: 'vs2017-win2016'
@@ -249,8 +246,6 @@ jobs:
   - bash: |
       set -x -e
       source activate testing
-      coverage report -m
-      coverage xml
       codecov -e PYTHON AGENT_OS
     env:
       CODECOV_TOKEN: $(codecov.token)

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ MANIFEST
 .ipynb_checkpoints/
 .vscode/
 tmp-test-dir-with-unique-name/
+coverage.xml
 htmlcov
 build/
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,6 @@ script:
 # Things to do if the build is successful
 after_success:
     # Upload coverage information
-    - coverage xml
     - codecov -e PYTHON
 
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 # Build, package, test, and clean
 PROJECT=pygmt
 TESTDIR=tmp-test-dir-with-unique-name
-PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -v --mpl --mpl-results-path=results --pyargs ${PYTEST_EXTRA}
+PYTEST_ARGS=--cov=$(PROJECT) --cov-config=../.coveragerc \
+			--cov-report=term-missing --cov-report=xml --cov-report=html \
+			--doctest-modules -v --mpl --mpl-results-path=results \
+			--pyargs ${PYTEST_EXTRA}
 BLACK_FILES=$(PROJECT) setup.py doc/conf.py examples
 FLAKE8_FILES=$(PROJECT) setup.py
 LINT_FILES=$(PROJECT) setup.py
@@ -27,7 +30,8 @@ test:
 	@cd $(TESTDIR); python -c "import $(PROJECT); $(PROJECT).show_versions()"
 	@echo ""
 	cd $(TESTDIR); pytest $(PYTEST_ARGS) $(PROJECT)
-	cp $(TESTDIR)/.coverage* . && coverage html
+	cp $(TESTDIR)/coverage.xml .
+	cp -r $(TESTDIR)/htmlcov .
 	rm -r $(TESTDIR)
 
 format:
@@ -43,6 +47,6 @@ lint:
 clean:
 	find . -name "*.pyc" -exec rm -v {} \;
 	find . -name "*~" -exec rm -v {} \;
-	rm -rvf build dist MANIFEST *.egg-info __pycache__ .coverage .cache htmlcov
+	rm -rvf build dist MANIFEST *.egg-info __pycache__ .coverage .cache htmlcov coverage.xml
 	rm -rvf $(TESTDIR)
 	rm -rvf baseline


### PR DESCRIPTION
Let pytest generate coverage reports in both XML and HTML formats.
HTML version is useful for viewing reports locally, and XML version is for codecov.

If all tests pass, the XML and HTML coverage reports will be copied into
the root directory; otherwise, they will be in the tmp-test-dir-with-unique-name
directory.