### PR TITLE
Let all tests pass for GMT 6.1.1 and master

### DIFF
--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -161,13 +161,8 @@ def test_call_module_error_message():
         try:
             lib.call_module("info", "bogus-data.bla")
         except GMTCLibError as error:
-            msg = "\n".join(
-                [
-                    "Module 'info' failed with status code 71:",
-                    "gmtinfo [ERROR]: Cannot find file bogus-data.bla",
-                ]
-            )
-            assert str(error) == msg
+            assert "Module 'info' failed with status code" in str(error)
+            assert "gmtinfo [ERROR]: Cannot find file bogus-data.bla" in str(error)
 
 
 def test_method_no_session():

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -73,7 +73,7 @@ def test_grdimage_file():
     return fig
 
 
-@pytest.mark.xfail(
+@pytest.mark.skip(
     reason="Upstream bug in GMT 6.1.1",
     condition=gmt_version <= Version("6.1.1"),
 )

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -1,6 +1,7 @@
 """
 Test Figure.grdimage
 """
+import sys
 import numpy as np
 import pytest
 import xarray as xr
@@ -75,7 +76,7 @@ def test_grdimage_file():
 
 @pytest.mark.skip(
     reason="Upstream bug in GMT 6.1.1",
-    condition=gmt_version <= Version("6.1.1"),
+    condition=gmt_version <= Version("6.1.1") and sys.platform == "darwin",
 )
 @check_figures_equal()
 @pytest.mark.parametrize(

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -43,7 +43,6 @@ def test_info_dataframe():
 
 
 @pytest.mark.xfail(
-    condition=gmt_version <= Version("6.1.1"),
     reason="UNIX timestamps returned instead of ISO datetime, should work on GMT 6.2.0 "
     "after https://github.com/GenericMappingTools/gmt/issues/4241 is resolved",
 )
@@ -63,7 +62,6 @@ def test_info_pandas_dataframe_time_column():
 
 
 @pytest.mark.xfail(
-    condition=gmt_version <= Version("6.1.1"),
     reason="UNIX timestamp returned instead of ISO datetime, should work on GMT 6.2.0 "
     "after https://github.com/GenericMappingTools/gmt/issues/4241 is resolved",
 )

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -8,16 +8,12 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 import xarray as xr
-from packaging.version import Version
 
-from .. import clib, info
+from .. import info
 from ..exceptions import GMTInvalidInput
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 POINTS_DATA = os.path.join(TEST_DATA_DIR, "points.txt")
-
-with clib.Session() as _lib:
-    gmt_version = Version(_lib.info["version"])
 
 
 def test_info():


### PR DESCRIPTION
**Description of proposed changes**

It's annoying to have failing CI tests. Every time I want to merge a PR, I have to change the branch protection rules, merge a PR, and then change the protection rules back. 

This PR contains two changes:

- The xarray shading test crashes with GMT 6.1.1, so `pytest.mark.xfail` doesn't work as we expect. 
- The two `info()` tests fail for the GMT master branch, unless the upstream issue https://github.com/GenericMappingTools/gmt/issues/4241 is fixed.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
