### PR TITLE
Add test test_basemap_map_scale

### DIFF
--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -102,3 +102,14 @@ def test_basemap_compass():
     fig_test.coast(region=[127.5, 128.5, 26, 27], shorelines="1/0.5p")
     fig_test.basemap(compass="jBR+w5c+d11.5")
     return fig_ref, fig_test
+
+
+@check_figures_equal()
+def test_basemap_map_scale():
+    "Create a map with coast and use basemap to add a map scale"
+    fig_ref, fig_test = Figure(), Figure()
+    fig_ref.coast(R="127.5/128.5/26/27", W="1/0.5p")
+    fig_ref.basemap(L="jMB+c1+w10k+l+f")
+    fig_test.coast(region=[127.5, 128.5, 26, 27], shorelines="1/0.5p")
+    fig_test.basemap(map_scale="jMB+c1+w10k+f+l")
+    return fig_ref, fig_test


### PR DESCRIPTION
Add test for using Figure.basemap() with only a `map_scale` argument, similar to tests created for `compass` and `rose` in #729.