### PR TITLE
Migrate PyPI release to GitHub Actions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -39,8 +39,8 @@ jobs:
       run: |
         # Change the versioneer format to "pre" so that the commit hash isn't
         # included (PyPI doesn't allow it). Can't do this permanently because
-        # we rely the hash to indicate to the tests that this is a local
-        # verison instead of a published version.
+        # we rely on the hash to tell the tests that this is a local version
+        # instead of a published version.
         #
         # The step is only necessary for testing purpose
         sed --in-place "s/pep440/pep440-pre/g" setup.cfg

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,15 +1,19 @@
-# Workflow for publishing archives to PyPI
+# Publish archives to PyPI and TestPyPI using GitHub Actions
+
 name: Publish to PyPI
 
+# Only run for pushes to the master branch and releases.
 on:
-  # Runs for pull requests for testing purposes
-  pull_request:
+  push:
     branches:
       - master
-  # Only runs for releases
   release:
     types:
       - published
+  # Runs for pull requests should be disable unless for testing purposes
+  pull_request:
+    branches:
+      - master
 
 jobs:
   publish-pypi:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,35 @@
+name: Publish to PyPI
+
+on: push
+
+jobs:
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: pip install wheel
+
+    - name: Build source distributions and wheels
+      run: python setup.py bdist_wheel
+
+    - name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -22,8 +22,17 @@ jobs:
     - name: Install dependencies
       run: pip install wheel
 
-    - name: Build source distributions and wheels
-      run: python setup.py bdist_wheel
+    - name: Build source and wheel distributions
+      run: |
+        # Change the versioneer format to "pre" so that the commit hash isn't
+        # included (PyPI doesn't allow it). Can't do this permanently because
+        # we rely the hash to indicate to the tests that this is a local
+        # verison instead of a published version.
+        sed --in-place "s/pep440/pep440-pre/g" setup.cfg
+        python setup.py sdist bdist_wheel
+        echo ""
+        echo "Generated files:"
+        ls -lh dist/
 
     - name: Publish to Test PyPI
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,10 +10,10 @@ on:
   release:
     types:
       - published
-  # Runs for pull requests should be disable unless for testing purposes
-  pull_request:
-    branches:
-      - master
+  # Runs for pull requests should be disabled other than for testing purposes
+  #pull_request:
+  #  branches:
+  #    - master
 
 jobs:
   publish-pypi:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,7 +9,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v2.3.4
+      with:
+        # fecth all history so that versioneer works
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v1

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,15 @@
+# Workflow for publishing archives to PyPI
 name: Publish to PyPI
 
-on: push
+on:
+  # Runs for pull requests for testing purposes
+  pull_request:
+    branches:
+      - master
+  # Only runs for releases
+  release:
+    types:
+      - published
 
 jobs:
   publish-pypi:
@@ -15,33 +24,38 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 
     - name: Install dependencies
-      run: pip install wheel
+      run: python -m pip install setuptools wheel
 
-    - name: Build source and wheel distributions
+    - name: Fix up version string
       run: |
         # Change the versioneer format to "pre" so that the commit hash isn't
         # included (PyPI doesn't allow it). Can't do this permanently because
         # we rely the hash to indicate to the tests that this is a local
         # verison instead of a published version.
+        #
+        # The step is only necessary for testing purpose
         sed --in-place "s/pep440/pep440-pre/g" setup.cfg
