### PR TITLE
Improve the cache step in GitHub Action

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -91,7 +91,7 @@ jobs:
           path: |
             ~/.gmt/cache
             ~/.gmt/server
-          key: cache-gmt-${{ runner.os }}-${{ github.ref }}-20200711
+          key: cache-gmt-${{ runner.os }}-${{ github.ref }}-20200715
           restore-keys: cache-gmt-${{ runner.os }}-refs/heads/master-
 
       # Workaround for the timeouts of 'gmt which' on Linux and Windows
@@ -99,14 +99,34 @@ jobs:
         shell: bash -l {0}
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then choco install wget; fi  # install wget on Windows
-          mkdir -p ~/.gmt ~/.gmt/cache ~/.gmt/server/earth/earth_relief/
-          wget --no-check-certificate https://oceania.generic-mapping-tools.org/gmt_hash_server.txt -P ~/.gmt/server/
-          for data in earth_relief_01d_p.grd earth_relief_01d_g.grd earth_relief_30m_p.grd earth_relief_30m_g.grd earth_relief_10m_p.grd earth_relief_10m_g.grd; do
-            wget --no-check-certificate https://oceania.generic-mapping-tools.org/server/earth/earth_relief/${data} -P ~/.gmt/server/earth/earth_relief/
+          GMT_DATA_SERVER=https://oceania.generic-mapping-tools.org
+          wget_input="wget_input.txt"
+          data="earth_relief_01d_p.grd earth_relief_01d_g.grd earth_relief_30m_p.grd earth_relief_30m_g.grd earth_relief_10m_p.grd earth_relief_10m_g.grd"
+          cache="ridge.txt Table_5_11.txt test.dat.nc tut_bathy.nc tut_quakes.ngdc tut_ship.xyz usgs_quakes_22.txt"
+
+          echo "${GMT_DATA_SERVER}/gmt_hash_server.txt" > $wget_input
+          echo "${GMT_DATA_SERVER}/gmt_data_server.txt" >> $wget_input
+          for file in $data; do
+            echo "${GMT_DATA_SERVER}/server/earth/earth_relief/$file" >> $wget_input
           done
-          for data in ridge.txt Table_5_11.txt test.dat.nc tut_bathy.nc tut_quakes.ngdc tut_ship.xyz usgs_quakes_22.txt; do
-            wget --no-check-certificate https://oceania.generic-mapping-tools.org/cache/${data} -P ~/.gmt/cache/
+          for file in $cache; do
+            echo "${GMT_DATA_SERVER}/cache/$file" >> $wget_input
           done
+
+          mkdir cachedir
+          wget --no-check-certificate -i $wget_input -P cachedir
+
+          mkdir -p ~/.gmt/cache ~/.gmt/server/earth/earth_relief
+          cd cachedir
+          mv gmt_hash_server.txt gmt_data_server.txt ~/.gmt/server/
+          for file in $data; do
+            mv $file ~/.gmt/server/earth/earth_relief/
+          done
+          for file in $cache; do
+            mv $file ~/.gmt/cache/
+          done
+          cd ..
+          rm -r cachedir $wget_input
         if: steps.cache.outputs.cache-hit != 'true' && runner.os != 'macOS'
 
       # Download remote files, if not already cached


### PR DESCRIPTION
Use one single `wget` command to download all cache files.

1. Create a list of files to download
2. Using one single wget command to download all files to cachedir
3. Move the downloaded files to the correct directories, overriding existing old files.

Fixes #523.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
