### PR TITLE
Cleanup track files in test_x2sys_cross_input_two_filenames

### DIFF
--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -121,6 +121,7 @@ def test_x2sys_cross_input_two_filenames(mock_x2sys_home):
         columns = list(output.columns)
         assert columns[:6] == ["x", "y", "i_1", "i_2", "dist_1", "dist_2"]
         assert columns[6:] == ["head_1", "head_2", "vel_1", "vel_2", "z_X", "z_M"]
+        [os.remove(f) for f in ["track_0.xyz", "track_1.xyz"]]  # cleanup track files
 
     return output
 

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -121,7 +121,7 @@ def test_x2sys_cross_input_two_filenames(mock_x2sys_home):
         columns = list(output.columns)
         assert columns[:6] == ["x", "y", "i_1", "i_2", "dist_1", "dist_2"]
         assert columns[6:] == ["head_1", "head_2", "vel_1", "vel_2", "z_X", "z_M"]
-        [os.remove(f) for f in ["track_0.xyz", "track_1.xyz"]]  # cleanup track files
+        _ = [os.remove(f"track_{i}.xyz") for i in range(2)]  # cleanup track files
 
     return output
 


### PR DESCRIPTION
**Description of proposed changes**

The `track_0.xyz` and `track_1.xyz` input test files were not removed after `test_x2sys_cross_input_two_filenames`.  Addresses https://github.com/GenericMappingTools/pygmt/pull/546#discussion_r461321393.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
