### PR TITLE
Cut Windows CI build time in half to 15 min

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -69,6 +69,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
+          miniconda-version: "latest"
 
       # Install GMT and other required dependencies from conda-forge
       - name: Install GMT and required dependencies

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -65,7 +65,7 @@ jobs:
 
       # Setup Miniconda
       - name: Setup Miniconda
-        uses: goanpeca/setup-miniconda@v1.6.0
+        uses: conda-incubator/setup-miniconda@v1.7.0
         with:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge


### PR DESCRIPTION
**Description of proposed changes**

Attempt at speeding up Windows builds by updating conda version. For Python 3.6, our current Windows build takes **~31min** which is too slow!! Should at least half that time to **~15** minutes to make it more in line with macOS/Linux builds. The bulk of the time (~24min) is spent just installing dependencies using conda, so that will be what this PR will focus on optimizing.

### Before

| Windows (~31min) | macOS (~11min) |
|---|---|
| ![Windows Python 3.6 CI in 31min](https://user-images.githubusercontent.com/23487320/92314618-63198480-f02e-11ea-8221-e721731bfad7.png) | ![macOS Python 3.6 CI in 11min](https://user-images.githubusercontent.com/23487320/92314631-847a7080-f02e-11ea-8903-2608853dd3c4.png) |

### After

| Windows (~15min) | macOS (~9min) |
|---|---|
| ![Windows Python 3.6 CI in 15min](https://user-images.githubusercontent.com/23487320/92315042-72033580-f034-11ea-9b94-72ea3653a8a3.png) | ![macOS Python 3.6 CI in 9min](https://user-images.githubusercontent.com/23487320/92315047-952de500-f034-11ea-9b99-861d422f084e.png) |





TODO:

- [x] Bump setup-miniconda from 1.6.0 to [1.7.0](https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.7.0), also note name change from goanpeca/setup-miniconda to [conda-incubator/setup-miniconda](https://github.com/conda-incubator/setup-miniconda)
- [x] Try using 'latest' miniconda version [4.8.3](https://github.com/conda/conda/releases/tag/4.8.3) instead of 4.6.14 on Windows
- [ ] Cache dependencies?

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Towards #584 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
