### PR TITLE
Improve the documentation of Figure.shift_origin()

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -298,7 +298,7 @@ class Figure(BasePlotting):
         Shift plot origin in x and/or y directions.
 
         This method shifts plot origin relative to the current origin by
-        (*xshift*,*yshift*) and optionally append the length unit (**c**,
+        (*xshift*, *yshift*) and optionally append the length unit (**c**,
         **i**, or **p**).
 
         Prepend **a** to shift the origin back to the original position after
@@ -308,7 +308,7 @@ class Figure(BasePlotting):
         move the origin relative to its current location.
 
         Detailed usage at
-        :gmt-docs:`GMT_Docs.html#plot-positioning-and-layout-the-x-y-options`
+        :gmt-docs:`cookbook/options.html#plot-positioning-and-layout-the-x-y-options`
 
         Parameters
         ----------
@@ -316,6 +316,12 @@ class Figure(BasePlotting):
             Shift plot origin in x direction.
         yshift : str
             Shift plot origin in y direction.
+
+        Notes
+        -----
+        This function can't be used as the first plotting function of
+        :meth:`pygmt.Figure`, since it relies the *region* and *projection*
+        settings from previous commands.
         """
         self._preprocess()
         args = ["-T"]

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -322,6 +322,8 @@ class Figure(BasePlotting):
         This function can't be used as the first plotting function of
         :meth:`pygmt.Figure`, since it relies the *region* and *projection*
         settings from previous commands.
+
+        .. TODO: Remove the notes when GMT 6.1.1 is released.
         """
         self._preprocess()
         args = ["-T"]

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -319,11 +319,11 @@ class Figure(BasePlotting):
 
         Notes
         -----
-        This function can't be used as the first plotting function of
-        :meth:`pygmt.Figure`, since it relies the *region* and *projection*
-        settings from previous commands.
+        For GMT 6.1.0, this function can't be used as the first plotting
+        function of :meth:`pygmt.Figure`, since it relies the *region* and
+        *projection* settings from previous commands.
 
-        .. TODO: Remove the notes when GMT 6.1.1 is released.
+        .. TODO: Remove the notes when PyGMT bumps to GMT>=6.1.1.
         """
         self._preprocess()
         args = ["-T"]


### PR DESCRIPTION
**Description of proposed changes**

- Fix a broken link
- Add a note that the function can't be used as the fisrt plotting command.

Address #514.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.