### PR TITLE
Fix the error message when IPython is not available

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -286,7 +286,7 @@ class Figure(BasePlotting):
                         [
                             "Cannot find IPython.",
                             "Make sure you have it installed",
-                            "or use 'external=True' to open in an external viewer.",
+                            "or use 'method=\"external\"' to open in an external viewer.",
                         ]
                     )
                 )


### PR DESCRIPTION
**Description of proposed changes**

When IPython is not available, `fig.show()` reports an error:
```
Cannot find IPython. Make sure you have it installed or use 'external=True' to open in an external viewer.
```

The error message is out-of-date. Instead, it should report:
```
Cannot find IPython. Make sure you have it installed or use 'method="external"' to open in an external viewer.
```

The issue was originally reported at https://forum.generic-mapping-tools.org/t/building-gmt-on-freebsd-12-1-release/967/20.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
