### PR TITLE
Fix typo for version number in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,6 @@ isort>=5
 pylint
 flake8
 sphinx
-sphinx_rtd_theme=0.4.3
+sphinx_rtd_theme==0.4.3
 sphinx-gallery
 nbsphinx


### PR DESCRIPTION
The current version of `requirements-dev.txt` includes `sphinx_rtd_theme=0.4.3`. To use `pip install -r requirements-dev.txt`, it requires the version number to be specified using `==`. I added the second `=` in the pull request.