+
+    - name: Build source and wheel distributions
+      run: |
         python setup.py sdist bdist_wheel
         echo ""
         echo "Generated files:"
         ls -lh dist/
 
     - name: Publish to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@v1.4.1
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@v1.4.1
       with:
         password: ${{ secrets.pypi_password }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ env:
         # Encrypted variables
         # GitHub Token for pushing the built docs (GH_TOKEN)
         - secure: "QII0477v0mmCCW3qSNXLCOtqraJaCICtSghiyrxYsuUdJTrXzXBNhX2KLIjcKYXOK1HdwYOFGf8xBVLl44clHlAW7R32ecEGeTJizr0yqTBvT3rNG1Xb7+E6jdXqrIs//PmPRaF8zOZxPl1SJKDK4jJpCx5HnAflg7wl/6tQLD6K3/dQ6FG2s3UKsc8o4qchOiEfxYhOuKo3jt2S0HdsNAQFw3mFHCCrclxDr3llSQtWSY0mirZnta7AI4nMvzxl2nUhdHEpxgzIjWxCWLAwmj3/NxLz0VSgNCtl2bNYk6AYrc5RcANGk2fcYaZr9mTU3Aax60S4389B39Pq95hBN21jYdbw9vCN810dYpTUk2siLysx8gF6r2JWEF8SskXlF79r3phtaFTMOS4GqeiuwjifZeaLAL/H1PTQFDDG/UKEwBpLuzrPMDw/84iRtyWKqWR/f14YdKhH4YAkcOuRglEXiI/1A0qWKiZ1iZfky8Tys+wN5nyss23w/JeYXVgBdTkNzvp3diFWK8+Wl9j3HYpX9LlEHJwASA1wHLL85t4ToymgLjo9gvLvwzB7T+fWNtEbh4ELbvI7jaKrvir8uSGYy4bGbfRclh5CktD//mTLhDyAsQDS8obF/Ri9mVqFzjK6417ORfu8qnpXU+mIHPRBoKvpS2WqnPtSwF8KPv8="
-        # TWINE_PASSWORD to deploy to PyPI
-        - secure: "md4fgPt9RC/sCoN5//5PcNHLUd9gWQGewV5hFpWW88MRTjxTng1Zfs8r7SqlF2AkEEepFfyzq0BEe9c3FMAnFbec3KmqdlQen4V8xDbLrcTlvkPlTrYGbAScUvdhhqojB//hMHoTD4KvxAv9CiUwFBO4hCMmj2buWHUbV9Ksu5WCW9mF/gkt/hIuYAU6Mbwt8PiYyMgUpzMHO1vruofcWRaVnvKwmBqHB0ae86D4/drpwn4CWjlM12WUnphT2bssiyPkw24FZtCN6kPVta6bLZKBxu0bZpw2vbXuUG+Yh19Q4mp8wNYT3XSHJf8Hl5LfujF48+cLWu+6rlCkdcelyVylhWLFc3rGOONAv4G8jWW2yNSz/bLQfJnMpd81fQEu5eySmFxB7mdB0uyKpvIG1jMJQ73LlYKakKLAPdYhMFyQAHoX9gvCE3S4QR95DBMi5gM/pZubOCcMLdjPHB5JKpJHSjxbOzyVwgmsUIEgd5Bi2vZvvYQXn1plk4xpQ3PhXc+/gi33bzY89mKcfOn0HJ2pD1vLqDXRCBsMCakoLZ0JB/6bacaz4FngbsGWuQ+I1cz20lJGL/MSi9bW1G7Uoidt3GXXWDmXrWt70vIXlLIxr8XV0Mu/rPbauGgWE+ZSYEfvdM5sP+FNF7vQ5de+Fkvzg5Z3tTfR+O1W+d7+vM4="
         - TWINE_USERNAME=Leonardo.Uieda
         # The file with the listed requirements to be installed by conda
         - CONDA_REQUIREMENTS=requirements.txt
@@ -60,12 +58,6 @@ script:
     - make -C doc all
 
 deploy:
-    # Make a release on PyPI
-    - provider: script
-      script: continuous-integration/travis/deploy-pypi.sh
-      on:
-          tags: true
-          condition: '$DEPLOY == "true"'
     # Push the built HTML in doc/_build/html to the gh-pages branch
     - provider: script
       script: continuous-integration/travis/deploy-gh-pages.sh

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -65,10 +65,10 @@ This is scheduled to run every Sunday at 12 noon.
 If new remote files are needed urgently, maintainers can manually uncomment
 the 'pull_request:' line in that `cache_data.yaml` file to refresh the cache.
 
-4. `publish-to-pypi.yml` (Publish archives to PyPI and TestPyPI)
+4. `publish-to-pypi.yml` (Publish wheels to PyPI and TestPyPI)
 
-This workflow is ran to publish archives to PyPI and TestPyPI (for testing only).
-Archives will be pushed to TestPyPI for every commit on the *master* branch and
+This workflow is ran to publish wheels to PyPI and TestPyPI (for testing only).
+Archives will be pushed to TestPyPI on every commit to the *master* branch and
 tagged releases, and to PyPI for tagged releases only.
 
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -47,7 +47,7 @@ conda and the `Makefile` to run the tests and checks.
 
 ### GitHub Actions
 
-There are 3 configuration files located in `.github/workflows`:
+There are 4 configuration files located in `.github/workflows`:
 
 1. `ci_tests.yaml` (Style Checks, Tests on Linux/macOS/Windows)
 
@@ -65,14 +65,20 @@ This is scheduled to run every Sunday at 12 noon.
 If new remote files are needed urgently, maintainers can manually uncomment
 the 'pull_request:' line in that `cache_data.yaml` file to refresh the cache.
 
+4. `publish-to-pypi.yml` (Publish archives to PyPI and TestPyPI)
+
+This workflow is ran to publish archives to PyPI and TestPyPI (for testing only).
+Archives will be pushed to TestPyPI for every commit on the *master* branch and
+tagged releases, and to PyPI for tagged releases only.
+
+
 ### Travis CI
 
 The configuration file is at `.travis.yml`.
-Travis runs tests (Linux only) and handles all of our deployments automatically:
+Travis runs tests (Linux only) and handles the documentation deployment automatically:
 
 * Updating the development documentation by pushing the built HTML pages from the
   *master* branch onto the `dev` folder of the *gh-pages* branch.
-* Uploading new releases to PyPI (only when the build was triggered by a git tag).
 * Updated the `latest` documentation link to the new release.
 
 This way, most day-to-day maintenance operations are automatic.


### PR DESCRIPTION
**Description of proposed changes**

This PR migrate the PyPI release job from Travis CI to GitHub Actions.

References:

- https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows.
- https://github.com/fatiando/boule/tree/master/.github/workflows

Address #566 

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
