### PR TITLE
Fix two typos in x2sys_cross docstrings

### DIFF
--- a/pygmt/x2sys.py
+++ b/pygmt/x2sys.py
@@ -206,8 +206,8 @@ def x2sys_cross(tracks=None, outfile=None, **kwargs):
         in the current directory and second in all directories listed in
         $X2SYS_HOME/TAG/TAG_paths.txt (if it exists). [If $X2SYS_HOME is not
         set it will default to $GMT_SHAREDIR/x2sys]. (Note: MGD77 files will
-        also be looked for via $MGD77_HOME/mgd77_paths.txt and *.gmt files will
-        be searched for via $GMT_SHAREDIR/mgg/gmtfile_paths).
+        also be looked for via $MGD77_HOME/mgd77_paths.txt and \\*.gmt files
+        will be searched for via $GMT_SHAREDIR/mgg/gmtfile_paths).
 
     outfile : str
         Optional. The file name for the output ASCII txt file to store the
@@ -271,7 +271,7 @@ def x2sys_cross(tracks=None, outfile=None, **kwargs):
         headings will not be computed (i.e., set to NaN) [Default calculates \
         headings regardless of speed].
 
-        For example, you can use ``speed=["l0", "u10", "h5"] to set a lower
+        For example, you can use ``speed=["l0", "u10", "h5"]`` to set a lower
         speed of 0, upper speed of 10, and disable heading calculations for
         speeds below 5.
 


### PR DESCRIPTION
**Description of proposed changes**

Before the fix, building the documentation gives the following warnings:

```
docstring of pygmt.x2sys_cross:32: WARNING: Inline emphasis start-string without end-string.
docstring of pygmt.x2sys_cross:94: WARNING: Inline literal start-string without end-string.
```

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.