### PR TITLE
Improve the readability of the grdview function

### DIFF
--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -598,18 +598,17 @@ class BasePlotting:
                 raise GMTInvalidInput(f"Unrecognized data type for grid: {type(grid)}")
 
             with contextlib.ExitStack() as stack:
-                fname = stack.enter_context(file_context)
-                if "G" in kwargs:
+                if "G" in kwargs:  # deal with kwargs["G"] if drapegrid is xr.DataArray
                     drapegrid = kwargs["G"]
                     if data_kind(drapegrid) in ("file", "grid"):
                         if data_kind(drapegrid) == "grid":
                             drape_context = lib.virtualfile_from_grid(drapegrid)
-                            drapefile = stack.enter_context(drape_context)
-                            kwargs["G"] = drapefile
+                            kwargs["G"] = stack.enter_context(drape_context)
                     else:
                         raise GMTInvalidInput(
                             f"Unrecognized data type for drapegrid: {type(drapegrid)}"
                         )
+                fname = stack.enter_context(file_context)
                 arg_str = " ".join([fname, build_arg_string(kwargs)])
                 lib.call_module("grdview", arg_str)
 


### PR DESCRIPTION
**Description of proposed changes**

When I worked on PR #750 based on the implemention of the `grdview` function,
I found that the `grdview` codes are a little difficult to understand.
The main reason is that `contextlib.ExitStack()` is new to me.
Another reason is that these two codes `fname = stack.enter_context(file_context)`
and `arg_str = " ".join([fname, build_arg_string(kwargs)])` are
separated by the long `if` block.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
