### PR TITLE
Disallow passing arguments like -XNone to GMT

### DIFF
--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -127,7 +127,8 @@ def build_arg_string(kwargs):
     Examples
     --------
 
-    >>> print(build_arg_string(dict(R='1/2/3/4', J="X4i", P='', E=200)))
+    >>> print(build_arg_string(dict(R='1/2/3/4', J="X4i", P='',
+    ...                             E=200, X=None, Y=None)))
     -E200 -JX4i -P -R1/2/3/4
     >>> print(build_arg_string(dict(R='1/2/3/4', J="X4i",
     ...                             B=['xaf', 'yaf', 'WSen'],
@@ -140,6 +141,8 @@ def build_arg_string(kwargs):
         if is_nonstr_iter(kwargs[key]):
             for value in kwargs[key]:
                 sorted_args.append("-{}{}".format(key, value))
+        elif kwargs[key] is None:  # arguments like -XNone are invalid
+            continue
         else:
             sorted_args.append("-{}{}".format(key, kwargs[key]))
 

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -127,7 +127,11 @@ def build_arg_string(kwargs):
     Examples
     --------
 
-    >>> print(build_arg_string(dict(R="1/2/3/4", J="X4i", P="", E=200, X=None, Y=None)))
+    >>> print(
+    ...     build_arg_string(
+    ...         dict(R="1/2/3/4", J="X4i", P="", E=200, X=None, Y=None)
+    ...     )
+    ... )
     -E200 -JX4i -P -R1/2/3/4
     >>> print(
     ...     build_arg_string(


### PR DESCRIPTION
**Description of proposed changes**

Arguments like `-XNone` are invalid for GMT.

This PR updates the function `build_arg_string` and checks if any value is `None`.
If yes, remove the argument.

**Limitations**:

Invalid arguments like `{'X': [None, None, None]}` are still not caught and
converted to `-XNone -XNone -XNone`, but it should be uncommon and more likely
a user error.

Fixes #380.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.