### PR TITLE
Add a Makefile target 'distclean' for deleting project metadata files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ help:
 	@echo "  check     run code style and quality checks (black, blackdoc and flake8)"
 	@echo "  lint      run pylint for a deeper (and slower) quality check"
 	@echo "  clean     clean up build and generated files"
+	@echo "  distclean clean up build and generated files, including project metadata files"
 	@echo ""
 
 install:
@@ -47,10 +48,13 @@ lint:
 	pylint $(LINT_FILES)
 
 clean:
-	find . -name "*.pyc" -exec rm -v {} \;
-	find . -name "*~" -exec rm -v {} \;
+	find . -name "*.pyc" -exec rm -v {} +
+	find . -name "*~" -exec rm -v {} +
 	find . -type d -name  "__pycache__" -exec rm -rv {} +
-	rm -rvf build dist MANIFEST *.egg-info .coverage .cache htmlcov coverage.xml
+	rm -rvf build dist MANIFEST .coverage .cache .pytest_cache htmlcov coverage.xml
 	rm -rvf $(TESTDIR)
 	rm -rvf baseline
 	rm -rvf result_images
+
+distclean: clean
+	rm -r *.egg-info


### PR DESCRIPTION
**Description of proposed changes**

See #737 for context.

Changes in this PR:

1. Do **NOT** delete the `*.egg-info` directory for `make clean`
2. Delete `.pytest_cache` (pytest cache files)
2. Add `make distclean` to delete all generated files and `*.egg-info` directory
3. Use similar syntax for the `find` commands

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #737.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
