### PR TITLE
Update cache_data workflow to download from successfully cached artifacts

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  pull_request:
+  # pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  # pull_request:
+  pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'
@@ -16,7 +16,7 @@ jobs:
     steps:
       # Setup Miniconda
       - name: Setup Miniconda
-        uses: conda-incubator/setup-minicondav2.0.0
+        uses: conda-incubator/setup-miniconda@v2.0.0
         with:
           channels: conda-forge
           miniconda-version: "latest"

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -97,9 +97,10 @@ jobs:
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub
-        uses: dawidd6/action-download-artifact@v2.6.3
+        uses: dawidd6/action-download-artifact@v2.10.0
         with:
           workflow: cache_data.yaml
+          workflow_conclusion: success
           name: gmt-cache
           path: .gmt
 

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -64,9 +64,10 @@ jobs:
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub
-        uses: dawidd6/action-download-artifact@v2.6.3
+        uses: dawidd6/action-download-artifact@v2.10.0
         with:
           workflow: cache_data.yaml
+          workflow_conclusion: success
           name: gmt-cache
           path: .gmt
 


### PR DESCRIPTION
**Description of proposed changes**

Adds a missing `@` back to cache workflow, accidental typo from #687. Also bumps [`dawidd6/action-download-artifact`](https://github.com/dawidd6/action-download-artifact) from 2.6.3 to 2.10.0 and make sure that we only grab from successfully cached artifacts next time (see https://github.com/dawidd6/action-download-artifact/pull/35).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
