### PR TITLE
Mark xarray shading test fail for GMT<=6.1.1

### DIFF
--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -4,11 +4,15 @@ Test Figure.grdimage
 import numpy as np
 import pytest
 import xarray as xr
+from packaging.version import Version
 
-from .. import Figure
+from .. import Figure, clib
 from ..datasets import load_earth_relief
 from ..exceptions import GMTInvalidInput
 from ..helpers.testing import check_figures_equal
+
+with clib.Session() as _lib:
+    gmt_version = Version(_lib.info["version"])
 
 
 @pytest.fixture(scope="module", name="grid")
@@ -69,7 +73,10 @@ def test_grdimage_file():
     return fig
 
 
-@pytest.mark.xfail(reason="Upstream bug in GMT 6.1.1")
+@pytest.mark.xfail(
+    reason="Upstream bug in GMT 6.1.1",
+    condition=gmt_version <= Version("6.1.1"),
+)
 @check_figures_equal()
 def test_grdimage_xarray_shading(grid):
     """


### PR DESCRIPTION
**Description of proposed changes**

The xarray shading issue in #364 was fixed by upstream GMT in https://github.com/GenericMappingTools/gmt/pull/4328. 

This PR updates the pytest xfail condition, so that the xarray shading test is expected to xfail only for GMT<=6.1.1.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
