### PR TITLE
Add frame as a parameter on the grdview documentation

### DIFF
--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -530,6 +530,8 @@ class BasePlotting:
         zscale/zsize : float or str
             Set z-axis scaling or z-axis size.
 
+        {B}
+
         cmap : str
             The name of the color palette table to use.
 


### PR DESCRIPTION
The parameter **frame** was not listed under the documentation for the grdview method. I added it to the documentation using "{B}" to standardize it with the documentation for the other methods in base_plotting.py.
