### PR TITLE
Add common aliases xshift (X) and yshift (Y)

### DIFF
--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -68,6 +68,8 @@ class BasePlotting:
         G="land",
         S="water",
         U="timestamp",
+        X="xshift",
+        Y="yshift",
         t="transparency",
     )
     @kwargs_to_strings(R="sequence")
@@ -129,6 +131,7 @@ class BasePlotting:
         shorelines : str
             ``'[level/]pen'``
             Draw shorelines [Default is no shorelines]. Append pen attributes.
+        {XY}
         {t}
 
         """
@@ -146,6 +149,8 @@ class BasePlotting:
         F="box",
         G="truncate",
         W="scale",
+        X="xshift",
+        Y="yshift",
         t="transparency",
     )
     @kwargs_to_strings(R="sequence", G="sequence")
@@ -208,6 +213,7 @@ class BasePlotting:
         scale : float
             Multiply all z-values in the CPT by the provided scale. By default
             the CPT is used as is.
+        {XY}
         {t}
 
         """
@@ -229,6 +235,8 @@ class BasePlotting:
         U="timestamp",
         W="pen",
         l="label",
+        X="xshift",
+        Y="yshift",
         t="transparency",
     )
     @kwargs_to_strings(R="sequence", L="sequence", A="sequence_plus")
@@ -279,6 +287,7 @@ class BasePlotting:
         {G}
         {U}
         {W}
+        {XY}
         label : str
             Add a legend entry for the contour being plotted. Normally, the
             annotated contour is selected for the legend. You can select the
@@ -309,6 +318,8 @@ class BasePlotting:
         B="frame",
         I="shading",
         C="cmap",
+        X="xshift",
+        Y="yshift",
         t="transparency",
         x="cores",
     )
@@ -327,6 +338,7 @@ class BasePlotting:
         ----------
         grid : str or xarray.DataArray
             The file name of the input grid or the grid loaded as a DataArray.
+        {XY}
         {t}
         {x}
 
@@ -360,6 +372,8 @@ class BasePlotting:
         Wf="facadepen",
         p="perspective",
         I="shading",
+        X="xshift",
+        Y="yshift",
         t="transparency",
     )
     @kwargs_to_strings(R="sequence", p="sequence")
@@ -437,6 +451,7 @@ class BasePlotting:
             intensity, and ambient arguments for that module, or just give
             ``+d`` to select the default arguments (``+a-45+nt1+m0``).
 
+        {XY}
         {t}
 
         """
@@ -602,6 +617,8 @@ class BasePlotting:
         i="columns",
         l="label",
         C="levels",
+        X="xshift",
+        Y="yshift",
         t="transparency",
     )
     @kwargs_to_strings(R="sequence", i="sequence_comma")
@@ -660,6 +677,7 @@ class BasePlotting:
             to be of the format [*annotcontlabel*][/*contlabel*]. If either
             label contains a slash (/) character then use ``|`` as the
             separator for the two labels instead.
+        {XY}
         {t}
 
         """
@@ -691,6 +709,8 @@ class BasePlotting:
         Td="rose",
         Tm="compass",
         U="timestamp",
+        X="xshift",
+        Y="yshift",
         t="transparency",
     )
     @kwargs_to_strings(R="sequence")
@@ -725,6 +745,7 @@ class BasePlotting:
             Draws a map magnetic rose on the map at the location defined by the
             reference and anchor points
         {U}
+        {XY}
         {t}
 
         """
@@ -741,6 +762,8 @@ class BasePlotting:
         U="timestamp",
         D="position",
         F="box",
+        X="xshift",
+        Y="yshift",
         t="transparency",
     )
     @kwargs_to_strings(R="sequence")
@@ -768,6 +791,7 @@ class BasePlotting:
             Without further options, draws a rectangular border around the
             GMT logo.
         {U}
+        {XY}
         {t}
 
         """
@@ -784,6 +808,8 @@ class BasePlotting:
         D="position",
         F="box",
         M="monochrome",
+        X="xshift",
+        Y="yshift",
         t="transparency",
     )
     @kwargs_to_strings(R="sequence")
@@ -819,6 +845,7 @@ class BasePlotting:
         monochrome : bool
             Convert color image to monochrome grayshades using the (television)
             YIQ-transformation.
