### PR TITLE
Add mini-galleries for methods and functions

### DIFF
--- a/doc/_templates/autosummary/method.rst
+++ b/doc/_templates/autosummary/method.rst
@@ -2,11 +2,10 @@
 
 .. currentmodule:: {{ module }}
 
-.. autofunction:: {{ objname }}
+.. automethod:: {{ objname }}
 
 .. include:: backreferences/{{ fullname }}.examples
 
 .. raw:: html
 
      <div style='clear:both'></div>
-


### PR DESCRIPTION
**Description of proposed changes**

This PR updates the [autosummary](https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html) templates, to show mini-galleries of all methods and functions at the end of the documentation page.

Here is the screenshot for the documentation of the `pygmt.Figure.plot()` method:

![image](https://user-images.githubusercontent.com/3974108/95647262-08939e00-0a9c-11eb-9158-99ea33ac4d96.png)

It's better to see the differences by comparing the API documentation of the current dev version and the preview of this branch.

- Current dev documentation: https://www.pygmt.org/dev/api/index.html
- Preview of current branch: https://pygmt-git-method-gallary.gmt.vercel.app/api/index.html


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
