### PR TITLE
Ensure surface and grdcut loads GMTDataArray accessor info into xarray

### DIFF
--- a/pygmt/gridding.py
+++ b/pygmt/gridding.py
@@ -90,7 +90,7 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
         if outfile == tmpfile.name:  # if user did not set outfile, return DataArray
             with xr.open_dataarray(outfile) as dataarray:
                 result = dataarray.load()
-                result.gmt  # load GMTDataArray accessor information
+                _ = result.gmt  # load GMTDataArray accessor information
         elif outfile != tmpfile.name:  # if user sets an outfile, return None
             result = None
 

--- a/pygmt/gridding.py
+++ b/pygmt/gridding.py
@@ -90,6 +90,7 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
         if outfile == tmpfile.name:  # if user did not set outfile, return DataArray
             with xr.open_dataarray(outfile) as dataarray:
                 result = dataarray.load()
+                result.gmt  # load GMTDataArray accessor information
         elif outfile != tmpfile.name:  # if user sets an outfile, return None
             result = None
 

--- a/pygmt/gridops.py
+++ b/pygmt/gridops.py
@@ -113,6 +113,7 @@ def grdcut(grid, **kwargs):
         if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
             with xr.open_dataarray(outgrid) as dataarray:
                 result = dataarray.load()
+                result.gmt  # load GMTDataArray accessor information
         else:
             result = None  # if user sets an outgrid, return None
 

--- a/pygmt/gridops.py
+++ b/pygmt/gridops.py
@@ -113,7 +113,7 @@ def grdcut(grid, **kwargs):
         if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
             with xr.open_dataarray(outgrid) as dataarray:
                 result = dataarray.load()
-                result.gmt  # load GMTDataArray accessor information
+                _ = result.gmt  # load GMTDataArray accessor information
         else:
             result = None  # if user sets an outgrid, return None
 

--- a/pygmt/tests/test_grdcut.py
+++ b/pygmt/tests/test_grdcut.py
@@ -26,6 +26,8 @@ def test_grdcut_file_in_dataarray_out():
     "grdcut an input grid file, and output as DataArray"
     outgrid = grdcut("@earth_relief_01d", region="0/180/0/90")
     assert isinstance(outgrid, xr.DataArray)
+    assert outgrid.gmt.registration == 1  # Pixel registration
+    assert outgrid.gmt.gtype == 1  # Geographic type
     # check information of the output grid
     # the '@earth_relief_01d' is in pixel registration, so the grid range is
     # not exactly 0/180/0/90

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -23,6 +23,8 @@ def test_surface_input_file():
     fname = which("@tut_ship.xyz", download="c")
     output = surface(data=fname, spacing="5m", region=[245, 255, 20, 30])
     assert isinstance(output, xr.DataArray)
+    assert output.gmt.registration == 0  # Gridline registration
+    assert output.gmt.gtype == 0  # Cartesian type
     return output
 
 


### PR DESCRIPTION
**Description of proposed changes**

For modules like `surface` and `grdcut` that output an xarray.DataArray grid, we need to ensure that the registration and gtype information is loaded properly into the xarray.DataArray before the temporary netcdf file gets deleted.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #524 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
