### PR TITLE
Add description for the "columns" arguments

### DIFF
--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -782,6 +782,11 @@ class BasePlotting:
             polygon in the input data. To apply it to the fill color, use
             ``color='+z'``. To apply it to the pen color, append **+z** to
             **pen**.
+        columns : str or 1d array
+            Choose which columns are x, y, color, and size, respectively if input 
+            is provided via *data*. E.g. ``columns = [0, 1]`` or ``columns = '0, 1'`` 
+            if the *x* values are stored in the first column and *y* values in the 
+            second one: Note: zero-based indexing is used.
         label : str
             Add a legend entry for the symbol or line being plotted.
 

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -783,10 +783,10 @@ class BasePlotting:
             ``color='+z'``. To apply it to the pen color, append **+z** to
             **pen**.
         columns : str or 1d array
-            Choose which columns are x, y, color, and size, respectively if 
-            input is provided via *data*. E.g. ``columns = [0, 1]`` or 
-            ``columns = '0,1'`` if the *x* values are stored in the first 
-            column and *y* values in the second one. Note: zero-based 
+            Choose which columns are x, y, color, and size, respectively if
+            input is provided via *data*. E.g. ``columns = [0, 1]`` or
+            ``columns = '0,1'`` if the *x* values are stored in the first
+            column and *y* values in the second one. Note: zero-based
             indexing is used.
         label : str
             Add a legend entry for the symbol or line being plotted.

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -784,7 +784,7 @@ class BasePlotting:
             **pen**.
         columns : str or 1d array
             Choose which columns are x, y, color, and size, respectively if input
-            is provided via *data*. E.g. ``columns = [0, 1]`` or ``columns = '0, 1'``
+            is provided via *data*. E.g. ``columns = [0, 1]`` or ``columns = '0,1'``
             if the *x* values are stored in the first column and *y* values in the
             second one: Note: zero-based indexing is used.
         label : str

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -783,9 +783,9 @@ class BasePlotting:
             ``color='+z'``. To apply it to the pen color, append **+z** to
             **pen**.
         columns : str or 1d array
-            Choose which columns are x, y, color, and size, respectively if input 
-            is provided via *data*. E.g. ``columns = [0, 1]`` or ``columns = '0, 1'`` 
-            if the *x* values are stored in the first column and *y* values in the 
+            Choose which columns are x, y, color, and size, respectively if input
+            is provided via *data*. E.g. ``columns = [0, 1]`` or ``columns = '0, 1'``
+            if the *x* values are stored in the first column and *y* values in the
             second one: Note: zero-based indexing is used.
         label : str
             Add a legend entry for the symbol or line being plotted.

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -786,7 +786,7 @@ class BasePlotting:
             Choose which columns are x, y, color, and size, respectively if input
             is provided via *data*. E.g. ``columns = [0, 1]`` or ``columns = '0,1'``
             if the *x* values are stored in the first column and *y* values in the
-            second one: Note: zero-based indexing is used.
+            second one. Note: zero-based indexing is used.
         label : str
             Add a legend entry for the symbol or line being plotted.
 

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -783,10 +783,11 @@ class BasePlotting:
             ``color='+z'``. To apply it to the pen color, append **+z** to
             **pen**.
         columns : str or 1d array
-            Choose which columns are x, y, color, and size, respectively if input
-            is provided via *data*. E.g. ``columns = [0, 1]`` or ``columns = '0,1'``
-            if the *x* values are stored in the first column and *y* values in the
-            second one. Note: zero-based indexing is used.
+            Choose which columns are x, y, color, and size, respectively if 
+            input is provided via *data*. E.g. ``columns = [0, 1]`` or 
+            ``columns = '0,1'`` if the *x* values are stored in the first 
+            column and *y* values in the second one. Note: zero-based 
+            indexing is used.
         label : str
             Add a legend entry for the symbol or line being plotted.
 


### PR DESCRIPTION
Add missing description for the columns argument in `Figure.plot`.

Closes #764.