### PR TITLE
Wrap triangulate

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -65,6 +65,7 @@ Operations on tabular data:
 
     blockmedian
     surface
+    triangulate
 
 Operations on grids:
 

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -15,7 +15,7 @@ from pkg_resources import get_distribution
 from .session_management import begin as _begin, end as _end
 from .figure import Figure
 from .filtering import blockmedian
-from .gridding import surface
+from .gridding import surface, triangulate
 from .sampling import grdtrack
 from .mathops import makecpt
 from .modules import GMTDataArrayAccessor, config, info, grdinfo, which

--- a/pygmt/gridding.py
+++ b/pygmt/gridding.py
@@ -1,19 +1,20 @@
 """
 GMT modules for Gridding of Data Tables
 """
+import pandas as pd
 import xarray as xr
 
 from .clib import Session
+from .exceptions import GMTInvalidInput
 from .helpers import (
+    GMTTempFile,
     build_arg_string,
     data_kind,
     dummy_context,
     fmt_docstring,
-    GMTTempFile,
     kwargs_to_strings,
     use_alias,
 )
-from .exceptions import GMTInvalidInput
 
 
 @fmt_docstring
@@ -95,5 +96,101 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
                 _ = result.gmt  # load GMTDataArray accessor information
         elif outfile != tmpfile.name:  # if user sets an outfile, return None
             result = None
+
+    return result
+
+
+@fmt_docstring
+@use_alias(
+    G="outgrid", I="spacing", J="projection", R="region", V="verbose", r="registration"
+)
+@kwargs_to_strings(R="sequence")
+def triangulate(x=None, y=None, z=None, data=None, **kwargs):
+    """
+    Delaunay triangulation or Voronoi partitioning and gridding of Cartesian
+    data.
+
+    Triangulate reads in x,y[,z] data and performs Delaunay triangulation,
+    i.e., it find how the points should be connected to give the most
+    equilateral triangulation possible. If a map projection (give *region*
+    and *projection*) is chosen then it is applied before the triangulation
+    is calculated.
+
+    Must provide either *data* or *x*, *y*, and *z*.
+
+    Full option list at :gmt-docs:`triangulate.html`
+
+    {aliases}
+
+    Parameters
+    ----------
+    x/y/z : np.ndarray
+        Arrays of x and y coordinates and values z of the data points.
+    data : str or np.ndarray
+        Either a data file name or a 2d numpy array with the tabular data.
+    projection : str
+        Select map projection.
+    region
+        ``'xmin/xmax/ymin/ymax[+r][+uunit]'``.
+        Specify the region of interest.
+    spacing : str
+        ``'xinc[unit][+e|n][/yinc[unit][+e|n]]'``.
+        x_inc [and optionally y_inc] is the grid spacing.
+    outgrid : bool or str
+        Use triangulation to grid the data onto an even grid (specified with
+        *region* and *spacing*). Set to True, or pass in the name of the output
+        grid file. The interpolation is performed in the original coordinates,
+        so if your triangles are close to the poles you are better off
+        projecting all data to a local coordinate system before using
+        *triangulate* (this is true of all gridding routines) or instead
+        select *sphtriangulate*.
+    {V}
+    {registration}
+        Only valid with *outgrid*.
+
+    Returns
+    -------
+    ret: xarray.DataArray or None
+        Return type depends on whether the outgrid parameter is set:
+
+        - pandas.DataFrame if outgrid is None (default)
+        - xarray.DataArray if outgrid is True
+        - None if outgrid is a str (grid output will be stored in outgrid)
+
+    """
+    kind = data_kind(data, x, y, z)
+    if kind == "vectors" and z is None:
+        raise GMTInvalidInput("Must provide z with x and y.")
+
+    with GMTTempFile(suffix=".nc") as tmpfile:
+        with Session() as lib:
+            if kind == "file":
+                file_context = dummy_context(data)
+            elif kind == "matrix":
+                file_context = lib.virtualfile_from_matrix(data)
+            elif kind == "vectors":
+                file_context = lib.virtualfile_from_vectors(x, y, z)
+            else:
+                raise GMTInvalidInput(f"Unrecognized data type: {type(data)}")
+
+            with file_context as infile:
+                if "G" not in kwargs:  # table output if outgrid is unset
+                    kwargs.update({">": tmpfile.name})
+                else:  # NetCDF or xarray.DataArray output if outgrid is set
+                    if kwargs["G"] == "":  # xarray.DataArray output if outgrid=True
+                        kwargs.update({"G": tmpfile.name})
+                    outgrid = kwargs["G"]
+                arg_str = " ".join([infile, build_arg_string(kwargs)])
+                lib.call_module(module="triangulate", args=arg_str)
+
+        try:
+            if outgrid == tmpfile.name:  # if user did not set outfile, return DataArray
+                with xr.open_dataarray(outgrid) as dataarray:
+                    result = dataarray.load()
+                    _ = result.gmt  # load GMTDataArray accessor information
+            elif outgrid != tmpfile.name:  # if user sets an outgrid, return None
+                result = None
+        except UnboundLocalError:  # if outgrid unset, return pd.DataFrame
+            result = pd.read_csv(tmpfile.name, sep="\t", header=None)
 
     return result

