### PR TITLE
Add cylindric descriptions

### DIFF
--- a/examples/projections/cyl/cyl_cassini.py
+++ b/examples/projections/cyl/cyl_cassini.py
@@ -2,6 +2,15 @@
 Cassini Cylindrical
 ============================
 
+This cylindrical projection was developed in 1745 by César-François Cassini de Thury
+for the survey of France. It is occasionally called Cassini-Soldner since the latter
+provided the more accurate mathematical analysis that led to the development of the
+ellipsoidal formulae. The projection is neither conformal nor equal-area, and behaves
+as a compromise between the two end-members. The distortion is zero along the central
+meridian. It is best suited for mapping regions of north-south extent. The central
+meridian, each meridian 90° away, and equator are straight lines; all other meridians
+and parallels are complex curves.
+
 ``Clon0/lat0/width``: ``lon0`` and ``lat0`` specifies the projection center.
 """
 import pygmt

--- a/examples/projections/cyl/cyl_equal_area.py
+++ b/examples/projections/cyl/cyl_equal_area.py
@@ -2,7 +2,12 @@
 Cylindrical equal-area
 ======================
 
-``Ylon0/lat0/width``: Give central meridian ``lon0``, the standard parallel ``lat0``, and the figure ``width``.
+This cylindrical projection is actually several projections, depending on what
+latitude is selected as the standard parallel. However, they are all equal area and
+hence non-conformal. All meridians and parallels are straight lines.
+
+``Ylon0/lat0/width``: Give central meridian ``lon0``, the standard parallel ``lat0``,
+and the figure ``width``.
 """
 import pygmt
 

--- a/examples/projections/cyl/cyl_equidistant.py
+++ b/examples/projections/cyl/cyl_equidistant.py
@@ -2,6 +2,10 @@
 Cylindrical equidistant
 =======================
 
+This simple cylindrical projection is really a linear scaling of longitudes and
+latitudes. The most common form is the Plate Carrée projection, where the scaling of
+longitudes and latitudes is the same. All meridians and parallels are straight lines.
+
 ``Qwidth``: Give the figure ``width``.
 """
 import pygmt

--- a/examples/projections/cyl/cyl_mercator.py
+++ b/examples/projections/cyl/cyl_mercator.py
@@ -2,6 +2,16 @@
 Mercator
 ========
 
+The Mercator projection takes its name from the Flemish cartographer Gheert Cremer,
+better known as Gerardus Mercator, who presented it in 1569. The projection is a
+cylindrical and conformal, with no distortion along the equator. A major navigational
+feature of the projection is that a line of constant azimuth is straight. Such a line
+is called a rhumb line or loxodrome. Thus, to sail from one point to another one only
+had to connect the points with a straight line, determine the azimuth of the line, and
+keep this constant course for the entire voyage. The Mercator projection has been used
+extensively for world maps in which the distortion towards the polar regions grows
+rather large.
+
 ``M[lon0/][lat0/]width``: Give central meridian ``lon0`` (optional) and
 standard parallel ``lat0`` (optional).
 """

--- a/examples/projections/cyl/cyl_miller.py
+++ b/examples/projections/cyl/cyl_miller.py
@@ -2,6 +2,13 @@
 Miller cylindrical
 ==================
 
+This cylindrical projection, presented by Osborn Maitland Miller of the American
+Geographic Society in 1942, is neither equal nor conformal. All meridians and
+parallels are straight lines. The projection was designed to be a compromise between
+Mercator and other cylindrical projections. Specifically, Miller spaced the parallels
+by using Mercator’s formula with 0.8 times the actual latitude, thus avoiding the
+singular poles; the result was then divided by 0.8.
+
 ``J[lon0/]width``: Give the optional central meridian ``lon0`` and the figure ``width``.
 """
 import pygmt

--- a/examples/projections/cyl/cyl_stereographic.py
+++ b/examples/projections/cyl/cyl_stereographic.py
@@ -2,6 +2,14 @@
 Cylindrical Stereographic
 =========================
 
+The cylindrical stereographic projections are certainly not as notable as other
+cylindrical projections, but are still used because of their relative simplicity and
+their ability to overcome some of the downsides of other cylindrical projections, like
+extreme distortions of the higher latitudes. The stereographic projections are
+perspective projections, projecting the sphere onto a cylinder in the direction of the
+antipodal point on the equator. The cylinder crosses the sphere at two standard
+parallels, equidistant from the equator.
+
 ``Cyl_stere/[lon0/][lat0/]width``: Give central meridian ``lon0`` (optional) and
 standard parallel ``lat0`` (optional). The standard parallel is typically one of these
 (but can be any value):

--- a/examples/projections/cyl/cyl_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_transverse_mercator.py
@@ -2,6 +2,12 @@
 Transverse Mercator
 ===================
 
+The transverse Mercator was invented by Johann Heinrich Lambert in 1772. In this
+projection the cylinder touches a meridian along which there is no distortion. The
+distortion increases away from the central meridian and goes to infinity at 90° from
+center. The central meridian, each meridian 90° away from the center, and equator are
+straight lines; other parallels and meridians are complex curves.
+
 ``T[lon0/][lat0/]width``: Give central meridian ``lon0``, the latitude of the
 origin ``lat0`` (optional), and the figure width.
 """

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -2,6 +2,18 @@
 Universal Transverse Mercator
 =============================
 
+A particular subset of the transverse Mercator is the Universal Transverse Mercator
+(UTM) which was adopted by the US Army for large-scale military maps. Here, the globe
+is divided into 60 zones between 84°S and 84°N, most of which are 6 wide. Each of these
+UTM zones have their unique central meridian. Furthermore, each zone is divided into
+latitude bands but these are not needed to specify the projection for most cases.
+
+In order to minimize the distortion in any given zone, a scale factor of 0.9996 has
+been factored into the formulae. This makes the UTM projection a secant projection and
+not a tangent projection like the transverse Mercator above. The scale only varies by
+1 part in 1,000 from true scale at equator. The ellipsoidal projection expressions are
+accurate for map areas that extend less than 10 away from the central meridian.
+
 ``U[UTM Zone/][lat0/]width``: Give UTM Zone ``UTM Zone``, and the figure width.
 """
 import pygmt


### PR DESCRIPTION
As discussed in #747, I have added descriptions for the cylindric gallery projections. They are mostly copied directly from the GMT docs.