### PR TITLE
Refactor info to allow datetime inputs from xarray.Dataset and pandas.DataFrame tables

### DIFF
--- a/pygmt/modules.py
+++ b/pygmt/modules.py
@@ -79,9 +79,9 @@ def info(table, **kwargs):
     Parameters
     ----------
     table : str or np.ndarray or pandas.DataFrame or xarray.Dataset
-        Pass in either a a file name to an ASCII data table, a 1D/2D numpy
-        array, a pandas dataframe, or an xarray dataset made up of 1D
-        xarray.DataArray data variables.
+        Pass in either a file name to an ASCII data table, a 1D/2D numpy array,
+        a pandas dataframe, or an xarray dataset made up of 1D xarray.DataArray
+        data variables.
     per_column : bool
         Report the min/max values per column in separate columns.
     spacing : str

--- a/pygmt/modules.py
+++ b/pygmt/modules.py
@@ -108,7 +108,7 @@ def info(table, **kwargs):
             file_context = dummy_context(table)
         elif kind == "matrix":
             try:
-                # pandas.DataFrame types
+                # pandas.DataFrame and xarray.Dataset types
                 arrays = [array for _, array in table.items()]
             except AttributeError:
                 # Python lists, tuples, and numpy ndarray types

--- a/pygmt/modules.py
+++ b/pygmt/modules.py
@@ -78,9 +78,10 @@ def info(table, **kwargs):
 
     Parameters
     ----------
-    table : pandas.DataFrame or np.ndarray or str
-        Either a pandas dataframe, a 1D/2D numpy.ndarray or a file name to an
-        ASCII data table.
+    table : str or np.ndarray or pandas.DataFrame or xarray.Dataset
+        Pass in either a a file name to an ASCII data table, a 1D/2D numpy
+        array, a pandas dataframe, or an xarray dataset made up of 1D
+        xarray.DataArray data variables.
     per_column : bool
         Report the min/max values per column in separate columns.
     spacing : str

--- a/pygmt/modules.py
+++ b/pygmt/modules.py
@@ -107,10 +107,13 @@ def info(table, **kwargs):
         if kind == "file":
             file_context = dummy_context(table)
         elif kind == "matrix":
-            _table = np.asanyarray(table)
-            if table.ndim == 1:  # 1D arrays need to be 2D and transposed
-                _table = np.transpose(np.atleast_2d(_table))
-            file_context = lib.virtualfile_from_matrix(_table)
+            try:
+                # pandas.DataFrame types
+                arrays = [array for _, array in table.items()]
+            except AttributeError:
+                # Python lists, tuples, and numpy ndarray types
+                arrays = np.atleast_2d(np.asanyarray(table).T)
+            file_context = lib.virtualfile_from_vectors(*arrays)
         else:
             raise GMTInvalidInput(f"Unrecognized data type: {type(table)}")
 

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -8,12 +8,16 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 import xarray as xr
+from packaging.version import Version
 
-from .. import info
+from .. import clib, info
 from ..exceptions import GMTInvalidInput
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 POINTS_DATA = os.path.join(TEST_DATA_DIR, "points.txt")
+
+with clib.Session() as _lib:
+    gmt_version = Version(_lib.info["version"])
 
 
 def test_info():
@@ -38,6 +42,11 @@ def test_info_dataframe():
     assert output == expected_output
 
 
