### PR TITLE
Exclude the CI job for Windows + Python 3.6

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -50,6 +50,11 @@ jobs:
         exclude:
           - isMaster: false  # i.e. on Pull Requests
             python-version: 3.6
+          # exclude Windows + Python 3.6 due to issue #693
+          # Remove it when we drop Python 3.6 support
+          - isMaster: true
+            python-version: 3.6
+            os: windows-latest
     # environmental variables used in coverage
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
**Description of proposed changes**

As per issue #693, the CI job for Windows + Python 3.6 fails recently, and we may not spend time debugging and fixing it. This PR excludes the CI job from our master branch CI jobs.

We can still test it works in PR #694.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
