### PR TITLE
Add more tests for xarray grid shading

### DIFF
--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -78,10 +78,19 @@ def test_grdimage_file():
     condition=gmt_version <= Version("6.1.1"),
 )
 @check_figures_equal()
-def test_grdimage_xarray_shading(grid):
+@pytest.mark.parametrize(
+    "shading",
+    [True, 0.5, "+a30+nt0.8", "@earth_relief_01d_g+d", "@earth_relief_01d_g+a60+nt0.8"],
+)
+def test_grdimage_shading_xarray(grid, shading):
     """
     Test that shading works well for xarray.
-    See https://github.com/GenericMappingTools/pygmt/issues/364
+
+    The ``shading`` can be True, a constant intensity, some modifiers, or
+    a grid with modifiers.
+
+    See https://github.com/GenericMappingTools/pygmt/issues/364 and
+    https://github.com/GenericMappingTools/pygmt/issues/618.
     """
     fig_ref, fig_test = Figure(), Figure()
     kwargs = dict(
@@ -89,7 +98,7 @@ def test_grdimage_xarray_shading(grid):
         frame=True,
         projection="Cyl_stere/6i",
         cmap="geo",
-        shading=True,
+        shading=shading,
     )
 
     fig_ref.grdimage("@earth_relief_01d_g", **kwargs)


### PR DESCRIPTION
**Description of proposed changes**

This PR adds more tests for xarray grid shading.

Valid `shading` values are:

- boolean
- a constant intensity
- some modifiers to automatically derive an intensity grid from input grid
- an intensity grid with modifiers
- an intensity grid in the (-1,+1) range

This PR covers the first 4 cases only. Of course, it only works for GMT>=6.2.0

Address #618.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
