### PR TITLE
Convert relative imports to absolute imports

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -538,8 +538,7 @@ min-public-methods=2
 
 # List of modules that can be imported at any level, not just the top level
 # one.
-allow-any-import-level=clib,
-                       clib.Session,
+allow-any-import-level=pygmt.clib.Session,
                        sys,
                        platform,
                        importlib,

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -12,16 +12,16 @@ import atexit as _atexit
 from pkg_resources import get_distribution
 
 # Import modules to make the high-level GMT Python API
-from .session_management import begin as _begin, end as _end
-from .figure import Figure
-from .filtering import blockmedian
-from .gridding import surface
-from .sampling import grdtrack
-from .mathops import makecpt
-from .modules import GMTDataArrayAccessor, config, info, grdinfo, which
-from .gridops import grdcut, grdfilter
-from .x2sys import x2sys_init, x2sys_cross
-from . import datasets
+from pygmt.session_management import begin as _begin, end as _end
+from pygmt.figure import Figure
+from pygmt.filtering import blockmedian
+from pygmt.gridding import surface
+from pygmt.sampling import grdtrack
+from pygmt.mathops import makecpt
+from pygmt.modules import GMTDataArrayAccessor, config, info, grdinfo, which
+from pygmt.gridops import grdcut, grdfilter
+from pygmt.x2sys import x2sys_init, x2sys_cross
+from pygmt import datasets
 
 # Get semantic version through setuptools-scm
 __version__ = f'v{get_distribution("pygmt").version}'  # e.g. v0.1.2.dev3+g0ab3cd78
@@ -40,7 +40,7 @@ def print_clib_info():
     Includes the GMT version, default values for parameters, the path to the
     ``libgmt`` shared library, and GMT directories.
     """
-    from .clib import Session
+    from pygmt.clib import Session
 
     lines = ["GMT library information:"]
     with Session() as ses:

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -6,9 +6,9 @@ import contextlib
 import numpy as np
 import pandas as pd
 
-from .clib import Session
-from .exceptions import GMTError, GMTInvalidInput
-from .helpers import (
+from pygmt.clib import Session
+from pygmt.exceptions import GMTError, GMTInvalidInput
+from pygmt.helpers import (
     build_arg_string,
     dummy_context,
     data_kind,

--- a/pygmt/clib/__init__.py
+++ b/pygmt/clib/__init__.py
@@ -5,4 +5,4 @@
 # The pygmt.clib.Session class wraps the GMT C shared library (libgmt) with a
 # pythonic interface. Access to the C library is done through ctypes.
 
-from .session import Session
+from pygmt.clib.session import Session

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -4,7 +4,7 @@ Functions to convert data types into ctypes friendly formats.
 import numpy as np
 import pandas as pd
 
-from ..exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput
 
 
 def dataarray_to_matrix(grid):

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -9,7 +9,7 @@ import sys
 import ctypes
 from ctypes.util import find_library
 
-from ..exceptions import GMTOSError, GMTCLibError, GMTCLibNotFoundError
+from pygmt.exceptions import GMTOSError, GMTCLibError, GMTCLibNotFoundError
 
 
 def load_libgmt():

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -11,14 +11,14 @@ from packaging.version import Version
 import numpy as np
 import pandas as pd
 
-from ..exceptions import (
+from pygmt.exceptions import (
     GMTCLibError,
     GMTCLibNoSessionError,
     GMTInvalidInput,
     GMTVersionError,
 )
-from .loading import load_libgmt
-from .conversion import (
+from pygmt.clib.loading import load_libgmt
+from pygmt.clib.conversion import (
     kwargs_to_ctypes_array,
     vectors_to_arrays,
     dataarray_to_matrix,

--- a/pygmt/datasets/__init__.py
+++ b/pygmt/datasets/__init__.py
@@ -2,10 +2,10 @@
 #
 # Load sample data included with GMT (downloaded from the GMT cache server).
 
-from .tutorial import (
+from pygmt.datasets.tutorial import (
     load_japan_quakes,
     load_ocean_ridge_points,
     load_sample_bathymetry,
     load_usgs_quakes,
 )
-from .earth_relief import load_earth_relief
+from pygmt.datasets.earth_relief import load_earth_relief

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -4,9 +4,9 @@ and load as DataArray. The grids are available in various resolutions.
 """
 import xarray as xr
 
