### PR TITLE
Allow np.object dtypes into virtualfile_from_vectors

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 
 from packaging.version import Version
 import numpy as np
+import pandas as pd
 
 from ..exceptions import (
     GMTCLibError,
@@ -1160,7 +1161,7 @@ class Session:
         # Assumes that first 2 columns contains coordinates like longitude
         # latitude, or datetime string types.
         for col, array in enumerate(arrays[2:]):
-            if np.issubdtype(array.dtype, np.str_):
+            if pd.api.types.is_string_dtype(array.dtype):
                 columns = col + 2
                 break
 
@@ -1189,6 +1190,7 @@ class Session:
                 strings = np.apply_along_axis(
                     func1d=" ".join, axis=0, arr=string_arrays
                 )
+            strings = np.asanyarray(a=strings, dtype=np.str)
             self.put_strings(
                 dataset, family="GMT_IS_VECTOR|GMT_IS_DUPLICATE", strings=strings
             )

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -397,12 +397,16 @@ def test_virtualfile_from_vectors():
             assert output == expected
 
 
-def test_virtualfile_from_vectors_one_string_column():
-    "Test passing in one column with string dtype into virtual file dataset"
+@pytest.mark.parametrize("dtype", [np.str, np.object])
+def test_virtualfile_from_vectors_one_string_or_object_column(dtype):
+    """
+    Test passing in one column with string or object dtype into virtual file
+    dataset
+    """
     size = 5
     x = np.arange(size, dtype=np.int32)
     y = np.arange(size, size * 2, 1, dtype=np.int32)
-    strings = np.array(["a", "bc", "defg", "hijklmn", "opqrst"], dtype=np.str)
+    strings = np.array(["a", "bc", "defg", "hijklmn", "opqrst"], dtype=dtype)
     with clib.Session() as lib:
         with lib.virtualfile_from_vectors(x, y, strings) as vfile:
             with GMTTempFile() as outfile:
@@ -412,13 +416,17 @@ def test_virtualfile_from_vectors_one_string_column():
         assert output == expected
 
 
-def test_virtualfile_from_vectors_two_string_columns():
-    "Test passing in two columns of string dtype into virtual file dataset"
+@pytest.mark.parametrize("dtype", [np.str, np.object])
+def test_virtualfile_from_vectors_two_string_or_object_columns(dtype):
+    """
+    Test passing in two columns of string or object dtype into virtual file
+    dataset
+    """
     size = 5
     x = np.arange(size, dtype=np.int32)
     y = np.arange(size, size * 2, 1, dtype=np.int32)
-    strings1 = np.array(["a", "bc", "def", "ghij", "klmno"], dtype=np.str)
-    strings2 = np.array(["pqrst", "uvwx", "yz!", "@#", "$"], dtype=np.str)
+    strings1 = np.array(["a", "bc", "def", "ghij", "klmno"], dtype=dtype)
+    strings2 = np.array(["pqrst", "uvwx", "yz!", "@#", "$"], dtype=dtype)
     with clib.Session() as lib:
         with lib.virtualfile_from_vectors(x, y, strings1, strings2) as vfile:
             with GMTTempFile() as outfile:


### PR DESCRIPTION
**Description of proposed changes**

Loosen the check in `virtualfile_from_vectors` to allow for any string-like dtype (np.str, np.object) by performing the check using `pd.api.types.is_string_dtype()`. The array is then converted (if needed) to a proper `np.str` dtype before giving it to `put_strings`.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Why is this needed ?**

This is one step in enabling text input into modules like:

- `meca`, see https://github.com/GenericMappingTools/pygmt/pull/516#issuecomment-657305554, https://github.com/GenericMappingTools/pygmt/pull/516/commits/ff164e654827024e76ec892f3acc2ee0d4c47bef
- `velo`, see https://github.com/GenericMappingTools/pygmt/pull/525#discussion_r519019697

Those modules rely on `pandas.DataFrame` inputs, but a 'str' column in pandas is typically stored as an 'object' dtype (see https://stackoverflow.com/questions/21018654/strings-in-a-dataframe-but-dtype-is-object), unless users take due care to store them in the new [pandas.StringDtype](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.StringDtype.html). Either way, when we convert these pandas.Series objects to a numpy array, their dtype becomes `np.object` rather than `np.str` (hence why our code needs to handle np.object too).

After this PR is merged, we can do something like:

```python
            if kind == "matrix":
                if pd.api.types.is_numeric_dtype(data):
                    # all numeric dtypes (e.g. int, float)
                    file_context = lib.virtualfile_from_matrix(data)
                else:
                    # contains a column with object (str) dtype
                    file_context = lib.virtualfile_from_vectors(
                        *[data[column] for column in data]
                    )
```



<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
