### PR TITLE
[DO NOT MERGE THIS PR] Add slash command "/black" to format PRs

### DIFF
--- a/.github/workflows/black-command.yaml
+++ b/.github/workflows/black-command.yaml
@@ -1,0 +1,44 @@
+name: black-command
+on:
+  repository_dispatch:
+    types: [black-command]
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the pull request branch
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref }}
+
+      # Setup Python environment
+      - uses: actions/setup-python@v1
+
+      # Install black
+      - name: Install black
+        run: pip install black
+
+      # Execute black in check mode
+      - name: Black
+        id: black
+        run: echo ::set-output name=format::$(black --check --quiet . || echo "true")
+
+      # Execute black and commit the change to the PR branch
+      - name: Commit to the PR branch
+        if: steps.black.outputs.format == 'true'
+        run: |
+          black .
+          git config --global user.name 'actions-bot'
+          git config --global user.email '58130806+actions-bot@users.noreply.github.com'
+          git commit -am "[black-command] fixes"
+          git push
+
+      - name: Add reaction
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reaction-type: hooray

--- a/.github/workflows/black-command.yml
+++ b/.github/workflows/black-command.yml
@@ -9,7 +9,7 @@ jobs:
       # Checkout the pull request branch
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          token: ${{ secrets.PAT }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
 

--- a/.github/workflows/black-command.yml
+++ b/.github/workflows/black-command.yml
@@ -9,7 +9,7 @@ jobs:
       # Checkout the pull request branch
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
@@ -38,7 +38,7 @@ jobs:
       - name: Add reaction
         uses: peter-evans/create-or-update-comment@v1
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reaction-type: hooray

--- a/.github/workflows/black-command.yml
+++ b/.github/workflows/black-command.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Add reaction
         uses: peter-evans/create-or-update-comment@v1
         with:
-          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          token: ${{ secrets.PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reaction-type: hooray

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -13,3 +13,4 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           commands: black
+          issue-type: pull-request

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -1,0 +1,15 @@
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    # Type "edited" added here for test purposes. Where possible, avoid
+    # using to prevent processing unnecessary events.
+    types: [created, edited]
+jobs:
+  slashCommandDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.PAT }}
+          commands: black


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a special github action to enable [slash commands](https://github.com/peter-evans/slash-command-dispatch) in comments. With the feature enabled, anyone, who have written permission to a pull request, can write `/black` at the first line of a comment to trigger the "black" action, which can format the codes automatically.

I tried to write the slash command `/black` in the comments below, but it doesn't work as I expect. It seems the special event "repository dispatch" can only read configurations files in the master branch. Thus, testing the action will definitely pollute the git history of the master branch. So I forked pygmt to my account (https://github.com/seisman/pygmt) and do some tests on my own fork. 

---

The slash command works well in my fork. Here are the changes to the master branch in my own fork: https://github.com/GenericMappingTools/pygmt/compare/master...seisman:master (I will open a PR to merge these changes into master branch).

https://github.com/seisman/pygmt/pull/5 is a PR I opened with some bad changes to codes. Writting `/format` (I use `/format` instead of `/black` in my fork) in the comment triggered the action to format the codes automatically.

Here is the screenshot:
![image](https://user-images.githubusercontent.com/3974108/95548986-4200d680-09d4-11eb-9939-da8fd0988981.png)

---

Please review the changes of https://github.com/GenericMappingTools/pygmt/compare/master...seisman:master (I made a PR in #646 for easier review).

BTW, feel free to submit PRs to my fork https://github.com/seisman/pygmt, to check if slash commands work for PRs from external contributors.

NOTE: PR #645 won't be merged.
