### PR TITLE
Add the shading parameter to colorbar() in base_plotting.py

### DIFF
--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -225,10 +225,10 @@ class BasePlotting:
             Multiply all z-values in the CPT by the provided scale. By default
             the CPT is used as is.
         shading : str or list or bool
-            Add illumination effects. Optionally, set the range of intensities from
-            -max_intens to +max_intens. If not specified, 1 is used. Alternatively,
-            append low/high intensities to specify an asymmetric range.
-            The default is no illumination.
+            Add illumination effects. Optionally, set the range of intensities
+            from -max_intens to +max_intens. If not specified, 1 is used.
+            Alternatively, append low/high intensities to specify an
+            asymmetric range. The default is no illumination.
         {V}
         {XY}
         {p}

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -227,8 +227,9 @@ class BasePlotting:
         shading : str or list or bool
             Add illumination effects. Optionally, set the range of intensities
             from -max_intens to +max_intens. If not specified, 1 is used.
-            Alternatively, append low/high intensities to specify an
-            asymmetric range. The default is no illumination.
+            Alternatively, set ``shading=[low, high]`` to specify an
+            asymmetric intensity range from *low* to *high*. 
+            The default is no illumination.
         {V}
         {XY}
         {p}

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -161,7 +161,7 @@ class BasePlotting:
         p="perspective",
         t="transparency",
     )
-    @kwargs_to_strings(R="sequence", G="sequence", p="sequence")
+    @kwargs_to_strings(R="sequence", G="sequence", p="sequence", I="sequence")
     def colorbar(self, **kwargs):
         """
         Plot a gray or color scale-bar on maps.
@@ -224,7 +224,7 @@ class BasePlotting:
         scale : float
             Multiply all z-values in the CPT by the provided scale. By default
             the CPT is used as is.
-        shading : str or bool
+        shading : str or list or bool
             Add illumination effects. Optionally, set the range of intensities from
             -max_intens to +max_intens. If not specified, 1 is used. Alternatively,
             append low/high intensities to specify an asymmetric range.

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -225,11 +225,10 @@ class BasePlotting:
             Multiply all z-values in the CPT by the provided scale. By default
             the CPT is used as is.
         shading : str or list or bool
-            Add illumination effects. Optionally, set the range of intensities
-            from -max_intens to +max_intens. If not specified, 1 is used.
-            Alternatively, set ``shading=[low, high]`` to specify an
-            asymmetric intensity range from *low* to *high*.
-            The default is no illumination.
+            Add illumination effects. Passing a single numerical value sets the range
+            of intensities from -value to +value. If not specified, 1 is used.
+            Alternatively, set ``shading=[low, high]`` to specify an asymmetric
+            intensity range from *low* to *high*. The default is no illumination.
         {V}
         {XY}
         {p}

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -224,8 +224,11 @@ class BasePlotting:
         scale : float
             Multiply all z-values in the CPT by the provided scale. By default
             the CPT is used as is.
-        shading : bool
-            Set shading for the color bar.
+        shading : str or bool
+            Add illumination effects. Optionally, set the range of intensities from
+            -max_intens to +max_intens. If not specified, 1 is used. Alternatively,
+            append low/high intensities to specify an asymmetric range.
+            The default is no illumination.
         {V}
         {XY}
         {p}

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -153,6 +153,7 @@ class BasePlotting:
         D="position",
         F="box",
         G="truncate",
+        I="shading",
         W="scale",
         V="verbose",
         X="xshift",
@@ -223,6 +224,8 @@ class BasePlotting:
         scale : float
             Multiply all z-values in the CPT by the provided scale. By default
             the CPT is used as is.
+        shading : bool
+            Set shading for the colorbar.
         {V}
         {XY}
         {p}

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -228,7 +228,7 @@ class BasePlotting:
             Add illumination effects. Optionally, set the range of intensities
             from -max_intens to +max_intens. If not specified, 1 is used.
             Alternatively, set ``shading=[low, high]`` to specify an
-            asymmetric intensity range from *low* to *high*. 
+            asymmetric intensity range from *low* to *high*.
             The default is no illumination.
         {V}
         {XY}

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -161,7 +161,7 @@ class BasePlotting:
         p="perspective",
         t="transparency",
     )
-    @kwargs_to_strings(R="sequence", G="sequence", p="sequence", I="sequence")
+    @kwargs_to_strings(R="sequence", G="sequence", I="sequence", p="sequence")
     def colorbar(self, **kwargs):
         """
         Plot a gray or color scale-bar on maps.

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -225,7 +225,7 @@ class BasePlotting:
             Multiply all z-values in the CPT by the provided scale. By default
             the CPT is used as is.
         shading : bool
-            Set shading for the colorbar.
+            Set shading for the color bar.
         {V}
         {XY}
         {p}

