### PR TITLE
Add a gallery example for the fig.image() method

### DIFF
--- a/examples/gallery/plot/image.py
+++ b/examples/gallery/plot/image.py
@@ -16,7 +16,7 @@ import pygmt
 
 fig = pygmt.Figure()
 
-fig.basemap(region=[0, 2, 0, 2], projection="x3c", frame=True)
+fig.basemap(region=[0, 2, 0, 2], projection="X6c", frame=True)
 
 # place and center the GMT logo from the GMT website to the position 1/1
 # on a basemap and draw a rectangular border around the image

--- a/examples/gallery/plot/image.py
+++ b/examples/gallery/plot/image.py
@@ -1,0 +1,27 @@
+"""
+Images or EPS files on maps
+---------------------------
+The :meth:`pygmt.Figure.image` method can be used to read and 
+place a raster image file or an Encapsulated PostScript file
+on a map. We must specify the file as *str* via the ``imagefile`` 
+argument or simply use the filename as first argument. You can 
+also use a full URL pointing to your desired image. The ``position`` 
+argument allows us to set a reference point on the map for the image.
+
+For more advanced style options, see the full option list 
+at :gmt-docs:`image.html`.
+"""
+
+import pygmt
+
+fig = pygmt.Figure()
+
+fig.basemap(region=[0, 2, 0, 2], projection="x3c", frame=True)    
+
+# place and center the GMT logo from the GMT website to the position 1/1 
+# on a basemap and draw a rectangular border around the image
+fig.image(imagefile='https://www.generic-mapping-tools.org/_static/gmt-logo.png', 
+          position='g1/1+w1.5i+jCM',
+          box=True)
+
+fig.show()

--- a/examples/gallery/plot/image.py
+++ b/examples/gallery/plot/image.py
@@ -16,12 +16,14 @@ import pygmt
 
 fig = pygmt.Figure()
 
-fig.basemap(region=[0, 2, 0, 2], projection="x3c", frame=True)    
+fig.basemap(region=[0, 2, 0, 2], projection="x3c", frame=True)
 
-# place and center the GMT logo from the GMT website to the position 1/1 
+# place and center the GMT logo from the GMT website to the position 1/1
 # on a basemap and draw a rectangular border around the image
-fig.image(imagefile='https://www.generic-mapping-tools.org/_static/gmt-logo.png', 
-          position='g1/1+w1.5i+jCM',
-          box=True)
+fig.image(
+    imagefile="https://www.generic-mapping-tools.org/_static/gmt-logo.png",
+    position="g1/1+w1.5i+jCM",
+    box=True,
+)
 
 fig.show()

--- a/examples/gallery/plot/image.py
+++ b/examples/gallery/plot/image.py
@@ -22,7 +22,7 @@ fig.basemap(region=[0, 2, 0, 2], projection="X6c", frame=True)
 # on a basemap and draw a rectangular border around the image
 fig.image(
     imagefile="https://www.generic-mapping-tools.org/_static/gmt-logo.png",
-    position="g1/1+w1.5i+jCM",
+    position="g1/1+w3c+jCM",
     box=True,
 )
 


### PR DESCRIPTION
Here's a simple gallery example that shows how to use the fig.image() method. As input I used the GMT logo from the main webpage, hope that's fine.