### PR TITLE
Update the path to the GMT build script

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -56,7 +56,7 @@ jobs:
 
       # Install GMT master branch
       - name: Install GMT from master
-        run: curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/build-gmt-master.sh | bash
+        run: curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/build-gmt.sh | bash
 
       # Download cached remote files (artifacts) from Github
       - name: Download remote data from Github


### PR DESCRIPTION
**Description of proposed changes**

The GMT build script `build-gmt-master.sh` was renamed to
`build-gmt.sh` in PR https://github.com/GenericMappingTools/gmt/pull/3841.

This PR updates the file path.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.