### PR TITLE
Allow anyone to run the /format command in PRs

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -22,3 +22,4 @@ jobs:
           commands: |
             format
           issue-type: pull-request
+          permission: none


### PR DESCRIPTION
**Description of proposed changes**

The default permission is `write` and only the maintainers can run the slash
dispatch commands. This PR fixes the permission to `none`.

Fixes #767.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
