### PR TITLE
Migrate pytest configurations to pyproject.toml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,11 +311,11 @@ Leave a comment in the PR and we'll help you out.
 
 You can also run tests in just one test script using:
 
-    pytest --verbose --mpl --mpl-results-path=results --doctest-modules pygmt/tests/NAME_OF_TEST_FILE.py
+    pytest pygmt/tests/NAME_OF_TEST_FILE.py
 
 or run tests which contain names that match a specific keyword expression:
 
-    pytest --verbose --mpl --mpl-results-path=results --doctest-modules -k KEYWORD pygmt/tests
+    pytest -k KEYWORD pygmt/tests
 
 ### Testing plots
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 # Build, package, test, and clean
 PROJECT=pygmt
 TESTDIR=tmp-test-dir-with-unique-name
-PYTEST_ARGS=--cov=$(PROJECT) --cov-config=../pyproject.toml \
+PYTEST_COV_ARGS=--cov=$(PROJECT) --cov-config=../pyproject.toml \
 			--cov-report=term-missing --cov-report=xml --cov-report=html \
-			--doctest-modules -v --mpl --mpl-results-path=results \
 			--pyargs ${PYTEST_EXTRA}
 BLACK_FILES=$(PROJECT) setup.py doc/conf.py examples
 BLACKDOC_OPTIONS=--line-length 79
@@ -30,7 +29,7 @@ test:
 	@echo ""
 	@cd $(TESTDIR); python -c "import $(PROJECT); $(PROJECT).show_versions()"
 	@echo ""
-	cd $(TESTDIR); pytest $(PYTEST_ARGS) $(PROJECT)
+	cd $(TESTDIR); pytest $(PYTEST_COV_ARGS) $(PROJECT)
 	cp $(TESTDIR)/coverage.xml .
 	cp -r $(TESTDIR)/htmlcov .
 	rm -r $(TESTDIR)

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
     - ipython
     - matplotlib
     - jupyter
-    - pytest
+    - pytest>=6.0
     - pytest-cov
     - pytest-mpl
     - coverage[toml]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
 [tool.coverage.run]
 omit = ["*/tests/*", "*pygmt/__init__.py"]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--verbose --doctest-modules --mpl --mpl-results-path=results"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 ipython
 matplotlib
 jupyter
-pytest
+pytest>=6.0
 pytest-cov
 pytest-mpl
 coverage[toml]


### PR DESCRIPTION
**Description of proposed changes**

This PR moves pytest configurations (actually some pytest options) to `pyproject.toml`.

**Motivation:**

Let's say I'm working on the `Figure.text()` function, and I want to run the `pygmt/tests/test_text.py` locally to make sure that my changes work. I should use the long command:
```
pytest --verbose --mpl --mpl-results-path=results --doctest-modules pygmt/tests/test_text.py
```
but sometimes (very often) I just run `pytest` without any options:
```
pytest pygmt/tests/test_text.py
```
As I don't give the `--verbose --mpl --mpl-results-path=results --doctest-modules` option, `pytest` doesn't do the image comparisons at all, and it reports that all tests pass. It often confuses me a lot before I realize that I missed the necessary options.

With this PR, `pytest` reads configurations from `pyproject.toml` and adds the necessary options automatically. So that the short command `pytest pygmt/tests/test_text.py` always do the image comparisons and doctests.

**Pros:**

1. Shorter and more intuitive command to run tests in one or a few files

**Cons:**

1. [`pyproject.toml` support](https://docs.pytest.org/en/stable/customize.html#pyproject-toml) needs pytest [v6.0 (released on 2020-07-28)](https://docs.pytest.org/en/stable/changelog.html#pytest-6-0-0-2020-07-28). _Note that Anaconda Python 3.7 ships pytest 6.1.1, while Anaconda Python 3.6 ships pytest 5.4.3. But we have dropped Python 3.6 recently. So it won't be a big issue, especially that `pytest` is only used when developing pygmt._
2. To generate baseline images, we still need to run `pytest --mpl-generate-path=baseline pygmt/tests/test_text.py`, and it gives an warning `UserWarning: Ignoring --mpl-result-path since --mpl-generate-path is set`. The warning is acceptable to me, and we are also trying our best to avoid storing baseline images in the repository. So I think it won't be a big issue.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
