### PR TITLE
Add an example for scatter plots with auto legends

### DIFF
--- a/examples/gallery/plot/scatter.py
+++ b/examples/gallery/plot/scatter.py
@@ -2,9 +2,11 @@
 Scatter plots with a legend
 ---------------------------
 
-TODO: Add more docstrings.
+To create a scatter plot with a legend one may use a loop and create one scatter
+plot per item to appear in the legend and set the label accordingly.
 
-Modified from the matplotlib example: https://matplotlib.org/gallery/lines_bars_and_markers/scatter_with_legend.html
+Modified from the matplotlib example:
+https://matplotlib.org/gallery/lines_bars_and_markers/scatter_with_legend.html
 """
 
 import numpy as np
@@ -21,17 +23,19 @@ fig.basemap(
 )
 for color in ["blue", "orange", "green"]:
     x, y = np.random.rand(2, n)  # random X and Y data in [0,1]
-    sizes = np.random.rand(n) * 0.5  # random size, in cm
-    # plot data points as circles ('c'), with different sizes
+    sizes = np.random.rand(n) * 0.5  # random size [0,0.5], in cm
+    # plot data points as circles (style="c"), with different sizes
     fig.plot(
         x=x,
         y=y,
         style="c",
         sizes=sizes,
         color=color,
+        # Set the legend label,
+        # and set the circle size to be 0.25 cm (+S0.25c) in legend
         label=f"{color}+S0.25c",
-        transparency=70,
+        transparency=70,  # set transparency level for all symbols
     )
 
-fig.legend(transparency=30)
+fig.legend(transparency=30)  # set transparency level for legends
 fig.show()

--- a/examples/gallery/plot/scatter.py
+++ b/examples/gallery/plot/scatter.py
@@ -1,0 +1,29 @@
+"""
+Scatter plots with a legend
+---------------------------
+
+TODO: Add more docstrings.
+
+Modified from the matplotlib example: https://matplotlib.org/gallery/lines_bars_and_markers/scatter_with_legend.html
+"""
+
+import numpy as np
+import pygmt
+
+np.random.seed(19680801)
+n = 200  # number of random data points
+
+fig = pygmt.Figure()
+fig.basemap(
+    region=[-0.1, 1.1, -0.1, 1.1],
+    projection="X10c/10c",
+    frame=["xa0.2fg", "ya0.2fg", "WSrt"],
+)
+for color in ["blue", "orange", "green"]:
+    x, y = np.random.rand(2, n)  # random X and Y data in [0,1]
+    sizes = np.random.rand(n) * 0.5  # random size, in cm
+    # plot data points as circles ('c'), with different sizes
+    fig.plot(x, y, style="c", sizes=sizes, color=color, label=f"{color}+S0.25c", t=70)
+
+fig.legend(t=30)
+fig.show()

--- a/examples/gallery/plot/scatter.py
+++ b/examples/gallery/plot/scatter.py
@@ -23,7 +23,15 @@ for color in ["blue", "orange", "green"]:
     x, y = np.random.rand(2, n)  # random X and Y data in [0,1]
     sizes = np.random.rand(n) * 0.5  # random size, in cm
     # plot data points as circles ('c'), with different sizes
-    fig.plot(x, y, style="c", sizes=sizes, color=color, label=f"{color}+S0.25c", t=70)
+    fig.plot(
+        x=x,
+        y=y,
+        style="c",
+        sizes=sizes,
+        color=color,
+        label=f"{color}+S0.25c",
+        transparency=70,
+    )
 
 fig.legend(t=30)
 fig.show()

--- a/examples/gallery/plot/scatter.py
+++ b/examples/gallery/plot/scatter.py
@@ -33,5 +33,5 @@ for color in ["blue", "orange", "green"]:
         transparency=70,
     )
 
-fig.legend(t=30)
+fig.legend(transparency=30)
 fig.show()


### PR DESCRIPTION
**Description of proposed changes**

**Preview:** https://pygmt-git-gallery-scatter.gmt.vercel.app/gallery/plot/scatter.html

Add a new example, modified from https://matplotlib.org/gallery/lines_bars_and_markers/scatter_with_legend.html.

![image](https://user-images.githubusercontent.com/3974108/93036131-fc3b3300-f60c-11ea-9d00-f8c56ba1a2b9.png)



To be discussed:

- [ ] Is it a good example?
- [ ] Should we have a separate directory/category for "symbols"?
- [x] We should add an alias for **-t** option (#614).

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
