### PR TITLE
Create gallery example for datetime inputs

### DIFF
--- a/examples/gallery/plot/datetime-inputs.py
+++ b/examples/gallery/plot/datetime-inputs.py
@@ -10,7 +10,7 @@ The :meth:`pygmt.Figure.plot` method can plot datetime inputs of individual type
 - raw datetime strings in ISO format (e.g. ``["YYYY-MM-DD", "YYYY-MM-DDTHH", "YYYY-MM-DDTHH:MM:SS"]``)
 - Python built-in :class:`datetime.datetime` and :class:`datetime.date`
 
-We can pass datetime inputs based on one of the types listed above directly to the ``x`` and ``y`` options.
+We can pass datetime inputs based on one of the types listed above directly to the ``x`` and ``y`` arguments.
  
 The ``region`` argument has to include the :math:`x` and :math:`y` axis limits as *str* in the form 
 ``"date_min/data_max/ymin/ymax"``.

--- a/examples/gallery/plot/datetime-inputs.py
+++ b/examples/gallery/plot/datetime-inputs.py
@@ -29,7 +29,7 @@ fig = pygmt.Figure()
 
 # create a basemap with limits of 2010-01-01 to 2020-06-01 on the x axis and
 # 0 to 10 on the y axis
-fig.basemap(projection="X15c/5c", region="2010-01-01/2020-06-01/0/10", frame=True)
+fig.basemap(projection="X15c/5c", region="2010-01-01/2020-06-01/0/10", frame=["WSen", "af"])
 
 # numpy.datetime64 types
 x = np.array(["2010-06-01", "2011-06-01T12", "2012-01-01T12:34:56"], dtype="datetime64")

--- a/examples/gallery/plot/datetime-inputs.py
+++ b/examples/gallery/plot/datetime-inputs.py
@@ -7,7 +7,7 @@ Datetime inputs of the following types are supported in PyGMT:
 - :class:`numpy.datetime64`
 - :class:`pandas.DatetimeIndex`
 - :class:`xarray.DataArray`: datetimes included in a *xarray.DataArray*
-- raw datetime strings in ISO format (e.g. ``["YYYY-MM-DD", "YYYY-MM-DDTHH", "YYYY-MM-DDTHH:MM:SS"]``)
+- raw datetime strings in `ISO format <https://en.wikipedia.org/wiki/ISO_8601>`__  (e.g. ``"YYYY-MM-DD"``, ``"YYYY-MM-DDTHH"``, and ``"YYYY-MM-DDTHH:MM:SS"``)
 - Python built-in :class:`datetime.datetime` and :class:`datetime.date`
 
 We can pass datetime inputs based on one of the types listed above directly to the ``x`` and ``y`` arguments

--- a/examples/gallery/plot/datetime-inputs.py
+++ b/examples/gallery/plot/datetime-inputs.py
@@ -1,0 +1,58 @@
+"""
+Datetime inputs
+---------------
+
+The :meth:`pygmt.Figure.plot` method can plot datetime inputs of individual types:
+
+- numpy.datetime64: for available options see https://numpy.org/doc/stable/reference/arrays.datetime.html
+- :class:`pandas.DatetimeIndex`
+- :class:`xarray.DataArray`: datetimes included in a *xarray.DataArray*
+- raw datetime strings in ISO format (e.g. ``["YYYY-MM-DD", "YYYY-MM-DDTHH", "YYYY-MM-DDTHH:MM:SS"]``)
+- Python built-in :class:`datetime.datetime` and :class:`datetime.date`
+
+We can pass datetime inputs based on one of the types listed above directly to the ``x`` and ``y`` options.
+ 
+The ``region`` argument has to include the :math:`x` and :math:`y` axis limits as *str* in the form 
+``"date_min/data_max/ymin/ymax"``.
+
+"""
+
+import datetime
+import numpy as np
+import pandas as pd
+import xarray as xr
+import pygmt
+
+fig = pygmt.Figure()
+
+# create a basemap with limits of 2010-01-01 to 2020-06-01 on the x axis and
+# 0 to 10 on the y axis
+fig.basemap(projection="X15c/5c", region="2010-01-01/2020-06-01/0/10", frame=True)
+
+# numpy.datetime64 types
+x = np.array(
+    ["2010-06-01", "2011-06-01T12", "2012-01-01T12:34:56"], dtype="datetime64")
+y = [1, 2, 3]
+fig.plot(x, y, style="c0.4c", pen="1p", color="red3")
+
+# pandas.DatetimeIndex
+x = pd.date_range("2013", periods=3, freq="YS")
+y = [4, 5, 6]
+fig.plot(x, y, style="t0.4c", pen="1p", color="gold")
+
+# xarray.DataArray
+x = xr.DataArray(data=pd.date_range(start="2015-03", periods=3, freq="QS"))
+y = [7.5, 6, 4.5]
+fig.plot(x, y, style="s0.4c", pen="1p")
+
+# raw datetime strings
+x = ["2016-02-01", "2016-06-04T14", "2016-10-04T00:00:15"]
+y = [7, 8, 9]
+fig.plot(x, y, style="a0.4c", pen="1p", color="dodgerblue")
+
+# the Python built-in datetime and date
+x = [datetime.date(2018, 1, 1), datetime.datetime(2019, 6, 1, 20, 5, 45)]
+y = [6.5, 4.5]
+fig.plot(x, y, style="i0.4c", pen="1p", color="seagreen")
+
+fig.show()

