### PR TITLE
Complete documentation of grdimage

### DIFF
--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -308,6 +308,7 @@ class BasePlotting:
         C="cmap",
         D="img_in",
         E="dpi",
+        G="bit_color",
         I="shading",
         J="projection",
         M="monochrome",
@@ -399,6 +400,14 @@ class BasePlotting:
             default, the projected grid will be of the same size (rows and
             columns) as the input file. Specify *i* to use the PostScript image
             operator to interpolate the image at the device resolution.
+        bit_color : str
+           ``color[+b|f]``.
+             This option only applies when a resulting 1-bit image otherwise
+             would consist of only two colors: black (0) and white (255). If
+             so, this option will instead use the image as a transparent mask
+             and paint the mask with the given color. Append **+b** to paint
+             the background pixels (1) or **+f** for the foreground pixels
+             [Default].
         {J}
         monochrome : bool
             Force conversion to monochrome image using the (television) YIQ

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -317,9 +317,37 @@ class BasePlotting:
     @kwargs_to_strings(R="sequence")
     def grdimage(self, grid, **kwargs):
         """
-        Project grids or images and plot them on maps.
+        Project and plot grids or images.
 
-        Takes a grid file name or an xarray.DataArray object as input.
+        Reads one 2-D grid file and produces a gray-shaded (or colored) map by
+        plotting rectangles centered on each grid node and assigning them a
+        gray-shade (or color) based on the z-value. Alternatively, `grdimage`
+        reads three 2-D grid files with the red, green, and blue components
+        directly (all must be in the 0-255 range). Optionally, illumination may
+        be added by providing a file with intensities in the (-1,+1) range or
+        instructions to derive intensities from the input data grid. Values
+        outside this range will be clipped. Such intensity files can be created
+        from the grid using `grdgradient` and, optionally, modified by
+        `grdmath` or `grdhisteq`. A third alternative is available when GMT is
+        build with GDAL support. Pass *img* which can be an image file
+        (geo-referenced or not). In this case the images can optionally be
+        illuminated with the file provided via the *shading* option. Here, if
+        image has no coordinates then those of the intensity file will be used.
+
+        When using map projections, the grid is first resampled on a new
+        rectangular grid with the same dimensions. Higher resolution images can
+        be obtained by using the *dpi* option. To obtain the resampled value
+        (and hence shade or color) of each map pixel, its location is inversely
+        projected back onto the input grid after which a value is interpolated
+        between the surrounding input grid values. By default bi-cubic
+        interpolation is used. Aliasing is avoided by also forward projecting
+        the input grid nodes. If two or more nodes are projected onto the same
+        pixel, their average will dominate in the calculation of the pixel
+        value. Interpolation and aliasing is controlled with the
+        *interpolation* option.
+
+        The *region* option can be used to select a map region larger or
+        smaller than that implied by the extent of the grid.
 
         Full option list at :gmt-docs:`grdimage.html`
 

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -414,13 +414,13 @@ class BasePlotting:
             columns) as the input file. Specify *i* to use the PostScript image
             operator to interpolate the image at the device resolution.
         bit_color : str
-           ``color[+b|f]``.
-             This option only applies when a resulting 1-bit image otherwise
-             would consist of only two colors: black (0) and white (255). If
-             so, this option will instead use the image as a transparent mask
-             and paint the mask with the given color. Append **+b** to paint
-             the background pixels (1) or **+f** for the foreground pixels
-             [Default].
+            ``color[+b|f]``.
+            This option only applies when a resulting 1-bit image otherwise
+            would consist of only two colors: black (0) and white (255). If so,
+            this option will instead use the image as a transparent mask and
+            paint the mask with the given color. Append **+b** to paint the
+            background pixels (1) or **+f** for the foreground pixels
+            [Default].
         {J}
         monochrome : bool
             Force conversion to monochrome image using the (television) YIQ

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -308,6 +308,9 @@ class BasePlotting:
         E="dpi",
         I="shading",
         J="projection",
+        M="monochrome",
+        N="noclip",
+        Q="nan_alpha",
         R="region",
         U="timestamp",
         V="verbose",
@@ -367,6 +370,16 @@ class BasePlotting:
             columns) as the input file. Specify *i* to use the PostScript image
             operator to interpolate the image at the device resolution.
         {J}
+        monochrome : bool
+            Force conversion to monochrome image using the (television) YIQ
+            transformation. Cannot be used with *nan_alpha*.
+        noclip : bool
+            Do not clip the image at the map boundary (only relevant for
+            non-rectangular maps).
+        nan_alpha : bool
+            Make grid nodes with z = NaN transparent, using the color-masking
+            feature in PostScript Level 3 (the PS device must support PS Level
+            3).
         {R}
         {V}
         {n}

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -379,7 +379,6 @@ class BasePlotting:
         Parameters
         ----------
         grid : str or xarray.DataArray
-            ``grid | image``.
             The file name or a DataArray containing the input 2-D gridded data
             set or image to be plotted (See GRID FILE FORMATS at
             :gmt-docs:`grdimage.html#grid-file-formats`).
@@ -392,7 +391,7 @@ class BasePlotting:
             *out_img* to select the image file name and extension. If the
             extension is one of .bmp, .gif, .jpg, .png, or .tif then no driver
             information is required. For other output formats you must append
-            the required GDAL driver. The driver is the driver code name used
+            the required GDAL driver. The *driver* is the driver code name used
             by GDAL; see your GDAL installation's documentation for available
             drivers. Append a **+c**\\ *options* string where options is a list
             of one or more concatenated number of GDAL **-co** options. For
@@ -418,8 +417,8 @@ class BasePlotting:
             Sets the resolution of the projected grid that will be created if a
             map projection other than Linear or Mercator was selected [100]. By
             default, the projected grid will be of the same size (rows and
-            columns) as the input file. Specify *i* to use the PostScript image
-            operator to interpolate the image at the device resolution.
+            columns) as the input file. Specify **i** to use the PostScript
+            image operator to interpolate the image at the device resolution.
         bit_color : str
             ``color[+b|f]``.
             This option only applies when a resulting 1-bit image otherwise
@@ -433,13 +432,14 @@ class BasePlotting:
             Give the name of a grid file with intensities in the (-1,+1) range,
             or a constant intensity to apply everywhere (affects the ambient
             light). Alternatively, derive an intensity grid from the input data
-            grid via a call to `grdgradient`; append **+aazimuth**, **+nargs**,
-            and **+mambient** to specify azimuth, intensity, and ambient
-            arguments for that module, or just give **+d** to select the
-            default arguments (``+a-45+nt1+m0``). If you want a more specific
-            intensity scenario then run `grdgradient` separately first. If we
-            should derive intensities from another file than grid, specify the
-            file with suitable modifiers [Default is no illumination].
+            grid via a call to `grdgradient`; append **+a** \\ *azimuth*,
+            **+n** \\ *args*, and **+m** \\ *ambient* to specify azimuth,
+            intensity, and ambient arguments for that module, or just give
+            **+d** to select the default arguments (``+a-45+nt1+m0``). If you
+            want a more specific intensity scenario then run `grdgradient`
+            separately first. If we should derive intensities from another file
+            than grid, specify the file with suitable modifiers [Default is no
+            illumination].
         {J}
         monochrome : bool
             Force conversion to monochrome image using the (television) YIQ

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -321,8 +321,8 @@ class BasePlotting:
         I="shading",
         J="projection",
         M="monochrome",
-        N="noclip",
-        Q="nan_alpha",
+        N="no_clip",
+        Q="nan_transparent",
         R="region",
         U="timestamp",
         V="verbose",
@@ -424,11 +424,11 @@ class BasePlotting:
         {J}
         monochrome : bool
             Force conversion to monochrome image using the (television) YIQ
-            transformation. Cannot be used with *nan_alpha*.
-        noclip : bool
+            transformation. Cannot be used with *nan_transparent*.
+        no_clip : bool
             Do not clip the image at the map boundary (only relevant for
             non-rectangular maps).
-        nan_alpha : bool
+        nan_transparent : bool
             Make grid nodes with z = NaN transparent, using the color-masking
             feature in PostScript Level 3 (the PS device must support PS Level
             3).

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -305,6 +305,7 @@ class BasePlotting:
     @use_alias(
         B="frame",
         C="cmap",
+        E="dpi",
         I="shading",
         J="projection",
         R="region",
@@ -330,6 +331,13 @@ class BasePlotting:
             The file name of the input grid or the grid loaded as a DataArray.
         {B}
         {CPT}
+        dpi : int
+            ``[i|dpi]``.
+            Sets the resolution of the projected grid that will be created if a
+            map projection other than Linear or Mercator was selected [100]. By
+            default, the projected grid will be of the same size (rows and
+            columns) as the input file. Specify *i* to use the PostScript image
+            operator to interpolate the image at the device resolution.
         {J}
         {R}
         {V}

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -421,6 +421,18 @@ class BasePlotting:
             paint the mask with the given color. Append **+b** to paint the
             background pixels (1) or **+f** for the foreground pixels
             [Default].
+        shading : str
+            ``[intensfile|intensity|modifiers]``.
+            Give the name of a grid file with intensities in the (-1,+1) range,
+            or a constant intensity to apply everywhere (affects the ambient
+            light). Alternatively, derive an intensity grid from the input data
+            grid via a call to `grdgradient`; append **+aazimuth**, **+nargs**,
+            and **+mambient** to specify azimuth, intensity, and ambient
+            arguments for that module, or just give **+d** to select the
+            default arguments (``+a-45+nt1+m0``). If you want a more specific
+            intensity scenario then run `grdgradient` separately first. If we
+            should derive intensities from another file than grid, specify the
+            file with suitable modifiers [Default is no illumination].
         {J}
         monochrome : bool
             Force conversion to monochrome image using the (television) YIQ

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -325,19 +325,17 @@ class BasePlotting:
         """
         Project and plot grids or images.
 