+@pytest.mark.xfail(
+    condition=gmt_version <= Version("6.1.1"),
+    reason="UNIX timestamps returned instead of ISO datetime, should work on GMT 6.2.0 "
+    "after https://github.com/GenericMappingTools/gmt/issues/4241 is resolved",
+)
 def test_info_pandas_dataframe_time_column():
     "Make sure info works on pandas.DataFrame inputs with a time column"
     table = pd.DataFrame(
@@ -53,6 +62,11 @@ def test_info_pandas_dataframe_time_column():
     assert output == expected_output
 
 
+@pytest.mark.xfail(
+    condition=gmt_version <= Version("6.1.1"),
+    reason="UNIX timestamp returned instead of ISO datetime, should work on GMT 6.2.0 "
+    "after https://github.com/GenericMappingTools/gmt/issues/4241 is resolved",
+)
 def test_info_xarray_dataset_time_column():
     "Make sure info works on xarray.Dataset 1D inputs with a time column"
     table = xr.Dataset(

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -53,6 +53,22 @@ def test_info_pandas_dataframe_time_column():
     assert output == expected_output
 
 
+def test_info_xarray_dataset_time_column():
+    "Make sure info works on xarray.Dataset 1D inputs with a time column"
+    table = xr.Dataset(
+        coords={"index": [0, 1, 2, 3, 4]},
+        data_vars={
+            "z": ("index", [10, 13, 12, 15, 14]),
+            "time": ("index", pd.date_range(start="2020-01-01", periods=5)),
+        },
+    )
+    output = info(table=table)
+    expected_output = (
+        "<vector memory>: N = 5 <10/15> <2020-01-01T00:00:00/2020-01-05T00:00:00>\n"
+    )
+    assert output == expected_output
+
+
 def test_info_2d_array():
     "Make sure info works on 2D numpy.ndarray inputs"
     table = np.loadtxt(POINTS_DATA)

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -33,7 +33,22 @@ def test_info_dataframe():
     table = pd.read_csv(POINTS_DATA, sep=" ", header=None)
     output = info(table=table)
     expected_output = (
-        "<matrix memory>: N = 20 <11.5309/61.7074> <-2.9289/7.8648> <0.1412/0.9338>\n"
+        "<vector memory>: N = 20 <11.5309/61.7074> <-2.9289/7.8648> <0.1412/0.9338>\n"
+    )
+    assert output == expected_output
+
+
+def test_info_pandas_dataframe_time_column():
+    "Make sure info works on pandas.DataFrame inputs with a time column"
+    table = pd.DataFrame(
+        data={
+            "z": [10, 13, 12, 15, 14],
+            "time": pd.date_range(start="2020-01-01", periods=5),
+        }
+    )
+    output = info(table=table)
+    expected_output = (
+        "<vector memory>: N = 5 <10/15> <2020-01-01T00:00:00/2020-01-05T00:00:00>\n"
     )
     assert output == expected_output
 
@@ -43,7 +58,7 @@ def test_info_2d_array():
     table = np.loadtxt(POINTS_DATA)
     output = info(table=table)
     expected_output = (
-        "<matrix memory>: N = 20 <11.5309/61.7074> <-2.9289/7.8648> <0.1412/0.9338>\n"
+        "<vector memory>: N = 20 <11.5309/61.7074> <-2.9289/7.8648> <0.1412/0.9338>\n"
     )
     assert output == expected_output
 
@@ -51,7 +66,7 @@ def test_info_2d_array():
 def test_info_1d_array():
     "Make sure info works on 1D numpy.ndarray inputs"
     output = info(table=np.arange(20))
-    expected_output = "<matrix memory>: N = 20 <0/19>\n"
+    expected_output = "<vector memory>: N = 20 <0/19>\n"
     assert output == expected_output
 
 


### PR DESCRIPTION
**Description of proposed changes**

In order to support datetime inputs into [`pygmt.info`](https://www.pygmt.org/v0.2.0/api/generated/pygmt.info.html), this PR changes the backend mechanism from using `lib.virtualfile_from_matrix()` (which only supports single non-datetime dtypes) to using `lib.virtualfile_from_vectors()` (which supports datetime inputs as of #464).

**Note**: While datetime inputs can be passed into `info` now, the resulting outputs (UNIX timestamp instead of ISO datetime) might not make sense due to the issue at https://github.com/GenericMappingTools/gmt/issues/4241.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Coincidentally, this refactor also enables the following:

- Properly handle pandas.DataFrame table inputs that may have mixed dtypes (e.g. int32/float32 on different columns, see also #547).
- Passing in [`xarray.Dataset`](http://xarray.pydata.org/en/v0.16.0/data-structures.html#dataset) inputs! Note: Only for `xarray.Dataset`s made up of 1D `xarray.DataArrays`s (e.g. what you might get from using [`xarray.Dataset.from_dataframe`](http://xarray.pydata.org/en/v0.16.0/generated/xarray.Dataset.from_dataframe.html)).


<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Addresses #597, will be fixed once https://github.com/GenericMappingTools/gmt/issues/4241 is resolved.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
