### PR TITLE
Add common alias cores (x) for grdimage and other multi-threaded modules

### DIFF
--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -310,6 +310,7 @@ class BasePlotting:
         I="shading",
         C="cmap",
         t="transparency",
+        x="cores",
     )
     @kwargs_to_strings(R="sequence")
     def grdimage(self, grid, **kwargs):
@@ -327,6 +328,7 @@ class BasePlotting:
         grid : str or xarray.DataArray
             The file name of the input grid or the grid loaded as a DataArray.
         {t}
+        {x}
 
         """
         kwargs = self._preprocess(**kwargs)

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -89,6 +89,16 @@ COMMON_OPTIONS = {
             Only visible when PDF or raster format output is selected.
             Only the PNG format selection adds a transparency layer
             in the image (for further processing). """,
+    "x": """\
+        cores : int
+            ``[[-]n]``.
+            Limit the number of cores to be used in any OpenMP-enabled
+            multi-threaded algorithms. By default we try to use all available
+            cores. Set a number *n* to only use n cores (if too large it will
+            be truncated to the maximum cores available). Finally, give a
+            negative number *-n* to select (all - n) cores (or at least 1 if
+            n equals or exceeds all).
+            """,
 }
 
 


### PR DESCRIPTION
**Description of proposed changes**

Used for setting the number of cores to be used in any OpenMP-enabled multi-threaded algorithms. E.g. for functions like `grdimage`, [`x2sys_solve`](https://docs.generic-mapping-tools.org/6.1/supplements/x2sys/x2sys_solve.html) (not yet available on PyGMT) and others. See also https://docs.generic-mapping-tools.org/6.1/cookbook/options.html#selecting-number-of-cpu-cores-the-x-option.

Note that the `cores` name follow upstream GMT's long option name convention at https://github.com/GenericMappingTools/gmt/blob/88421f9f8fe9759692302905268f4036b287adcb/src/gmt_init.c#L414

Related to #620.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
