### PR TITLE
Complete most of documentation for makecpt

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,10 +37,8 @@ napoleon_use_ivar = True
 
 # configure links to GMT docs
 extlinks = {
-    "gmt-docs": (
-        "https://docs.generic-mapping-tools.org/latest/%s",
-        "https://docs.generic-mapping-tools.org/latest/",
-    )
+    "gmt-docs": ("https://docs.generic-mapping-tools.org/latest/%s", None),
+    "gmt-term": ("https://docs.generic-mapping-tools.org/latest/gmt.conf#term-%s", ""),
 }
 
 # intersphinx configuration

--- a/pygmt/mathops.py
+++ b/pygmt/mathops.py
@@ -10,10 +10,13 @@ from .helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_ali
 @use_alias(
     A="transparency",
     C="cmap",
+    D="background",
     F="color_model",
     G="truncate",
     H="output",
     I="reverse",
+    M="overrule_bg",
+    N="no_bg",
     Q="log",
     T="series",
     V="verbose",
@@ -28,8 +31,8 @@ def makecpt(**kwargs):
     This is a module that will help you make static color palette tables
     (CPTs). In classic mode we write the CPT to standard output, while under
     modern mode we simply save the CPT as the current session CPT (but see
-    **output**). You define an equidistant set of contour intervals or pass
-    your own z-table or list, and create a new CPT based on an existing master
+    *output*). You define an equidistant set of contour intervals or pass your
+    own z-table or list, and create a new CPT based on an existing master
     (dynamic) CPT. The resulting CPT can be reversed relative to the master
     cpt, and can be made continuous or discrete. For color tables beyond the
     standard GMT offerings, visit
@@ -46,14 +49,14 @@ def makecpt(**kwargs):
     the new master file. If not, the parameters :gmt-term:`COLOR_BACKGROUND`,
     :gmt-term:`COLOR_FOREGROUND`, and :gmt-term:`COLOR_NAN` from the
     :gmt-docs:`gmt.conf <gmt.conf>` file or the command line will be used. This
-    default behavior can be overruled using the options **-D**, **-M** or
-    **-N**.
+    default behavior can be overruled using the options *background*,
+    *overrule_bg* or *no_bg*.
 
     The color model (RGB, HSV or CMYK) of the palette created by **makecpt**
     will be the same as specified in the header of the master CPT. When there
     is no :gmt-term:`COLOR_MODEL` entry in the master CPT, the
-    :gmt-term:`COLOR_MODEL` specified in the :doc:`gmt.conf` file or on the
-    command line will be used.
+    :gmt-term:`COLOR_MODEL` specified in the :gmt-docs:`gmt.conf <gmt.conf>`
+    file or on the command line will be used.
 
     Full option list at :gmt-docs:`makecpt.html`
 
@@ -69,6 +72,14 @@ def makecpt(**kwargs):
         Selects the master color palette table (CPT) to use in the
         interpolation. Full list of built-in color palette tables can be found
         at :gmt-docs:`cookbook/cpts.html#built-in-color-palette-tables-cpt`.
+    background : bool or str
+        Select the back- and foreground colors to match the colors for lowest
+        and highest *z*-values in the output CPT [Default (``background=True``
+        or ``background='o'``) uses the colors specified in the master file, or
+        those defined by the parameters :gmt-term:`COLOR_BACKGROUND`,
+        :gmt-term:`COLOR_FOREGROUND`, and :gmt-term:`COLOR_NAN`]. Use
+        ``background='i'`` to match the colors for the lowest and highest
+        values in the input (instead of the output) CPT.
     color_model :
         ``[R|r|h|c][+c[label]]``.
         Force output CPT to be written with r/g/b codes, gray-scale values or
@@ -107,6 +118,15 @@ def makecpt(**kwargs):
         happens before *truncate* and *series* values are used so the latter
         must be compatible with the changed *z*-range. See also
         :gmt-docs:`cookbook/features.html#manipulating-cpts`.
+    overrule_bg :
+        Overrule background, foreground, and NaN colors specified in the master
+        CPT with the values of the parameters :gmt-term:`COLOR_BACKGROUND`,
+        :gmt-term:`COLOR_FOREGROUND`, and :gmt-term:`COLOR_NAN` specified in
+        the :gmt-docs:`gmt.conf <gmt.conf>` file or on the command line. When
+        combined with **background**, only :gmt-term:`COLOR_NAN` is considered.
+    no_bg : bool
+        Do not write out the background, foreground, and NaN-color fields
+        [Default will write them, i.e. ``no_bg=False``].
     log : bool
         For logarithmic interpolation scheme with input given as logarithms.
         Expects input z-values provided via **series** to be log10(*z*),

