### PR TITLE
Add slash command "/format" to automatically format PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,3 +15,7 @@ Fixes #
 - [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
 - [ ] Write detailed docstrings for all functions/methods.
 - [ ] If adding new functionality, add an example to docstrings or tutorials.
+
+**Notes**
+
+- You can write `/foramt` in the first line of a comment to automatically format your codes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,4 +18,4 @@ Fixes #
 
 **Notes**
 
-- You can write `/foramt` in the first line of a comment to automatically format your codes
+- You can write `/format` in the first line of a comment to lint the code automatically

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -6,10 +6,17 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
+      # Generate token from GenericMappingTools bot
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       # Checkout the pull request branch
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
@@ -34,7 +41,7 @@ jobs:
       - name: Add reaction
         uses: peter-evans/create-or-update-comment@v1
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reaction-type: hooray

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -1,0 +1,44 @@
+name: format-command
+on:
+  repository_dispatch:
+    types: [format-command]
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the pull request branch
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref }}
+
+      # Setup Python environment
+      - uses: actions/setup-python@v1
+
+      # Install formatting tools
+      - name: Install formatting tools
+        run: pip install black blackdoc flake8
+
+      # Run "make check"
+      - name: Style check
+        id: format
+        run: echo ::set-output name=format::$(make check || echo "true")
+
+      # Run "make format" and commit the change to the PR branch
+      - name: Commit to the PR branch
+        if: steps.format.outputs.format == 'true'
+        run: |
+          make format
+          git config --global user.name 'actions-bot'
+          git config --global user.email '58130806+actions-bot@users.noreply.github.com'
+          git commit -am "[format-command] fixes"
+          git push
+
+      - name: Add reaction
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reaction-type: hooray

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           make check
           echo ::set-output name=format::$?
+        continue-on-error: true
 
       # Run "make format" and commit the change to the PR branch
       - name: Commit to the PR branch

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -28,6 +28,10 @@ jobs:
           echo ::set-output name=format::$?
         continue-on-error: true
 
+      - name: Debug
+        run: |
+          echo ${{ steps.check.outputs.format }}
+
       # Run "make format" and commit the change to the PR branch
       - name: Commit to the PR branch
         if: steps.check.outputs.format != 0

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -20,27 +20,16 @@ jobs:
       - name: Install formatting tools
         run: pip install black blackdoc flake8
 
-      # Run "make check"
-      - name: Style check
-        id: check
-        run: |
-          make check
-          echo ::set-output name=format::$?
-        continue-on-error: true
-
-      - name: Debug
-        run: |
-          echo ${{ steps.check.outputs.format }}
-
       # Run "make format" and commit the change to the PR branch
-      - name: Commit to the PR branch
-        if: steps.check.outputs.format != 0
+      - name: Commit to the PR branch if any changes
         run: |
           make format
-          git config --global user.name 'actions-bot'
-          git config --global user.email '58130806+actions-bot@users.noreply.github.com'
-          git commit -am "[format-command] fixes"
-          git push
+          if [ $(git ls-files -m) ]; then
+            git config --global user.name 'actions-bot'
+            git config --global user.email '58130806+actions-bot@users.noreply.github.com'
+            git commit -am "[format-command] fixes"
+            git push
+          fi
 
       - name: Add reaction
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Commit to the PR branch if any changes
         run: |
           make format
-          if [ $(git ls-files -m) ]; then
+          if [[ $(git ls-files -m) ]]; then
             git config --global user.name 'actions-bot'
             git config --global user.email '58130806+actions-bot@users.noreply.github.com'
             git commit -am "[format-command] fixes"

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -22,12 +22,14 @@ jobs:
 
       # Run "make check"
       - name: Style check
-        id: format
-        run: echo ::set-output name=format::$(make check || echo "true")
+        id: check
+        run: |
+          make check
+          echo ::set-output name=format::$?
 
       # Run "make format" and commit the change to the PR branch
       - name: Commit to the PR branch
-        if: steps.format.outputs.format == 'true'
+        if: steps.check.outputs.format != 0
         run: |
           make format
           git config --global user.name 'actions-bot'

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -8,10 +8,17 @@ jobs:
   slashCommandDispatch:
     runs-on: ubuntu-latest
     steps:
+      # Generate token from GenericMappingTools bot
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v2
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           commands: |
             format
           issue-type: pull-request

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -1,0 +1,17 @@
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+    # Add "edited" type for test purposes. Where possible, avoid using to prevent processing unnecessary events.
+    # types: [created, edited]
+jobs:
+  slashCommandDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.PAT }}
+          commands: |
+            format
+          issue-type: pull-request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,8 +257,8 @@ make format
 
 Don't worry if you forget to do it. Our continuous integration systems will
 warn us and you can make a new commit with the formatted code.
-Even better, you can just write `/format` in the first line of any comments to
-automatically format your codes.
+Even better, you can just write `/format` in the first line of any comment in a
+Pull Request to lint the code automatically.
 
 We also use [flake8](http://flake8.pycqa.org/en/latest/) and
 [pylint](https://www.pylint.org/) to check the quality of the code and quickly catch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,9 +255,10 @@ Before committing, run it to automatically format your code:
 make format
 ```
 
-Don't worry if you forget to do it.
-Our continuous integration systems will warn us and you can make a new commit with the
-formatted code.
+Don't worry if you forget to do it. Our continuous integration systems will
+warn us and you can make a new commit with the formatted code.
+Even better, you can just write `/format` in the first line of any comments to
+automatically format your codes.
 
 We also use [flake8](http://flake8.pycqa.org/en/latest/) and
 [pylint](https://www.pylint.org/) to check the quality of the code and quickly catch


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a special github action to enable [slash commands](https://github.com/peter-evans/slash-command-dispatch) in comments. With the feature enabled, anyone, who have written permission to a pull request, can write `/format` at the first line of a comment to trigger the "format" action, which can format the codes automatically.

See #645 for context. 

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