--- a/examples/gallery/plot/datetime-inputs.py
+++ b/examples/gallery/plot/datetime-inputs.py
@@ -4,7 +4,7 @@ Datetime inputs
 
 The :meth:`pygmt.Figure.plot` method can plot datetime inputs of individual types:
 
-- numpy.datetime64: for available options see https://numpy.org/doc/stable/reference/arrays.datetime.html
+- :class:`numpy.datetime64`
 - :class:`pandas.DatetimeIndex`
 - :class:`xarray.DataArray`: datetimes included in a *xarray.DataArray*
 - raw datetime strings in ISO format (e.g. ``["YYYY-MM-DD", "YYYY-MM-DDTHH", "YYYY-MM-DDTHH:MM:SS"]``)

--- a/examples/gallery/plot/datetime-inputs.py
+++ b/examples/gallery/plot/datetime-inputs.py
@@ -14,7 +14,7 @@ We can pass datetime inputs based on one of the types listed above directly to t
 of e.g. the :meth:`pygmt.Figure.plot` method:
 
 The ``region`` argument has to include the :math:`x` and :math:`y` axis limits as *str* in the form 
-``"date_min/date_max/ymin/ymax"``.
+*date_min/date_max/ymin/ymax*.
 
 """
 

--- a/examples/gallery/plot/datetime-inputs.py
+++ b/examples/gallery/plot/datetime-inputs.py
@@ -2,7 +2,7 @@
 Datetime inputs
 ---------------
 
-The :meth:`pygmt.Figure.plot` method can plot datetime inputs of individual types:
+Datetime inputs of the following types are supported in PyGMT:
 
 - :class:`numpy.datetime64`
 - :class:`pandas.DatetimeIndex`
@@ -10,10 +10,11 @@ The :meth:`pygmt.Figure.plot` method can plot datetime inputs of individual type
 - raw datetime strings in ISO format (e.g. ``["YYYY-MM-DD", "YYYY-MM-DDTHH", "YYYY-MM-DDTHH:MM:SS"]``)
 - Python built-in :class:`datetime.datetime` and :class:`datetime.date`
 
-We can pass datetime inputs based on one of the types listed above directly to the ``x`` and ``y`` arguments.
- 
+We can pass datetime inputs based on one of the types listed above directly to the ``x`` and ``y`` arguments
+of e.g. the :meth:`pygmt.Figure.plot` method:
+
 The ``region`` argument has to include the :math:`x` and :math:`y` axis limits as *str* in the form 
-``"date_min/data_max/ymin/ymax"``.
+``"date_min/date_max/ymin/ymax"``.
 
 """
 

--- a/examples/gallery/plot/datetime-inputs.py
+++ b/examples/gallery/plot/datetime-inputs.py
@@ -29,7 +29,9 @@ fig = pygmt.Figure()
 
 # create a basemap with limits of 2010-01-01 to 2020-06-01 on the x axis and
 # 0 to 10 on the y axis
-fig.basemap(projection="X15c/5c", region="2010-01-01/2020-06-01/0/10", frame=["WSen", "af"])
+fig.basemap(
+    projection="X15c/5c", region="2010-01-01/2020-06-01/0/10", frame=["WSen", "af"]
+)
 
 # numpy.datetime64 types
 x = np.array(["2010-06-01", "2011-06-01T12", "2012-01-01T12:34:56"], dtype="datetime64")

--- a/examples/gallery/plot/datetime-inputs.py
+++ b/examples/gallery/plot/datetime-inputs.py
@@ -18,10 +18,11 @@ The ``region`` argument has to include the :math:`x` and :math:`y` axis limits a
 """
 
 import datetime
+
 import numpy as np
 import pandas as pd
-import xarray as xr
 import pygmt
+import xarray as xr
 
 fig = pygmt.Figure()
 
@@ -30,8 +31,7 @@ fig = pygmt.Figure()
 fig.basemap(projection="X15c/5c", region="2010-01-01/2020-06-01/0/10", frame=True)
 
 # numpy.datetime64 types
-x = np.array(
-    ["2010-06-01", "2011-06-01T12", "2012-01-01T12:34:56"], dtype="datetime64")
+x = np.array(["2010-06-01", "2011-06-01T12", "2012-01-01T12:34:56"], dtype="datetime64")
 y = [1, 2, 3]
 fig.plot(x, y, style="c0.4c", pen="1p", color="red3")
 


### PR DESCRIPTION
Based on #464 and #549 I prepared a gallery example for plotting datetime inputs which includes:

- numpy.datetime64
- pandas.DateTimeIndex
- xarray.DataArray with 'datetime64' dtype
- Raw datetime strings in ISO format
- Python's built-in datetime and date