--- a/pygmt/mathops.py
+++ b/pygmt/mathops.py
@@ -32,6 +32,25 @@ def makecpt(**kwargs):
     `cpt-city <http://soliton.vm.bytemark.co.uk/pub/cpt-city/>`_ and
     `Scientific Colour-Maps <http://www.fabiocrameri.ch/colourmaps.php>`_.
 
+    The CPT includes three additional colors beyond the range of z-values.
+    These are the background color (B) assigned to values lower than the lowest
+    *z*-value, the foreground color (F) assigned to values higher than the
+    highest *z*-value, and the NaN color (N) painted wherever values are
+    undefined.
+
+    If the master CPT includes B, F, and N entries, these will be copied into
+    the new master file. If not, the parameters :gmt-term:`COLOR_BACKGROUND`,
+    :gmt-term:`COLOR_FOREGROUND`, and :gmt-term:`COLOR_NAN` from the
+    :gmt-docs:`gmt.conf <gmt.conf>` file or the command line will be used. This
+    default behavior can be overruled using the options **-D**, **-M** or
+    **-N**.
+
+    The color model (RGB, HSV or CMYK) of the palette created by **makecpt**
+    will be the same as specified in the header of the master CPT. When there
+    is no :gmt-term:`COLOR_MODEL` entry in the master CPT, the
+    :gmt-term:`COLOR_MODEL` specified in the :doc:`gmt.conf` file or on the
+    command line will be used.
+
     Full option list at :gmt-docs:`makecpt.html`
 
     {aliases}

--- a/pygmt/mathops.py
+++ b/pygmt/mathops.py
@@ -30,13 +30,12 @@ def makecpt(**kwargs):
     Make GMT color palette tables.
 
     This is a module that will help you make static color palette tables
-    (CPTs). In classic mode we write the CPT to standard output, while under
-    modern mode we simply save the CPT as the current session CPT (but see
-    *output*). You define an equidistant set of contour intervals or pass your
-    own z-table or list, and create a new CPT based on an existing master
-    (dynamic) CPT. The resulting CPT can be reversed relative to the master
-    cpt, and can be made continuous or discrete. For color tables beyond the
-    standard GMT offerings, visit
+    (CPTs). By default, the CPT will simply be saved to the current session,
+    but you can use *output* to save it to a file. You define an equidistant
+    set of contour intervals or pass your own z-table or list, and create a new
+    CPT based on an existing master (dynamic) CPT. The resulting CPT can be
+    reversed relative to the master cpt, and can be made continuous or
+    discrete. For color tables beyond the standard GMT offerings, visit
     `cpt-city <http://soliton.vm.bytemark.co.uk/pub/cpt-city/>`_ and
     `Scientific Colour-Maps <http://www.fabiocrameri.ch/colourmaps.php>`_.
 

--- a/pygmt/mathops.py
+++ b/pygmt/mathops.py
@@ -17,6 +17,7 @@ from .helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_ali
     Q="log",
     T="series",
     V="verbose",
+    W="categorical",
     Z="continuous",
 )
 @kwargs_to_strings(T="sequence", G="sequence")
@@ -113,8 +114,14 @@ def makecpt(**kwargs):
     continuous : bool
         Force a continuous CPT when building from a list of colors and a list
         of z-values [Default is None, i.e. discrete values].
-
     {V}
+    categorical : bool or str
+        Do not interpolate the input color table but pick the output colors
+        starting at the beginning of the color table, until colors for all
+        intervals are assigned. This is particularly useful in combination with
+        a categorical color table, like "categorical". Alternatively, use
+        ``categorical='w'`` to produce a wrapped (cyclic) color table that
+        endlessly repeats its range.
 
     """
     with Session() as lib:

--- a/pygmt/mathops.py
+++ b/pygmt/mathops.py
@@ -9,17 +9,28 @@ from .helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_ali
 @fmt_docstring
 @use_alias(
     C="cmap",
-    T="series",
     G="truncate",
     H="output",
     I="reverse",
+    T="series",
     V="verbose",
     Z="continuous",
 )
 @kwargs_to_strings(T="sequence", G="sequence")
 def makecpt(**kwargs):
     """
-    Creates a static color palette table (CPT).
+    Make GMT color palette tables.
+
+    This is a module that will help you make static color palette tables
+    (CPTs). In classic mode we write the CPT to standard output, while under
+    modern mode we simply save the CPT as the current session CPT (but see
+    **output**). You define an equidistant set of contour intervals or pass
+    your own z-table or list, and create a new CPT based on an existing master
+    (dynamic) CPT. The resulting CPT can be reversed relative to the master
+    cpt, and can be made continuous or discrete. For color tables beyond the
+    standard GMT offerings, visit
+    `cpt-city <http://soliton.vm.bytemark.co.uk/pub/cpt-city/>`_ and
+    `Scientific Colour-Maps <http://www.fabiocrameri.ch/colourmaps.php>`_.
 
     Full option list at :gmt-docs:`makecpt.html`
 
