### PR TITLE
Fix the failing test test_config()

### DIFF
--- a/pygmt/tests/test_config.py
+++ b/pygmt/tests/test_config.py
@@ -6,17 +6,14 @@ import pytest
 from .. import Figure, config
 
 
-@pytest.mark.xfail(
-    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
-)
 @pytest.mark.mpl_image_compare
 def test_config():
     """
     Test if config works globally and locally.
     """
-    # Change global settings
-    config(FONT_ANNOT_PRIMARY="blue")
     fig = Figure()
+    # Change global settings of current figure
+    config(FONT_ANNOT_PRIMARY="blue")
     fig.basemap(
         region="0/10/0/10", projection="X10c/10c", frame=["af", '+t"Blue Annotation"']
     )
@@ -35,7 +32,7 @@ def test_config():
         frame=["af", '+t"Blue Annotation"'],
         X="15c",
     )
-    # Revert to default settings
+    # Revert to default settings in current figure
     config(FONT_ANNOT_PRIMARY="black")
     return fig
 


### PR DESCRIPTION
**Description of proposed changes**

The `test_config()` fails because `config(FONT_ANNOT_PRIMARY="blue")` before calling `pygmt.Figure()` changes the session settings or changes the settings of previous figure, depending on the execution order of the tests.

This PR moves the `config(FONT_ANNOT_PRIMARY="blue")` after `pygmt.Figure()` so we know that it only change the settings of current figure.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
