### PR TITLE
WIP: Skip CI jobs if "[skip ci]" is in the commit message

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -1,4 +1,4 @@
-# This workflow installs PyGMT dependencies, build documentation and run tests
+# This workflow installs PyGMT dependencies, builds documentation, runs linters, and runs tests
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Tests
@@ -51,6 +51,10 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
 
     steps:
+      - name: Debug
+        run: |
+          echo "${{ toJson(github) }}"
+
       # Checkout current git repository
       - name: Checkout
         uses: actions/checkout@v2.3.1


### PR DESCRIPTION
**Description of proposed changes**

We don't run CI jobs for some tiny changes (e.g., typos). Like other CI services, if the commit message contains `[skip ci]`, then the CI jobs (testing) should be skipped.

~The solution comes from https://github.community/t/github-actions-does-not-respect-skip-ci/17325~.

The solution above doesn't work. Currently, the github action variable `github` doesn't contain the commit message anymore.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