@@ -32,16 +43,20 @@ def makecpt(**kwargs):
         interpolation. Full list of built-in color palette tables can be found
         at :gmt-docs:`cookbook/cpts.html#built-in-color-palette-tables-cpt`.
     series : list or str
-        ``[min/max/inc[+b|l|n]|file|list]``. Defines the range of the new CPT
-        by giving the lowest and highest z-value (and optionally an interval).
-        If this is not given, the existing range in the master CPT will be used
-        intact.
+        ``[min/max/inc[+b|l|n]|file|list]``.
+        Defines the range of the new CPT by giving the lowest and highest
+        z-value (and optionally an interval). If this is not given, the
+        existing range in the master CPT will be used intact. The values
+        produced defines the color slice boundaries.  If **+n** is used it
+        refers to the number of such boundaries and not the number of slices.
+        For details on array creation, see
+        :gmt-docs:`makecpt.html#generate-1d-array`.
     truncate : list or str
-        ``zlo/zhi``. Truncate the incoming CPT so that the lowest and highest
-        z-levels are to zlo and zhi. If one of these equal NaN then we leave
-        that end of the CPT alone. The truncation takes place before any
-        resampling. See also
-        :gmt-docs:`cookbook/features.html#manipulating-cpts`.
+        ``zlo/zhi``.
+        Truncate the incoming CPT so that the lowest and highest z-levels are
+        to *zlo* and *zhi*. If one of these equal NaN then we leave that end of
+        the CPT alone. The truncation takes place before any resampling. See
+        also :gmt-docs:`cookbook/features.html#manipulating-cpts`.
     output : str
         Optional. The file name with extension .cpt to store the generated CPT
         file. If not given or False (default), saves the CPT as the session
@@ -51,14 +66,11 @@ def makecpt(**kwargs):
         progression in the master CPT. Set this to z to reverse the sign of
         z-values in the color table. Note that this change of z-direction
         happens before *truncate* and *series* values are used so the latter
-        must be compatible with the changed z-range. See also
+        must be compatible with the changed *z*-range. See also
         :gmt-docs:`cookbook/features.html#manipulating-cpts`.
     continuous : bool
-        Creates a continuous CPT [Default is discontinuous, i.e., constant
-        colors for each interval]. This option has no effect when no *series*
-        is used, or when using *series=[z_min, z_max]*; in the first case the
-        input CPT remains untouched, in the second case it is only scaled to
-        match the range z_min/z_max.
+        Force a continuous CPT when building from a list of colors and a list
+        of z-values [Default is None, i.e. discrete values].
 
     {V}
 

--- a/pygmt/mathops.py
+++ b/pygmt/mathops.py
@@ -8,10 +8,13 @@ from .helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_ali
 
 @fmt_docstring
 @use_alias(
+    A="transparency",
     C="cmap",
+    F="color_model",
     G="truncate",
     H="output",
     I="reverse",
+    Q="log",
     T="series",
     V="verbose",
     Z="continuous",
@@ -57,10 +60,26 @@ def makecpt(**kwargs):
 
     Parameters
     ----------
+    transparency : str
+        Sets a constant level of transparency (0-100) for all color slices.
+        Append **+a** to also affect the fore-, back-, and nan-colors
+        [Default is no transparency, i.e., 0 (opaque)].
     cmap : str
         Selects the master color palette table (CPT) to use in the
         interpolation. Full list of built-in color palette tables can be found
         at :gmt-docs:`cookbook/cpts.html#built-in-color-palette-tables-cpt`.
+    color_model :
+        ``[R|r|h|c][+c[label]]``.
+        Force output CPT to be written with r/g/b codes, gray-scale values or
+        color name (**R**, default) or r/g/b codes only (**r**), or h-s-v codes
+        (**h**), or c/m/y/k codes (**c**).  Optionally or alternatively, append
+        **+c** to write discrete palettes in categorical format. If *label* is
+        appended then we create labels for each category to be used when the
+        CPT is plotted. The *label* may be a comma-separated list of category
+        names (you can skip a category by not giving a name), or give
+        *start*[-], where we automatically build monotonically increasing
+        labels from *start* (a single letter or an integer). Append - to build
+        ranges *start*-*start+1* instead.
     series : list or str
         ``[min/max/inc[+b|l|n]|file|list]``.
         Defines the range of the new CPT by giving the lowest and highest
@@ -87,6 +106,10 @@ def makecpt(**kwargs):
         happens before *truncate* and *series* values are used so the latter
         must be compatible with the changed *z*-range. See also
         :gmt-docs:`cookbook/features.html#manipulating-cpts`.
+    log : bool
+        For logarithmic interpolation scheme with input given as logarithms.
+        Expects input z-values provided via **series** to be log10(*z*),
+        assigns colors, and writes out *z*.
     continuous : bool
         Force a continuous CPT when building from a list of colors and a list
         of z-values [Default is None, i.e. discrete values].

--- a/pygmt/mathops.py
+++ b/pygmt/mathops.py
@@ -21,6 +21,7 @@ from .helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_ali
     T="series",
     V="verbose",
     W="categorical",
+    Ww="cyclic",
     Z="continuous",
 )
 @kwargs_to_strings(T="sequence", G="sequence")
