### PR TITLE
Refactor three xfail grdcontour tests

### DIFF
--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -6,10 +6,9 @@ import os
 import numpy as np
 import pytest
 
-from .. import Figure, grdcut
+from .. import Figure
 from ..exceptions import GMTInvalidInput
 from ..datasets import load_earth_relief
-from ..helpers import GMTTempFile
 from ..helpers.testing import check_figures_equal
 
 
@@ -60,15 +59,11 @@ def test_grdcontour_slice(grid):
     fig_ref, fig_test = Figure(), Figure()
 
     grid_ = grid.sel(lat=slice(-30, 30))
-    fig_test.grdcontour(grid_, interval="1000", projection="M6i")
-
-    with GMTTempFile(suffix=".nc") as tmpgrid:
-        grdcut(
-            grid="@earth_relief_01d_g",
-            region=[-180, 180, -30, 30],
-            outgrid=tmpgrid.name,
-        )
-        fig_ref.grdcontour(tmpgrid.name, interval="1000", projection="M6i")
+    kwargs = dict(interval="1000", projection="M6i")
+    fig_ref.grdcontour(
+        grid="@earth_relief_01d_g", region=[-180, 180, -30, 30], **kwargs
+    )
+    fig_test.grdcontour(grid=grid_, **kwargs)
     return fig_ref, fig_test
 
 

--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -6,9 +6,11 @@ import os
 import numpy as np
 import pytest
 
-from .. import Figure
+from .. import Figure, grdcut
 from ..exceptions import GMTInvalidInput
 from ..datasets import load_earth_relief
+from ..helpers import GMTTempFile
+from ..helpers.testing import check_figures_equal
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
@@ -21,49 +23,53 @@ def fixture_grid():
     return load_earth_relief(registration="gridline")
 
 
-@pytest.mark.xfail(
-    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
-)
-@pytest.mark.mpl_image_compare
+@check_figures_equal()
 def test_grdcontour(grid):
     """Plot a contour image using an xarray grid
     with fixed contour interval
     """
-    fig = Figure()
-    fig.grdcontour(grid, interval="1000", projection="W0/6i")
-    return fig
+    fig_ref, fig_test = Figure(), Figure()
+    kwargs = dict(interval="1000", projection="W0/6i")
+    fig_ref.grdcontour("@earth_relief_01d_g", **kwargs)
+    fig_test.grdcontour(grid, **kwargs)
+    return fig_ref, fig_test
 
 
-@pytest.mark.xfail(
-    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
-)
-@pytest.mark.mpl_image_compare
+@check_figures_equal()
 def test_grdcontour_labels(grid):
     """Plot a contour image using a xarray grid
     with contour labels and alternate colors
     """
-    fig = Figure()
-    fig.grdcontour(
-        grid,
+    fig_ref, fig_test = Figure(), Figure()
+    kwargs = dict(
         interval="1000",
         annotation="5000",
         projection="W0/6i",
         pen=["a1p,red", "c0.5p,black"],
         label_placement="d3i",
     )
-    return fig
+    fig_ref.grdcontour("@earth_relief_01d_g", **kwargs)
+    fig_test.grdcontour(grid, **kwargs)
+    return fig_ref, fig_test
 
 
-@pytest.mark.xfail(
-    reason="Baseline image not updated to use earth relief grid in GMT 6.1.0",
-)
-@pytest.mark.mpl_image_compare
+@check_figures_equal()
 def test_grdcontour_slice(grid):
     "Plot an contour image using an xarray grid that has been sliced"
+
+    fig_ref, fig_test = Figure(), Figure()
+
     grid_ = grid.sel(lat=slice(-30, 30))
-    fig = Figure()
-    fig.grdcontour(grid_, interval="1000", projection="M6i")
-    return fig
+    fig_test.grdcontour(grid_, interval="1000", projection="M6i")
+
+    with GMTTempFile(suffix=".nc") as tmpgrid:
+        grdcut(
+            grid="@earth_relief_01d_g",
+            region=[-180, 180, -30, 30],
+            outgrid=tmpgrid.name,
+        )
+        fig_ref.grdcontour(tmpgrid.name, interval="1000", projection="M6i")
+    return fig_ref, fig_test
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -71,7 +71,7 @@ def test_grdimage_file():
 
 @pytest.mark.xfail(reason="Upstream bug in GMT 6.1.1")
 @check_figures_equal()
-def test_grdimage_xarray_shading(grid, fig_ref, fig_test):
+def test_grdimage_xarray_shading(grid):
     """
     Test that shading works well for xarray.
     See https://github.com/GenericMappingTools/pygmt/issues/364


### PR DESCRIPTION
**Description of proposed changes**

Refractor three grdcontour tests using the `@check_figures_equal` decorator so that they no longer xfail.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
