### PR TITLE
Add a test to make sure shift_origin does not crash

### DIFF
--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -121,6 +121,9 @@ def test_figure_show():
 def test_shift_origin():
     "Test if fig.shift_origin works"
     fig = Figure()
+    # First call shift_origin without -J & -R.
+    # Test the issue https://github.com/GenericMappingTools/pygmt/issues/514
+    fig.shift_origin(xshift="2i", yshift="3i")
     fig.basemap(R="10/70/-300/300", J="X3i/5i", B="af")
     fig.shift_origin(xshift="4i")
     fig.basemap(R="10/70/-300/300", J="X3i/5i", B="af")

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -48,7 +48,7 @@ def test_figure_region_country_codes():
 def test_figure_savefig_exists():
     "Make sure the saved figure has the right name"
     fig = Figure()
-    fig.basemap(region="10/70/-300/800", J="X3i/5i", B="af")
+    fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
     prefix = "test_figure_savefig_exists"
     for fmt in "png pdf jpg bmp eps tif".split():
         fname = ".".join([prefix, fmt])
@@ -60,7 +60,7 @@ def test_figure_savefig_exists():
 def test_figure_savefig_transparent():
     "Check if fails when transparency is not supported"
     fig = Figure()
-    fig.basemap(region="10/70/-300/800", J="X3i/5i", B="af")
+    fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
     prefix = "test_figure_savefig_transparent"
     for fmt in "pdf jpg bmp eps tif".split():
         fname = ".".join([prefix, fmt])
@@ -112,7 +112,7 @@ def test_figure_savefig():
 def test_figure_show():
     "Test that show creates the correct file name and deletes the temp dir"
     fig = Figure()
-    fig.basemap(R="10/70/-300/800", J="X3i/5i", B="af")
+    fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
     img = fig.show(width=800)
     assert img.width == 800
 
@@ -121,14 +121,14 @@ def test_figure_show():
 def test_shift_origin():
     "Test if fig.shift_origin works"
     fig = Figure()
-    # First call shift_origin without -J & -R.
+    # First call shift_origin without projection and region.
     # Test the issue https://github.com/GenericMappingTools/pygmt/issues/514
     fig.shift_origin(xshift="2i", yshift="3i")
-    fig.basemap(R="10/70/-300/300", J="X3i/5i", B="af")
+    fig.basemap(region="10/70/-300/300", projection="X3i/5i", frame="af")
     fig.shift_origin(xshift="4i")
-    fig.basemap(R="10/70/-300/300", J="X3i/5i", B="af")
+    fig.basemap(region="10/70/-300/300", projection="X3i/5i", frame="af")
     fig.shift_origin(yshift="6i")
-    fig.basemap(R="10/70/-300/300", J="X3i/5i", B="af")
+    fig.basemap(region="10/70/-300/300", projection="X3i/5i", frame="af")
     fig.shift_origin(xshift="-4i", yshift="6i")
-    fig.basemap(R="10/70/-300/300", J="X3i/5i", B="af")
+    fig.basemap(region="10/70/-300/300", projection="X3i/5i", frame="af")
     return fig


### PR DESCRIPTION
**Description of proposed changes**

Call `shift_origin()` before setting **-J** and **-R**. It crashes for GMT<=6.1.0,
but works after GMT>=6.1.1.

Closes #514.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.