### PR TITLE
Conic projection descriptions

### DIFF
--- a/examples/projections/conic/conic_albers.py
+++ b/examples/projections/conic/conic_albers.py
@@ -13,9 +13,6 @@ The opposite is true for the scale along meridians.
 
 ``Blon0/lat0/lat1/lat2/width``: Give projection center ``lon0/lat0`` and two standard
 parallels ``lat1/lat2``.
-
-For further information, see
-:gmt-docs:`cookbook/map-projections.html#albers-conic-equal-area-projection-jb-jb`
 """
 import pygmt
 

--- a/examples/projections/conic/conic_albers.py
+++ b/examples/projections/conic/conic_albers.py
@@ -1,6 +1,7 @@
 """
 Albers Conic Equal Area
 =======================
+
 This projection, developed by Heinrich C. Albers in 1805, is predominantly used to map
 regions of large east-west extent, in particular the United States. It is a conic,
 equal-area projection, in which parallels are unequally spaced arcs of concentric

--- a/examples/projections/conic/conic_albers.py
+++ b/examples/projections/conic/conic_albers.py
@@ -1,9 +1,20 @@
 """
 Albers Conic Equal Area
 =======================
+This projection, developed by Heinrich C. Albers in 1805, is predominantly used to map
+regions of large east-west extent, in particular the United States. It is a conic,
+equal-area projection, in which parallels are unequally spaced arcs of concentric
+circles, more closely spaced at the north and south edges of the map. Meridians, on the
+other hand, are equally spaced radii about a common center, and cut the parallels at
+right angles. Distortion in scale and shape vanishes along the two standard parallels.
+Between them, the scale along parallels is too small; beyond them it is too large.
+The opposite is true for the scale along meridians.
 
 ``Blon0/lat0/lat1/lat2/width``: Give projection center ``lon0/lat0`` and two standard
 parallels ``lat1/lat2``.
+
+For further information, see
+:gmt-docs:`cookbook/map-projections.html#albers-conic-equal-area-projection-jb-jb`
 """
 import pygmt
 

--- a/examples/projections/conic/conic_equidistant.py
+++ b/examples/projections/conic/conic_equidistant.py
@@ -9,9 +9,6 @@ standard parallels.
 
 ``Dlon0/lat0/lat1/lat2/width``: Give projection center ``lon0/lat0``, two standard
 parallels ``lat1/lat2``, and the map width.
-
-For further information, see
-:gmt-docs:`cookbook/map-projections.html#equidistant-conic-projection-jd-jd`
 """
 import pygmt
 

--- a/examples/projections/conic/conic_equidistant.py
+++ b/examples/projections/conic/conic_equidistant.py
@@ -1,9 +1,16 @@
 """
 Equidistant conic
 =================
+The equidistant conic projection was described by the Greek philosopher Claudius
+Ptolemy about A.D. 150. It is neither conformal or equal-area, but serves as a
+compromise between them. The scale is true along all meridians and the
+standard parallels.
 
 ``Dlon0/lat0/lat1/lat2/width``: Give projection center ``lon0/lat0``, two standard
 parallels ``lat1/lat2``, and the map width.
+
+For further information, see
+:gmt-docs:`cookbook/map-projections.html#equidistant-conic-projection-jd-jd`
 """
 import pygmt
 

--- a/examples/projections/conic/conic_equidistant.py
+++ b/examples/projections/conic/conic_equidistant.py
@@ -1,6 +1,7 @@
 """
 Equidistant conic
 =================
+
 The equidistant conic projection was described by the Greek philosopher Claudius
 Ptolemy about A.D. 150. It is neither conformal or equal-area, but serves as a
 compromise between them. The scale is true along all meridians and the

