### PR TITLE
Automatically cancel in-progress CI runs of old commits

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -50,6 +50,12 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
 
     steps:
+      # Cancel previous runs that are not completed
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
       # Checkout current git repository
       - name: Checkout
         uses: actions/checkout@v2.3.1

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -30,6 +30,12 @@ jobs:
         shell: bash -l {0}
 
     steps:
+      # Cancel previous runs that are not completed
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
       # Checkout current git repository
       - name: Checkout
         uses: actions/checkout@v2.3.1


### PR DESCRIPTION
**Description of proposed changes**

Add the [Cancel Workflow Action](https://github.com/styfle/cancel-workflow-action) action as the first step for testing.

When a new commit is pushed, the previous runs in the same PR will be cancelled. So we don't have to wait for too long time for the previous outdated CI jobs.

Fixes #543


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
