### PR TITLE
Raise an error if short- and long-form arguments coexist

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -180,8 +180,9 @@ def use_alias(**aliases):
     R = bla J = meh
     >>> my_module(region='bla', projection='meh')
     R = bla J = meh
-    >>> my_module(region='bla', projection='meh', J="bla")
-    # doctest: +NORMALIZE_WHITESPACE
+    >>> my_module(
+    ...    region='bla', projection='meh', J="bla"
+    ... )  # doctest: +NORMALIZE_WHITESPACE
     Traceback (most recent call last):
       ...
     pygmt.exceptions.GMTInvalidInput:

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -181,9 +181,11 @@ def use_alias(**aliases):
     >>> my_module(region='bla', projection='meh')
     R = bla J = meh
     >>> my_module(region='bla', projection='meh', J="bla")
+    # doctest: +NORMALIZE_WHITESPACE
     Traceback (most recent call last):
       ...
-    pygmt.exceptions.GMTInvalidInput: Arguments in short-form (J) and long-form (projection) can't coexist
+    pygmt.exceptions.GMTInvalidInput:
+        Arguments in short-form (J) and long-form (projection) can't coexist
     """
 
     def alias_decorator(module_func):

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -180,7 +180,10 @@ def use_alias(**aliases):
     R = bla J = meh
     >>> my_module(region='bla', projection='meh')
     R = bla J = meh
-
+    >>> my_module(region='bla', projection='meh', J="bla")
+    Traceback (most recent call last):
+      ...
+    pygmt.exceptions.GMTInvalidInput: Arguments in short-form (J) and long-form (projection) can't coexist
     """
 
     def alias_decorator(module_func):
@@ -194,6 +197,10 @@ def use_alias(**aliases):
             New module that parses and replaces the registered aliases.
             """
             for arg, alias in aliases.items():
+                if alias in kwargs and arg in kwargs:
+                    raise GMTInvalidInput(
+                        f"Arguments in short-form ({arg}) and long-form ({alias}) can't coexist"
+                    )
                 if alias in kwargs:
                     kwargs[arg] = kwargs.pop(alias)
             return module_func(*args, **kwargs)


### PR DESCRIPTION
**Description of proposed changes**

Raise an error if both short- and long-form arguments are used. Also add a doctest for it.

See #377 for the bug report. 

Fixes #377


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
