### PR TITLE
Fix docstrings for blackdoc v0.3 by adding newline after block

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -115,6 +115,7 @@ class Session:
     ...             )
     ...             # Read the contents of the temp file before it's deleted.
     ...             print(fout.read().strip())
+    ...
     -180 180 -90 90 -8182 5651.5 1 1 360 180 1 1
     """
 
@@ -273,6 +274,7 @@ class Session:
         ...     func = lib.get_libgmt_func(
         ...         "GMT_Destroy_Session", argtypes=[c_void_p], restype=c_int
         ...     )
+        ...
         >>> type(func)
         <class 'ctypes.CDLL.__init__.<locals>._FuncPtr'>
 
@@ -707,11 +709,13 @@ class Session:
         >>> with Session() as ses:
         ...     gmttype = ses._check_dtype_and_dim(data, ndim=1)
         ...     gmttype == ses["GMT_DOUBLE"]
+        ...
         True
         >>> data = np.ones((5, 2), dtype="float32")
         >>> with Session() as ses:
         ...     gmttype = ses._check_dtype_and_dim(data, ndim=2)
         ...     gmttype == ses["GMT_FLOAT"]
+        ...
         True
 
         """
@@ -1041,6 +1045,7 @@ class Session:
         ...             args = "{} ->{}".format(vfile, ofile.name)
         ...             lib.call_module("info", args)
         ...             print(ofile.read().strip())
+        ...
         <vector memory>: N = 5 <0/4> <5/9>
 
         """
@@ -1137,6 +1142,7 @@ class Session:
         ...                 "info", "{} ->{}".format(fin, fout.name)
         ...             )
         ...             print(fout.read().strip())
+        ...
         <vector memory>: N = 3 <1/3> <4/6> <7/9>
 
         """
@@ -1249,6 +1255,7 @@ class Session:
         ...                 "info", "{} ->{}".format(fin, fout.name)
         ...             )
         ...             print(fout.read().strip())
+        ...
         <matrix memory>: N = 4 <0/9> <1/10> <2/11>
 
         """
@@ -1331,6 +1338,7 @@ class Session:
         ...             args = "{} -L0 -Cn ->{}".format(fin, fout.name)
         ...             ses.call_module("grdinfo", args)
         ...             print(fout.read().strip())
+        ...
         -180 180 -90 90 -8182 5651.5 1 1 360 180 1 1
         >>> # The output is: w e s n z0 z1 dx dy n_columns n_rows reg gtype
 
@@ -1387,6 +1395,7 @@ class Session:
         ... )
         >>> with Session() as lib:
         ...     wesn = lib.extract_region()
+        ...
         >>> print(", ".join(["{:.2f}".format(x) for x in wesn]))
         0.00, 10.00, -20.00, -10.00
 
@@ -1399,6 +1408,7 @@ class Session:
         ... )
         >>> with Session() as lib:
         ...     wesn = lib.extract_region()
+        ...
         >>> print(", ".join(["{:.2f}".format(x) for x in wesn]))
         -164.71, -154.81, 18.91, 23.58
 
@@ -1412,6 +1422,7 @@ class Session:
         ... )
         >>> with Session() as lib:
         ...     wesn = lib.extract_region()
+        ...
         >>> print(", ".join(["{:.2f}".format(x) for x in wesn]))
         -165.00, -150.00, 15.00, 25.00
 

--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -50,6 +50,7 @@ class GMTTempFile:
     ...     print(lines)
     ...     nx, ny, nz = tmpfile.loadtxt(unpack=True, dtype=float)
     ...     print(nx, ny, nz)
+    ...
     0.0 1.0 2.0
     0.0 1.0 2.0
     0.0 1.0 2.0

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -57,6 +57,7 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
     ...     return fig_ref, fig_test
     >>> with pytest.raises(GMTImageComparisonFailure):
     ...     test_check_figures_unequal()
+    ...
     >>> for suffix in ["", "-expected", "-failed-diff"]:
     ...     assert os.path.exists(
     ...         os.path.join(
@@ -64,6 +65,7 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
     ...             f"test_check_figures_unequal{suffix}.png",
     ...         )
     ...     )
+    ...
     >>> shutil.rmtree(path="tmp_result_images")  # cleanup folder if tests pass
     """
     # pylint: disable=invalid-name

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -96,6 +96,7 @@ def dummy_context(arg):
 
     >>> with dummy_context("some argument") as temp:
     ...     print(temp)
+    ...
     some argument
 
     """


### PR DESCRIPTION
**Description of proposed changes**

Blackdoc v0.3 was released (https://github.com/keewis/blackdoc/releases/tag/v0.3) and this broke our style checks :sweat_smile: This is just a quickfix to add some newlines with `...` following the change at https://github.com/keewis/blackdoc/pull/62

```diff
        ...     )
+       ...
```


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
