### PR TITLE
Add a gallery example for varying transparent points

### DIFF
--- a/examples/gallery/plot/points-transparency.py
+++ b/examples/gallery/plot/points-transparency.py
@@ -10,16 +10,16 @@ import numpy as np
 import pygmt
 
 # prepare the input x and y data
-x = np.linspace(0, 3.0 * np.pi, 100)
-y = np.sin(x)
+x = np.arange(0, 105, 5)
+y = np.ones(x.size)
 # transparency level in percentage from 0 (i.e., opaque) to 100
-transparency = np.linspace(0, 100, x.size)
+transparency = x
 
 fig = pygmt.Figure()
 fig.basemap(
-    region=[x.min(), x.max(), y.min() * 1.1, y.max() * 1.1],
-    frame=["af", 'WSrt+t"Varying Transparency"'],
-    projection="X10c/6c",
+    region=[-5, 105, 0, 2],
+    frame=['xaf+l"Transparency level"+u%', "WSrt"],
+    projection="X15c/6c",
 )
-fig.plot(x=x, y=y, style="c0.15c", color="blue", transparency=transparency)
+fig.plot(x=x, y=y, style="c0.6c", color="blue", pen="1p,red", transparency=transparency)
 fig.show()

--- a/examples/gallery/plot/points-transparency.py
+++ b/examples/gallery/plot/points-transparency.py
@@ -2,8 +2,8 @@
 Points with varying transparency
 --------------------------------
 
-Plotting points with varying transparency is simply passing an array to the
-``transparency`` argument.
+Points can be plotted with different transparency levels by passing in an array to the
+``transparency`` argument of :meth:`pygmt.Figure.plot`.
 """
 
 import numpy as np

--- a/examples/gallery/plot/points-transparency.py
+++ b/examples/gallery/plot/points-transparency.py
@@ -1,0 +1,25 @@
+"""
+Points with varying transparency
+--------------------------------
+
+Plotting points with varying transparency is simply passing an array to the
+``transparency`` argument.
+"""
+
+import numpy as np
+import pygmt
+
+# prepare the input x and y data
+x = np.linspace(0, 3.0 * np.pi, 100)
+y = np.sin(x)
+# transparency level in percentage from 0 (i.e., opaque) to 100
+transparency = np.linspace(0, 100, x.size)
+
+fig = pygmt.Figure()
+fig.basemap(
+    region=[x.min(), x.max(), y.min() * 1.1, y.max() * 1.1],
+    frame=["af", 'WSrt+t"Varying Transparency"'],
+    projection="X10c/6c",
+)
+fig.plot(x=x, y=y, style="c0.15c", color="blue", transparency=transparency)
+fig.show()


### PR DESCRIPTION
**Description of proposed changes**

Add a gallery example for the new feature in #626.
![image](https://user-images.githubusercontent.com/3974108/96403329-1a64f780-11a6-11eb-8879-78b04823abdd.png)

Address #615. 

Preview: https://pygmt-qmth2blje.vercel.app/gallery/plot/points-transparency.html

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [x] If adding new functionality, add an example to docstrings or tutorials.
