### PR TITLE
Fix Github to GitHub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 <!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->
 
-<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
+<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
 Fixes #
 
 

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -37,8 +37,8 @@ jobs:
                         @tut_bathy.nc @tut_quakes.ngdc @tut_ship.xyz \
                         @usgs_quakes_22.txt
 
-      # Upload the downloaded files as artifacts to Github
-      - name: Upload artifacts to Github
+      # Upload the downloaded files as artifacts to GitHub
+      - name: Upload artifacts to GitHub
         uses: actions/upload-artifact@v2
         with:
           name: gmt-cache

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -89,8 +89,8 @@ jobs:
         shell: bash -l {0}
         run: conda list
 
-      # Download cached remote files (artifacts) from Github
-      - name: Download remote data from Github
+      # Download cached remote files (artifacts) from GitHub
+      - name: Download remote data from GitHub
         uses: dawidd6/action-download-artifact@v2.6.3
         with:
           workflow: cache_data.yaml

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -61,8 +61,8 @@ jobs:
         env:
           GMT_GIT_REF: ${{ matrix.gmt_git_ref }}
 
-      # Download cached remote files (artifacts) from Github
-      - name: Download remote data from Github
+      # Download cached remote files (artifacts) from GitHub
+      - name: Download remote data from GitHub
         uses: dawidd6/action-download-artifact@v2.6.3
         with:
           workflow: cache_data.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ branches:
 env:
     global:
         # Encrypted variables
-        # Github Token for pushing the built docs (GH_TOKEN)
+        # GitHub Token for pushing the built docs (GH_TOKEN)
         - secure: "QII0477v0mmCCW3qSNXLCOtqraJaCICtSghiyrxYsuUdJTrXzXBNhX2KLIjcKYXOK1HdwYOFGf8xBVLl44clHlAW7R32ecEGeTJizr0yqTBvT3rNG1Xb7+E6jdXqrIs//PmPRaF8zOZxPl1SJKDK4jJpCx5HnAflg7wl/6tQLD6K3/dQ6FG2s3UKsc8o4qchOiEfxYhOuKo3jt2S0HdsNAQFw3mFHCCrclxDr3llSQtWSY0mirZnta7AI4nMvzxl2nUhdHEpxgzIjWxCWLAwmj3/NxLz0VSgNCtl2bNYk6AYrc5RcANGk2fcYaZr9mTU3Aax60S4389B39Pq95hBN21jYdbw9vCN810dYpTUk2siLysx8gF6r2JWEF8SskXlF79r3phtaFTMOS4GqeiuwjifZeaLAL/H1PTQFDDG/UKEwBpLuzrPMDw/84iRtyWKqWR/f14YdKhH4YAkcOuRglEXiI/1A0qWKiZ1iZfky8Tys+wN5nyss23w/JeYXVgBdTkNzvp3diFWK8+Wl9j3HYpX9LlEHJwASA1wHLL85t4ToymgLjo9gvLvwzB7T+fWNtEbh4ELbvI7jaKrvir8uSGYy4bGbfRclh5CktD//mTLhDyAsQDS8obF/Ri9mVqFzjK6417ORfu8qnpXU+mIHPRBoKvpS2WqnPtSwF8KPv8="
         # TWINE_PASSWORD to deploy to PyPI
         - secure: "md4fgPt9RC/sCoN5//5PcNHLUd9gWQGewV5hFpWW88MRTjxTng1Zfs8r7SqlF2AkEEepFfyzq0BEe9c3FMAnFbec3KmqdlQen4V8xDbLrcTlvkPlTrYGbAScUvdhhqojB//hMHoTD4KvxAv9CiUwFBO4hCMmj2buWHUbV9Ksu5WCW9mF/gkt/hIuYAU6Mbwt8PiYyMgUpzMHO1vruofcWRaVnvKwmBqHB0ae86D4/drpwn4CWjlM12WUnphT2bssiyPkw24FZtCN6kPVta6bLZKBxu0bZpw2vbXuUG+Yh19Q4mp8wNYT3XSHJf8Hl5LfujF48+cLWu+6rlCkdcelyVylhWLFc3rGOONAv4G8jWW2yNSz/bLQfJnMpd81fQEu5eySmFxB7mdB0uyKpvIG1jMJQ73LlYKakKLAPdYhMFyQAHoX9gvCE3S4QR95DBMi5gM/pZubOCcMLdjPHB5JKpJHSjxbOzyVwgmsUIEgd5Bi2vZvvYQXn1plk4xpQ3PhXc+/gi33bzY89mKcfOn0HJ2pD1vLqDXRCBsMCakoLZ0JB/6bacaz4FngbsGWuQ+I1cz20lJGL/MSi9bW1G7Uoidt3GXXWDmXrWt70vIXlLIxr8XV0Mu/rPbauGgWE+ZSYEfvdM5sP+FNF7vQ5de+Fkvzg5Z3tTfR+O1W+d7+vM4="

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ for the project where you can ask questions.
 
 ## Reporting a Bug
 
