### PR TITLE
Fix a typo in the "first figure" tutorial

### DIFF
--- a/examples/tutorials/first-figure.py
+++ b/examples/tutorials/first-figure.py
@@ -27,7 +27,7 @@ fig = pygmt.Figure()
 ########################################################################################
 # Add elements to the figure using its methods. For example, let's start a map with an
 # automatic frame and ticks around a given longitude and latitude bound, set the
-# projection to Mercator (``M``), and the figure width to 8 inches:
+# projection to Mercator (``M``), and the map width to 8 inches:
 
 fig.basemap(region=[-90, -70, 0, 20], projection="M8i", frame=True)
 


### PR DESCRIPTION
**Description of proposed changes**

projection='M8i' sets the map width to 8 inch, not the figure width.
The figure with is larger than 8 inch, including frames and annotations.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.