### PR TITLE
Revert plotting across dateline workarounds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,7 @@ test:
 	@echo ""
 	@cd $(TESTDIR); python -c "import $(PROJECT); $(PROJECT).show_versions()"
 	@echo ""
-	# There are two steps to the test here because `test_grdimage_over_dateline`
-	# passes only when it runs before the other tests.
-	# See also https://github.com/GenericMappingTools/pygmt/pull/476
-	cd $(TESTDIR); pytest -m runfirst $(PYTEST_ARGS) $(PROJECT)
-	cd $(TESTDIR); pytest -m 'not runfirst' $(PYTEST_ARGS) $(PROJECT)
+	cd $(TESTDIR); pytest $(PYTEST_ARGS) $(PROJECT)
 	cp $(TESTDIR)/coverage.xml .
 	cp -r $(TESTDIR)/htmlcov .
 	rm -r $(TESTDIR)

--- a/examples/gallery/grid/track_sampling.py
+++ b/examples/gallery/grid/track_sampling.py
@@ -24,7 +24,7 @@ track = pygmt.grdtrack(points=points, grid=grid, newcolname="bathymetry")
 
 fig = pygmt.Figure()
 # Plot the earth relief grid on Cylindrical Stereographic projection, masking land areas
-fig.basemap(region="d", frame=True, projection="Cyl_stere/8i")
+fig.basemap(region="g", frame=True, projection="Cyl_stere/150/-20/8i")
 fig.grdimage(grid=grid, cmap="gray")
 fig.coast(land="#666666")
 # Plot using circles (c) of 0.15cm, the sampled bathymetry points

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -76,10 +76,6 @@ def test_grdimage_fails():
         fig.grdimage(np.arange(20).reshape((4, 5)))
 
 
-# This test needs to run first before the other tests (on Linux at least) so
-# that a black image isn't plotted due to an `inf` value when resampling.
-# See also https://github.com/GenericMappingTools/pygmt/pull/476
-@pytest.mark.runfirst
 @pytest.mark.mpl_image_compare
 def test_grdimage_over_dateline(xrgrid):
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,3 @@ max-line-length = 88
 max-doc-length = 79
 exclude =
     pygmt/_version.py
-
-[tool:pytest]
-markers =
-    mpl_image_compare: compare generated plots with correct baseline version
-    runfirst: runs the test(s) first before the other ones


### PR DESCRIPTION
**Description of proposed changes**

Remove some workarounds that were added because plotting grids across the dateline would crash, not needed since we've bumped the minimum required GMT version to 6.1.1 at #577. These are cherrypicked commits from #560 to keep diff small. Specifically, this PR will:

- Remove the `runfirst` workaround added in #476, so there won't be a two-step `make test` in our Makefile anymore
- Remove grdtrack gallery example workaround (due to a segfault crash) added in #531.
- Unregister setup.cfg pytest markers `runfirst`, and also 'mpl_image_compare` added in #323 (since the issue has been fixed upstream at https://github.com/matplotlib/pytest-mpl/pull/83)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
