### PR TITLE
Generalize check figures equal to work with pytest.marks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -328,9 +328,8 @@ Here's an example:
 @check_figures_equal()
 def test_my_plotting_case():
   "Test that my plotting function works"
-  fig_ref = Figure()
+  fig_ref, fig_test = Figure(), Figure()
   fig_ref.grdimage("@earth_relief_01d_g", projection="W120/15c", cmap="geo")
-  fig_test = Figure()
   fig_test.grdimage(grid, projection="W120/15c", cmap="geo")
   return fig_ref, fig_test
 ```

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -15,9 +15,8 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
     """
     Decorator for test cases that generate and compare two figures.
 
-    The decorated function must take two arguments, *fig_ref* and *fig_test*,
-    and draw the reference and test images on them. After the function
-    returns, the figures are saved and compared.
+    The decorated function must return two arguments, *fig_ref* and *fig_test*,
+    these two figures will then be saved and compared against each other.
 
     This decorator is practically identical to matplotlib's check_figures_equal
     function, but adapted for PyGMT figures. See also the original code at

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -80,13 +80,15 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
         old_sig = inspect.signature(func)
 
         @pytest.mark.parametrize("ext", extensions)
-        def wrapper(*args, ext, request, **kwargs):
+        def wrapper(*args, ext="png", request=None, **kwargs):
             if "ext" in old_sig.parameters:
                 kwargs["ext"] = ext
             if "request" in old_sig.parameters:
                 kwargs["request"] = request
-
-            file_name = "".join(c for c in request.node.name if c in ALLOWED_CHARS)
+            try:
+                file_name = "".join(c for c in request.node.name if c in ALLOWED_CHARS)
+            except AttributeError:  # 'NoneType' object has no attribute 'node'
+                file_name = func.__name__
             try:
                 fig_ref, fig_test = func(*args, **kwargs)
                 ref_image_path = os.path.join(result_dir, f"{file_name}-expected.{ext}")

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -6,9 +6,7 @@ import os
 import string
 
 from matplotlib.testing.compare import compare_images
-
 from ..exceptions import GMTImageComparisonFailure
-from ..figure import Figure
 
 
 def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_images"):

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -69,6 +69,7 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
     ...     )
     >>> shutil.rmtree(path="tmp_result_images")  # cleanup folder if tests pass
     """
+    # pylint: disable=invalid-name
     ALLOWED_CHARS = set(string.digits + string.ascii_letters + "_-[]()")
     KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
 


### PR DESCRIPTION
**Description of proposed changes**

Our `@check_figures_equal` decorator used for comparing two images doesn't work with `pytest.mark.parametrize`. These are cherry-picked commits from #560.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Changes in this PR are following the cue of matplotlib's `check_figures_equal` decorator. See https://github.com/matplotlib/matplotlib/pull/15199 and https://github.com/matplotlib/matplotlib/pull/17267.

Note also issue #579 on how we should really just vendor off the `check_figures_equal` function in the future instead of keeping this bit of code up to date with `matplotlib`.

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