--- a/pygmt/tests/test_colorbar.py
+++ b/pygmt/tests/test_colorbar.py
@@ -164,7 +164,7 @@ def test_colorbar_shading_boolean():
     fig_ref, fig_test = Figure(), Figure()
     # Use single-character arguments for the reference image
     fig_ref.basemap(R="0/10/0/10", J="X15c", B="a")
-    fig_ref.colorbar(C="geo", I=True)
+    fig_ref.colorbar(C="geo", I="")
 
     fig_test.basemap(region=[0, 10, 0, 10], projection="X15c", frame="a")
     fig_test.colorbar(cmap="geo", shading=True)

--- a/pygmt/tests/test_colorbar.py
+++ b/pygmt/tests/test_colorbar.py
@@ -154,3 +154,63 @@ def test_colorbar_scaled_z_values():
     fig = Figure()
     fig.colorbar(cmap="rainbow", scale=0.1, position="x0c/0c+w2c/0.5c")
     return fig
+
+
+@check_figures_equal()
+def test_colorbar_shading_boolean():
+    """
+    Create colorbar and set shading with a Boolean value
+    """
+    fig_ref, fig_test = Figure(), Figure()
+    # Use single-character arguments for the reference image
+    fig_ref.basemap(R="0/10/0/10", J="X15c", B="a")
+    fig_ref.colorbar(C="geo", I=True)
+
+    fig_test.basemap(region=[0, 10, 0, 10], projection="X15c", frame="a")
+    fig_test.colorbar(cmap="geo", shading=True)
+    return fig_ref, fig_test
+
+
+@check_figures_equal()
+def test_colorbar_shading_float():
+    """
+    Create colorbar and set shading with a single float variable
+    """
+    fig_ref, fig_test = Figure(), Figure()
+    # Use single-character arguments for the reference image
+    fig_ref.basemap(R="0/10/0/10", J="X15c", B="a")
+    fig_ref.colorbar(C="geo", I="0.5")
+
+    fig_test.basemap(region=[0, 10, 0, 10], projection="X15c", frame="a")
+    fig_test.colorbar(cmap="geo", shading=0.5)
+    return fig_ref, fig_test
+
+
+@check_figures_equal()
+def test_colorbar_shading_string():
+    """
+    Create colorbar and set shading by passing the high/low values as a string
+    """
+    fig_ref, fig_test = Figure(), Figure()
+    # Use single-character arguments for the reference image
+    fig_ref.basemap(R="0/10/0/10", J="X15c", B="a")
+    fig_ref.colorbar(C="geo", I="-0.7/0.2")
+
+    fig_test.basemap(region=[0, 10, 0, 10], projection="X15c", frame="a")
+    fig_test.colorbar(cmap="geo", shading="-0.7/0.2")
+    return fig_ref, fig_test
+
+
+@check_figures_equal()
+def test_colorbar_shading_list():
+    """
+    Create colorbar and set shading by passing the high/low values as a list
+    """
+    fig_ref, fig_test = Figure(), Figure()
+    # Use single-character arguments for the reference image
+    fig_ref.basemap(R="0/10/0/10", J="X15c", B="a")
+    fig_ref.colorbar(C="geo", I="-0.7/0.2")
+
+    fig_test.basemap(region=[0, 10, 0, 10], projection="X15c", frame="a")
+    fig_test.colorbar(cmap="geo", shading=[-0.7, 0.2])
+    return fig_ref, fig_test

--- a/pygmt/tests/test_colorbar.py
+++ b/pygmt/tests/test_colorbar.py
@@ -189,7 +189,7 @@ def test_colorbar_shading_float():
 @check_figures_equal()
 def test_colorbar_shading_string():
     """
-    Create colorbar and set shading by passing the high/low values as a string
+    Create colorbar and set shading by passing the low/high values as a string
     """
     fig_ref, fig_test = Figure(), Figure()
     # Use single-character arguments for the reference image

--- a/pygmt/tests/test_colorbar.py
+++ b/pygmt/tests/test_colorbar.py
@@ -179,7 +179,7 @@ def test_colorbar_shading_float():
     fig_ref, fig_test = Figure(), Figure()
     # Use single-character arguments for the reference image
     fig_ref.basemap(R="0/10/0/10", J="X15c", B="a")
-    fig_ref.colorbar(C="geo", I="0.5")
+    fig_ref.colorbar(C="geo", I=0.5)
 
     fig_test.basemap(region=[0, 10, 0, 10], projection="X15c", frame="a")
     fig_test.colorbar(cmap="geo", shading=0.5)


### PR DESCRIPTION
As mentioned in #749, this adds the `shading` alias/parameter to `pygmt.Figure.colorbar`.

I'm not familiar with how shading will affect the color bar, other than that it makes it look different and darker, so I left a pretty vague description for it under the parameter list.