### PR TITLE
Allow datetime inputs to region argument

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -359,9 +359,13 @@ def kwargs_to_strings(convert_bools=True, **conversions):
                     if issequence and is_nonstr_iter(value):
                         for index, item in enumerate(value):
                             try:
+                                # check if there is a space " " when converting
+                                # a pandas.Timestamp/xr.DataArray to a string.
+                                # If so, use np.datetime_as_string instead.
                                 assert " " not in str(item)
                             except AssertionError:
-                                # convert datetime-like items to string format
+                                # convert datetime-like item to ISO 8601
+                                # string format like YYYY-MM-DDThh:mm:ss.ffffff
                                 value[index] = np.datetime_as_string(
                                     np.asarray(item, dtype=np.datetime64)
                                 )

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -8,6 +8,8 @@ etc.
 import textwrap
 import functools
 
+import numpy as np
+
 from .utils import is_nonstr_iter
 from ..exceptions import GMTInvalidInput
 
@@ -302,6 +304,23 @@ def kwargs_to_strings(convert_bools=True, **conversions):
     >>> module(123, bla=(1, 2, 3), foo=True, A=False, i=(5, 6))
     {'bla': (1, 2, 3), 'foo': '', 'i': '5,6'}
     args: 123
+    >>> import datetime
+    >>> module(
+    ...     R=[
+    ...         np.datetime64("2010-01-01T16:00:00"),
+    ...         datetime.datetime(2020, 1, 1, 12, 23, 45),
+    ...     ]
+    ... )
+    {'R': '2010-01-01T16:00:00/2020-01-01T12:23:45.000000'}
+    >>> import pandas as pd
+    >>> import xarray as xr
+    >>> module(
+    ...     R=[
+    ...         xr.DataArray(data=np.datetime64("2005-01-01T08:00:00")),
+    ...         pd.Timestamp("2015-01-01T12:00:00.123456789"),
+    ...     ]
+    ... )
+    {'R': '2005-01-01T08:00:00.000000000/2015-01-01T12:00:00.123456'}
 
     """
     valid_conversions = [
@@ -338,9 +357,15 @@ def kwargs_to_strings(convert_bools=True, **conversions):
                     value = kwargs[arg]
                     issequence = fmt in separators
                     if issequence and is_nonstr_iter(value):
-                        kwargs[arg] = separators[fmt].join(
-                            "{}".format(item) for item in value
-                        )
+                        for index, item in enumerate(value):
+                            try:
+                                assert " " not in str(item)
+                            except AssertionError:
+                                # convert datetime-like items to string format
+                                value[index] = np.datetime_as_string(
+                                    np.asarray(item, dtype=np.datetime64)
+                                )
+                        kwargs[arg] = separators[fmt].join(f"{item}" for item in value)
             # Execute the original function and return its output
             return module_func(*args, **kwargs)
 

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -294,7 +294,16 @@ def test_plot_scalar_xy():
 def test_plot_datetime():
     """Test various datetime input data"""
     fig = Figure()
-    fig.basemap(projection="X15c/5c", region="2010-01-01/2020-01-01/0/10", frame=True)
+    fig.basemap(
+        projection="X15c/5c",
+        region=[
+            np.array("2010-01-01T00:00:00", dtype=np.datetime64),
+            pd.Timestamp("2020-01-01"),
+            0,
+            10,
+        ],
+        frame=True,
+    )
 
     # numpy.datetime64 types
     x = np.array(


### PR DESCRIPTION
**Description of proposed changes**

Allow users to pass in datetime-like inputs to the 'region' argument in modules like `plot`, `basemap`, and so on. Helpful for people who usually just want to use something like `region = [data.min(), data.max(), ...]`.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->


Includes support for:

- [x] Python's [built-in datetime and date](https://docs.python.org/3/library/datetime.html)
- [x] [numpy.datetime64](https://numpy.org/doc/stable/reference/arrays.datetime.html)
- [x] [pandas.Timestamp](https://pandas.pydata.org/docs/reference/api/pandas.Timestamp.html)
- [x] [xarray.DataArray](http://xarray.pydata.org/en/v0.16.0/generated/xarray.DataArray.html#xarray.DataArray) with 'datetime64' dtype

What is not supported:

- Raw datetime strings in non-ISO format, e.g.,  `1/1/2018`, `Jul 5, 2019`

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #561


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
