### PR TITLE
Fix a bug of Figure.text() when "text" is a non-string array

### DIFF
--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -1536,7 +1536,8 @@ class BasePlotting:
                         np.atleast_1d(x),
                         np.atleast_1d(y),
                         *extra_arrays,
-                        np.atleast_1d(text),
+                        # text must be in str type, see issue #706
+                        np.atleast_1d(text).astype(str),
                     )
             with file_context as fname:
                 arg_str = " ".join([fname, build_arg_string(kwargs)])

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -338,3 +338,26 @@ def test_text_varying_transparency():
     fig_test.text(x=x, y=y, text=text, transparency=transparency)
 
     return fig_ref, fig_test
+
+
+@check_figures_equal()
+def test_text_nonstr_text():
+    "Input text is in non-string type (e.g., int, float)"
+    fig_ref, fig_test = Figure(), Figure()
+
+    # Use single-character arguments and input files for the reference image
+    with GMTTempFile(suffix=".txt") as tempfile:
+        with open(tempfile.name, "w") as tmpfile:
+            tmpfile.write("1 1 1.0\n2 2 2.0\n3 3 3.0\n4 4 4.0\n")
+        fig_ref.text(R="0/10/0/10", J="X10c", B="", textfiles=tempfile.name)
+
+    fig_test.text(
+        region=[0, 10, 0, 10],
+        projection="X10c",
+        frame=True,
+        x=[1, 2, 3, 4],
+        y=[1, 2, 3, 4],
+        text=[1, 2, 3.0, 4.0],
+    )
+
+    return fig_ref, fig_test


### PR DESCRIPTION
**Description of proposed changes**

See #706 for the bug report.

We need to pass an string-type array to `lib.virtualfile_from_vectors`
function.

Closes #706.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
