### PR TITLE
Bump the required minimum GMT version to 6.1.1

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -23,7 +23,7 @@ jobs:
       # Install GMT
       - name: Install GMT
         shell: bash -l {0}
-        run: conda install -c conda-forge gmt=6.1.0
+        run: conda install -c conda-forge gmt=6.1.1
 
       # Download remote files
       - name: Download remote data

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -77,7 +77,7 @@ jobs:
           requirements_file=full-conda-requirements.txt
           cat requirements.txt requirements-dev.txt > $requirements_file
           cat << EOF >> $requirements_file
-          gmt=6.1.0
+          gmt=6.1.1
           make
           codecov
           EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
         # The file with the listed requirements to be installed by conda
         - CONDA_REQUIREMENTS=requirements.txt
         - CONDA_REQUIREMENTS_DEV=requirements-dev.txt
-        - CONDA_INSTALL_EXTRA="codecov twine gmt=6.1.0"
+        - CONDA_INSTALL_EXTRA="codecov twine gmt=6.1.1"
         # These variables control which actions are performed in a build
         - DEPLOY=false
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -31,7 +31,7 @@ Which GMT?
 PyGMT requires Generic Mapping Tools (GMT) version 6 as a minimum, which is the latest
 released version that can be found at
 the `GMT official site <https://www.generic-mapping-tools.org>`__.
-We need the latest GMT (>=6.1.0) since there are many changes being made to GMT itself in
+We need the latest GMT (>=6.1.1) since there are many changes being made to GMT itself in
 response to the development of PyGMT, mainly the new
 `modern execution mode <https://docs.generic-mapping-tools.org/latest/cookbook/introduction.html#modern-and-classic-mode>`__.
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
     - python=3.7
     - pip
-    - gmt=6.1.0
+    - gmt=6.1.1
     - numpy
     - pandas
     - xarray

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build:miniconda": "curl -o ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash ~/miniconda.sh -b -p $HOME/miniconda",
-    "build:pygmt": "conda env create -f environment.yml && source activate pygmt && conda install -c conda-forge -y gmt==6.1.0 && make install",
+    "build:pygmt": "conda env create -f environment.yml && source activate pygmt && conda install -c conda-forge -y gmt==6.1.1 && make install",
     "build:docs": "source activate pygmt && cd doc && make all && mv _build/html ../public",
     "build": "export PATH=$HOME/miniconda/bin:$PATH && npm run build:miniconda && npm run build:pygmt && npm run build:docs"
   }

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -119,7 +119,7 @@ class Session:
     """
 
     # The minimum version of GMT required
-    required_version = "6.1.0"
+    required_version = "6.1.1"
 
     @property
     def session_pointer(self):

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -316,14 +316,6 @@ class Figure(BasePlotting):
             Shift plot origin in x direction.
         yshift : str
             Shift plot origin in y direction.
-
-        Notes
-        -----
-        For GMT 6.1.0, this function can't be used as the first plotting
-        function of :meth:`pygmt.Figure`, since it relies the *region* and
-        *projection* settings from previous commands.
-
-        .. TODO: Remove the notes when PyGMT bumps to GMT>=6.1.1.
         """
         self._preprocess()
         args = ["-T"]

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -402,10 +402,6 @@ def test_virtualfile_from_vectors():
             assert output == expected
 
 
-@pytest.mark.xfail(
-    condition=gmt_version < Version("6.1.1"),
-    reason="GMT_Put_Strings only works for GMT 6.1.1 and above",
-)
 def test_virtualfile_from_vectors_one_string_column():
     "Test passing in one column with string dtype into virtual file dataset"
     size = 5
@@ -421,10 +417,6 @@ def test_virtualfile_from_vectors_one_string_column():
         assert output == expected
 
 
-@pytest.mark.xfail(
-    condition=gmt_version < Version("6.1.1"),
-    reason="GMT_Put_Strings only works for GMT 6.1.1 and above",
-)
 def test_virtualfile_from_vectors_two_string_columns():
     "Test passing in two columns of string dtype into virtual file dataset"
     size = 5
@@ -688,7 +680,7 @@ def test_get_default():
     with clib.Session() as lib:
         assert lib.get_default("API_GRID_LAYOUT") in ["rows", "columns"]
         assert int(lib.get_default("API_CORES")) >= 1
-        assert Version(lib.get_default("API_VERSION")) >= Version("6.1.0")
+        assert Version(lib.get_default("API_VERSION")) >= Version("6.1.1")
 
 
 def test_get_default_fails():

--- a/pygmt/tests/test_clib_put_strings.py
+++ b/pygmt/tests/test_clib_put_strings.py
@@ -14,10 +14,6 @@ with clib.Session() as _lib:
     gmt_version = Version(_lib.info["version"])
 
 
-@pytest.mark.xfail(
-    condition=gmt_version < Version("6.1.1"),
-    reason="GMT_Put_Strings only works for GMT 6.1.1 and above",
-)
 def test_put_strings():
     "Check that assigning a numpy array of dtype str to a dataset works"
     with clib.Session() as lib:


### PR DESCRIPTION
**Description of proposed changes**

Bumps [gmt](https://github.com/GenericMappingTools/gmt) from 6.1.0 to 6.1.1.
  - [Release notes](https://github.com/GenericMappingTools/gmt/releases)
  - [Commits](https://github.com/GenericMappingTools/gmt/compare/6.1.0...6.1.1)

TODO:
- [x] Bump the required minimum GMT version to 6.1.1
- [x] Remove pytest xfails that were set to previous 6.1.0 version
- [ ] Remove compatibility codes for GMT 6.1.0 (if any)
- [ ] etc

Issues marked [upstream](https://github.com/GenericMappingTools/pygmt/labels/upstream) that are resolved in GMT 6.1.1 will be handled in separate Pull Requests.

Supersedes #507

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