--- a/pygmt/tests/test_triangulate.py
+++ b/pygmt/tests/test_triangulate.py
@@ -1,0 +1,128 @@
+"""
+Tests for triangulate
+"""
+import os
+
+import pandas as pd
+import pytest
+import xarray as xr
+
+from .. import triangulate, which
+from ..datasets import load_sample_bathymetry
+from ..exceptions import GMTInvalidInput
+from ..helpers import data_kind
+
+TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+TEMP_GRID = os.path.join(TEST_DATA_DIR, "tmp_grid.nc")
+
+
+@pytest.fixture(scope="module", name="ship_data")
+def fixture_ship_data():
+    """
+    Load the grid data from the sample bathymetry file
+    """
+    ship_data = load_sample_bathymetry()
+    return ship_data
+
+
+def test_triangulate_input_file():
+    """
+    Run triangulate by passing in a filename
+    """
+    fname = which("@tut_ship.xyz", download="c")
+    output = triangulate(data=fname)
+    assert isinstance(output, pd.DataFrame)
+    assert output.shape == (161935, 3)
+    return output
+
+
+def test_triangulate_input_data_array(ship_data):
+    """
+    Run triangulate by passing in a numpy array into data
+    """
+    data = ship_data.to_numpy()
+    output = triangulate(data=data)
+    assert isinstance(output, pd.DataFrame)
+    assert output.shape == (161935, 3)
+    return output
+
+
+def test_triangulate_input_xyz(ship_data):
+    """
+    Run triangulate by passing in x, y, z numpy.ndarrays individually
+    """
+    output = triangulate(
+        x=ship_data.longitude,
+        y=ship_data.latitude,
+        z=ship_data.bathymetry,
+    )
+    assert isinstance(output, pd.DataFrame)
+    assert output.shape == (161935, 3)
+    return output
+
+
+def test_triangulate_input_xy_no_z(ship_data):
+    """
+    Run triangulate by passing in x and y, but no z
+    """
+    with pytest.raises(GMTInvalidInput):
+        triangulate(x=ship_data.longitude, y=ship_data.latitude)
+
+
+def test_triangulate_wrong_kind_of_input(ship_data):
+    """
+    Run triangulate using grid input that is not file/matrix/vectors
+    """
+    data = ship_data.bathymetry.to_xarray()  # convert pandas.Series to xarray.DataArray
+    assert data_kind(data) == "grid"
+    with pytest.raises(GMTInvalidInput):
+        triangulate(data=data)
+
+
+def test_triangulate_with_outgrid_true(ship_data):
+    """
+    Run triangulate with outgrid=True and see it load into an xarray.DataArray
+    """
+    data = ship_data.to_numpy()
+    output = triangulate(
+        data=data, spacing="5m", region=[245, 255, 20, 30], outgrid=True
+    )
+    assert isinstance(output, xr.DataArray)
+    assert output.shape == (121, 121)
+    return output
+
+
+def test_triangulate_with_outgrid_param(ship_data):
+    """
+    Run triangulate with the -Goutputfile.nc parameter
+    """
+    data = ship_data.to_numpy()
+    try:
+        output = triangulate(
+            data=data, spacing="5m", region=[245, 255, 20, 30], outgrid=TEMP_GRID
+        )
+        assert output is None  # check that output is None since outgrid is set
+        assert os.path.exists(path=TEMP_GRID)  # check that outgrid exists at path
+        with xr.open_dataarray(TEMP_GRID) as grid:
+            assert isinstance(grid, xr.DataArray)  # ensure netcdf grid loads ok
+            assert grid.shape == (121, 121)
+    finally:
+        os.remove(path=TEMP_GRID)
+    return output
+
+
+def test_triangulate_short_aliases(ship_data):
+    """
+    Run triangulate using short aliases -I for spacing, -R for region, -G for
+    outgrid
+    """
+    data = ship_data.to_numpy()
+    try:
+        output = triangulate(data=data, I="5m", R=[245, 255, 20, 30], G=TEMP_GRID)
+        assert output is None  # check that output is None since outgrid is set
+        assert os.path.exists(path=TEMP_GRID)  # check that outgrid exists at path
+        with xr.open_dataarray(TEMP_GRID) as grid:
+            assert isinstance(grid, xr.DataArray)  # ensure netcdf grid loads ok
+    finally:
+        os.remove(path=TEMP_GRID)
+    return output


### PR DESCRIPTION
Wrapping the [triangulate](https://docs.generic-mapping-tools.org/6.1/triangulate.html) function which does "Delaunay triangulation or Voronoi partitioning and gridding of Cartesian data", implemented under gridding.py.

Live documentation preview for this Pull Request is at https://pygmt-git-gridding-triangulate.gmt.vercel.app/api/generated/pygmt.triangulate.html.

**Description of proposed changes**

Note that this is just a minimal implementation of `triangulate` for now, and I don't expect to wrap and test all the aliases here as they are super complicated. Just that I've just been using `triangulate` secretly at https://github.com/weiji14/pyissm/blob/5c9e3be4c4983ccc79a67cc6471421922e8c3af7/plot_figures.py#L68-L83 and thought it should get into `pygmt` proper :smile:

The complicated thing about `triangulate` is that it generates either text (table) or NetCDF (grid) outputs, and I've implemented it as so:

- [x] When `outgrid=None` (default), output table as `pandas.DataFrame`
- [ ] (Won't be implemented?), output table as textfile 
- [x] When `outgrid=True`, output grid as 'xarray.DataArray`
- [x] When `outgrid=None`, output grid to NetCDF file

Welcome to other suggestions on implementation details.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
