### PR TITLE
Add a workflow checking links in plaintext and HTML files

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -3,7 +3,7 @@ name: Check Links
 
 on:
   # Uncomment the 'pull_request' line below to trigger the workflow in PR
-  pull_request:
+  # pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,55 @@
+# This workflow checks the links in plaintext and HTML files
+name: Check Links
+
+on:
+  # Uncomment the 'pull_request' line below to trigger the workflow in PR
+  pull_request:
+  # Schedule runs on 12 noon every Sunday
+  schedule:
+    - cron: '0 12 * * 0'
+
+jobs:
+  check_links:
+    name: Check Links
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v2.3.4
+      with:
+        path: repository
+
+    - name: Checkout the documentation
+      uses: actions/checkout@v2.3.4
+      with:
+        ref: gh-pages
+        path: documentation
+
+    - name: Link Checker
+      uses: lycheeverse/lychee-action@v1.0.4
+      with:
+        # 429: Too many requests
+        args: >
+          --accept 429
+          --exclude "^https://zenodo.org/badge/DOI/$"
+          --exclude "^https://github.com/GenericMappingTools/pygmt/pull/[0-9]*$"
+          --exclude "^https://github.com/GenericMappingTools/pygmt/issues/[0-9]*$"
+          --exclude "^https://www.generic-mapping-tools.org/_static/gmt-logo.png/$"
+          --exclude "^https://www.generic-mapping-tools.org/_static/gmt-logo.png/n/n$"
+          --exclude "^``@ridge.txt$"
+          --exclude "^git"
+          --exclude "^file://"
+          --exclude "^https://docs.generic-mapping-tools.org/latest/%s$"
+          --verbose
+          "repository/**/*.rst"
+          "repository/**/*.md"
+          "repository/**/*.py"
+          "documentation/dev/**/*.html"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create Issue From File
+      uses: peter-evans/create-issue-from-file@v2.3.2
+      with:
+        title: Link Checker Report
+        content-filepath: ./lychee/out.md


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a workflow to check external links in plaintext and HTML files, using action https://github.com/lycheeverse/lychee-action.

- External links in the ReST, Markdown and Python files in the master branch are checked
- External links in the dev documentation (https://www.pygmt.org/dev/) are checked
- Internal links are **NOT** checked, but when we build the documentation, we should see the warnings if internal links are broken.
- Links to PRs and issues are excluded, because they are unlikely to be broken
- The workflow runs weekly. If broken links (404) are detected, it will report an issue (see https://github.com/GenericMappingTools/pygmt/issues/927 for an example, in which I added a broken link https://www.pygmt.org/abc/def for testing).
 
FYI, the workflow takes 50 seconds to check >1000 links. See the workflow runs in https://github.com/GenericMappingTools/pygmt/runs/1931775335?check_suite_focus=true.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #535


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