-        Reads one 2-D grid file and produces a gray-shaded (or colored) map by
-        plotting rectangles centered on each grid node and assigning them a
-        gray-shade (or color) based on the z-value. Alternatively, `grdimage`
-        reads three 2-D grid files with the red, green, and blue components
-        directly (all must be in the 0-255 range). Optionally, illumination may
-        be added by providing a file with intensities in the (-1,+1) range or
-        instructions to derive intensities from the input data grid. Values
+        Reads a 2-D grid file and produces a gray-shaded (or colored) map by
+        building a rectangular image and assigning pixels a gray-shade (or
+        color) based on the z-value and the CPT file. Optionally, illumination
+        may be added by providing a file with intensities in the (-1,+1) range
+        or instructions to derive intensities from the input data grid. Values
         outside this range will be clipped. Such intensity files can be created
         from the grid using `grdgradient` and, optionally, modified by
         `grdmath` or `grdhisteq`. A third alternative is available when GMT is
-        build with GDAL support. Pass *img* which can be an image file
-        (geo-referenced or not). In this case the images can optionally be
-        illuminated with the file provided via the *shading* option. Here, if
+        build with GDAL support. Pass **image** which can be an image file
+        (geo-referenced or not). In this case the image can optionally be
+        illuminated with the file provided via the **shading** option. Here, if
         image has no coordinates then those of the intensity file will be used.
 
         When using map projections, the grid is first resampled on a new
