### PR TITLE
Fix pylint 2.6.0 raise-missing-from warning

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -725,10 +725,10 @@ class Session:
             try:
                 # Try to convert any unknown numpy data types to np.datetime64
                 array = np.asarray(array, dtype=np.datetime64)
-            except ValueError:
+            except ValueError as e:
                 raise GMTInvalidInput(
-                    "Unsupported numpy data type '{}'.".format(array.dtype.type)
-                )
+                    f"Unsupported numpy data type '{array.dtype.type}'."
+                ) from e
         return self[DTYPES[array.dtype.type]]
 
     def put_vector(self, dataset, column, vector):


### PR DESCRIPTION
**Description of proposed changes**

Fixes failing style checks due to `pylint` 2.6.0 adding a new "raise-missing-from" check for exceptions that should have a cause. The try-except cause needs to be re-written as:

```python
try:
    # do something
except Error as e:
    raise GMTInvalidInput("some better error message") from e
```

See also:
- https://docs.pylint.org/en/latest/whatsnew/2.6.html#new-checkers
- [PEP 3134 -- Exception Chaining and Embedded Tracebacks](https://www.python.org/dev/peps/pep-3134/)
- https://blog.ram.rachum.com/post/621791438475296768/improving-python-exception-chaining-with

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
