### PR TITLE
Add frame and cmap to the colorbar parameters list

### DIFF
--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -179,7 +179,8 @@ class BasePlotting:
 
         Parameters
         ----------
-        {B}
+        frame : str or list
+            Set color bar boundary frame, labels, and axes attributes.
         {CPT}
         position : str
             ``[g|j|J|n|x]refpoint[+wlength[/width]][+e[b|f][length]][+h|v]

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -179,6 +179,8 @@ class BasePlotting:
 
         Parameters
         ----------
+        {B}
+        {CPT}
         position : str
             ``[g|j|J|n|x]refpoint[+wlength[/width]][+e[b|f][length]][+h|v]
             [+jjustify][+m[a|c|l|u]][+n[txt]][+odx[/dy]]``. Defines the

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -68,13 +68,14 @@ def clib_names(os_name):
     """
     if os_name.startswith("linux"):
         libnames = ["libgmt.so"]
-    elif os_name == "darwin":
-        # Darwin is macOS
+    elif os_name == "darwin":  # Darwin is macOS
         libnames = ["libgmt.dylib"]
     elif os_name == "win32":
         libnames = ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
+    elif os_name.startswith("freebsd"):  # FreeBSD
+        libnames = ["libgmt.so"]
     else:
-        raise GMTOSError('Operating system "{}" not supported.'.format(sys.platform))
+        raise GMTOSError(f'Operating system "{sys.platform}" not supported.')
     return libnames
 
 


### PR DESCRIPTION
The documentation for pygmt.Figure.colorbar() includes frame and cmap under the aliases list, but doesn't include them under the parameters list. I added them in this pull request.