@@ -135,16 +136,19 @@ def makecpt(**kwargs):
         Force a continuous CPT when building from a list of colors and a list
         of z-values [Default is None, i.e. discrete values].
     {V}
-    categorical : bool or str
+    categorical : bool
         Do not interpolate the input color table but pick the output colors
         starting at the beginning of the color table, until colors for all
         intervals are assigned. This is particularly useful in combination with
-        a categorical color table, like "categorical". Alternatively, use
-        ``categorical='w'`` to produce a wrapped (cyclic) color table that
-        endlessly repeats its range.
-
+        a categorical color table, like ``cmap='categorical'``.
+    cyclic : bool
+        Produce a wrapped (cyclic) color table that endlessly repeats its
+        range. Note that ``cyclic=True`` cannot be set together with
+        ``categorical=True``.
     """
     with Session() as lib:
+        if "W" in kwargs and "Ww" in kwargs:
+            raise GMTInvalidInput("Set only categorical or cyclic to True, not both.")
         if "H" not in kwargs.keys():  # if no output is set
             arg_str = build_arg_string(kwargs)
         elif "H" in kwargs.keys():  # if output is set

--- a/pygmt/tests/test_makecpt.py
+++ b/pygmt/tests/test_makecpt.py
@@ -182,3 +182,41 @@ def test_makecpt_continuous(grid):
     makecpt(cmap="blue,white", continuous=True, series="-4500,4500")
     fig.grdimage(grid, projection="W0/6i")
     return fig
+
+
+@check_figures_equal()
+def test_makecpt_categorical(region):
+    """
+    Use static color palette table that is categorical.
+    """
+    fig_ref = Figure()
+    makecpt(C="categorical", W="")
+    fig_ref.colorbar(cmap=True, region=region, frame=True, position="JBC")
+
+    fig_test = Figure()
+    makecpt(cmap="categorical", categorical=True)
+    fig_test.colorbar(cmap=True, region=region, frame=True, position="JBC")
+    return fig_ref, fig_test
+
+
+@check_figures_equal()
+def test_makecpt_cyclic(region):
+    """
+    Use static color palette table that is cyclic.
+    """
+    fig_ref = Figure()
+    makecpt(C="cork", W="w")
+    fig_ref.colorbar(cmap=True, region=region, frame=True, position="JBC")
+
+    fig_test = Figure()
+    makecpt(cmap="cork", cyclic=True)
+    fig_test.colorbar(cmap=True, region=region, frame=True, position="JBC")
+    return fig_ref, fig_test
+
+
+def test_makecpt_categorical_and_cyclic():
+    """
+    Use incorrect setting by setting both categorical and cyclic to True.
+    """
+    with pytest.raises(GMTInvalidInput):
+        makecpt(cmap="batlow", categorical=True, cyclic=True)


### PR DESCRIPTION
**Description of proposed changes**

Finish up aliasing **most** arguments for `makecpt`, improving the documentattion to be better than what we currently have at https://www.pygmt.org/v0.2.0/api/generated/pygmt.makecpt.html! For reference, upstream GMT docs is at https://docs.generic-mapping-tools.org/6.1/makecpt.html and https://github.com/GenericMappingTools/gmt/blame/master/doc/rst/source/makecpt.rst.

Live documentation preview is at https://pygmt-git-complete-docs-makecpt.gmt.vercel.app/api/generated/pygmt.makecpt.html

TODO:

Arguments/Aliases to document (see also https://www.generic-mapping-tools.org/GMT.jl/latest/makecpt/). New aliases are highlighted in **bold**:

- [x] A - **transparency**
- [x] C - cmap
- [x] D - **background**/~~**foreground**~~?
- [ ] [E](https://docs.generic-mapping-tools.org/6.1/makecpt.html#e) - **data_levels/nlevels**?
- [x] F - **color_model**
- [x] G - truncate
- [x] H - output
- [x] I - reverse
- [x] M - **overrule_bg**?
- [x] N - **no_bg**?
- [x] Q - **log**
- [ ] [S](https://docs.generic-mapping-tools.org/6.1/makecpt.html#s) - **auto**
- [x] T - series
- [x] V - verbose
- [x] W - **categorical**
- [x] Ww - **cyclic**
- [x] Z - continuous

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically