### PR TITLE
Fix a failing test due to GMT API change

### DIFF
--- a/pygmt/tests/test_clib_put_matrix.py
+++ b/pygmt/tests/test_clib_put_matrix.py
@@ -76,7 +76,7 @@ def test_put_matrix_grid():
             with GMTTempFile() as tmp_file:
                 lib.write_data(
                     "GMT_IS_MATRIX",
-                    "GMT_IS_SURFACE",
+                    "GMT_IS_POINT",
                     "GMT_CONTAINER_AND_DATA",
                     wesn,
                     tmp_file.name,


### PR DESCRIPTION
**Description of proposed changes**

The test `test_put_matrix_grid` fails with GMT latest due to recent changes of GMT API
in https://github.com/GenericMappingTools/gmt/pull/3848.

Before this PR, for a matrix grid, calling GMT_Write_Data always writes
the matrix grid as a matrix, no matter the geometry is `GMT_IS_POINT` or
`GMT_IS_SURFACE`.

This PR declares it as a bug (or an improvement). With that PR merged,
`geometry=GMT_IS_POINT` writes the matrix as a table, `geometry=GMT_IS_SURFACE`
writes the matrix grid as a netCDF file.

This test expects a matrix, but the new API writes a netCDF grid.
That's why it fails.

This PR fixes the issue by simply changing `GMT_IS_SURFACE` to
`GMT_IS_POINT`, so that the test can pass for GMT 6.1.0, 6.1 and master
branches.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.