### PR TITLE
Add PyGMT Zenodo BibTeX entry to main README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,12 +162,9 @@ Developers". Feel free to cite our work in your research using the following Bib
                       Toney, Liam and
                       Newton, Tyler and
                       Wessel, Paul},
-      title        = {{PyGMT: A Python interface for the Generic Mapping
-                       Tools}},
+      title        = {{PyGMT: A Python interface for the Generic Mapping Tools}},
       month        = sep,
       year         = 2020,
-      note         = {{The development of PyGMT was supported by NSF
-                       grants 1558403 and 1948602.}},
       publisher    = {Zenodo},
       version      = {v0.2.0},
       doi          = {10.5281/zenodo.4025418},

--- a/README.rst
+++ b/README.rst
@@ -145,13 +145,37 @@ mistakes. That's how we all improve and we are happy to help others learn.
 `MetPy project <https://github.com/Unidata/MetPy>`__.
 
 
-Who we are
-----------
+Citing PyGMT
+------------
 
 PyGMT is a community developed project. See the
 `AUTHORS.md <https://github.com/GenericMappingTools/pygmt/blob/master/AUTHORS.md>`__
 file on GitHub for a list of the people involved and a definition of the term "PyGMT
-Developers".
+Developers". Feel free to cite our work in your research using the following BibTeX:
+
+.. code-block::
+
+    @software{uieda_leonardo_2020_4025418,
+      author       = {Uieda, Leonardo and
+                      Tian, Dongdong and
+                      Leong, Wei Ji and
+                      Toney, Liam and
+                      Newton, Tyler and
+                      Wessel, Paul},
+      title        = {{PyGMT: A Python interface for the Generic Mapping
+                       Tools}},
+      month        = sep,
+      year         = 2020,
+      note         = {{The development of PyGMT was supported by NSF
+                       grants 1558403 and 1948602.}},
+      publisher    = {Zenodo},
+      version      = {v0.2.0},
+      doi          = {10.5281/zenodo.4025418},
+      url          = {https://doi.org/10.5281/zenodo.4025418}
+    }
+
+To cite a specific version of PyGMT, go to our Zenodo page at
+https://doi.org/10.5281/zenodo.3781524 and use the Export to BibTeX function there.
 
 
 License

--- a/README.rst
+++ b/README.rst
@@ -172,7 +172,7 @@ Developers". Feel free to cite our work in your research using the following Bib
     }
 
 To cite a specific version of PyGMT, go to our Zenodo page at
-https://doi.org/10.5281/zenodo.3781524 and use the Export to BibTeX function there.
+https://doi.org/10.5281/zenodo.3781524 and use the "Export to BibTeX" function there.
 It is also strongly recommended to cite the
 `GMT6 paper <https://doi.org/10.1029/2019GC008515>`__ (which PyGMT wraps around).
 Note that some modules like ``surface`` and ``x2sys`` also have their dedicated citation.

--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,10 @@ Developers". Feel free to cite our work in your research using the following Bib
 
 To cite a specific version of PyGMT, go to our Zenodo page at
 https://doi.org/10.5281/zenodo.3781524 and use the Export to BibTeX function there.
+It is also strongly recommended to cite the
+`GMT6 paper <https://doi.org/10.1029/2019GC008515>`__ (which PyGMT wraps around).
+Note that some modules like ``surface`` and ``x2sys`` also have their dedicated citation.
+Further information for all these can be found at https://www.generic-mapping-tools.org/cite.
 
 
 License


### PR DESCRIPTION
**Description of proposed changes**

To ensure that people will cite PyGMT consistently in their research work, this PR adds a PyGMT BibTeX entry to the main README.md (copied from Zenodo at https://zenodo.org/record/4025418/export/hx).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Also point to https://www.generic-mapping-tools.org/cite for GMT specific modules.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #653


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
