### PR TITLE
Improve the gallery example for line styles

### DIFF
--- a/examples/gallery/line/linestyles.py
+++ b/examples/gallery/line/linestyles.py
@@ -47,8 +47,8 @@ for linestyle in [
 # plot the line like a railway track (black/white)
 # the trick here is plotting the same line twice but with different line styles
 y -= 1
-for linestyle in ["5p,black", "4p,white,20p_20p"]:
-    fig.plot(x=x, y=y, pen=linestyle)
+fig.plot(x=x, y=y, pen="5p,black")
+fig.plot(x=x, y=y, pen="4p,white,20p_20p")
 fig.text(x=x[-1], y=y[-1], text="5p,black", justify="ML", offset="0.2c/0.2c")
 fig.text(x=x[-1], y=y[-1], text="4p,white,20p_20p", justify="ML", offset="0.2c/-0.2c")
 

--- a/examples/gallery/line/linestyles.py
+++ b/examples/gallery/line/linestyles.py
@@ -20,23 +20,35 @@ For more advanced *pen* attributes, see the GMT cookbook
 import numpy as np
 import pygmt
 
-# Generate a sample line for plotting
-x = np.linspace(0, 10, 500)
-y = np.sin(x)
+# Generate a two-point line for plotting
+x = np.array([0, 7])
+y = np.array([9, 9])
 
 fig = pygmt.Figure()
-fig.basemap(region=[0, 10, -3, 3], projection="X15c/8c", frame=["xaf", "yaf", "WSrt"])
+fig.basemap(region=[0, 10, 0, 10], projection="X15c/8c", frame='+t"Line Styles"')
 
 # Plot the line using the default line style
 fig.plot(x=x, y=y)
+fig.text(x=x[-1], y=y[-1], text="solid (default)", justify="ML", offset="0.2c/0c")
 
-# Plot the lines using different line styles
-fig.plot(x=x, y=y + 1.5, pen="1p,red,-")
-fig.plot(x=x, y=y + 1.0, pen="2p,blue,.")
-fig.plot(x=x, y=y + 0.5, pen="1p,red,-.")
+# plot the line using different line styles
+for linestyle in [
+    "1p,red,-",  # dashed line
+    "1p,blue,.",  # dotted line
+    "1p,lightblue,-.",  # dash-dotted line
+    "2p,blue,..-",  # dot-dot-dashed line
+    "2p,tomato,--.",  # dash-dash-dotted line
+    "2p,tomato,4_2:2p",  # A pattern of 4-point-long line segment and 2-point-gap between segment
+]:
+    y -= 1  # Move the current line down
+    fig.plot(x=x, y=y, pen=linestyle)
+    fig.text(x=x[-1], y=y[-1], text=linestyle, justify="ML", offset="0.2c/0c")
 
-fig.plot(x=x, y=y - 0.5, pen="2p,blue,..-")
-fig.plot(x=x, y=y - 1.0, pen="3p,tomato,--.")
-fig.plot(x=x, y=y - 1.5, pen="3p,tomato,4_2:2p")
+# plot the line just like a railway track (black/white)
+y -= 1
+for linestyle in ["5p,black", "4p,white,20p_20p"]:
+    fig.plot(x=x, y=y, pen=linestyle)
+fig.text(x=x[-1], y=y[-1], text="5p,black", justify="ML", offset="0.2c/0.2c")
+fig.text(x=x[-1], y=y[-1], text="4p,white,20p_20p", justify="ML", offset="0.2c/-0.2c")
 
 fig.show()

--- a/examples/gallery/line/linestyles.py
+++ b/examples/gallery/line/linestyles.py
@@ -44,7 +44,8 @@ for linestyle in [
     fig.plot(x=x, y=y, pen=linestyle)
     fig.text(x=x[-1], y=y[-1], text=linestyle, justify="ML", offset="0.2c/0c")
 
-# plot the line just like a railway track (black/white)
+# plot the line like a railway track (black/white)
+# the trick here is plotting the same line twice but with different line styles
 y -= 1
 for linestyle in ["5p,black", "4p,white,20p_20p"]:
     fig.plot(x=x, y=y, pen=linestyle)

--- a/examples/gallery/line/linestyles.py
+++ b/examples/gallery/line/linestyles.py
@@ -31,7 +31,7 @@ fig.basemap(region=[0, 10, 0, 10], projection="X15c/8c", frame='+t"Line Styles"'
 fig.plot(x=x, y=y)
 fig.text(x=x[-1], y=y[-1], text="solid (default)", justify="ML", offset="0.2c/0c")
 
-# plot the line using different line styles
+# Plot the line using different line styles
 for linestyle in [
     "1p,red,-",  # dashed line
     "1p,blue,.",  # dotted line
@@ -44,9 +44,9 @@ for linestyle in [
     fig.plot(x=x, y=y, pen=linestyle)
     fig.text(x=x[-1], y=y[-1], text=linestyle, justify="ML", offset="0.2c/0c")
 
-# plot the line like a railway track (black/white)
-# the trick here is plotting the same line twice but with different line styles
-y -= 1
+# Plot the line like a railway track (black/white).
+# The trick here is plotting the same line twice but with different line styles
+y -= 1  # move the current line down
 fig.plot(x=x, y=y, pen="5p,black")
 fig.plot(x=x, y=y, pen="4p,white,20p_20p")
 fig.text(x=x[-1], y=y[-1], text="5p,black", justify="ML", offset="0.2c/0.2c")


### PR DESCRIPTION
**Description of proposed changes**

| Old example | New example | 
|---|---|
| ![image](https://user-images.githubusercontent.com/3974108/96947102-358a7c80-14b0-11eb-8a60-b4db3924067e.png) | ![image](https://user-images.githubusercontent.com/3974108/96947041-07a53800-14b0-11eb-8c30-23f434e8947f.png) | 

Address the comment in https://github.com/GenericMappingTools/pygmt/pull/604#issuecomment-709694802.

**Preview:** https://pygmt-git-improve-linestyle.gmt.vercel.app/gallery/line/linestyles.html

The last line (white/black railway track style) is a little tricky. I like it but I'm OK if you think we should remove it.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
