### PR TITLE
Re-enable Windows builds

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -43,8 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        #os: [ubuntu-latest, macOS-latest, windows-latest]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
     # environmental variables used in coverage
     env:
       OS: ${{ matrix.os }}

--- a/pygmt/tests/test_image.py
+++ b/pygmt/tests/test_image.py
@@ -2,6 +2,7 @@
 Tests image.
 """
 import os
+import sys
 
 import pytest
 
@@ -11,6 +12,7 @@ from .. import Figure
 TEST_IMG = os.path.join(os.path.dirname(__file__), "baseline", "test_logo.png")
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="crashes on Windows")
 @pytest.mark.mpl_image_compare
 def test_image():
     "Place images on map"

--- a/pygmt/tests/test_image.py
+++ b/pygmt/tests/test_image.py
@@ -11,6 +11,7 @@ from .. import Figure
 TEST_IMG = os.path.join(os.path.dirname(__file__), "baseline", "test_logo.png")
 
 
+@pytest.mark.runfirst
 @pytest.mark.mpl_image_compare
 def test_image():
     "Place images on map"

--- a/pygmt/tests/test_image.py
+++ b/pygmt/tests/test_image.py
@@ -11,7 +11,6 @@ from .. import Figure
 TEST_IMG = os.path.join(os.path.dirname(__file__), "baseline", "test_logo.png")
 
 
-@pytest.mark.runfirst
 @pytest.mark.mpl_image_compare
 def test_image():
     "Place images on map"


### PR DESCRIPTION
**Description of proposed changes**

The test `test_image()` crashes on Windows. It's unclear to me why it fails, because it's a very simple test. 

This PR skips the test on Windows, and enables Windows builds.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
