### PR TITLE
Add common alias distcalc (j)

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -39,6 +39,20 @@ COMMON_OPTIONS = {
     "W": """\
         pen : str
             Set pen attributes for lines or the outline of symbols.""",
+    "j": """\
+        distcalc : str
+            ``e|f|g``.
+            Determine how spherical distances are calculated.
+
+            - **e** - Ellipsoidal (or geodesic) mode
+            - **f** - Flat Earth mode
+            - **g** - Great circle distance [Default]
+
+            All spherical distance calculations depend on the current ellipsoid
+            (PROJ_ELLIPSOID), the definition of the mean radius
+            (PROJ_MEAN_RADIUS), and the specification of latitude type
+            (PROJ_AUX_LATITUDE). Geodesic distance calculations is also
+            controlled by method (PROJ_GEODESIC).""",
     "n": """\
         interpolation : str
             ``[b|c|l|n][+a][+bBC][+c][+tthreshold]``


### PR DESCRIPTION
**Description of proposed changes**

Determine how spherical distances are calculated. See https://docs.generic-mapping-tools.org/6.1/gmt.html#distcalc-full.

- **e** - Ellipsoidal (or geodesic) mode
- **f** - Flat Earth mode
- **g** - Great circle distance [Default]

All spherical distance calculations depend on the current ellipsoid
(PROJ_ELLIPSOID), the definition of the mean radius
(PROJ_MEAN_RADIUS), and the specification of latitude type
(PROJ_AUX_LATITUDE). Geodesic distance calculations is also
controlled by method (PROJ_GEODESIC).

Cherry picked from #546.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
