### PR TITLE
Do not skip xarray shading tests on all platforms

### DIFF
--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -80,7 +80,7 @@ def test_grdimage_file():
 )
 @pytest.mark.xfail(
     condition=gmt_version <= Version("6.1.1") and sys.platform != "darwin",
-    reason="Upstream bug in GMT 6.1.1",
+    reason="Upstream bug in GMT 6.1.1 that causes this test to fail on Linux/WIndows",
 )
 @check_figures_equal()
 @pytest.mark.parametrize(

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -78,7 +78,7 @@ def test_grdimage_file():
     gmt_version <= Version("6.1.1") and sys.platform == "darwin",
     reason="Upstream bug in GMT 6.1.1",
 )
-@pytest.mark.skipif(
+@pytest.mark.xfail(
     condition=gmt_version <= Version("6.1.1") and sys.platform != "darwin",
     reason="Upstream bug in GMT 6.1.1",
 )

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -76,7 +76,7 @@ def test_grdimage_file():
 
 @pytest.mark.skipif(
     gmt_version <= Version("6.1.1") and sys.platform == "darwin",
-    reason="Upstream bug in GMT 6.1.1",
+    reason="Upstream bug in GMT 6.1.1 that causes segfault on macOS",
 )
 @pytest.mark.xfail(
     condition=gmt_version <= Version("6.1.1") and sys.platform != "darwin",

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -78,6 +78,10 @@ def test_grdimage_file():
     gmt_version <= Version("6.1.1") and sys.platform == "darwin",
     reason="Upstream bug in GMT 6.1.1",
 )
+@pytest.mark.skipif(
+    condition=gmt_version <= Version("6.1.1") and sys.platform != "darwin",
+    reason="Upstream bug in GMT 6.1.1",
+)
 @check_figures_equal()
 @pytest.mark.parametrize(
     "shading",

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -80,7 +80,7 @@ def test_grdimage_file():
 )
 @pytest.mark.xfail(
     condition=gmt_version <= Version("6.1.1") and sys.platform != "darwin",
-    reason="Upstream bug in GMT 6.1.1 that causes this test to fail on Linux/WIndows",
+    reason="Upstream bug in GMT 6.1.1 that causes this test to fail on Linux/Windows",
 )
 @check_figures_equal()
 @pytest.mark.parametrize(

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -74,9 +74,9 @@ def test_grdimage_file():
     return fig
 
 
-@pytest.mark.skip(
+@pytest.mark.skipif(
+    gmt_version <= Version("6.1.1") and sys.platform == "darwin",
     reason="Upstream bug in GMT 6.1.1",
-    condition=gmt_version <= Version("6.1.1") and sys.platform == "darwin",
 )
 @check_figures_equal()
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Description of proposed changes**

~~In PR #668, we add the `pytest.mark.skip` marker to skip the xarray shading tests on macOS. 
However, the `skip` marker doesn't have the *condition* argument, so the test is skipped on 
all platforms. In This PR, I change the `skip` marker to `skipif`.~~

xarray grid shading is known to fail with GMT 6.1.1. That's why we want to mark the test `xfail`. The `xfail` marker works well for Linux and Windows, but not for macOS, due to segmentation faults.

So ideally what we should do is:

- GMT 6.1.1 + Linux/Windows: xfail
- GMT 6.1.1 + macOS: skip
- GMT master + Linux/Windows/macOS: no marker

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