-Find the *Issues* tab on the top of the Github repository and click *New Issue*.
+Find the *Issues* tab on the top of the GitHub repository and click *New Issue*.
 You'll be prompted to choose between different types of issue, like bug reports and
 feature requests.
 Choose the one that best matches your need.
@@ -92,7 +92,7 @@ download and install anything:
 * On each documentation page, there should be an "Improve This Page" link at the very
   top.
 * Click on that link to open the respective source file (usually an `.rst` file in the
-  `doc` folder) on Github for editing online (you'll need a Github account).
+  `doc` folder) on GitHub for editing online (you'll need a GitHub account).
 * Make your desired changes.
 * When you're done, scroll to the bottom of the page.
 * Fill out the two fields under "Commit changes": the first is a short title describing
@@ -428,7 +428,7 @@ Some things that will increase the chance that your pull request is accepted qui
 
 Pull requests will automatically have tests run by TravisCI.
 This includes running both the unit tests as well as code linters.
-Github will show the status of these checks on the pull request.
+GitHub will show the status of these checks on the pull request.
 Try to get them all passing (green).
 If you have any trouble, leave a comment in the PR or
 [get in touch](#how-can-i-talk-to-you).

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -11,7 +11,7 @@ If you want to make a contribution to the project, see the
 
 * *master*: Always tested and ready to become a new version. Don't push directly to this
   branch. Make a new branch and submit a pull request instead.
-* *gh-pages*: Holds the HTML documentation and is served by Github. Pages for the master
+* *gh-pages*: Holds the HTML documentation and is served by GitHub. Pages for the master
   branch are in the `dev` folder. Pages for each release are in their own folders.
   **Automatically updated by TravisCI** so you shouldn't have to make commits here.
 
@@ -40,12 +40,12 @@ The main advantages of this are:
 
 ## Continuous Integration
 
-We use Github Actions and TravisCI continuous integration (CI) services to
+We use GitHub Actions and TravisCI continuous integration (CI) services to
 build and test the project on Linux, macOS and Windows.
 They rely on the `requirements.txt` file to install required dependencies using
 conda and the `Makefile` to run the tests and checks.
 
-### Github Actions
+### GitHub Actions
 
 There are 3 configuration files located in `.github/workflows`:
 
@@ -59,7 +59,7 @@ It is also scheduled to run daily on the *master* branch.
 This is only triggered when a review is requested or re-requested on a PR.
 It is also scheduled to run daily on the *master* branch.
 
-3. `cache_data.yaml` (Caches GMT remote data files needed for Github Actions CI)
+3. `cache_data.yaml` (Caches GMT remote data files needed for GitHub Actions CI)
 
 This is scheduled to run every Sunday at 12 noon.
 If new remote files are needed urgently, maintainers can manually uncomment
@@ -85,7 +85,7 @@ submit pull requests to that repository.
 
 ## Continuous Documentation
 
-We use the [Zeit Now for Github integration](https://zeit.co/github) to preview changes
+We use the [Zeit Now for GitHub integration](https://zeit.co/github) to preview changes
 made to our documentation website every time we make a commit in a pull request.
 The integration service has a configuration file `now.json`, with a list of options to
 change the default behaviour at https://zeit.co/docs/configuration.
@@ -103,10 +103,10 @@ There are a few steps that still must be done manually, though.
 
 ### Updating the changelog
 
-The Release Drafter Github Action will automatically keep a draft changelog at
+The Release Drafter GitHub Action will automatically keep a draft changelog at
 https://github.com/GenericMappingTools/pygmt/releases, adding a new entry
 every time a Pull Request (with a proper label) is merged into the master branch.
-This release drafter tool has two configuration files, one for the Github Action
+This release drafter tool has two configuration files, one for the GitHub Action
 at .github/workflows/release-drafter.yml, and one for the changelog template
 at .github/release-drafter.yml. Configuration settings can be found at
 https://github.com/release-drafter/release-drafter.
@@ -122,7 +122,7 @@ publishing the actual release notes at https://www.pygmt.org/latest/changes.html
 
 2. Edit the changes list to remove any trivial changes (updates to the README, typo
    fixes, CI configuration, etc).
-3. Replace the PR number in the commit titles with a link to the Github PR page.
+3. Replace the PR number in the commit titles with a link to the GitHub PR page.
    Use ``sed -i.bak -E 's$\(#([0-9]*)\)$(`#\1 <https://github.com/GenericMappingTools/pygmt/pull/\1>`__)$g' changes.rst``
    to make the change automatically.
 4. Copy the remaining changes to `doc/changes.rst` under a new section for the
@@ -142,7 +142,7 @@ publishing the actual release notes at https://www.pygmt.org/latest/changes.html
 
 ### Check the README syntax
 
-Github is a bit forgiving when it comes to the RST syntax in the README but PyPI is not.
+GitHub is a bit forgiving when it comes to the RST syntax in the README but PyPI is not.
 So slightly broken RST can cause the PyPI page to not render the correct content. Check
 using the `rst2html.py` script that comes with docutils:
 
@@ -167,7 +167,7 @@ this new folder.
 
 ### Archiving on Zenodo
 
-Grab a zip file from the Github release and upload to Zenodo using the previously
+Grab a zip file from the GitHub release and upload to Zenodo using the previously
 reserved DOI.
 
 ### Updating the conda package

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ implement new features. **This is not a finished product, use with caution.**
 
 We welcome any feedback and ideas!
 Let us know by submitting
-`issues on Github <https://github.com/GenericMappingTools/pygmt/issues>`__
+`issues on GitHub <https://github.com/GenericMappingTools/pygmt/issues>`__
 or by posting on our `Discourse forum <https://forum.generic-mapping-tools.org>`__.
 
 About
@@ -96,7 +96,7 @@ Project goals
 Contacting Us
 -------------
 
-* Most discussion happens `on Github
+* Most discussion happens `on GitHub
   <https://github.com/GenericMappingTools/pygmt>`__. Feel free to `open an issue
   <https://github.com/GenericMappingTools/pygmt/issues/new>`__ or comment on any
   open issue or pull request.
@@ -150,7 +150,7 @@ Who we are
 
 PyGMT is a community developed project. See the
 `AUTHORS.md <https://github.com/GenericMappingTools/pygmt/blob/master/AUTHORS.md>`__
-file on Github for a list of the people involved and a definition of the term "PyGMT
+file on GitHub for a list of the people involved and a definition of the term "PyGMT
 Developers".
 
 
@@ -186,7 +186,7 @@ Other Python wrappers for GMT:
 Documentation for other versions
 --------------------------------
 * `Development <https://www.pygmt.org/dev>`__ (reflects the *master* branch on
-  Github)
+  GitHub)
 * `Latest release <https://www.pygmt.org/latest>`__
 * `v0.2.0 <https://www.pygmt.org/v0.2.0>`__
 * `v0.1.2 <https://www.pygmt.org/v0.1.2>`__

--- a/doc/_templates/breadcrumbs.html
+++ b/doc/_templates/breadcrumbs.html
@@ -1,4 +1,4 @@
-{# Extend the RTD template to include "Edit on Github" and option to download
+{# Extend the RTD template to include "Edit on GitHub" and option to download
    notebook generated pages from nbsphinx #}
 {% extends "!breadcrumbs.html" %}
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -59,10 +59,10 @@ Maintenance:
 * Eliminate unnecessary jobs from Travis CI (`#567 <https://github.com/GenericMappingTools/pygmt/pull/567>`__) and Azure Pipelines (`#513 <https://github.com/GenericMappingTools/pygmt/pull/513>`__)
 * Improve the workflow to test both GMT master (`#485 <https://github.com/GenericMappingTools/pygmt/pull/485>`__) and 6.1 branches (`#554 <https://github.com/GenericMappingTools/pygmt/pull/554>`__)
 * Automatically cancel in-progress CI runs of old commits (`#544 <https://github.com/GenericMappingTools/pygmt/pull/544>`__)
-* Remove the Stickler CI configuration file (`#538 <https://github.com/GenericMappingTools/pygmt/pull/538>`__), run style checks using Github Actions (`#519 <https://github.com/GenericMappingTools/pygmt/pull/519>`__)
-* Cache GMT remote data as artifacts on Github (`#530 <https://github.com/GenericMappingTools/pygmt/pull/530>`__)
+* Remove the Stickler CI configuration file (`#538 <https://github.com/GenericMappingTools/pygmt/pull/538>`__), run style checks using GitHub Actions (`#519 <https://github.com/GenericMappingTools/pygmt/pull/519>`__)
+* Cache GMT remote data as artifacts on GitHub (`#530 <https://github.com/GenericMappingTools/pygmt/pull/530>`__)
 * Let pytest generate both HTML and XML coverage reports (`#512 <https://github.com/GenericMappingTools/pygmt/pull/512>`__)
-* Run Continuous Integration tests on Github Actions (`#475 <https://github.com/GenericMappingTools/pygmt/pull/475>`__)
+* Run Continuous Integration tests on GitHub Actions (`#475 <https://github.com/GenericMappingTools/pygmt/pull/475>`__)
 
 Contributors:
 
@@ -225,7 +225,7 @@ Bug Fixes:
 Maintenance:
 
 * Quickfix Zeit Now miniconda installer link to anaconda.com (`#413 <https://github.com/GenericMappingTools/pygmt/pull/413>`__)
-* Fix Github Pages deployment from Travis (`#410 <https://github.com/GenericMappingTools/pygmt/pull/410>`__)
+* Fix GitHub Pages deployment from Travis (`#410 <https://github.com/GenericMappingTools/pygmt/pull/410>`__)
 * Update and clean TravisCI configuration (`#404 <https://github.com/GenericMappingTools/pygmt/pull/404>`__)
 * Quickfix min elevation for new SRTM15+V2.1 earth relief grids (`#401 <https://github.com/GenericMappingTools/pygmt/pull/401>`__)
 * Wrap docstrings to 79 chars and check with flake8 (`#384 <https://github.com/GenericMappingTools/pygmt/pull/384>`__)

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -9,7 +9,7 @@ Installing
 
     We welcome any feedback and ideas!
     Let us know by submitting
-    `issues on Github <https://github.com/GenericMappingTools/pygmt/issues>`__
+    `issues on GitHub <https://github.com/GenericMappingTools/pygmt/issues>`__
     or by posting on our `Discourse forum <https://forum.generic-mapping-tools.org>`__.
 
 
@@ -98,7 +98,7 @@ or use ``pip`` to install from `PyPI <https://pypi.org/project/pygmt>`__::
 
     pip install pygmt
 
-Alternatively, you can install the development version from the Github repository::
+Alternatively, you can install the development version from the GitHub repository::
 
     pip install https://github.com/GenericMappingTools/pygmt/archive/master.zip
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -165,7 +165,7 @@ which may help identify what went wrong).
 ## Known Limitations
 
 Some situations are known to cause problems for Versioneer. This details the
-most significant ones. More can be found on Github
+most significant ones. More can be found on GitHub
 [issues page](https://github.com/warner/python-versioneer/issues).
 
 ### Subprojects


### PR DESCRIPTION
**Description of proposed changes**

We should use "github" or "GitHub", not "Github".

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
