### PR TITLE
Migrate coverage configurations to pyproject.toml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-[run]
-omit =
-    */tests/*
-    */_version.py
-    *pygmt/__init__.py

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Build, package, test, and clean
 PROJECT=pygmt
 TESTDIR=tmp-test-dir-with-unique-name
-PYTEST_ARGS=--cov=$(PROJECT) --cov-config=../.coveragerc \
+PYTEST_ARGS=--cov=$(PROJECT) --cov-config=../pyproject.toml \
 			--cov-report=term-missing --cov-report=xml --cov-report=html \
 			--doctest-modules -v --mpl --mpl-results-path=results \
 			--pyargs ${PYTEST_EXTRA}

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
     - pytest
     - pytest-cov
     - pytest-mpl
-    - coverage
+    - coverage[toml]
     - black
     - blackdoc
     - pylint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.coverage.run]
+omit = ["*/tests/*", "*/_version.py", "*pygmt/__init__.py"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ jupyter
 pytest
 pytest-cov
 pytest-mpl
-coverage
+coverage[toml]
 black
 blackdoc
 pylint


### PR DESCRIPTION
**Description of proposed changes**

The project is using many different tools (e.g., black, coverage) and each tool may have many configurations, saved in different configurations files (e.g., `.coveragerc`, `setup.cfg`). PEP 518 introduced a standard configuration file `pyproject.toml` where tools can put their configurations.

This PR tries to migrate the `coverage` configurations from `.coveragerc` to `pyproject.toml`. We may migrate more configurations (e.g., `black`, `pytest`, `setuptools-scm`) in separate PRs.

Coverage configurations: https://coverage.readthedocs.io/en/latest/config.html

References:

- https://www.python.org/dev/peps/pep-0518/
- https://www.python.org/dev/peps/pep-0621/
- https://snarky.ca/clarifying-pep-518/
- https://snarky.ca/what-the-heck-is-pyproject-toml/

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
