### PR TITLE
Black lint to remove unneeded commas

### DIFF
--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -1013,7 +1013,7 @@ class BasePlotting:
 
     @fmt_docstring
     @use_alias(R="region", J="projection", B="frame", C="offset")
-    @kwargs_to_strings(R="sequence",)
+    @kwargs_to_strings(R="sequence")
     def meca(
         self,
         spec,

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1065,7 +1065,7 @@ class Session:
         family_int = self._parse_constant(family, valid=FAMILIES, valid_modifiers=VIAS)
         geometry_int = self._parse_constant(geometry, valid=GEOMETRIES)
         direction_int = self._parse_constant(
-            direction, valid=["GMT_IN", "GMT_OUT"], valid_modifiers=METHODS,
+            direction, valid=["GMT_IN", "GMT_OUT"], valid_modifiers=METHODS
         )
 
         buff = ctp.create_string_buffer(self["GMT_VF_LEN"])

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -25,7 +25,7 @@ def fixture_dataarray():
     )
 
 
-@pytest.mark.xfail(reason="The reason why it fails is unclear now",)
+@pytest.mark.xfail(reason="The reason why it fails is unclear now")
 def test_grdtrack_input_dataframe_and_dataarray(dataarray):
     """
     Run grdtrack by passing in a pandas.DataFrame and xarray.DataArray as
@@ -41,7 +41,7 @@ def test_grdtrack_input_dataframe_and_dataarray(dataarray):
     return output
 
 
-@pytest.mark.xfail(reason="The reason why it fails is unclear now",)
+@pytest.mark.xfail(reason="The reason why it fails is unclear now")
 def test_grdtrack_input_csvfile_and_dataarray(dataarray):
     """
     Run grdtrack by passing in a csvfile and xarray.DataArray as inputs

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -8,7 +8,7 @@ from ..clib import Session
 
 
 def test_begin_end():
-    """"
+    """
     Run a command inside a begin-end modern mode block.
     First, end the global session. When finished, restart it.
     """


### PR DESCRIPTION
**Description of proposed changes**

Yet another Style Check fix. [Black v20.8b0 (released on 2020-08-27)](https://pypi.org/project/black/20.8b0/) (and newer) treats trailing commas as a signal to split the code onto a newline. E.g.:

```python
somefunction(A="abc",)
```
would reformat to:
```python
somefunction(
    A="abc",
)
```
And this causes the Style Checks test to fail (see https://github.com/GenericMappingTools/pygmt/runs/1033691109?check_suite_focus=true). Note that I had to explicitly use `pip install --upgrade black` to get this new version, as the conda-forge [`black-feedstock`](https://github.com/conda-forge/black-feedstock) still uses `black=19.10b0`.


See also:
- https://github.com/psf/black/blob/master/CHANGES.md#208b0
- https://github.com/psf/black/issues/1288

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
