### PR TITLE
Update test_coast_aliases

### DIFF
--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -37,23 +37,49 @@ def test_coast_iceland():
     return fig_ref, fig_test
 
 
-@pytest.mark.mpl_image_compare
+@check_figures_equal()
 def test_coast_aliases():
     "Test that all aliases work"
-    fig = Figure()
-    fig.coast(
-        region="-30/30/-40/40",
-        projection="m0.1i",
-        frame="afg",
-        rivers="1/1p,black",
-        borders="1/0.5p,-",
-        shorelines="0.25p,white",
-        land="moccasin",
-        water="skyblue",
-        resolution="i",
-        area_thresh=1000,
+    fig_ref, fig_test = Figure(), Figure()
+    fig_ref.coast(
+        R="-30/30/-40/40",
+        J="M25c",
+        B="afg",
+        I="1/1p,black",
+        N="1/0.5p,-",
+        W="0.25p,white",
+        G="moccasin",
+        S="skyblue",
+        D="i",
+        A=1000,
+        L="jMM+c1+w1000k+f+l",
+        U=True,
+        V="q",
+        X="a4c",
+        Y="a10c",
+        p="135/25",
+        t=13,
     )
-    return fig
+    fig_test.coast(
+        region=[-30, 30, -40, 40],  # R
+        projection="M25c",  # J
+        frame="afg",  # B
+        rivers="1/1p,black",  # I
+        borders="1/0.5p,-",  # N
+        shorelines="0.25p,white",  # W
+        land="moccasin",  # G
+        water="skyblue",  # S
+        resolution="i",  # D
+        area_thresh=1000,  # A
+        map_scale="jMM+c1+w1000k+f+l",  # L
+        timestamp=True,  # U
+        verbose="q",  # V
+        xshift="a4c",  # X
+        yshift="a10c",  # Y
+        perspective=[135, 25],  # p
+        transparency=13,  # t
+    )
+    return fig_ref, fig_test
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -73,7 +73,6 @@ def test_coast_aliases():
         area_thresh=1000,  # A
         map_scale="jCM+c1+w1000k+f+l",  # L
         timestamp=True,  # U
-        verbose="q",  # V
         xshift="a4c",  # X
         yshift="a10c",  # Y
         perspective=[135, 25],  # p

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -54,7 +54,6 @@ def test_coast_aliases():
         A=1000,
         L="jCM+c1+w1000k+f+l",
         U=True,
-        V="q",
         X="a4c",
         Y="a10c",
         p="135/25",

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -52,7 +52,7 @@ def test_coast_aliases():
         S="skyblue",
         D="i",
         A=1000,
-        L="jMM+c1+w1000k+f+l",
+        L="jCM+c1+w1000k+f+l",
         U=True,
         V="q",
         X="a4c",
@@ -71,7 +71,7 @@ def test_coast_aliases():
         water="skyblue",  # S
         resolution="i",  # D
         area_thresh=1000,  # A
-        map_scale="jMM+c1+w1000k+f+l",  # L
+        map_scale="jCM+c1+w1000k+f+l",  # L
         timestamp=True,  # U
         verbose="q",  # V
         xshift="a4c",  # X


### PR DESCRIPTION
The current `test_coast_aliases()` in `test_coast.py` does not include all of the current aliases in PyGMT v0.2.1; I updated the function to include all of the aliases and changed the test format to use `@check_figures_equal`.