-from .. import grdcut, which
-from ..exceptions import GMTInvalidInput
-from ..helpers import kwargs_to_strings
+from pygmt import grdcut, which
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import kwargs_to_strings
 
 
 @kwargs_to_strings(region="sequence")

--- a/pygmt/datasets/tutorial.py
+++ b/pygmt/datasets/tutorial.py
@@ -3,7 +3,7 @@ Functions to load sample data from the GMT tutorials.
 """
 import pandas as pd
 
-from .. import which
+from pygmt import which
 
 
 def load_japan_quakes():

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -10,10 +10,10 @@ try:
 except ImportError:
     Image = None
 
-from .clib import Session
-from .base_plotting import BasePlotting
-from .exceptions import GMTError, GMTInvalidInput
-from .helpers import (
+from pygmt.clib import Session
+from pygmt.base_plotting import BasePlotting
+from pygmt.exceptions import GMTError, GMTInvalidInput
+from pygmt.helpers import (
     build_arg_string,
     fmt_docstring,
     use_alias,

--- a/pygmt/filtering.py
+++ b/pygmt/filtering.py
@@ -3,9 +3,9 @@ GMT modules for Filtering of 1-D and 2-D Data
 """
 import pandas as pd
 
-from .clib import Session
-from .exceptions import GMTInvalidInput
-from .helpers import (
+from pygmt.clib import Session
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import (
     build_arg_string,
     data_kind,
     dummy_context,

--- a/pygmt/gridding.py
+++ b/pygmt/gridding.py
@@ -3,8 +3,8 @@ GMT modules for Gridding of Data Tables
 """
 import xarray as xr
 
-from .clib import Session
-from .helpers import (
+from pygmt.clib import Session
+from pygmt.helpers import (
     build_arg_string,
     data_kind,
     dummy_context,
@@ -13,7 +13,7 @@ from .helpers import (
     kwargs_to_strings,
     use_alias,
 )
-from .exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput
 
 
 @fmt_docstring

--- a/pygmt/gridops.py
+++ b/pygmt/gridops.py
@@ -5,8 +5,8 @@ GMT modules for grid operations
 import xarray as xr
 
 
-from .clib import Session
-from .helpers import (
+from pygmt.clib import Session
+from pygmt.helpers import (
     build_arg_string,
     fmt_docstring,
     kwargs_to_strings,
@@ -15,7 +15,7 @@ from .helpers import (
     data_kind,
     dummy_context,
 )
-from .exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput
 
 
 @fmt_docstring

--- a/pygmt/helpers/__init__.py
+++ b/pygmt/helpers/__init__.py
@@ -1,9 +1,9 @@
 """
 Functions, classes, decorators, and context managers to help wrap GMT modules.
 """
-from .decorators import fmt_docstring, use_alias, kwargs_to_strings
-from .tempfile import GMTTempFile, unique_name
-from .utils import (
+from pygmt.helpers.decorators import fmt_docstring, use_alias, kwargs_to_strings
+from pygmt.helpers.tempfile import GMTTempFile, unique_name
+from pygmt.helpers.utils import (
     data_kind,
     dummy_context,
     build_arg_string,

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -10,8 +10,8 @@ import functools
 
 import numpy as np
 
-from .utils import is_nonstr_iter
-from ..exceptions import GMTInvalidInput
+from pygmt.helpers.utils import is_nonstr_iter
+from pygmt.exceptions import GMTInvalidInput
 
 
 COMMON_OPTIONS = {

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -6,7 +6,7 @@ import os
 import string
 
 from matplotlib.testing.compare import compare_images
-from ..exceptions import GMTImageComparisonFailure
+from pygmt.exceptions import GMTImageComparisonFailure
 
 
 def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_images"):

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 
 import xarray as xr
 
-from ..exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput
 
 
 def data_kind(data, x=None, y=None, z=None):

--- a/pygmt/mathops.py
+++ b/pygmt/mathops.py
@@ -1,9 +1,9 @@
 """
 GMT modules for Mathematical operations on tables or grids
 """
-from .clib import Session
-from .exceptions import GMTInvalidInput
-from .helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
+from pygmt.clib import Session
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 
 @fmt_docstring

--- a/pygmt/modules.py
+++ b/pygmt/modules.py
@@ -4,8 +4,8 @@ Non-plot GMT modules.
 import numpy as np
 import xarray as xr
 
-from .clib import Session
-from .helpers import (
+from pygmt.clib import Session
+from pygmt.helpers import (
     build_arg_string,
     fmt_docstring,
     GMTTempFile,
@@ -13,7 +13,7 @@ from .helpers import (
     data_kind,
     dummy_context,
 )
-from .exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput
 
 
 @fmt_docstring

--- a/pygmt/sampling.py
+++ b/pygmt/sampling.py
@@ -3,8 +3,8 @@ GMT modules for Sampling of 1-D and 2-D Data
 """
 import pandas as pd
 
-from .clib import Session
-from .helpers import (
+from pygmt.clib import Session
+from pygmt.helpers import (
     build_arg_string,
     fmt_docstring,
     GMTTempFile,
@@ -12,7 +12,7 @@ from .helpers import (
     dummy_context,
     use_alias,
 )
-from .exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput
 
 
 @fmt_docstring

--- a/pygmt/session_management.py
+++ b/pygmt/session_management.py
@@ -1,7 +1,7 @@
 """
 Modern mode session management modules.
 """
-from .clib import Session
+from pygmt.clib import Session
 
 
 def begin():

--- a/pygmt/sphinx_gallery.py
+++ b/pygmt/sphinx_gallery.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     figure_rst = None
 
-from .figure import SHOWED_FIGURES
+from pygmt.figure import SHOWED_FIGURES
 
 
 class PyGMTScraper:  # pylint: disable=too-few-public-methods

--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -4,8 +4,8 @@ Test the behaviour of the GMTDataArrayAccessor class
 import pytest
 import xarray as xr
 
-from .. import which
-from ..exceptions import GMTInvalidInput
+from pygmt import which
+from pygmt.exceptions import GMTInvalidInput
 
 
 def test_accessor_gridline_cartesian():

--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -3,9 +3,9 @@ Tests fig.basemap.
 """
 import pytest
 
-from .. import Figure
-from ..helpers.testing import check_figures_equal
-from ..exceptions import GMTInvalidInput
+from pygmt import Figure
+from pygmt.helpers.testing import check_figures_equal
+from pygmt.exceptions import GMTInvalidInput
 
 
 def test_basemap_required_args():

--- a/pygmt/tests/test_blockmedian.py
+++ b/pygmt/tests/test_blockmedian.py
@@ -7,10 +7,10 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 
-from .. import blockmedian
-from ..datasets import load_sample_bathymetry
-from ..exceptions import GMTInvalidInput
-from ..helpers import data_kind, GMTTempFile
+from pygmt import blockmedian
+from pygmt.datasets import load_sample_bathymetry
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import data_kind, GMTTempFile
 
 
 def test_blockmedian_input_dataframe():

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -12,17 +12,17 @@ import xarray as xr
 from packaging.version import Version
 import pytest
 
-from .. import clib
-from ..clib.session import FAMILIES, VIAS
-from ..clib.conversion import dataarray_to_matrix
-from ..exceptions import (
+from pygmt import clib
+from pygmt.clib.session import FAMILIES, VIAS
+from pygmt.clib.conversion import dataarray_to_matrix
+from pygmt.exceptions import (
     GMTCLibError,
     GMTCLibNoSessionError,
     GMTInvalidInput,
     GMTVersionError,
 )
-from ..helpers import GMTTempFile
-from .. import Figure
+from pygmt.helpers import GMTTempFile
+from pygmt import Figure
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -4,8 +4,8 @@ Test the functions that load libgmt
 import os
 import pytest
 
-from ..clib.loading import clib_names, load_libgmt, check_libgmt
-from ..exceptions import GMTCLibError, GMTOSError, GMTCLibNotFoundError
+from pygmt.clib.loading import clib_names, load_libgmt, check_libgmt
+from pygmt.exceptions import GMTCLibError, GMTOSError, GMTCLibNotFoundError
 
 
 def test_check_libgmt():

--- a/pygmt/tests/test_clib_put_matrix.py
+++ b/pygmt/tests/test_clib_put_matrix.py
@@ -7,10 +7,10 @@ import pytest
 import xarray as xr
 
 
-from .test_clib import mock
-from .. import clib
-from ..exceptions import GMTCLibError
-from ..helpers import GMTTempFile
+from pygmt.tests.test_clib import mock
+from pygmt import clib
+from pygmt.exceptions import GMTCLibError
+from pygmt.helpers import GMTTempFile
 
 
 def test_put_matrix():

--- a/pygmt/tests/test_clib_put_strings.py
+++ b/pygmt/tests/test_clib_put_strings.py
@@ -6,9 +6,9 @@ import numpy.testing as npt
 import pytest
 from packaging.version import Version
 
-from .. import clib
-from ..exceptions import GMTCLibError
-from ..helpers import GMTTempFile
+from pygmt import clib
+from pygmt.exceptions import GMTCLibError
+from pygmt.helpers import GMTTempFile
 
 with clib.Session() as _lib:
     gmt_version = Version(_lib.info["version"])

--- a/pygmt/tests/test_clib_put_vector.py
+++ b/pygmt/tests/test_clib_put_vector.py
@@ -6,9 +6,9 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from .. import clib
-from ..exceptions import GMTCLibError, GMTInvalidInput
-from ..helpers import GMTTempFile
+from pygmt import clib
+from pygmt.exceptions import GMTCLibError, GMTInvalidInput
+from pygmt.helpers import GMTTempFile
 
 
 def test_put_vector():

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -3,8 +3,8 @@ Tests for coast
 """
 import pytest
 
-from .. import Figure
-from ..helpers.testing import check_figures_equal
+from pygmt import Figure
+from pygmt.helpers.testing import check_figures_equal
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_colorbar.py
+++ b/pygmt/tests/test_colorbar.py
@@ -3,8 +3,8 @@ Tests colorbar
 """
 import pytest
 
-from .. import Figure
-from ..helpers.testing import check_figures_equal
+from pygmt import Figure
+from pygmt.helpers.testing import check_figures_equal
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_config.py
+++ b/pygmt/tests/test_config.py
@@ -3,7 +3,7 @@ Tests for gmt config
 """
 import pytest
 
-from .. import Figure, config
+from pygmt import Figure, config
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -8,8 +8,8 @@ from itertools import product
 import numpy as np
 import pytest
 
-from .. import Figure
-from ..exceptions import GMTInvalidInput
+from pygmt import Figure
+from pygmt.exceptions import GMTInvalidInput
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")

--- a/pygmt/tests/test_datasets.py
+++ b/pygmt/tests/test_datasets.py
@@ -5,14 +5,14 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from ..datasets import (
+from pygmt.datasets import (
     load_japan_quakes,
     load_earth_relief,
     load_ocean_ridge_points,
     load_sample_bathymetry,
     load_usgs_quakes,
 )
-from ..exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput
 
 
 def test_japan_quakes():

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -8,8 +8,8 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from .. import Figure
-from ..exceptions import GMTInvalidInput
+from pygmt import Figure
+from pygmt.exceptions import GMTInvalidInput
 
 
 def test_figure_region():

--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -6,10 +6,10 @@ import os
 import numpy as np
 import pytest
 
-from .. import Figure
-from ..exceptions import GMTInvalidInput
-from ..datasets import load_earth_relief
-from ..helpers.testing import check_figures_equal
+from pygmt import Figure
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.datasets import load_earth_relief
+from pygmt.helpers.testing import check_figures_equal
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")

--- a/pygmt/tests/test_grdcut.py
+++ b/pygmt/tests/test_grdcut.py
@@ -6,10 +6,10 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from .. import grdcut, grdinfo
-from ..datasets import load_earth_relief
-from ..exceptions import GMTInvalidInput
-from ..helpers import GMTTempFile
+from pygmt import grdcut, grdinfo
+from pygmt.datasets import load_earth_relief
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import GMTTempFile
 
 
 @pytest.fixture(scope="module", name="grid")

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -7,10 +7,10 @@ import pytest
 import xarray as xr
 from packaging.version import Version
 
-from .. import Figure, clib
-from ..datasets import load_earth_relief
-from ..exceptions import GMTInvalidInput
-from ..helpers.testing import check_figures_equal
+from pygmt import Figure, clib
+from pygmt.datasets import load_earth_relief
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers.testing import check_figures_equal
 
 with clib.Session() as _lib:
     gmt_version = Version(_lib.info["version"])

--- a/pygmt/tests/test_grdinfo.py
+++ b/pygmt/tests/test_grdinfo.py
@@ -4,9 +4,9 @@ Tests for grdinfo
 import numpy as np
 import pytest
 
-from .. import grdinfo
-from ..datasets import load_earth_relief
-from ..exceptions import GMTInvalidInput
+from pygmt import grdinfo
+from pygmt.datasets import load_earth_relief
+from pygmt.exceptions import GMTInvalidInput
 
 
 def test_grdinfo():

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -7,11 +7,11 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 
-from .. import grdtrack
-from .. import which
-from ..datasets import load_earth_relief, load_ocean_ridge_points
-from ..exceptions import GMTInvalidInput
-from ..helpers import data_kind
+from pygmt import grdtrack
+from pygmt import which
+from pygmt.datasets import load_earth_relief, load_ocean_ridge_points
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import data_kind
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 TEMP_TRACK = os.path.join(TEST_DATA_DIR, "tmp_track.txt")

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -3,10 +3,10 @@ Tests grdview
 """
 import pytest
 
-from .. import Figure, grdcut, which
-from ..exceptions import GMTInvalidInput
-from ..helpers import GMTTempFile, data_kind
-from ..helpers.testing import check_figures_equal
+from pygmt import Figure, grdcut, which
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import GMTTempFile, data_kind
+from pygmt.helpers.testing import check_figures_equal
 
 
 @pytest.fixture(scope="module", name="region")

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -6,8 +6,8 @@ import os
 import pytest
 import numpy as np
 
-from ..helpers import kwargs_to_strings, GMTTempFile, unique_name, data_kind
-from ..exceptions import GMTInvalidInput
+from pygmt.helpers import kwargs_to_strings, GMTTempFile, unique_name, data_kind
+from pygmt.exceptions import GMTInvalidInput
 
 
 @pytest.mark.parametrize(

--- a/pygmt/tests/test_image.py
+++ b/pygmt/tests/test_image.py
@@ -6,7 +6,7 @@ import sys
 
 import pytest
 
-from .. import Figure
+from pygmt import Figure
 
 
 TEST_IMG = os.path.join(os.path.dirname(__file__), "baseline", "test_logo.png")

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -9,8 +9,8 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from .. import info
-from ..exceptions import GMTInvalidInput
+from pygmt import info
+from pygmt.exceptions import GMTInvalidInput
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 POINTS_DATA = os.path.join(TEST_DATA_DIR, "points.txt")

--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -3,10 +3,10 @@ Tests for legend
 """
 import pytest
 
-from .. import Figure
-from ..exceptions import GMTInvalidInput
-from ..helpers import GMTTempFile
-from ..helpers.testing import check_figures_equal
+from pygmt import Figure
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import GMTTempFile
+from pygmt.helpers.testing import check_figures_equal
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_logo.py
+++ b/pygmt/tests/test_logo.py
@@ -1,8 +1,8 @@
 """
 Tests for fig.logo
 """
-from .. import Figure
-from ..helpers.testing import check_figures_equal
+from pygmt import Figure
+from pygmt.helpers.testing import check_figures_equal
 
 
 @check_figures_equal()

--- a/pygmt/tests/test_makecpt.py
+++ b/pygmt/tests/test_makecpt.py
@@ -6,11 +6,11 @@ import os
 import numpy as np
 import pytest
 
-from .. import Figure, makecpt
-from ..datasets import load_earth_relief
-from ..exceptions import GMTInvalidInput
-from ..helpers import GMTTempFile
-from ..helpers.testing import check_figures_equal
+from pygmt import Figure, makecpt
+from pygmt.datasets import load_earth_relief
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import GMTTempFile
+from pygmt.helpers.testing import check_figures_equal
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 POINTS_DATA = os.path.join(TEST_DATA_DIR, "points.txt")

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -5,7 +5,7 @@ import os
 import pandas as pd
 import numpy as np
 import pytest
-from pygmt.helpers import GMTTempFile
+from ..helpers import GMTTempFile
 
 from .. import Figure
 

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -5,9 +5,9 @@ import os
 import pandas as pd
 import numpy as np
 import pytest
-from ..helpers import GMTTempFile
+from pygmt.helpers import GMTTempFile
 
-from .. import Figure
+from pygmt import Figure
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -11,10 +11,10 @@ import xarray as xr
 
 import pytest
 
-from .. import Figure
-from ..exceptions import GMTInvalidInput
-from ..helpers import GMTTempFile
-from ..helpers.testing import check_figures_equal
+from pygmt import Figure
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import GMTTempFile
+from pygmt.helpers.testing import check_figures_equal
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -6,10 +6,10 @@ import os
 import numpy as np
 import pytest
 
-from .. import Figure
-from ..exceptions import GMTInvalidInput
-from ..helpers import GMTTempFile
-from ..helpers.testing import check_figures_equal
+from pygmt import Figure
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import GMTTempFile
+from pygmt.helpers.testing import check_figures_equal
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")

--- a/pygmt/tests/test_psconvert.py
+++ b/pygmt/tests/test_psconvert.py
@@ -3,7 +3,7 @@ Tests psconvert.
 """
 import os
 
-from .. import Figure
+from pygmt import Figure
 
 
 def test_psconvert():

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -3,8 +3,8 @@ Test the session management modules.
 """
 import os
 
-from ..session_management import begin, end
-from ..clib import Session
+from pygmt.session_management import begin, end
+from pygmt.clib import Session
 
 
 def test_begin_end():

--- a/pygmt/tests/test_sphinx_gallery.py
+++ b/pygmt/tests/test_sphinx_gallery.py
@@ -10,8 +10,8 @@ try:
 except ImportError:
     sphinx_gallery = None
 
-from ..figure import Figure, SHOWED_FIGURES
-from ..sphinx_gallery import PyGMTScraper
+from pygmt.figure import Figure, SHOWED_FIGURES
+from pygmt.sphinx_gallery import PyGMTScraper
 
 
 @pytest.mark.skipif(sphinx_gallery is None, reason="requires sphinx-gallery")

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -6,11 +6,11 @@ import os
 import xarray as xr
 import pytest
 
-from .. import surface
-from .. import which
-from ..datasets import load_sample_bathymetry
-from ..exceptions import GMTInvalidInput
-from ..helpers import data_kind
+from pygmt import surface
+from pygmt import which
+from pygmt.datasets import load_sample_bathymetry
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import data_kind
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 TEMP_GRID = os.path.join(TEST_DATA_DIR, "tmp_grid.nc")

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -7,10 +7,10 @@ import os
 import pytest
 import numpy as np
 
-from .. import Figure
-from ..exceptions import GMTCLibError, GMTInvalidInput
-from ..helpers import GMTTempFile
-from ..helpers.testing import check_figures_equal
+from pygmt import Figure
+from pygmt.exceptions import GMTCLibError, GMTInvalidInput
+from pygmt.helpers import GMTTempFile
+from pygmt.helpers.testing import check_figures_equal
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 POINTS_DATA = os.path.join(TEST_DATA_DIR, "points.txt")

--- a/pygmt/tests/test_which.py
+++ b/pygmt/tests/test_which.py
@@ -5,8 +5,8 @@ import os
 
 import pytest
 
-from .. import which
-from ..helpers import unique_name
+from pygmt import which
+from pygmt.helpers import unique_name
 
 
 def test_which():

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -10,10 +10,10 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 
-from .. import x2sys_cross, x2sys_init
-from ..datasets import load_sample_bathymetry
-from ..exceptions import GMTInvalidInput
-from ..helpers import data_kind
+from pygmt import x2sys_cross, x2sys_init
+from pygmt.datasets import load_sample_bathymetry
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import data_kind
 
 
 @pytest.fixture(name="mock_x2sys_home")

--- a/pygmt/tests/test_x2sys_init.py
+++ b/pygmt/tests/test_x2sys_init.py
@@ -7,7 +7,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
-from .. import x2sys_init
+from pygmt import x2sys_init
 
 
 @pytest.fixture(name="mock_x2sys_home")

--- a/pygmt/x2sys.py
+++ b/pygmt/x2sys.py
@@ -7,9 +7,9 @@ from pathlib import Path
 
 import pandas as pd
 
-from .clib import Session
-from .exceptions import GMTInvalidInput
-from .helpers import (
+from pygmt.clib import Session
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import (
     GMTTempFile,
     build_arg_string,
     data_kind,


### PR DESCRIPTION
**Description of proposed changes**

This PR converts all relative imports to absolute imports.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
