### PR TITLE
Add result_images folder to gitignore and make clean list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ MANIFEST
 .pytest_cache/
 .ipynb_checkpoints/
 .vscode/
+result_images/
 tmp-test-dir-with-unique-name/
 coverage.xml
 htmlcov

--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,4 @@ clean:
 	rm -rvf build dist MANIFEST *.egg-info __pycache__ .coverage .cache htmlcov coverage.xml
 	rm -rvf $(TESTDIR)
 	rm -rvf baseline
+	rm -rvf result_images


### PR DESCRIPTION
**Description of proposed changes**

Tell git to ignore PNG files in 'result_images' folder, and add it to list of folders to clean for `make clean`. Patches #555.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
