### PR TITLE
Add a test for xarray shading

### DIFF
--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -75,22 +75,18 @@ def test_grdimage_xarray_shading(grid, fig_ref, fig_test):
     Test that shading works well for xarray.
     See https://github.com/GenericMappingTools/pygmt/issues/364
     """
-    fig_ref.grdimage(
-        "@earth_relief_01d_g",
+    fig_ref, fig_test = Figure(), Figure()
+    kwargs = dict(
         region=[-180, 180, -90, 90],
         frame=True,
         projection="Cyl_stere/6i",
         cmap="geo",
         shading=True,
     )
-    fig_test.grdimage(
-        grid,
-        region=[-180, 180, -90, 90],
-        frame=True,
-        projection="Cyl_stere/6i",
-        cmap="geo",
-        shading=True,
-    )
+
+    fig_ref.grdimage("@earth_relief_01d_g", **kwargs)
+    fig_test.grdimage(grid, **kwargs)
+    return fig_ref, fig_test
 
 
 def test_grdimage_fails():

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -69,6 +69,7 @@ def test_grdimage_file():
     return fig
 
 
+@pytest.mark.xfail(reason="Upstream bug in GMT 6.1.1")
 @check_figures_equal()
 def test_grdimage_xarray_shading(grid, fig_ref, fig_test):
     """

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -69,6 +69,30 @@ def test_grdimage_file():
     return fig
 
 
+@check_figures_equal()
+def test_grdimage_xarray_shading(grid, fig_ref, fig_test):
+    """
+    Test that shading works well for xarray.
+    See https://github.com/GenericMappingTools/pygmt/issues/364
+    """
+    fig_ref.grdimage(
+        "@earth_relief_01d_g",
+        region=[-180, 180, -90, 90],
+        frame=True,
+        projection="Cyl_stere/6i",
+        cmap="geo",
+        shading=True,
+    )
+    fig_test.grdimage(
+        grid,
+        region=[-180, 180, -90, 90],
+        frame=True,
+        projection="Cyl_stere/6i",
+        cmap="geo",
+        shading=True,
+    )
+
+
 def test_grdimage_fails():
     "Should fail for unrecognized input"
     fig = Figure()


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a test checking if grid shading works for xarray.

It may work for GMT 6.1.0, but unfortunately, it doesn't work for GMT 6.1.1.

Tried to address #364 but failed.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.