--- a/examples/projections/conic/conic_lambert.py
+++ b/examples/projections/conic/conic_lambert.py
@@ -1,6 +1,7 @@
 """
 Lambert Conic Conformal Projection
 ==================================
+
 This conic projection was designed by the Alsatian mathematician Johann Heinrich
 Lambert (1772) and has been used extensively for mapping of regions with predominantly
 east-west orientation, just like the Albers projection. Unlike the Albers projection,

--- a/examples/projections/conic/conic_lambert.py
+++ b/examples/projections/conic/conic_lambert.py
@@ -11,9 +11,6 @@ with Albers projection, it is only the two standard parallels that are distortio
 
 ``Llon0/lat0/lat1/lat2/width``: Give projection center ``lon0/lat0``, two standard
 parallels ``lat1/lat2``, and the map width.
-
-For further information, see
-:gmt-docs:`cookbook/map-projections.html#lambert-conic-conformal-projection-jl-jl`
 """
 import pygmt
 

--- a/examples/projections/conic/conic_lambert.py
+++ b/examples/projections/conic/conic_lambert.py
@@ -1,9 +1,18 @@
 """
 Lambert Conic Conformal Projection
 ==================================
+This conic projection was designed by the Alsatian mathematician Johann Heinrich
+Lambert (1772) and has been used extensively for mapping of regions with predominantly
+east-west orientation, just like the Albers projection. Unlike the Albers projection,
+Lambert’s conformal projection is not equal-area. The parallels are arcs of circles
+with a common origin, and meridians are the equally spaced radii of these circles. As
+with Albers projection, it is only the two standard parallels that are distortion-free.
 
 ``Llon0/lat0/lat1/lat2/width``: Give projection center ``lon0/lat0``, two standard
 parallels ``lat1/lat2``, and the map width.
+
+For further information, see
+:gmt-docs:`cookbook/map-projections.html#lambert-conic-conformal-projection-jl-jl`
 """
 import pygmt
 

--- a/examples/projections/conic/polyconic.py
+++ b/examples/projections/conic/polyconic.py
@@ -19,9 +19,6 @@ consequence, no parallel is standard because conformity is lost with the lengthe
 the meridians.
 
 ``Poly/width``:  The only additional argument for the projection is the map width.
-
-For further information, see
-:gmt-docs:`cookbook/map-projections.html#american-polyconic-projection-jpoly-jpoly`
 """
 import pygmt
 

--- a/examples/projections/conic/polyconic.py
+++ b/examples/projections/conic/polyconic.py
@@ -1,8 +1,26 @@
 """
 Polyconic Projection
 ====================
+The polyconic projection, in Europe usually referred to as the American polyconic
+projection, was introduced shortly before 1820 by the Swiss-American cartographer
+Ferdinand Rodulph Hassler (1770–1843). As head of the Survey of the Coast, he was
+looking for a projection that would give the least distortion for mapping the coast of
+the United States. The projection acquired its name from the construction of each
+parallel, which is achieved by projecting the parallel onto the cone while it is rolled
+around the globe, along the central meridian, tangent to that parallel. As a
+consequence, the projection involves many cones rather than a single one used in
+regular conic projections.
+
+The polyconic projection is neither equal-area, nor conformal. It is true to scale
+without distortion along the central meridian. Each parallel is true to scale as well,
+but the meridians are not as they get further away from the central meridian. As a
+consequence, no parallel is standard because conformity is lost with the lengthening of
+the meridians.
 
 ``Poly/width``:  The only additional argument for the projection is the map width.
+
+For further information, see
+:gmt-docs:`cookbook/map-projections.html#american-polyconic-projection-jpoly-jpoly`
 """
 import pygmt
 

--- a/examples/projections/conic/polyconic.py
+++ b/examples/projections/conic/polyconic.py
@@ -1,6 +1,7 @@
 """
 Polyconic Projection
 ====================
+
 The polyconic projection, in Europe usually referred to as the American polyconic
 projection, was introduced shortly before 1820 by the Swiss-American cartographer
 Ferdinand Rodulph Hassler (1770–1843). As head of the Survey of the Coast, he was


### PR DESCRIPTION
Adding projection descriptions for the conic gallery examples, as discussed in #747.

These projection descriptions are copied directly from the GMT documentation.