### PR TITLE
Add isort to sort imports alphabetically

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install packages
         run: |
-          pip install black blackdoc flake8 pylint
+          pip install black blackdoc flake8 pylint isort
           sudo apt-get install dos2unix
 
       - name: Formatting check (black and flake8)

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -26,7 +26,7 @@ jobs:
       # Install formatting tools
       - name: Install formatting tools
         run: |
-          pip install black blackdoc flake8
+          pip install black blackdoc flake8 isort
           sudo apt-get install dos2unix
 
       # Run "make format" and commit the change to the PR branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,7 +245,12 @@ directory).
 
 ### Code style
 
-We use [Black](https://github.com/ambv/black) and [blackdoc](https://github.com/keewis/blackdoc)
+We use some tools:
+
+- [Black](https://github.com/ambv/black)
+- [blackdoc](https://github.com/keewis/blackdoc)
+- [isort](https://pycqa.github.io/isort/)
+
 to format the code so we don't have to think about it.
 Black loosely follows the [PEP8](http://pep8.org) guide but with a few differences.
 Regardless, you won't have to worry about formatting the code yourself.
@@ -268,7 +273,7 @@ common errors.
 The [`Makefile`](Makefile) contains rules for running both checks:
 
 ```bash
-make check   # Runs flake8, black and blackdoc (in check mode)
+make check   # Runs flake8, black, blackdoc and isort (in check mode)
 make lint    # Runs pylint, which is a bit slower
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 	@echo "  install   install in editable mode"
 	@echo "  test      run the test suite (including doctests) and report coverage"
 	@echo "  format    run black and blackdoc to automatically format the code"
-	@echo "  check     run code style and quality checks (black, blackdoc and flake8)"
+	@echo "  check     run code style and quality checks (black, blackdoc, isort and flake8)"
 	@echo "  lint      run pylint for a deeper (and slower) quality check"
 	@echo "  clean     clean up build and generated files"
 	@echo "  distclean clean up build and generated files, including project metadata files"
@@ -36,10 +36,12 @@ test:
 	rm -r $(TESTDIR)
 
 format:
+	isort .
 	black $(BLACK_FILES)
 	blackdoc $(BLACKDOC_OPTIONS) $(BLACK_FILES)
 
 check:
+	isort . --check
 	black --check $(BLACK_FILES)
 	blackdoc --check $(BLACKDOC_OPTIONS) $(BLACK_FILES)
 	flake8 $(FLAKE8_FILES)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -6,12 +6,15 @@ Sphinx documentation configuration file.
 
 import datetime
 
-from pygmt import __commit__, __version__
-from pygmt.sphinx_gallery import PyGMTScraper
+# isort: off
 from sphinx_gallery.sorting import (  # pylint: disable=no-name-in-module
     ExplicitOrder,
     FileNameSortKey,
 )
+from pygmt import __commit__, __version__
+from pygmt.sphinx_gallery import PyGMTScraper
+
+# isort: on
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,13 +5,13 @@ Sphinx documentation configuration file.
 # pylint: disable=invalid-name
 
 import datetime
-from sphinx_gallery.sorting import (  # pylint: disable=no-name-in-module
-    FileNameSortKey,
-    ExplicitOrder,
-)
-from pygmt import __version__, __commit__
-from pygmt.sphinx_gallery import PyGMTScraper
 
+from pygmt import __commit__, __version__
+from pygmt.sphinx_gallery import PyGMTScraper
+from sphinx_gallery.sorting import (  # pylint: disable=no-name-in-module
+    ExplicitOrder,
+    FileNameSortKey,
+)
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
     - coverage[toml]
     - black
     - blackdoc
+    - isort>=5
     - pylint
     - flake8
     - sphinx

--- a/examples/gallery/grid/grdview_surface.py
+++ b/examples/gallery/grid/grdview_surface.py
@@ -12,8 +12,8 @@ axis scaling. The ``shading`` argument specifies illumination; here we choose an
 45° with ``shading="+a45"``.
 """
 
-import pygmt
 import numpy as np
+import pygmt
 import xarray as xr
 
 

--- a/examples/gallery/line/linestyles.py
+++ b/examples/gallery/line/linestyles.py
@@ -17,8 +17,8 @@ For more advanced *pen* attributes, see the GMT cookbook
 
 """
 
-import pygmt
 import numpy as np
+import pygmt
 
 # Generate a two-point line for plotting
 x = np.array([0, 7])

--- a/examples/gallery/line/linestyles.py
+++ b/examples/gallery/line/linestyles.py
@@ -17,8 +17,8 @@ For more advanced *pen* attributes, see the GMT cookbook
 
 """
 
-import numpy as np
 import pygmt
+import numpy as np
 
 # Generate a two-point line for plotting
 x = np.array([0, 7])

--- a/examples/gallery/plot/points-transparency.py
+++ b/examples/gallery/plot/points-transparency.py
@@ -6,8 +6,8 @@ Points can be plotted with different transparency levels by passing in an array 
 ``transparency`` argument of :meth:`pygmt.Figure.plot`.
 """
 
-import pygmt
 import numpy as np
+import pygmt
 
 # prepare the input x and y data
 x = np.arange(0, 105, 5)

--- a/examples/gallery/plot/points-transparency.py
+++ b/examples/gallery/plot/points-transparency.py
@@ -6,8 +6,8 @@ Points can be plotted with different transparency levels by passing in an array 
 ``transparency`` argument of :meth:`pygmt.Figure.plot`.
 """
 
-import numpy as np
 import pygmt
+import numpy as np
 
 # prepare the input x and y data
 x = np.arange(0, 105, 5)

--- a/examples/gallery/plot/points.py
+++ b/examples/gallery/plot/points.py
@@ -5,8 +5,8 @@ Points
 The :meth:`pygmt.Figure.plot` method can plot points. We must specify the plot symbol
 and size through the ``style`` argument.
 """
-import numpy as np
 import pygmt
+import numpy as np
 
 # Generate a random set of points to plot
 np.random.seed(42)

--- a/examples/gallery/plot/points.py
+++ b/examples/gallery/plot/points.py
@@ -5,8 +5,8 @@ Points
 The :meth:`pygmt.Figure.plot` method can plot points. We must specify the plot symbol
 and size through the ``style`` argument.
 """
-import pygmt
 import numpy as np
+import pygmt
 
 # Generate a random set of points to plot
 np.random.seed(42)

--- a/examples/gallery/plot/scatter.py
+++ b/examples/gallery/plot/scatter.py
@@ -9,8 +9,8 @@ Modified from the matplotlib example:
 https://matplotlib.org/gallery/lines_bars_and_markers/scatter_with_legend.html
 """
 
-import pygmt
 import numpy as np
+import pygmt
 
 np.random.seed(19680801)
 n = 200  # number of random data points

--- a/examples/gallery/plot/scatter.py
+++ b/examples/gallery/plot/scatter.py
@@ -9,8 +9,8 @@ Modified from the matplotlib example:
 https://matplotlib.org/gallery/lines_bars_and_markers/scatter_with_legend.html
 """
 
-import numpy as np
 import pygmt
+import numpy as np
 
 np.random.seed(19680801)
 n = 200  # number of random data points

--- a/examples/gallery/plot/scatter3d.py
+++ b/examples/gallery/plot/scatter3d.py
@@ -14,8 +14,8 @@ control the azimuth and elevation angle of the view, and ``zscale`` to adjust
 the vertical exaggeration factor.
 """
 
-import pandas as pd
 import pygmt
+import pandas as pd
 
 # Load sample iris data, and convert 'species' column to categorical dtype
 df = pd.read_csv("https://github.com/mwaskom/seaborn-data/raw/master/iris.csv")

--- a/examples/gallery/plot/scatter3d.py
+++ b/examples/gallery/plot/scatter3d.py
@@ -14,8 +14,8 @@ control the azimuth and elevation angle of the view, and ``zscale`` to adjust
 the vertical exaggeration factor.
 """
 
-import pygmt
 import pandas as pd
+import pygmt
 
 # Load sample iris data, and convert 'species' column to categorical dtype
 df = pd.read_csv("https://github.com/mwaskom/seaborn-data/raw/master/iris.csv")

--- a/examples/tutorials/plot.py
+++ b/examples/tutorials/plot.py
@@ -11,7 +11,6 @@ automatically downloaded and saved to a cache directory the first time you use t
 
 import pygmt
 
-
 ########################################################################################
 # For example, let's load the sample dataset of tsunami generating earthquakes around
 # Japan (:func:`pygmt.datasets.load_japan_quakes`). The data is loaded as a

--- a/examples/tutorials/text.py
+++ b/examples/tutorials/text.py
@@ -7,6 +7,7 @@ It is often useful to add annotations to a map plot. This is handled by
 """
 
 import os
+
 import pygmt
 
 ###############################################################################

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -10,6 +10,8 @@
 import atexit as _atexit
 
 from pkg_resources import get_distribution
+
+# Import modules to make the high-level GMT Python API
 from pygmt import datasets
 from pygmt.figure import Figure
 from pygmt.filtering import blockmedian
@@ -18,8 +20,6 @@ from pygmt.gridops import grdcut, grdfilter
 from pygmt.mathops import makecpt
 from pygmt.modules import GMTDataArrayAccessor, config, grdinfo, info, which
 from pygmt.sampling import grdtrack
-
-# Import modules to make the high-level GMT Python API
 from pygmt.session_management import begin as _begin
 from pygmt.session_management import end as _end
 from pygmt.x2sys import x2sys_cross, x2sys_init

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -9,19 +9,20 @@
 
 import atexit as _atexit
 
+from pygmt import datasets
 from pkg_resources import get_distribution
-
-# Import modules to make the high-level GMT Python API
-from pygmt.session_management import begin as _begin, end as _end
 from pygmt.figure import Figure
 from pygmt.filtering import blockmedian
 from pygmt.gridding import surface
-from pygmt.sampling import grdtrack
-from pygmt.mathops import makecpt
-from pygmt.modules import GMTDataArrayAccessor, config, info, grdinfo, which
 from pygmt.gridops import grdcut, grdfilter
-from pygmt.x2sys import x2sys_init, x2sys_cross
-from pygmt import datasets
+from pygmt.mathops import makecpt
+from pygmt.modules import GMTDataArrayAccessor, config, grdinfo, info, which
+from pygmt.sampling import grdtrack
+
+# Import modules to make the high-level GMT Python API
+from pygmt.session_management import begin as _begin
+from pygmt.session_management import end as _end
+from pygmt.x2sys import x2sys_cross, x2sys_init
 
 # Get semantic version through setuptools-scm
 __version__ = f'v{get_distribution("pygmt").version}'  # e.g. v0.1.2.dev3+g0ab3cd78
@@ -60,10 +61,10 @@ def show_versions():
     - GMT library information
     """
 
-    import sys
-    import platform
     import importlib
+    import platform
     import subprocess
+    import sys
 
     def _get_module_version(modname):
         """Get version information of a Python module."""

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -9,8 +9,8 @@
 
 import atexit as _atexit
 
-from pygmt import datasets
 from pkg_resources import get_distribution
+from pygmt import datasets
 from pygmt.figure import Figure
 from pygmt.filtering import blockmedian
 from pygmt.gridding import surface

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -3,19 +3,19 @@ Base class with plot generating commands.
 Does not define any special non-GMT methods (savefig, show, etc).
 """
 import contextlib
+
 import numpy as np
 import pandas as pd
-
 from pygmt.clib import Session
 from pygmt.exceptions import GMTError, GMTInvalidInput
 from pygmt.helpers import (
     build_arg_string,
-    dummy_context,
     data_kind,
+    dummy_context,
     fmt_docstring,
-    use_alias,
-    kwargs_to_strings,
     is_nonstr_iter,
+    kwargs_to_strings,
+    use_alias,
 )
 
 

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -3,7 +3,6 @@ Functions to convert data types into ctypes friendly formats.
 """
 import numpy as np
 import pandas as pd
-
 from pygmt.exceptions import GMTInvalidInput
 
 

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -4,12 +4,12 @@ Utility functions to load libgmt as ctypes.CDLL.
 The path to the shared library can be found automatically by ctypes or set
 through the GMT_LIBRARY_PATH environment variable.
 """
+import ctypes
 import os
 import sys
-import ctypes
 from ctypes.util import find_library
 
-from pygmt.exceptions import GMTOSError, GMTCLibError, GMTCLibNotFoundError
+from pygmt.exceptions import GMTCLibError, GMTCLibNotFoundError, GMTOSError
 
 
 def load_libgmt():

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -3,27 +3,26 @@ Defines the Session class to create and destroy a GMT API session and provides
 access to the API functions. Uses ctypes to wrap most of the core functions
 from the C API.
 """
-import sys
 import ctypes as ctp
+import sys
 from contextlib import contextmanager
 
-from packaging.version import Version
 import numpy as np
 import pandas as pd
-
+from packaging.version import Version
+from pygmt.clib.conversion import (
+    array_to_datetime,
+    as_c_contiguous,
+    dataarray_to_matrix,
+    kwargs_to_ctypes_array,
+    vectors_to_arrays,
+)
+from pygmt.clib.loading import load_libgmt
 from pygmt.exceptions import (
     GMTCLibError,
     GMTCLibNoSessionError,
     GMTInvalidInput,
     GMTVersionError,
-)
-from pygmt.clib.loading import load_libgmt
-from pygmt.clib.conversion import (
-    kwargs_to_ctypes_array,
-    vectors_to_arrays,
-    dataarray_to_matrix,
-    as_c_contiguous,
-    array_to_datetime,
 )
 
 FAMILIES = [

--- a/pygmt/datasets/__init__.py
+++ b/pygmt/datasets/__init__.py
@@ -2,10 +2,10 @@
 #
 # Load sample data included with GMT (downloaded from the GMT cache server).
 
+from pygmt.datasets.earth_relief import load_earth_relief
 from pygmt.datasets.tutorial import (
     load_japan_quakes,
     load_ocean_ridge_points,
     load_sample_bathymetry,
     load_usgs_quakes,
 )
-from pygmt.datasets.earth_relief import load_earth_relief

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -3,7 +3,6 @@ Function to download the Earth relief datasets from the GMT data server,
 and load as DataArray. The grids are available in various resolutions.
 """
 import xarray as xr
-
 from pygmt import grdcut, which
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import kwargs_to_strings

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -3,9 +3,10 @@ Function to download the Earth relief datasets from the GMT data server,
 and load as DataArray. The grids are available in various resolutions.
 """
 import xarray as xr
-from pygmt import grdcut, which
 from pygmt.exceptions import GMTInvalidInput
+from pygmt.gridops import grdcut
 from pygmt.helpers import kwargs_to_strings
+from pygmt.modules import which
 
 
 @kwargs_to_strings(region="sequence")

--- a/pygmt/datasets/tutorial.py
+++ b/pygmt/datasets/tutorial.py
@@ -2,7 +2,7 @@
 Functions to load sample data from the GMT tutorials.
 """
 import pandas as pd
-from pygmt import which
+from pygmt.modules import which
 
 
 def load_japan_quakes():

--- a/pygmt/datasets/tutorial.py
+++ b/pygmt/datasets/tutorial.py
@@ -2,7 +2,6 @@
 Functions to load sample data from the GMT tutorials.
 """
 import pandas as pd
-
 from pygmt import which
 
 

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -1,27 +1,26 @@
 """
 Define the Figure class that handles all plotting.
 """
+import base64
 import os
 from tempfile import TemporaryDirectory
-import base64
 
 try:
     from IPython.display import Image
 except ImportError:
     Image = None
 
-from pygmt.clib import Session
 from pygmt.base_plotting import BasePlotting
+from pygmt.clib import Session
 from pygmt.exceptions import GMTError, GMTInvalidInput
 from pygmt.helpers import (
     build_arg_string,
     fmt_docstring,
-    use_alias,
     kwargs_to_strings,
     launch_external_viewer,
     unique_name,
+    use_alias,
 )
-
 
 # A registry of all figures that have had "show" called in this session.
 # This is needed for the sphinx-gallery scraper in pygmt/sphinx_gallery.py

--- a/pygmt/filtering.py
+++ b/pygmt/filtering.py
@@ -2,15 +2,14 @@
 GMT modules for Filtering of 1-D and 2-D Data
 """
 import pandas as pd
-
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
+    GMTTempFile,
     build_arg_string,
     data_kind,
     dummy_context,
     fmt_docstring,
-    GMTTempFile,
     kwargs_to_strings,
     use_alias,
 )

--- a/pygmt/gridding.py
+++ b/pygmt/gridding.py
@@ -2,18 +2,17 @@
 GMT modules for Gridding of Data Tables
 """
 import xarray as xr
-
 from pygmt.clib import Session
+from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
+    GMTTempFile,
     build_arg_string,
     data_kind,
     dummy_context,
     fmt_docstring,
-    GMTTempFile,
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.exceptions import GMTInvalidInput
 
 
 @fmt_docstring

--- a/pygmt/gridops.py
+++ b/pygmt/gridops.py
@@ -3,19 +3,17 @@ GMT modules for grid operations
 """
 
 import xarray as xr
-
-
 from pygmt.clib import Session
+from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
     GMTTempFile,
-    use_alias,
+    build_arg_string,
     data_kind,
     dummy_context,
+    fmt_docstring,
+    kwargs_to_strings,
+    use_alias,
 )
-from pygmt.exceptions import GMTInvalidInput
 
 
 @fmt_docstring

--- a/pygmt/helpers/__init__.py
+++ b/pygmt/helpers/__init__.py
@@ -1,12 +1,12 @@
 """
 Functions, classes, decorators, and context managers to help wrap GMT modules.
 """
-from pygmt.helpers.decorators import fmt_docstring, use_alias, kwargs_to_strings
+from pygmt.helpers.decorators import fmt_docstring, kwargs_to_strings, use_alias
 from pygmt.helpers.tempfile import GMTTempFile, unique_name
 from pygmt.helpers.utils import (
+    build_arg_string,
     data_kind,
     dummy_context,
-    build_arg_string,
     is_nonstr_iter,
     launch_external_viewer,
 )

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -5,14 +5,12 @@ Apply them to functions wrapping GMT modules to automate: alias generation for
 arguments, insert common text into docstrings, transform arguments to strings,
 etc.
 """
-import textwrap
 import functools
+import textwrap
 
 import numpy as np
-
-from pygmt.helpers.utils import is_nonstr_iter
 from pygmt.exceptions import GMTInvalidInput
-
+from pygmt.helpers.utils import is_nonstr_iter
 
 COMMON_OPTIONS = {
     "R": """\

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -1,15 +1,14 @@
 """
 Utilities and common tasks for wrapping the GMT modules.
 """
-import sys
 import shutil
 import subprocess
+import sys
 import webbrowser
 from collections.abc import Iterable
 from contextlib import contextmanager
 
 import xarray as xr
-
 from pygmt.exceptions import GMTInvalidInput
 
 

--- a/pygmt/modules.py
+++ b/pygmt/modules.py
@@ -3,17 +3,16 @@ Non-plot GMT modules.
 """
 import numpy as np
 import xarray as xr
-
 from pygmt.clib import Session
+from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
-    build_arg_string,
-    fmt_docstring,
     GMTTempFile,
-    use_alias,
+    build_arg_string,
     data_kind,
     dummy_context,
+    fmt_docstring,
+    use_alias,
 )
-from pygmt.exceptions import GMTInvalidInput
 
 
 @fmt_docstring

--- a/pygmt/sampling.py
+++ b/pygmt/sampling.py
@@ -2,17 +2,16 @@
 GMT modules for Sampling of 1-D and 2-D Data
 """
 import pandas as pd
-
 from pygmt.clib import Session
+from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
-    build_arg_string,
-    fmt_docstring,
     GMTTempFile,
+    build_arg_string,
     data_kind,
     dummy_context,
+    fmt_docstring,
     use_alias,
 )
-from pygmt.exceptions import GMTInvalidInput
 
 
 @fmt_docstring

--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -3,7 +3,6 @@ Test the behaviour of the GMTDataArrayAccessor class
 """
 import pytest
 import xarray as xr
-
 from pygmt import which
 from pygmt.exceptions import GMTInvalidInput
 

--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -2,10 +2,9 @@
 Tests fig.basemap.
 """
 import pytest
-
 from pygmt import Figure
-from pygmt.helpers.testing import check_figures_equal
 from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers.testing import check_figures_equal
 
 
 def test_basemap_required_args():

--- a/pygmt/tests/test_blockmedian.py
+++ b/pygmt/tests/test_blockmedian.py
@@ -6,11 +6,10 @@ import os
 import numpy.testing as npt
 import pandas as pd
 import pytest
-
 from pygmt import blockmedian
 from pygmt.datasets import load_sample_bathymetry
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import data_kind, GMTTempFile
+from pygmt.helpers import GMTTempFile, data_kind
 
 
 def test_blockmedian_input_dataframe():

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -8,13 +8,12 @@ from contextlib import contextmanager
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
-import xarray as xr
-from packaging.version import Version
 import pytest
-
-from pygmt import clib
-from pygmt.clib.session import FAMILIES, VIAS
+import xarray as xr
+from pygmt import Figure, clib
+from packaging.version import Version
 from pygmt.clib.conversion import dataarray_to_matrix
+from pygmt.clib.session import FAMILIES, VIAS
 from pygmt.exceptions import (
     GMTCLibError,
     GMTCLibNoSessionError,
@@ -22,8 +21,6 @@ from pygmt.exceptions import (
     GMTVersionError,
 )
 from pygmt.helpers import GMTTempFile
-from pygmt import Figure
-
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -10,8 +10,8 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 import xarray as xr
-from pygmt import Figure, clib
 from packaging.version import Version
+from pygmt import Figure, clib
 from pygmt.clib.conversion import dataarray_to_matrix
 from pygmt.clib.session import FAMILIES, VIAS
 from pygmt.exceptions import (

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -2,10 +2,10 @@
 Test the functions that load libgmt
 """
 import os
-import pytest
 
-from pygmt.clib.loading import clib_names, load_libgmt, check_libgmt
-from pygmt.exceptions import GMTCLibError, GMTOSError, GMTCLibNotFoundError
+import pytest
+from pygmt.clib.loading import check_libgmt, clib_names, load_libgmt
+from pygmt.exceptions import GMTCLibError, GMTCLibNotFoundError, GMTOSError
 
 
 def test_check_libgmt():

--- a/pygmt/tests/test_clib_put_matrix.py
+++ b/pygmt/tests/test_clib_put_matrix.py
@@ -5,12 +5,10 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 import xarray as xr
-
-
-from pygmt.tests.test_clib import mock
 from pygmt import clib
 from pygmt.exceptions import GMTCLibError
 from pygmt.helpers import GMTTempFile
+from pygmt.tests.test_clib import mock
 
 
 def test_put_matrix():

--- a/pygmt/tests/test_clib_put_strings.py
+++ b/pygmt/tests/test_clib_put_strings.py
@@ -4,8 +4,8 @@ Test the functions that put string data into GMT.
 import numpy as np
 import numpy.testing as npt
 import pytest
-from pygmt import clib
 from packaging.version import Version
+from pygmt import clib
 from pygmt.exceptions import GMTCLibError
 from pygmt.helpers import GMTTempFile
 

--- a/pygmt/tests/test_clib_put_strings.py
+++ b/pygmt/tests/test_clib_put_strings.py
@@ -4,9 +4,8 @@ Test the functions that put string data into GMT.
 import numpy as np
 import numpy.testing as npt
 import pytest
-from packaging.version import Version
-
 from pygmt import clib
+from packaging.version import Version
 from pygmt.exceptions import GMTCLibError
 from pygmt.helpers import GMTTempFile
 

--- a/pygmt/tests/test_clib_put_vector.py
+++ b/pygmt/tests/test_clib_put_vector.py
@@ -2,10 +2,10 @@
 Test the functions that put vector data into GMT.
 """
 import itertools
+
 import numpy as np
 import numpy.testing as npt
 import pytest
-
 from pygmt import clib
 from pygmt.exceptions import GMTCLibError, GMTInvalidInput
 from pygmt.helpers import GMTTempFile

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -2,7 +2,6 @@
 Tests for coast
 """
 import pytest
-
 from pygmt import Figure
 from pygmt.helpers.testing import check_figures_equal
 

--- a/pygmt/tests/test_colorbar.py
+++ b/pygmt/tests/test_colorbar.py
@@ -2,7 +2,6 @@
 Tests colorbar
 """
 import pytest
-
 from pygmt import Figure
 from pygmt.helpers.testing import check_figures_equal
 

--- a/pygmt/tests/test_config.py
+++ b/pygmt/tests/test_config.py
@@ -2,7 +2,6 @@
 Tests for gmt config
 """
 import pytest
-
 from pygmt import Figure, config
 
 

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -7,10 +7,8 @@ from itertools import product
 
 import numpy as np
 import pytest
-
 from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput
-
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 POINTS_DATA = os.path.join(TEST_DATA_DIR, "points.txt")

--- a/pygmt/tests/test_datasets.py
+++ b/pygmt/tests/test_datasets.py
@@ -4,10 +4,9 @@ Test basic functionality for loading datasets.
 import numpy as np
 import numpy.testing as npt
 import pytest
-
 from pygmt.datasets import (
-    load_japan_quakes,
     load_earth_relief,
+    load_japan_quakes,
     load_ocean_ridge_points,
     load_sample_bathymetry,
     load_usgs_quakes,

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -7,7 +7,6 @@ import os
 import numpy as np
 import numpy.testing as npt
 import pytest
-
 from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput
 

--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -5,12 +5,10 @@ import os
 
 import numpy as np
 import pytest
-
 from pygmt import Figure
-from pygmt.exceptions import GMTInvalidInput
 from pygmt.datasets import load_earth_relief
+from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers.testing import check_figures_equal
-
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 TEST_CONTOUR_FILE = os.path.join(TEST_DATA_DIR, "contours.txt")

--- a/pygmt/tests/test_grdcut.py
+++ b/pygmt/tests/test_grdcut.py
@@ -2,10 +2,10 @@
 Tests for grdcut
 """
 import os
+
 import numpy as np
 import pytest
 import xarray as xr
-
 from pygmt import grdcut, grdinfo
 from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -6,8 +6,8 @@ import sys
 import numpy as np
 import pytest
 import xarray as xr
-from pygmt import Figure, clib
 from packaging.version import Version
+from pygmt import Figure, clib
 from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers.testing import check_figures_equal

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -2,12 +2,12 @@
 Test Figure.grdimage
 """
 import sys
+
 import numpy as np
 import pytest
 import xarray as xr
-from packaging.version import Version
-
 from pygmt import Figure, clib
+from packaging.version import Version
 from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers.testing import check_figures_equal

--- a/pygmt/tests/test_grdinfo.py
+++ b/pygmt/tests/test_grdinfo.py
@@ -3,7 +3,6 @@ Tests for grdinfo
 """
 import numpy as np
 import pytest
-
 from pygmt import grdinfo
 from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -6,9 +6,7 @@ import os
 import numpy.testing as npt
 import pandas as pd
 import pytest
-
-from pygmt import grdtrack
-from pygmt import which
+from pygmt import grdtrack, which
 from pygmt.datasets import load_earth_relief, load_ocean_ridge_points
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import data_kind

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -2,7 +2,6 @@
 Tests grdview
 """
 import pytest
-
 from pygmt import Figure, grdcut, which
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile, data_kind

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -3,11 +3,10 @@ Tests the helper functions/classes/etc used in wrapping GMT
 """
 import os
 
-import pytest
 import numpy as np
-
-from pygmt.helpers import kwargs_to_strings, GMTTempFile, unique_name, data_kind
+import pytest
 from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import GMTTempFile, data_kind, kwargs_to_strings, unique_name
 
 
 @pytest.mark.parametrize(

--- a/pygmt/tests/test_image.py
+++ b/pygmt/tests/test_image.py
@@ -5,9 +5,7 @@ import os
 import sys
 
 import pytest
-
 from pygmt import Figure
-
 
 TEST_IMG = os.path.join(os.path.dirname(__file__), "baseline", "test_logo.png")
 

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -8,7 +8,6 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 import xarray as xr
-
 from pygmt import info
 from pygmt.exceptions import GMTInvalidInput
 

--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -2,7 +2,6 @@
 Tests for legend
 """
 import pytest
-
 from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile

--- a/pygmt/tests/test_makecpt.py
+++ b/pygmt/tests/test_makecpt.py
@@ -5,7 +5,6 @@ import os
 
 import numpy as np
 import pytest
-
 from pygmt import Figure, makecpt
 from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -2,13 +2,12 @@
 Tests for meca
 """
 import os
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 import pytest
-from pygmt.helpers import GMTTempFile
-
 from pygmt import Figure
-
+from pygmt.helpers import GMTTempFile
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -7,15 +7,12 @@ import os
 
 import numpy as np
 import pandas as pd
-import xarray as xr
-
 import pytest
-
+import xarray as xr
 from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import check_figures_equal
-
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 POINTS_DATA = os.path.join(TEST_DATA_DIR, "points.txt")

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -5,12 +5,10 @@ import os
 
 import numpy as np
 import pytest
-
 from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import check_figures_equal
-
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 POINTS_DATA = os.path.join(TEST_DATA_DIR, "points.txt")

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -3,8 +3,8 @@ Test the session management modules.
 """
 import os
 
-from pygmt.session_management import begin, end
 from pygmt.clib import Session
+from pygmt.session_management import begin, end
 
 
 def test_begin_end():

--- a/pygmt/tests/test_sphinx_gallery.py
+++ b/pygmt/tests/test_sphinx_gallery.py
@@ -3,6 +3,7 @@ Test the sphinx-gallery scraper and code required to make it work.
 """
 import os
 from tempfile import TemporaryDirectory
+
 import pytest
 
 try:
@@ -10,7 +11,7 @@ try:
 except ImportError:
     sphinx_gallery = None
 
-from pygmt.figure import Figure, SHOWED_FIGURES
+from pygmt.figure import SHOWED_FIGURES, Figure
 from pygmt.sphinx_gallery import PyGMTScraper
 
 

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -3,11 +3,9 @@ Tests for surface
 """
 import os
 
-import xarray as xr
 import pytest
-
-from pygmt import surface
-from pygmt import which
+import xarray as xr
+from pygmt import surface, which
 from pygmt.datasets import load_sample_bathymetry
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import data_kind

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -4,9 +4,8 @@ Tests text
 """
 import os
 
-import pytest
 import numpy as np
-
+import pytest
 from pygmt import Figure
 from pygmt.exceptions import GMTCLibError, GMTInvalidInput
 from pygmt.helpers import GMTTempFile

--- a/pygmt/tests/test_which.py
+++ b/pygmt/tests/test_which.py
@@ -4,7 +4,6 @@ Tests for pygmt.which
 import os
 
 import pytest
-
 from pygmt import which
 from pygmt.helpers import unique_name
 

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -9,7 +9,6 @@ import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
-
 from pygmt import x2sys_cross, x2sys_init
 from pygmt.datasets import load_sample_bathymetry
 from pygmt.exceptions import GMTInvalidInput

--- a/pygmt/tests/test_x2sys_init.py
+++ b/pygmt/tests/test_x2sys_init.py
@@ -6,7 +6,6 @@ import os
 from tempfile import TemporaryDirectory
 
 import pytest
-
 from pygmt import x2sys_init
 
 

--- a/pygmt/x2sys.py
+++ b/pygmt/x2sys.py
@@ -6,7 +6,6 @@ import os
 from pathlib import Path
 
 import pandas as pd
-
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,4 @@ addopts = "--verbose --doctest-modules --mpl --mpl-results-path=results"
 [tool.isort]
 profile = "black"
 skip_gitignore = true
-force_to_top = "pygmt"
 known_third_party = "pygmt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,9 @@ omit = ["*/tests/*", "*pygmt/__init__.py"]
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "--verbose --doctest-modules --mpl --mpl-results-path=results"
+
+[tool.isort]
+profile = "black"
+skip_gitignore = true
+force_to_top = "pygmt"
+known_third_party = "pygmt"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ pytest-mpl
 coverage[toml]
 black
 blackdoc
+isort>=5
 pylint
 flake8
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 """
 Build and install the project.
 """
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 NAME = "pygmt"
 FULLNAME = "PyGMT"


### PR DESCRIPTION
**Description of proposed changes**

This PR adds [`isort`](https://pycqa.github.io/isort/) to automatically sort imports.

**Notes:**

- `profile = "black"` is added to `pyproject.toml` for compatibility between `black` and `isort`, which requires isort>=5
- `pylint` also depends on `isort`. Thus when we install pylint, `isort` is already installed.

**References:**

- https://black.readthedocs.io/en/stable/compatible_configs.html#isort
- https://pycqa.github.io/isort/docs/configuration/profiles/

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
