### PR TITLE
Fix the grdtrack example to avoid crashes on macOS

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -112,9 +112,9 @@ jobs:
         run: make test PYTEST_EXTRA="-r P"
 
       # Build the documentation
-      #- name: Build the documentation
-      #  shell: bash -l {0}
-      #  run: make -C doc clean all
+      - name: Build the documentation
+        shell: bash -l {0}
+        run: make -C doc clean all
 
       # Upload coverage to Codecov
       - name: Upload coverage to Codecov

--- a/examples/gallery/grid/track_sampling.py
+++ b/examples/gallery/grid/track_sampling.py
@@ -24,7 +24,7 @@ track = pygmt.grdtrack(points=points, grid=grid, newcolname="bathymetry")
 
 fig = pygmt.Figure()
 # Plot the earth relief grid on Cylindrical Stereographic projection, masking land areas
-fig.basemap(region="g", frame=True, projection="Cyl_stere/150/-20/8i")
+fig.basemap(region="d", frame=True, projection="Cyl_stere/8i")
 fig.grdimage(grid=grid, cmap="gray")
 fig.coast(land="#666666")
 # Plot using circles (c) of 0.15cm, the sampled bathymetry points


### PR DESCRIPTION
**Description of proposed changes**

grdimage doesn't always work well for xarray grids. It works for some projection parameters, but not others (also see #515). It possibly relates to an upstream GMT bug.

The grdtrack gallery examples gives the wrong result on Linux and crashes on macOS. This PR changes the `region` and `projection` parameters to make the example work on both Linux and macOS, so that the documentation can be built and show the correct image.

See https://pygmt-cvvmhke34.vercel.app/gallery/grid/track_sampling.html#sphx-glr-gallery-grid-track-sampling-py for the new output image.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
