### PR TITLE
Improve Makefile to clean __pycache__ directory recursively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ lint:
 clean:
 	find . -name "*.pyc" -exec rm -v {} \;
 	find . -name "*~" -exec rm -v {} \;
-	rm -rvf build dist MANIFEST *.egg-info __pycache__ .coverage .cache htmlcov coverage.xml
+	find . -type d -name  "__pycache__" -exec rm -rv {} +
+	rm -rvf build dist MANIFEST *.egg-info .coverage .cache htmlcov coverage.xml
 	rm -rvf $(TESTDIR)
 	rm -rvf baseline
 	rm -rvf result_images


### PR DESCRIPTION
**Description of proposed changes**

Running `make clean` only deletes the __pycache__ directory in the
project root. There are still a few __pycache__ directory left in the
subdirectories.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.