### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -44,8 +44,6 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        isMaster:
-          - ${{ contains(github.ref, 'master') }}
     # environmental variables used in coverage
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -42,19 +42,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        # Run Python 3.6 tests on master branch only to conserve CI resources
         isMaster:
           - ${{ contains(github.ref, 'master') }}
-        exclude:
-          - isMaster: false  # i.e. on Pull Requests
-            python-version: 3.6
-          # exclude Windows + Python 3.6 due to issue #693
-          # Remove it when we drop Python 3.6 support
-          - isMaster: true
-            python-version: 3.6
-            os: windows-latest
     # environmental variables used in coverage
     env:
       OS: ${{ matrix.os }}

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -17,7 +17,7 @@ Which Python?
 -------------
 
 You'll need **Python 3.7 or greater** to run PyGMT. Old Python versions may
-work, but there is no guranteen that PyGMT will work as expected with old versions.
+work, but there is no guarantee that PyGMT will work as expected with old versions.
 
 We recommend using the `Anaconda <https://www.anaconda.com/distribution>`__ Python
 distribution to ensure you have all dependencies installed and the ``conda``

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -16,7 +16,8 @@ Installing
 Which Python?
 -------------
 
-You'll need **Python 3.6 or greater** to run PyGMT.
+You'll need **Python 3.7 or greater** to run PyGMT. Old Python versions may
+work, but there is no guranteen that PyGMT will work as expected with old versions.
 
 We recommend using the `Anaconda <https://www.anaconda.com/distribution>`__ Python
 distribution to ensure you have all dependencies installed and the ``conda``

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ CLASSIFIERS = [
     "Intended Audience :: Education",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
**Description of proposed changes**

- Remove Python 3.6 from our CI jobs
- Bump the minimum required Python version to 3.7 in the documentation
- Remove Python 3.6 from setup.py

Address #690.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
