### PR TITLE
Fix typo in link to English Wikipedia page for Iris data set

### DIFF
--- a/examples/gallery/plot/scatter3d.py
+++ b/examples/gallery/plot/scatter3d.py
@@ -4,7 +4,7 @@
 
 The :meth:`pygmt.Figure.plot3d` method can be used to plot symbols in 3D.
 In the example below, we show how the
-`Iris flower dataset <https://en.wikipedia.org/wiki/Iris_flower_data_set/>`__
+`Iris flower dataset <https://en.wikipedia.org/wiki/Iris_flower_data_set>`__
 can be visualized using a perspective 3-dimensional plot. The ``region``
 argument has to include the :math:`x`, :math:`y`, :math:`z` axis limits in the
 form of (xmin, xmax, ymin, ymax, zmin, zmax), which can be done automatically


### PR DESCRIPTION
The previous link to the Wikipedia page for the Iris data set include a forward slash at the end of the URL, which linked to a non-existent Wikipedia page that does not redirect to the correct page. I removed the forward slash and the URL now goes to the correct page.