@@ -362,7 +360,10 @@ class BasePlotting:
         Parameters
         ----------
         grid : str or xarray.DataArray
-            The file name of the input grid or the grid loaded as a DataArray.
+            ``grid | image``.
+            The file name or a DataArray containing the input 2-D gridded data
+            set or image to be plotted (See GRID FILE FORMATS at
+            :gmt-docs:`grdimage.html#grid-file-formats`).
         img_out : str
             ``out_img[=driver]``.
             Save an image in a raster format instead of PostScript. Use

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -303,12 +303,14 @@ class BasePlotting:
 
     @fmt_docstring
     @use_alias(
-        R="region",
-        J="projection",
-        W="pen",
         B="frame",
-        I="shading",
         C="cmap",
+        I="shading",
+        J="projection",
+        R="region",
+        U="timestamp",
+        V="verbose",
+        n="interpolation",
         t="transparency",
     )
     @kwargs_to_strings(R="sequence")
@@ -326,6 +328,12 @@ class BasePlotting:
         ----------
         grid : str or xarray.DataArray
             The file name of the input grid or the grid loaded as a DataArray.
+        {B}
+        {CPT}
+        {J}
+        {R}
+        {V}
+        {n}
         {t}
 
         """

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -354,7 +354,7 @@ class BasePlotting:
         `grdmath` or `grdhisteq`. A third alternative is available when GMT is
         build with GDAL support. Pass **image** which can be an image file
         (geo-referenced or not). In this case the image can optionally be
-        illuminated with the file provided via the **shading** option. Here, if
+        illuminated with the file provided via the *shading* option. Here, if
         image has no coordinates then those of the intensity file will be used.
 
         When using map projections, the grid is first resampled on a new
@@ -394,7 +394,7 @@ class BasePlotting:
             information is required. For other output formats you must append
             the required GDAL driver. The driver is the driver code name used
             by GDAL; see your GDAL installation's documentation for available
-            drivers. Append a **+coptions** string where options is a list of
+            drivers. Append a **+c**\ *options* string where options is a list of
             one or more concatenated number of GDAL **-co** options. For
             example, to write a GeoPDF with the TerraGo format use
             ``=PDF+cGEO_ENCODING=OGC_BP``. Notes: (1) If a tiff file (.tif) is
@@ -407,9 +407,9 @@ class BasePlotting:
             ``[r]``
             GMT will automatically detect standard image files (Geotiff, TIFF,
             JPG, PNG, GIF, etc.) and will read those via GDAL. For very obscure
-            image formats you may need to explicitly set **img_in**, which
+            image formats you may need to explicitly set *img_in*, which
             specifies that the grid is in fact an image file to be read via
-            GDAL. Append **r** to assign the region specified by **region**
+            GDAL. Append **r** to assign the region specified by *region*
             to the image. For example, if you have used ``region='d'`` then the
             image will be assigned a global domain. This mode allows you to
             project a raw image (an image without referencing coordinates).

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -394,8 +394,8 @@ class BasePlotting:
             information is required. For other output formats you must append
             the required GDAL driver. The driver is the driver code name used
             by GDAL; see your GDAL installation's documentation for available
-            drivers. Append a **+c**\ *options* string where options is a list of
-            one or more concatenated number of GDAL **-co** options. For
+            drivers. Append a **+c**\\ *options* string where options is a list
+            of one or more concatenated number of GDAL **-co** options. For
             example, to write a GeoPDF with the TerraGo format use
             ``=PDF+cGEO_ENCODING=OGC_BP``. Notes: (1) If a tiff file (.tif) is
             selected then we will write a GeoTiff image if the GMT projection

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -303,8 +303,10 @@ class BasePlotting:
 
     @fmt_docstring
     @use_alias(
+        A="img_out",
         B="frame",
         C="cmap",
+        D="img_in",
         E="dpi",
         I="shading",
         J="projection",
@@ -360,8 +362,36 @@ class BasePlotting:
         ----------
         grid : str or xarray.DataArray
             The file name of the input grid or the grid loaded as a DataArray.
+        img_out : str
+            ``out_img[=driver]``.
+            Save an image in a raster format instead of PostScript. Use
+            extension .ppm for a Portable Pixel Map format which is the only
+            raster format GMT can natively write. For GMT installations
+            configured with GDAL support there are more choices: Append
+            *out_img* to select the image file name and extension. If the
+            extension is one of .bmp, .gif, .jpg, .png, or .tif then no driver
+            information is required. For other output formats you must append
+            the required GDAL driver. The driver is the driver code name used
+            by GDAL; see your GDAL installation's documentation for available
+            drivers. Append a **+coptions** string where options is a list of
+            one or more concatenated number of GDAL **-co** options. For
+            example, to write a GeoPDF with the TerraGo format use
+            ``=PDF+cGEO_ENCODING=OGC_BP``. Notes: (1) If a tiff file (.tif) is
+            selected then we will write a GeoTiff image if the GMT projection
+            syntax translates into a PROJ syntax, otherwise a plain tiff file
+            is produced. (2) Any vector elements will be lost.
         {B}
         {CPT}
+        img_in : str
+            ``[r]``
+            GMT will automatically detect standard image files (Geotiff, TIFF,
+            JPG, PNG, GIF, etc.) and will read those via GDAL. For very obscure
+            image formats you may need to explicitly set **img_in**, which
+            specifies that the grid is in fact an image file to be read via
+            GDAL. Append **r** to assign the region specified by **region**
+            to the image. For example, if you have used ``region='d'`` then the
+            image will be assigned a global domain. This mode allows you to
+            project a raw image (an image without referencing coordinates).
         dpi : int
             ``[i|dpi]``.
             Sets the resolution of the projected grid that will be created if a

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -351,11 +351,11 @@ class BasePlotting:
         or instructions to derive intensities from the input data grid. Values
         outside this range will be clipped. Such intensity files can be created
         from the grid using `grdgradient` and, optionally, modified by
-        `grdmath` or `grdhisteq`. A third alternative is available when GMT is
-        build with GDAL support. Pass **image** which can be an image file
-        (geo-referenced or not). In this case the image can optionally be
-        illuminated with the file provided via the *shading* option. Here, if
-        image has no coordinates then those of the intensity file will be used.
+        `grdmath` or `grdhisteq`. If GMT is built with GDAL support, *grid* can
+        be an image file (geo-referenced or not). In this case the image can
+        optionally be illuminated with the file provided via the *shading*
+        option. Here, if image has no coordinates then those of the intensity
+        file will be used.
 
         When using map projections, the grid is first resampled on a new
         rectangular grid with the same dimensions. Higher resolution images can

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -432,8 +432,8 @@ class BasePlotting:
             Give the name of a grid file with intensities in the (-1,+1) range,
             or a constant intensity to apply everywhere (affects the ambient
             light). Alternatively, derive an intensity grid from the input data
-            grid via a call to `grdgradient`; append **+a** \\ *azimuth*,
-            **+n** \\ *args*, and **+m** \\ *ambient* to specify azimuth,
+            grid via a call to `grdgradient`; append **+a**\\ *azimuth*,
+            **+n**\\ *args*, and **+m**\\ *ambient* to specify azimuth,
             intensity, and ambient arguments for that module, or just give
             **+d** to select the default arguments (``+a-45+nt1+m0``). If you
             want a more specific intensity scenario then run `grdgradient`


### PR DESCRIPTION
**Description of proposed changes**

Time to put an end to all the noise about `grdimage` not being properly documented! To be fair, the documentation at https://www.pygmt.org/v0.2.0/api/generated/pygmt.Figure.grdimage.html *is* pretty embarrasing, considering that `grdimage` is one of the more widely used functions! For reference, upstream GMT docs is at https://docs.generic-mapping-tools.org/6.1/grdimage.html

Mentioned before at https://github.com/GenericMappingTools/pygmt/issues/364#issuecomment-669268901 and https://forum.generic-mapping-tools.org/t/grdgradient-in-pygmt/723/12.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Live documentation preview is at https://pygmt-git-grdimage-documentallargs.gmt.vercel.app/api/generated/pygmt.Figure.grdimage.html#pygmt.Figure.grdimage.

TODO:

Arguments/Aliases to document (see also https://www.generic-mapping-tools.org/GMT.jl/latest/#GMT.grdimage):

- [x] A - img_out
- [x] B - frame
- [x] C - cmap
- [x] D - img_in
- [x] E - dpi
- [x] G - color
- [x] I - shading
- [x] M - monochrome
- [x] N - noclip
- [x] Q - nan_alpha
- [x] R - region
- [x] U - timestamp
- [x] V - verbose
- [x] X - xshift
- [x] Y - yshift (done at #624)
-  ~f~ 
- [x] n - interpolation
- [x] p - perspective (done at #627)
- [x] t - transparency
- [x] x - cores (done at #625)

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