+        {XY}
         {t}
         """
         kwargs = self._preprocess(**kwargs)
@@ -832,6 +859,8 @@ class BasePlotting:
         J="projection",
         D="position",
         F="box",
+        X="xshift",
+        Y="yshift",
         t="transparency",
     )
     @kwargs_to_strings(R="sequence")
@@ -868,6 +897,7 @@ class BasePlotting:
             rectangular border around the legend using **MAP_FRAME_PEN**. By
             default, uses '+gwhite+p1p' which draws a box around the legend
             using a 1 point black pen and adds a white background.
+        {XY}
         {t}
         """
         kwargs = self._preprocess(**kwargs)
@@ -897,6 +927,8 @@ class BasePlotting:
         D="offset",
         G="fill",
         W="pen",
+        X="xshift",
+        Y="yshift",
         t="transparency",
     )
     @kwargs_to_strings(
@@ -1003,6 +1035,7 @@ class BasePlotting:
             Sets the pen used to draw a rectangle around the text string
             (see *clearance*) [Default is width = default, color = black,
             style = solid].
+        {XY}
         {t}
         """
         kwargs = self._preprocess(**kwargs)
@@ -1058,6 +1091,8 @@ class BasePlotting:
         J="projection",
         B="frame",
         C="offset",
+        X="xshift",
+        Y="yshift",
         t="transparency",
     )
     @kwargs_to_strings(R="sequence")
@@ -1155,6 +1190,7 @@ class BasePlotting:
         {J}
         {R}
         {B}
+        {XY}
         {t}
         """
 

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -476,6 +476,8 @@ class BasePlotting:
         l="label",
         C="cmap",
         U="timestamp",
+        X="xshift",
+        Y="yshift",
         t="transparency",
     )
     @kwargs_to_strings(R="sequence", i="sequence_comma")
@@ -544,6 +546,8 @@ class BasePlotting:
             quoted lines).
         {W}
         {U}
+        {X}
+        {Y}
         label : str
             Add a legend entry for the symbol or line being plotted.
 

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -548,8 +548,7 @@ class BasePlotting:
             quoted lines).
         {W}
         {U}
-        {X}
-        {Y}
+        {XY}
         label : str
             Add a legend entry for the symbol or line being plotted.
 

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -53,6 +53,16 @@ COMMON_OPTIONS = {
     "W": """\
         pen : str
             Set pen attributes for lines or the outline of symbols.""",
+    "X": """\
+        xshift : str
+            ``[a|c|f|r][xshift]``.
+            Shift plot origin in x-direction.
+         """,
+    "Y": """\
+        yshift : str
+            ``[a|c|f|r]yshift``.
+            Shift plot origin in y-direction.
+         """,
     "j": """\
         distcalc : str
             ``e|f|g``.

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -53,15 +53,14 @@ COMMON_OPTIONS = {
     "W": """\
         pen : str
             Set pen attributes for lines or the outline of symbols.""",
-    "X": """\
+    "XY": """\
         xshift : str
             ``[a|c|f|r][xshift]``.
             Shift plot origin in x-direction.
-         """,
-    "Y": """\
         yshift : str
-            ``[a|c|f|r]yshift``.
-            Shift plot origin in y-direction.
+            ``[a|c|f|r][yshift]``.
+            Shift plot origin in y-direction. Full documentation is at
+            :gmt-docs:`gmt.html#xy-full`.
          """,
     "j": """\
         distcalc : str


### PR DESCRIPTION
**Description of proposed changes**

Used for shifting plots along the x and y dimensions. See https://docs.generic-mapping-tools.org/6.1/gmt.html#xy-full.

![xshift yshift minimal docs with link to gmt manpage](https://user-images.githubusercontent.com/23487320/93729197-93107c80-fc17-11ea-894d-5673305058c3.png)

Live documentation preview for this PR/branch is at https://pygmt-git-common-aliases-xy.gmt.vercel.app/api/generated/pygmt.Figure.plot.html

Note that the xshift/yshift names follow upstream GMT long option name conventions at https://github.com/GenericMappingTools/gmt/blob/88421f9f8fe9759692302905268f4036b287adcb/src/gmt_init.c#L393-L394

Details to address:
1. Should we have separate `{X}` and `{Y}` entries, or a single `{XY}` entry?
2. Do we want a) full documentation from https://docs.generic-mapping-tools.org/6.1/gmt.html#xy-full, or b) just the simplified shortened docsting found at https://docs.generic-mapping-tools.org/6.1/std-opts.html? 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
See related issue at #380. This PR will be a part of #620 too.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
