### PR TITLE
Refactor xfail tests to avoid storing baseline images

### DIFF
--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -4,6 +4,7 @@ Tests fig.basemap.
 import pytest
 
 from .. import Figure
+from ..helpers.testing import check_figures_equal
 from ..exceptions import GMTInvalidInput
 
 
@@ -54,15 +55,15 @@ def test_basemap_power_axis():
     return fig
 
 
-@pytest.mark.xfail(
-    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
-)
-@pytest.mark.mpl_image_compare
+@check_figures_equal()
 def test_basemap_polar():
     "Create a polar basemap plot"
-    fig = Figure()
-    fig.basemap(R="0/360/0/1000", J="P6i", B="afg")
-    return fig
+    fig_ref, fig_test = Figure(), Figure()
+    # Use single-character arguments for the reference image
+    fig_ref.basemap(R="0/360/0/1000", J="P6i", B="afg")
+    fig_test.basemap(region=[0, 360, 0, 1000], projection="P6i", frame="afg")
+
+    return fig_ref, fig_test
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -4,6 +4,7 @@ Tests for coast
 import pytest
 
 from .. import Figure
+from ..helpers.testing import check_figures_equal
 
 
 @pytest.mark.mpl_image_compare
@@ -25,15 +26,16 @@ def test_coast():
     return fig
 
 
-@pytest.mark.xfail(
-    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
-)
-@pytest.mark.mpl_image_compare
+@check_figures_equal()
 def test_coast_iceland():
     "Test passing in R as a list"
-    fig = Figure()
-    fig.coast(R=[-30, -10, 60, 65], J="m1c", B=True, G="p28+r100")
-    return fig
+    fig_ref, fig_test = Figure(), Figure()
+    # Use single-character arguments for the reference image
+    fig_ref.coast(R="-30/-10/60/65", J="m1c", B="", G="p28+r100")
+    fig_test.coast(
+        region=[-30, -10, 60, 65], projection="m1c", frame=True, land="p28+r100"
+    )
+    return fig_ref, fig_test
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_colorbar.py
+++ b/pygmt/tests/test_colorbar.py
@@ -4,6 +4,7 @@ Tests colorbar
 import pytest
 
 from .. import Figure
+from ..helpers.testing import check_figures_equal
 
 
 @pytest.mark.mpl_image_compare
@@ -37,18 +38,19 @@ def test_colorbar_positioned_using_map_coordinates():
     return fig
 
 
-@pytest.mark.xfail(
-    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
-)
-@pytest.mark.mpl_image_compare
+@check_figures_equal()
 def test_colorbar_positioned_using_justification_code():
     """
     Create colorbar at Top Center inside the map frame with length 2cm.
     """
-    fig = Figure()
-    fig.basemap(region=[2, 4, 6, 8], projection="t0/2c", frame=True)
-    fig.colorbar(cmap="rainbow", position="jTC+w2c")
-    return fig
+    fig_ref, fig_test = Figure(), Figure()
+    # Use single-character arguments for the reference image
+    fig_ref.basemap(R="2/4/6/8", J="t0/2c", B="")
+    fig_ref.colorbar(C="rainbow", D="jTC+w2c")
+
+    fig_test.basemap(region=[2, 4, 6, 8], projection="t0/2c", frame=True)
+    fig_test.colorbar(cmap="rainbow", position="jTC+w2c")
+    return fig_ref, fig_test
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -109,7 +109,7 @@ def test_grdcontour_interval_file_full_opts():
     fig_test.grdcontour(
         **comargs_test, limit=(-25000, -1), pen=["a1p,blue", "c0.5p,blue"]
     )
-    fig_test.grdcontour(**comargs_test, limit="0", pen=["a1p,black", "c0.5p,black"])
+    fig_test.grdcontour(**comargs_test, limit=0, pen=["a1p,black", "c0.5p,black"])
 
     return fig_ref, fig_test
 

--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -82,14 +82,23 @@ def test_grdcontour_file():
     return fig
 
 
-@pytest.mark.xfail(
-    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
-)
-@pytest.mark.mpl_image_compare
+@check_figures_equal()
 def test_grdcontour_interval_file_full_opts():
     """ Plot based on external contour level file """
