### PR TITLE
Add a test for Session.write_data() writing netCDF grids

### DIFF
--- a/pygmt/tests/test_clib_put_matrix.py
+++ b/pygmt/tests/test_clib_put_matrix.py
@@ -56,7 +56,7 @@ def test_put_matrix_fails():
 
 
 def test_put_matrix_grid():
-    "Check that assigning a numpy 2d array to a grid works"
+    "Check that assigning a numpy 2d array to an ASCII and NetCDF grid works"
     dtypes = "float32 float64 int32 int64 uint32 uint64".split()
     wesn = [10, 15, 30, 40, 0, 0]
     inc = [1, 1]
@@ -87,7 +87,7 @@ def test_put_matrix_grid():
                 newdata = tmp_file.loadtxt(dtype=dtype)
                 npt.assert_allclose(newdata, data)
 
-            # Save the data to a netCDF grid and check
+            # Save the data to a netCDF grid and check that xarray can load it
             with GMTTempFile() as tmp_grid:
                 lib.write_data(
                     "GMT_IS_MATRIX",


### PR DESCRIPTION
**Description of proposed changes**

`write_data()` can write a netCDF grid since GMT 6.1.1, if `geometry` is
`GMT_IS_SURFACE`.

This PR adds a test to make sure `write_data()` works as expected.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #557.

**Reminders**

- [X] Run `make format` and `make check` to make sure the code follows the style guide.
- [X] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.