### PR TITLE
Eliminate unnecessary jobs from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,14 +33,6 @@ env:
 jobs:
     # Build under the following configurations
     include:
-        - name: "Linux - Python 3.8"
-          os: linux
-          env:
-              - PYTHON=3.8
-        - name: "Linux - Python 3.7"
-          os: linux
-          env:
-              - PYTHON=3.7
         - name: "Linux - Python 3.6 (deploy)"
           os: linux
           env:
@@ -66,11 +58,6 @@ script:
     - make test PYTEST_EXTRA="-r P"
     # Build the documentation
     - make -C doc all
-
-# Things to do if the build is successful
-after_success:
-    # Upload coverage information
-    - codecov -e PYTHON
 
 deploy:
     # Make a release on PyPI


### PR DESCRIPTION
We already have full tests (Python 3.6-3.8 on Linux, macOS and Windows)
running on GitHub Actions. No need to waste CI resources on Travis.

Address #566.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.