### PR TITLE
Update GMT argument in the azimuthal projections gallery to doc standards

### DIFF
--- a/examples/projections/azim/azim_equidistant.py
+++ b/examples/projections/azim/azim_equidistant.py
@@ -8,8 +8,8 @@ projection center are correct. It is very useful for a global view on locations
 that lie within a certain distance or for comparing distances of different
 locations relative to the projection center.
 
-**e**\ *lon0*\ */*\ *lat0*\ [/*horizon*]/*scale* or
-**E***lon0***/***lat0*[**/***horizon*]**/***width*
+**e**\ *lon0*\ **/**\ *lat0*\ [**/**\ *horizon*]\ **/**\ *scale* or
+**E**\ *lon0*\ **/**\ *lat0*\ [**/**\ *horizon*]\ **/**\ *width*
 
 *lon0***/***lat0* specifies the projection center. The optional parameter
 *horizon* specifies the max distance to the projection center (i.e. the

--- a/examples/projections/azim/azim_equidistant.py
+++ b/examples/projections/azim/azim_equidistant.py
@@ -11,9 +11,10 @@ locations relative to the projection center.
 **e**\ *lon0*\ **/**\ *lat0*\ [**/**\ *horizon*]\ **/**\ *scale* or
 **E**\ *lon0*\ **/**\ *lat0*\ [**/**\ *horizon*]\ **/**\ *width*
 
-*lon0***/***lat0* specifies the projection center. The optional parameter
+*lon0*\ **/**\ *lat0* specifies the projection center. The optional parameter
 *horizon* specifies the max distance to the projection center (i.e. the
-visibile portion of the rest of the world map) in degrees <= 180° (default 180°).
+visibile portion of the rest of the world map) in degrees <= 180° (default 180°). The
+size of the figure is set by *scale* or *width*.
 """
 import pygmt
 

--- a/examples/projections/azim/azim_equidistant.py
+++ b/examples/projections/azim/azim_equidistant.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Azimuthal Equidistant
 =====================
 
@@ -8,7 +8,7 @@ projection center are correct. It is very useful for a global view on locations
 that lie within a certain distance or for comparing distances of different
 locations relative to the projection center.
 
-**e***lon0*/*lat0*[/*horizon*]/*scale* or
+**e**\ *lon0*| */*\ *lat0*\ [/*horizon*]/*scale* or
 **E***lon0***/***lat0*[**/***horizon*]**/***width*
 
 *lon0***/***lat0* specifies the projection center. The optional parameter

--- a/examples/projections/azim/azim_equidistant.py
+++ b/examples/projections/azim/azim_equidistant.py
@@ -8,10 +8,10 @@ projection center are correct. It is very useful for a global view on locations
 that lie within a certain distance or for comparing distances of different
 locations relative to the projection center.
 
-**e**\ *lon0*\ **/**\ *lat0*\ [**/**\ *horizon*]\ **/**\ *scale* or
-**E**\ *lon0*\ **/**\ *lat0*\ [**/**\ *horizon*]\ **/**\ *width*
+**e**\ *lon0/at0*\ [*/horizon*]\ */scale* or
+**E**\ *lon0/lat0*\ [*/horizon*]\ */width*
 
-*lon0*\ **/**\ *lat0* specifies the projection center. The optional parameter
+*lon0/lat0* specifies the projection center. The optional parameter
 *horizon* specifies the max distance to the projection center (i.e. the
 visibile portion of the rest of the world map) in degrees <= 180° (default 180°). The
 size of the figure is set by *scale* or *width*.

--- a/examples/projections/azim/azim_equidistant.py
+++ b/examples/projections/azim/azim_equidistant.py
@@ -8,8 +8,8 @@ projection center are correct. It is very useful for a global view on locations
 that lie within a certain distance or for comparing distances of different
 locations relative to the projection center.
 
-**e***lon0***/***lat0*[**/***horizon*]**/***scale*`` or
-``**E***lon0***/***lat0*[**/***horizon*]**/***width*``
+**e** *lon0* **/** *lat0* [ **/** *horizon* ] **/** *scale* or
+**E***lon0***/***lat0*[**/***horizon*]**/***width*
 
 *lon0***/***lat0* specifies the projection center. The optional parameter
 *horizon* specifies the max distance to the projection center (i.e. the

--- a/examples/projections/azim/azim_equidistant.py
+++ b/examples/projections/azim/azim_equidistant.py
@@ -11,10 +11,10 @@ locations relative to the projection center.
 **e**\ *lon0/at0*\ [*/horizon*]\ */scale* or
 **E**\ *lon0/lat0*\ [*/horizon*]\ */width*
 
-*lon0/lat0* specifies the projection center. The optional parameter
-*horizon* specifies the max distance to the projection center (i.e. the
-visibile portion of the rest of the world map) in degrees <= 180° (default 180°). The
-size of the figure is set by *scale* or *width*.
+The projection type is set with **e** or **E**, *lon0/lat0* specifies the projection
+center, and the optional parameter *horizon* specifies the max distance to the
+projection center (i.e. the visibile portion of the rest of the world map) in
+degrees <= 180° (default 180°). The size of the figure is set by *scale* or *width*.
 """
 import pygmt
 

--- a/examples/projections/azim/azim_equidistant.py
+++ b/examples/projections/azim/azim_equidistant.py
@@ -8,7 +8,7 @@ projection center are correct. It is very useful for a global view on locations
 that lie within a certain distance or for comparing distances of different
 locations relative to the projection center.
 
-**e** *lon0* **/** *lat0* [ **/** *horizon* ] **/** *scale* or
+**e***lon0*/*lat0*[/*horizon*]/*scale* or
 **E***lon0***/***lat0*[**/***horizon*]**/***width*
 
 *lon0***/***lat0* specifies the projection center. The optional parameter

--- a/examples/projections/azim/azim_equidistant.py
+++ b/examples/projections/azim/azim_equidistant.py
@@ -8,7 +8,7 @@ projection center are correct. It is very useful for a global view on locations
 that lie within a certain distance or for comparing distances of different
 locations relative to the projection center.
 
-**e**\ *lon0/at0*\ [*/horizon*]\ */scale* or
+**e**\ *lon0/lat0*\ [*/horizon*]\ */scale* or
 **E**\ *lon0/lat0*\ [*/horizon*]\ */width*
 
 The projection type is set with **e** or **E**, *lon0/lat0* specifies the projection

--- a/examples/projections/azim/azim_equidistant.py
+++ b/examples/projections/azim/azim_equidistant.py
@@ -8,10 +8,11 @@ projection center are correct. It is very useful for a global view on locations
 that lie within a certain distance or for comparing distances of different
 locations relative to the projection center.
 
-``elon0/lat0[/horizon]/scale`` or ``Elon0/lat0[/horizon]/width``
+**e***lon0***/***lat0*[**/***horizon*]**/***scale*`` or
+``**E***lon0***/***lat0*[**/***horizon*]**/***width*``
 
-``lon0/lat0`` specifies the projection center. The optional parameter
-``horizon`` specifies the max distance to the projection center (i.e. the
+*lon0***/***lat0* specifies the projection center. The optional parameter
+*horizon* specifies the max distance to the projection center (i.e. the
 visibile portion of the rest of the world map) in degrees <= 180° (default 180°).
 """
 import pygmt

--- a/examples/projections/azim/azim_equidistant.py
+++ b/examples/projections/azim/azim_equidistant.py
@@ -8,7 +8,7 @@ projection center are correct. It is very useful for a global view on locations
 that lie within a certain distance or for comparing distances of different
 locations relative to the projection center.
 
-**e**\ *lon0*| */*\ *lat0*\ [/*horizon*]/*scale* or
+**e**\ *lon0*\ */*\ *lat0*\ [/*horizon*]/*scale* or
 **E***lon0***/***lat0*[**/***horizon*]**/***width*
 
 *lon0***/***lat0* specifies the projection center. The optional parameter

--- a/examples/projections/azim/azim_general_perspective.py
+++ b/examples/projections/azim/azim_general_perspective.py
@@ -1,4 +1,4 @@
-"""
+r"""
 General Perspective
 ===================
 

--- a/examples/projections/azim/azim_general_perspective.py
+++ b/examples/projections/azim/azim_general_perspective.py
@@ -6,16 +6,19 @@ The general perspective projection imitates the view of the Earth from a finite
 point in space. In a full view of the earth one third of its surface area can
 be seen.
 
-``lon0/lat0/altitude/azimuth/tilt/twist/Width/Height/scale`` or ``width``
+**g**\ *lon0*\ **/**\ *lat0*\ **/**\ *altitude*\ **/**\ *azimuth*\ **/**\ *tilt*\ **/**\ *twist*\ **/**\ *Width*\ **/**\ *Height*\ **/**\ *scale*
+or **G**\ *lon0*\ **/**\ *lat0*\ **/**\ *altitude*\ **/**\ *azimuth*\ **/**\ *tilt*\ **/**\ *twist*\ **/**\ *Width*\ **/**\ *Height*\ **/**\ *width*
 
-``lon0/lat0`` specifies the projection center, ``altitude`` the height
+The ``projection`` is set with **g** or **G**.
+*lon0*\ **/**\ *lat0* specifies the projection center, *altitude* the height
 in km of the viewpoint above local sea level (If altitude is less than 10,
 then it is the distance from the center of the earth to the viewpoint in earth
-radii). With ``azimuth`` the direction (in degrees) in which you are looking is
-specified, measured clockwise from north. ``tilt`` is given in degrees and is the
+radii). With *azimuth* the direction (in degrees) in which you are looking is
+specified, measured clockwise from north. *tilt* is given in degrees and is the
 viewing angle relative to zenith. A tilt of 0° is looking straight down, 60° is
-looking 30° above horizon. ``twist`` is the clockwise rotation of the image (in
-degrees). ``Width`` and ``Height`` describe the viewport angle in degrees.
+looking 30° above horizon. *twist* is the clockwise rotation of the image (in
+degrees). *Width* and *Height* describe the viewport angle in degrees, and *scale*
+or *width* determine the size of the figure.
 
 The example shows the coast of northern europe viewed from 250 km above sea
 level looking 30° from north at a tilt of 45°. The height and width of the

--- a/examples/projections/azim/azim_general_perspective.py
+++ b/examples/projections/azim/azim_general_perspective.py
@@ -6,8 +6,8 @@ The general perspective projection imitates the view of the Earth from a finite
 point in space. In a full view of the earth one third of its surface area can
 be seen.
 
-**g**\ *lon0*\ **/**\ *lat0*\ **/**\ *altitude*\ **/**\ *azimuth*\ **/**\ *tilt*\ **/**\ *twist*\ **/**\ *Width*\ **/**\ *Height*\ **/**\ *scale*
-or **G**\ *lon0*\ **/**\ *lat0*\ **/**\ *altitude*\ **/**\ *azimuth*\ **/**\ *tilt*\ **/**\ *twist*\ **/**\ *Width*\ **/**\ *Height*\ **/**\ *width*
+**g**\ *lon0/lat0*\ */altitude*\ */azimuth*\ */tilt*\ */twist*\ */Width*\ */Height*\ */scale*
+or **G**\ *lon0/lat0*\ */altitude*\ */azimuth*\ */tilt*\ */twist*\ */Width*\ */Height*\ */width*
 
 The ``projection`` is set with **g** or **G**.
 *lon0*\ **/**\ *lat0* specifies the projection center, *altitude* the height

--- a/examples/projections/azim/azim_general_perspective.py
+++ b/examples/projections/azim/azim_general_perspective.py
@@ -10,7 +10,7 @@ be seen.
 or **G**\ *lon0/lat0*\ */altitude*\ */azimuth*\ */tilt*\ */twist*\ */Width*\ */Height*\ */width*
 
 The ``projection`` is set with **g** or **G**.
-*lon0*\ **/**\ *lat0* specifies the projection center, *altitude* the height
+*lon0/lat0* specifies the projection center and *altitude* sets the height
 in km of the viewpoint above local sea level (If altitude is less than 10,
 then it is the distance from the center of the earth to the viewpoint in earth
 radii). With *azimuth* the direction (in degrees) in which you are looking is

--- a/examples/projections/azim/azim_general_perspective.py
+++ b/examples/projections/azim/azim_general_perspective.py
@@ -9,7 +9,7 @@ be seen.
 **g**\ *lon0/lat0*\ */altitude*\ */azimuth*\ */tilt*\ */twist*\ */Width*\ */Height*\ */scale*
 or **G**\ *lon0/lat0*\ */altitude*\ */azimuth*\ */tilt*\ */twist*\ */Width*\ */Height*\ */width*
 
-The ``projection`` is set with **g** or **G**.
+The projection type is set with **g** or **G**.
 *lon0/lat0* specifies the projection center and *altitude* sets the height
 in km of the viewpoint above local sea level (If altitude is less than 10,
 then it is the distance from the center of the earth to the viewpoint in earth

--- a/examples/projections/azim/azim_general_stereographic.py
+++ b/examples/projections/azim/azim_general_stereographic.py
@@ -13,7 +13,8 @@ projection.
 or **S**\ *lon0*\ **/**\ *lat0*\ [\ **/**\ *horizon*\ ]\ **/**\ *width*
 
 *lon0*\ **/**\ *lat0* specifies the projection center, the optional *horizon* parameter
-specifies the max distance from projection center (in degrees, < 180, default 90).
+specifies the max distance from projection center (in degrees, < 180, default 90), and
+the *scale* or *width* sets the size of the figure.
 """
 import pygmt
 

--- a/examples/projections/azim/azim_general_stereographic.py
+++ b/examples/projections/azim/azim_general_stereographic.py
@@ -12,9 +12,10 @@ projection.
 **s**\ *lon0*\ **/**\ *lat0*\ [\ **/**\ *horizon*\ ]\ **/**\ *scale*
 or **S**\ *lon0*\ **/**\ *lat0*\ [\ **/**\ *horizon*\ ]\ **/**\ *width*
 
-*lon0*\ **/**\ *lat0* specifies the projection center, the optional *horizon* parameter
-specifies the max distance from projection center (in degrees, < 180, default 90), and
-the *scale* or *width* sets the size of the figure.
+The ``projection`` is set with **s** or **S**. *lon0*\ **/**\ *lat0* specifies the
+projection center, the optional *horizon* parameter specifies the max distance from
+projection center (in degrees, < 180, default 90), and the *scale* or *width* sets the
+size of the figure.
 """
 import pygmt
 

--- a/examples/projections/azim/azim_general_stereographic.py
+++ b/examples/projections/azim/azim_general_stereographic.py
@@ -14,13 +14,6 @@ or **S**\ *lon0*\ **/**\ *lat0*\ [\ **/**\ *horizon*\ ]\ **/**\ *width*
 
 *lon0*\ **/**\ *lat0* specifies the projection center, the optional *horizon* parameter
 specifies the max distance from projection center (in degrees, < 180, default 90).
-
-This projection can be displayed:
-
-* With map boundaries coinciding with longitude and latitude:
-  ``region`` specified via ``xmin/xmax/ymin/ymax``
-* As a map with rectangular boundaries: ``region`` specified as lower left and
-  upper right corner ``xlleft/ylleft/xuright/yurightr``. Note the appended ``r``.
 """
 import pygmt
 

--- a/examples/projections/azim/azim_general_stereographic.py
+++ b/examples/projections/azim/azim_general_stereographic.py
@@ -9,9 +9,10 @@ the distances in this projection are not displayed in correct proportions.
 It is often used as a hemisphere map like the Lambert Azimuthal Equal Area
 projection.
 
-``slon0/lat0[/horizon]/scale`` or ``Slon0/lat0[/horizon]/width``
+**s**\ *lon0*\ **/**\ *lat0*\ [\ **/**\ *horizon*\ ]\ **/**\ *scale*
+or **S**\ *lon0*\ **/**\ *lat0*\ [\ **/**\ *horizon*\ ]\ **/**\ *width*
 
-``lon0/lat0`` specifies the projection center, the optional ``horizon`` parameter
+*lon0*\ **/**\ *lat0* specifies the projection center, the optional *horizon* parameter
 specifies the max distance from projection center (in degrees, < 180, default 90).
 
 This projection can be displayed:

--- a/examples/projections/azim/azim_general_stereographic.py
+++ b/examples/projections/azim/azim_general_stereographic.py
@@ -1,4 +1,4 @@
-"""
+r"""
 General Stereographic
 =====================
 

--- a/examples/projections/azim/azim_general_stereographic.py
+++ b/examples/projections/azim/azim_general_stereographic.py
@@ -9,10 +9,10 @@ the distances in this projection are not displayed in correct proportions.
 It is often used as a hemisphere map like the Lambert Azimuthal Equal Area
 projection.
 
-**s**\ *lon0*\ **/**\ *lat0*\ [\ **/**\ *horizon*\ ]\ **/**\ *scale*
-or **S**\ *lon0*\ **/**\ *lat0*\ [\ **/**\ *horizon*\ ]\ **/**\ *width*
+**s**\ *lon0/lat0*\ [*/horizon*]\ */scale*
+or **S**\ *lon0/lat0*\ [*/horizon*\]\ */width*
 
-The ``projection`` is set with **s** or **S**. *lon0*\ **/**\ *lat0* specifies the
+The ``projection`` is set with **s** or **S**. *lon0/lat0* specifies the
 projection center, the optional *horizon* parameter specifies the max distance from
 projection center (in degrees, < 180, default 90), and the *scale* or *width* sets the
 size of the figure.

--- a/examples/projections/azim/azim_general_stereographic.py
+++ b/examples/projections/azim/azim_general_stereographic.py
@@ -12,7 +12,7 @@ projection.
 **s**\ *lon0/lat0*\ [*/horizon*]\ */scale*
 or **S**\ *lon0/lat0*\ [*/horizon*\]\ */width*
 
-The ``projection`` is set with **s** or **S**. *lon0/lat0* specifies the
+The projection type is set with **s** or **S**. *lon0/lat0* specifies the
 projection center, the optional *horizon* parameter specifies the max distance from
 projection center (in degrees, < 180, default 90), and the *scale* or *width* sets the
 size of the figure.

--- a/examples/projections/azim/azim_gnomonic.py
+++ b/examples/projections/azim/azim_gnomonic.py
@@ -13,9 +13,10 @@ projection center (at a maximum of 60°).
 **f**\ *lon0/lat0*\ [*/horizon*\ ]\ */scale*
 or **F**\ *lon0/lat0*\ [*/horizon*\ ]\ */width*
 
-*lon0/lat0* specify the projection center, the optional parameter *horizon*
-specifies the max distance from projection center (in degrees, < 90, default 60), and
-*scale* or *width* sets the size of the figure..
+**f** or **F** specifies the projection type, *lon0/lat0* specifies the projection
+center, the optional parameter *horizon* specifies the max distance from projection
+center (in degrees, < 90, default 60), and *scale* or *width* sets the size of the
+figure.
 """
 import pygmt
 

--- a/examples/projections/azim/azim_gnomonic.py
+++ b/examples/projections/azim/azim_gnomonic.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Gnomonic
 ========
 
@@ -10,10 +10,12 @@ distortion increases greatly with distance to the projection center. It follows
 that the scope of application is restricted to a small area around the
 projection center (at a maximum of 60°).
 
-``flon0/lat0[/horizon]/scale`` or ``Flon0/lat0[/horizon]/width``
+**f**\ *lon0/lat0*\ [*/horizon*\ ]\ */scale*
+or **F**\ *lon0/lat0*\ [*/horizon*\ ]\ */width*
 
-``lon0/lat0`` specify the projection center, the optional parameter ``horizon``
-specifies the max distance from projection center (in degrees, < 90, default 60).
+*lon0/lat0* specify the projection center, the optional parameter *horizon*
+specifies the max distance from projection center (in degrees, < 90, default 60), and
+*scale* or *width* sets the size of the figure..
 """
 import pygmt
 

--- a/examples/projections/azim/azim_lambert.py
+++ b/examples/projections/azim/azim_lambert.py
@@ -11,7 +11,7 @@ projection, and increases radially away from this point.
 or **A**\ *lon0/lat0*\ [*/horizon*\ ]\ */width*
 
 **a** or **A** specifies the projection type, and *lon0/lat0* specifies the projection
-center, ``horizon`` specifies the max distance from projection center (in degrees,
+center, *horizon* specifies the max distance from projection center (in degrees,
 <= 180, default 90), and *scale* or *width* sets the size of the figure.
 """
 import pygmt

--- a/examples/projections/azim/azim_lambert.py
+++ b/examples/projections/azim/azim_lambert.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Lambert Azimuthal Equal Area
 ============================
 
@@ -7,9 +7,12 @@ for mapping large regions like continents and hemispheres. It is an azimuthal,
 equal-area projection, but is not perspective. Distortion is zero at the center of the
 projection, and increases radially away from this point.
 
-``Alon0/lat0[/horizon]/width``: ``lon0`` and ``lat0`` specifies the projection center.
-``horizon`` specifies the max distance from projection center (in degrees, <= 180,
-default 90).
+**a**\ *lon0/lat0*\ [*/horizon*\ ]\ */scale*
+or **A**\ *lon0/lat0*\ [*/horizon*\ ]\ */width*
+
+**a** or **A** specifies the projection type, and *lon0/lat0* specifies the projection
+center, ``horizon`` specifies the max distance from projection center (in degrees,
+<= 180, default 90), and *scale* or *width* sets the size of the figure.
 """
 import pygmt
 

--- a/examples/projections/azim/azim_orthographic.py
+++ b/examples/projections/azim/azim_orthographic.py
@@ -11,9 +11,9 @@ equal-area and the distortion increases near the edges.
 **g**\ *lon0/lat0*\ [*/horizon*\ ]\ */scale*
 or **G**\ *lon0/lat0*\ [*/horizon*\ ]\ */width*
 
-**g** or **G** specifies the projection type, ``lon0/lat0`` specifies the projection
-center, the optional parameter ``horizon`` specifies the max distance from projection
-center (in degrees, <= 90, default 90)
+**g** or **G** specifies the projection type, *lon0/lat0* specifies the projection
+center, the optional parameter *horizon* specifies the max distance from projection
+center (in degrees, <= 90, default 90), and *scale* and *width* set the figure size.
 """
 import pygmt
 

--- a/examples/projections/azim/azim_orthographic.py
+++ b/examples/projections/azim/azim_orthographic.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Orthographic
 ============
 
@@ -8,10 +8,12 @@ It is therefore often used to give the appearance of a globe viewed from outer
 space, were one hemisphere can be seen as a whole. It is neither conformal nor
 equal-area and the distortion increases near the edges.
 
-``glon0/lat0[/horizon]/scale`` or ``Glon0/lat0[/horizon]/width``
+**g**\ *lon0/lat0*\ [*/horizon*\ ]\ */scale*
+or **G**\ *lon0/lat0*\ [*/horizon*\ ]\ */width*
 
-``lon0/lat0`` specifies the projection center, the optional parameter ``horizon``
-specifies the max distance from projection center (in degrees, <= 90, default 90)
+**g** or **G** specifies the projection type, ``lon0/lat0`` specifies the projection
+center, the optional parameter ``horizon`` specifies the max distance from projection
+center (in degrees, <= 90, default 90)
 """
 import pygmt
 


### PR DESCRIPTION
As discussed in #631, this is a review and update of the documentation for the azimuthal projections to accurately display the GMT arguments.