### PR TITLE
Add common alias verbose (V)

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -36,6 +36,18 @@ COMMON_OPTIONS = {
         color : str
             Select color or pattern for filling of symbols or polygons. Default
             is no fill.""",
+    "V": """\
+        verbose : str
+            Select verbosity level [Default is w], which modulates the messages
+            written to stderr. Choose among 7 levels of verbosity:
+
+            - **q** - Quiet, not even fatal error messages are produced
+            - **e** - Error messages only
+            - **w** - Warnings [Default]
+            - **t** - Timings (report runtimes for time-intensive algorthms);
+            - **i** - Informational messages (same as "verbose=True")
+            - **c** - Compatibility warnings
+            - **d** - Debugging messages""",
     "W": """\
         pen : str
             Set pen attributes for lines or the outline of symbols.""",


### PR DESCRIPTION
**Description of proposed changes**

Select verbosity level [Default is w], which modulates the messages written to stderr. See https://docs.generic-mapping-tools.org/6.1/gmt.html#v-full. Choose among 7 levels of verbosity:

- **q** - Quiet, not even fatal error messages are produced
- **e** - Error messages only
- **w** - Warnings [Default]
- **t** - Timings (report runtimes for time-intensive algorthms);
- **i** - Informational messages (same as "verbose=True")
- **c** - Compatibility warnings
- **d** - Debugging messages

Cherry-picked from #546.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
