### PR TITLE
Add a CI job testing GMT master branch on Windows

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -20,12 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9]
-        os: [ubuntu-20.04, macOS-10.15]
+        os: [ubuntu-20.04, macOS-10.15, windows-latest]
         gmt_git_ref: [master]
-    env:
-      # LD_LIBRARY_PATH: ${{ github.workspace }}/gmt/lib:$LD_LIBRARY_PATH
-      GMT_INSTALL_DIR: ${{ github.workspace }}/gmt-install-dir
-      GMT_LIBRARY_PATH: ${{ github.workspace }}/gmt-install-dir/lib
     defaults:
       run:
         shell: bash -l {0}
@@ -57,10 +53,16 @@ jobs:
         run: conda install cmake libblas libcblas liblapack fftw gdal ghostscript libnetcdf hdf5 zlib curl pcre ipython pytest pytest-cov pytest-mpl
 
       # Build and install latest GMT from GitHub
-      - name: Install GMT ${{ matrix.gmt_git_ref }} branch
+      - name: Install GMT ${{ matrix.gmt_git_ref }} branch (Linux/macOS)
         run: curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/build-gmt.sh | bash
         env:
           GMT_GIT_REF: ${{ matrix.gmt_git_ref }}
+          GMT_INSTALL_DIR: ${{ github.workspace }}/gmt-install-dir
+        if: runner.os != 'Windows'
+
+      - name: Install GMT dev version from conda-forge (Windows)
+        run: conda install -c conda-forge/label/dev gmt
+        if: runner.os == 'Windows'
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub
@@ -86,8 +88,16 @@ jobs:
           pip install dist/*
 
       # Run the tests
-      - name: Test with pytest
+      - name: Test with pytest (Linux/macOS)
         run: make test PYTEST_EXTRA="-r P"
+        env:
+          GMT_LIBRARY_PATH: ${{ github.workspace }}/gmt-install-dir/lib
+        if: runner.os != 'Windows'
+
+      # Run the tests
+      - name: Test with pytest (Windows)
+        run: make test PYTEST_EXTRA="-r P"
+        if: runner.os == 'Windows'
 
       # Upload diff images on test failure
       - name: Upload diff images if any test fails

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -60,7 +60,7 @@ On the *master* branch, the workflow also handles the documentation deployment:
   *master* branch onto the `dev` folder of the *gh-pages* branch.
 * Updated the `latest` documentation link to the new release.
 
-2. `ci_tests_dev.yaml` (GMT Latest Tests on Linux/macOS).
+2. `ci_tests_dev.yaml` (GMT Latest Tests on Linux/macOS/Windows).
 
 This is only triggered when a review is requested or re-requested on a PR.
 It is also scheduled to run daily on the *master* branch.


### PR DESCRIPTION
**Description of proposed changes**

This PR tests PyGMT with GMT **master** branch on **Windows**, 
using the GMT dev versions from conda-forge.

Note that, on Linux and macOS, we test GMT master branch by building the lastest
GMT source codes. However, on Windows, the GMT dev versions from conda-forge
are one or a few weeks behind the GMT master branch.

Fixes #755.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
