### PR TITLE
Provide basic support for FreeBSD

### DIFF
--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -68,13 +68,14 @@ def clib_names(os_name):
     """
     if os_name.startswith("linux"):
         libnames = ["libgmt.so"]
-    elif os_name == "darwin":
-        # Darwin is macOS
+    elif os_name == "darwin":  # Darwin is macOS
         libnames = ["libgmt.dylib"]
     elif os_name == "win32":
         libnames = ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
+    elif os_name.startswith("freebsd"):  # FreeBSD
+        libnames = ["libgmt.so"]
     else:
-        raise GMTOSError('Operating system "{}" not supported.'.format(sys.platform))
+        raise GMTOSError(f'Operating system "{sys.platform}" not supported.')
     return libnames
 
 


### PR DESCRIPTION
**Description of proposed changes**

This PR provides basic support for FreeBSD. 

For FreeBSD, `sys.platform` returns `freebsdX`, and the suffix of shared libraries is `.so`. 

As per the feedback in the forum https://forum.generic-mapping-tools.org/t/building-gmt-on-freebsd-12-1-release/967/20. FreeBSD users can import pygmt correctly using this PR.

Fixes #698.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