-    fig = Figure()
-    comargs = {
+    fig_ref, fig_test = Figure(), Figure()
+    # Use single-character arguments for the reference image
+    comargs_ref = {
+        "grid": "@earth_relief_10m",
+        "R": "-161.5/-154/18.5/23",
+        "C": TEST_CONTOUR_FILE,
+        "S": 100,
+        "J": "M6i",
+        "Q": 10,
+    }
+    fig_ref.grdcontour(**comargs_ref, L="-25000/-1", W=["a1p,blue", "c0.5p,blue"])
+    fig_ref.grdcontour(**comargs_ref, L="0", W=["a1p,black", "c0.5p,black"])
+
+    comargs_test = {
         "region": [-161.5, -154, 18.5, 23],
         "interval": TEST_CONTOUR_FILE,
         "grid": "@earth_relief_10m",
@@ -97,11 +106,12 @@ def test_grdcontour_interval_file_full_opts():
         "projection": "M6i",
         "cut": 10,
     }
+    fig_test.grdcontour(
+        **comargs_test, limit=(-25000, -1), pen=["a1p,blue", "c0.5p,blue"]
+    )
+    fig_test.grdcontour(**comargs_test, limit="0", pen=["a1p,black", "c0.5p,black"])
 
-    fig.grdcontour(**comargs, limit=(-25000, -1), pen=["a1p,blue", "c0.5p,blue"])
-
-    fig.grdcontour(**comargs, limit="0", pen=["a1p,black", "c0.5p,black"])
-    return fig
+    return fig_ref, fig_test
 
 
 def test_grdcontour_fails():

--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -6,6 +6,7 @@ import pytest
 from .. import Figure
 from ..exceptions import GMTInvalidInput
 from ..helpers import GMTTempFile
+from ..helpers.testing import check_figures_equal
 
 
 @pytest.mark.mpl_image_compare
@@ -44,32 +45,42 @@ def test_legend_default_position():
     return fig
 
 
-@pytest.mark.xfail(
-    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
-)
-@pytest.mark.mpl_image_compare
+@check_figures_equal()
 def test_legend_entries():
     """
     Test different marker types/shapes.
     """
+    fig_ref, fig_test = Figure(), Figure()
 
-    fig = Figure()
+    # Use single-character arguments for the reference image
+    fig_ref = Figure()
+    fig_ref.basemap(J="x1i", R="0/7/3/7", B="")
+    fig_ref.plot(
+        data="@Table_5_11.txt",
+        S="c0.15i",
+        G="lightgreen",
+        W="faint",
+        l="Apples",
+    )
+    fig_ref.plot(data="@Table_5_11.txt", W="1.5p,gray", l='"My lines"')
+    fig_ref.plot(data="@Table_5_11.txt", S="t0.15i", G="orange", l="Oranges")
+    fig_ref.legend(D="JTR+jTR")
 
-    fig.basemap(projection="x1i", region=[0, 7, 3, 7], frame=True)
-
-    fig.plot(
+    fig_test.basemap(projection="x1i", region=[0, 7, 3, 7], frame=True)
+    fig_test.plot(
         data="@Table_5_11.txt",
         style="c0.15i",
         color="lightgreen",
         pen="faint",
-        l="Apples",
+        label="Apples",
     )
-    fig.plot(data="@Table_5_11.txt", pen="1.5p,gray", label='"My lines"')
-    fig.plot(data="@Table_5_11.txt", style="t0.15i", color="orange", label="Oranges")
+    fig_test.plot(data="@Table_5_11.txt", pen="1.5p,gray", label='"My lines"')
+    fig_test.plot(
+        data="@Table_5_11.txt", style="t0.15i", color="orange", label="Oranges"
+    )
+    fig_test.legend(position="JTR+jTR")
 
-    fig.legend(position="JTR+jTR")
-
-    return fig
+    return fig_ref, fig_test
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_logo.py
+++ b/pygmt/tests/test_logo.py
@@ -5,23 +5,32 @@ import pytest
 
 from .. import Figure
 from ..exceptions import GMTInvalidInput
+from ..helpers.testing import check_figures_equal
 
 
-@pytest.mark.mpl_image_compare
+@check_figures_equal()
 def test_logo():
     "Plot a GMT logo of a 2 inch width as a stand-alone plot"
-    fig = Figure()
-    fig.logo(D="x0/0+w2i")
-    return fig
+    fig_ref, fig_test = Figure(), Figure()
+    # Use single-character arguments for the reference image
+    fig_ref.logo(D="x0/0+w2i")
+    fig_test.logo(position="x0/0+w2i")
+    return fig_ref, fig_test
 
 
-@pytest.mark.mpl_image_compare
+@check_figures_equal()
 def test_logo_on_a_map():
     "Plot a GMT logo in the upper right corner of a map"
-    fig = Figure()
-    fig.coast(region=[-90, -70, 0, 20], projection="M6i", land="chocolate", frame=True)
-    fig.logo(D="jTR+o0.1i/0.1i+w3i", F=True)
-    return fig
+    fig_ref, fig_test = Figure(), Figure()
+    # Use single-character arguments for the reference image
+    fig_ref.coast(R="-90/-70/0/20", J="M6i", G="chocolate", B="")
+    fig_ref.logo(D="jTR+o0.1i/0.1i+w3i", F="")
+
+    fig_test.coast(
+        region=[-90, -70, 0, 20], projection="M6i", land="chocolate", frame=True
+    )
+    fig_test.logo(position="jTR+o0.1i/0.1i+w3i", box=True)
+    return fig_ref, fig_test
 
 
 def test_logo_fails():

--- a/pygmt/tests/test_makecpt.py
+++ b/pygmt/tests/test_makecpt.py
@@ -10,6 +10,7 @@ from .. import Figure, makecpt
 from ..datasets import load_earth_relief
 from ..exceptions import GMTInvalidInput
 from ..helpers import GMTTempFile
+from ..helpers.testing import check_figures_equal
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 POINTS_DATA = os.path.join(TEST_DATA_DIR, "points.txt")
@@ -62,19 +63,21 @@ def test_makecpt_to_plot_grid(grid):
     return fig
 
 
-@pytest.mark.xfail(
-    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
-)
-@pytest.mark.mpl_image_compare
+@check_figures_equal()
 def test_makecpt_to_plot_grid_scaled_with_series(grid):
     """
     Use static color palette table scaled to a min/max series to change color
     of grid
     """
-    fig = Figure()
+    # Use single-character arguments for the reference image
+    fig_ref = Figure()
+    makecpt(C="oleron", T="-4500/4500")
+    fig_ref.grdimage(grid, J="W0/6i")
+
+    fig_test = Figure()
     makecpt(cmap="oleron", series="-4500/4500")
-    fig.grdimage(grid, projection="W0/6i")
-    return fig
+    fig_test.grdimage(grid, projection="W0/6i")
+    return fig_ref, fig_test
 
 
 def test_makecpt_output_to_cpt_file():

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -13,6 +13,7 @@ import pytest
 
 from .. import Figure
 from ..exceptions import GMTInvalidInput
+from ..helpers.testing import check_figures_equal
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
@@ -126,11 +127,21 @@ def test_plot_projection(data):
     return fig
 
 
-@pytest.mark.mpl_image_compare
+@check_figures_equal()
 def test_plot_colors(data, region):
     "Plot the data using z as sizes"
-    fig = Figure()
-    fig.plot(
+    fig_ref, fig_test = Figure(), Figure()
+    # Use single-character arguments for the reference image
+    fig_ref.plot(
+        data=POINTS_DATA,
+        J="X3i",
+        R="/".join(map(str, region)),
+        B="af",
+        S="c0.5c",
+        C="cubhelix",
+    )
+
+    fig_test.plot(
         x=data[:, 0],
         y=data[:, 1],
         color=data[:, 2],
@@ -140,7 +151,7 @@ def test_plot_colors(data, region):
         cmap="cubhelix",
         frame="af",
     )
-    return fig
+    return fig_ref, fig_test
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -135,11 +135,11 @@ def test_plot_colors(data, region):
     # Use single-character arguments for the reference image
     fig_ref.plot(
         data=POINTS_DATA,
-        J="X3i",
         R="/".join(map(str, region)),
-        B="af",
+        J="X3i",
         S="c0.5c",
         C="cubhelix",
+        B="af",
     )
 
     fig_test.plot(


### PR DESCRIPTION
**Description of proposed changes**

This PR refactors the xfail/fail tests to let the tests pass and avoid storing baseline images.

The baseline images are generated by calling the same modules using plain text or grid files are input, and using single-character arguments. 

Address #451.

**Remaining issues:**

- [ ] The two xfailing tests in `test_config` are not refactored. There is no easy way to generate references images for them.

**TODOs for future PRs:**

- [ ] Tests that are passing are not refactored. These tests still use the images in the `pygmt/test/baselines` directory as baselines.
- [ ] Images of those xfailing/failing tests are no longer needed, but this PR doesn't delete them from the repository. 


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
