### PR TITLE
Clean up docstring in projections/README.txt

### DIFF
--- a/examples/projections/README.txt
+++ b/examples/projections/README.txt
@@ -4,7 +4,7 @@ Projections
 PyGMT support many map projections. Use the ``projection`` argument to specify which one
 you want to use in all plotting modules. The projection is specified by a one letter
 code along with (sometimes optional) reference longitude and latitude and the width of
-the map (for example, ``Alon0/lat0[/horizon]/width``). The map height is determined
-based on the region and projection.
+the map (for example, **A**\ *lon0/lat0*\ [*/horizon*\ ]\ */width*). The map height is
+determined based on the region and projection.
 
 These are all the available projections:


### PR DESCRIPTION
Made a change to the README for the projections gallery to keep the GMT arguments in line with the discussion in #631.