### PR TITLE
Update GMT argument in the conic projections gallery to doc standards

### DIFF
--- a/examples/projections/conic/conic_albers.py
+++ b/examples/projections/conic/conic_albers.py
@@ -11,8 +11,12 @@ right angles. Distortion in scale and shape vanishes along the two standard para
 Between them, the scale along parallels is too small; beyond them it is too large.
 The opposite is true for the scale along meridians.
 
-``Blon0/lat0/lat1/lat2/width``: Give projection center ``lon0/lat0`` and two standard
-parallels ``lat1/lat2``.
+**b**\ *lon0/lat0*\ /\ *lat1/lat2*\ */scale*
+or **B**\ *lon0/lat0*\ /\ *lat1/lat2*\ */width*``
+
+The projection is set with **b** or **B**. The projection center is set by *lon0/lat0*
+and two standard parallels for the map are set with *lat1/lat2*. The figure size is set
+with *scale* or *width*.
 """
 import pygmt
 

--- a/examples/projections/conic/conic_albers.py
+++ b/examples/projections/conic/conic_albers.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Albers Conic Equal Area
 =======================
 

--- a/examples/projections/conic/conic_albers.py
+++ b/examples/projections/conic/conic_albers.py
@@ -12,7 +12,7 @@ Between them, the scale along parallels is too small; beyond them it is too larg
 The opposite is true for the scale along meridians.
 
 **b**\ *lon0/lat0*\ /\ *lat1/lat2*\ */scale*
-or **B**\ *lon0/lat0*\ /\ *lat1/lat2*\ */width*``
+or **B**\ *lon0/lat0*\ /\ *lat1/lat2*\ */width*
 
 The projection is set with **b** or **B**. The projection center is set by *lon0/lat0*
 and two standard parallels for the map are set with *lat1/lat2*. The figure size is set

--- a/examples/projections/conic/conic_equidistant.py
+++ b/examples/projections/conic/conic_equidistant.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Equidistant conic
 =================
 

--- a/examples/projections/conic/conic_equidistant.py
+++ b/examples/projections/conic/conic_equidistant.py
@@ -7,8 +7,12 @@ Ptolemy about A.D. 150. It is neither conformal or equal-area, but serves as a
 compromise between them. The scale is true along all meridians and the
 standard parallels.
 
-``Dlon0/lat0/lat1/lat2/width``: Give projection center ``lon0/lat0``, two standard
-parallels ``lat1/lat2``, and the map width.
+**d**\ *lon0/lat0*\ /\ *lat1/lat2*\ */scale*
+or **D**\ *lon0/lat0*\ /\ *lat1/lat2*\ */width*
+
+The projection is set with **d** or **D**. The projection center is set by *lon0/lat0*
+and two standard parallels for the map are set with *lat1/lat2*. The figure size is set
+with *scale* or *width*.
 """
 import pygmt
 

--- a/examples/projections/conic/conic_lambert.py
+++ b/examples/projections/conic/conic_lambert.py
@@ -9,8 +9,12 @@ Lambert’s conformal projection is not equal-area. The parallels are arcs of ci
 with a common origin, and meridians are the equally spaced radii of these circles. As
 with Albers projection, it is only the two standard parallels that are distortion-free.
 
-``Llon0/lat0/lat1/lat2/width``: Give projection center ``lon0/lat0``, two standard
-parallels ``lat1/lat2``, and the map width.
+**l**\ *lon0/lat0*\ /\ *lat1/lat2*\ */scale*
+or **L**\ *lon0/lat0*\ /\ *lat1/lat2*\ */width*
+
+The projection is set with **l** or **L**. The projection center is set by *lon0/lat0*
+and two standard parallels for the map are set with *lat1/lat2*. The figure size is set
+with *scale* or *width*.
 """
 import pygmt
 

--- a/examples/projections/conic/conic_lambert.py
+++ b/examples/projections/conic/conic_lambert.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Lambert Conic Conformal Projection
 ==================================
 

--- a/examples/projections/conic/polyconic.py
+++ b/examples/projections/conic/polyconic.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Polyconic Projection
 ====================
 

--- a/examples/projections/conic/polyconic.py
+++ b/examples/projections/conic/polyconic.py
@@ -18,7 +18,10 @@ but the meridians are not as they get further away from the central meridian. As
 consequence, no parallel is standard because conformity is lost with the lengthening of
 the meridians.
 
-``Poly/width``:  The only additional argument for the projection is the map width.
+**poly**\ */scale* or **Poly**\ */width*
+
+The projection is set with **poly** or **Poly**. The figure size is set
+with *scale* or *width*.
 """
 import pygmt
 

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -37,23 +37,49 @@ def test_coast_iceland():
     return fig_ref, fig_test
 
 
-@pytest.mark.mpl_image_compare
+@check_figures_equal()
 def test_coast_aliases():
     "Test that all aliases work"
-    fig = Figure()
-    fig.coast(
-        region="-30/30/-40/40",
-        projection="m0.1i",
-        frame="afg",
-        rivers="1/1p,black",
-        borders="1/0.5p,-",
-        shorelines="0.25p,white",
-        land="moccasin",
-        water="skyblue",
-        resolution="i",
-        area_thresh=1000,
+    fig_ref, fig_test = Figure(), Figure()
+    fig_ref.coast(
+        R="-30/30/-40/40",
+        J="M25c",
+        B="afg",
+        I="1/1p,black",
+        N="1/0.5p,-",
+        W="0.25p,white",
+        G="moccasin",
+        S="skyblue",
+        D="i",
+        A=1000,
+        L="jMM+c1+w1000k+f+l",
+        U=True,
+        V="q",
+        X="a4c",
+        Y="a10c",
+        p="135/25",
+        t=13,
     )
-    return fig
+    fig_test.coast(
+        region=[-30, 30, -40, 40],  # R
+        projection="M25c",  # J
+        frame="afg",  # B
+        rivers="1/1p,black",  # I
+        borders="1/0.5p,-",  # N
+        shorelines="0.25p,white",  # W
+        land="moccasin",  # G
+        water="skyblue",  # S
+        resolution="i",  # D
+        area_thresh=1000,  # A
+        map_scale="jMM+c1+w1000k+f+l",  # L
+        timestamp=True,  # U
+        verbose="q",  # V
+        xshift="a4c",  # X
+        yshift="a10c",  # Y
+        perspective=[135, 25],  # p
+        transparency=13,  # t
+    )
+    return fig_ref, fig_test
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -54,7 +54,6 @@ def test_coast_aliases():
         A=1000,
         L="jCM+c1+w1000k+f+l",
         U=True,
-        V="q",
         X="a4c",
         Y="a10c",
         p="135/25",
@@ -73,7 +72,6 @@ def test_coast_aliases():
         area_thresh=1000,  # A
         map_scale="jCM+c1+w1000k+f+l",  # L
         timestamp=True,  # U
-        verbose="q",  # V
         xshift="a4c",  # X
         yshift="a10c",  # Y
         perspective=[135, 25],  # p

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -52,7 +52,7 @@ def test_coast_aliases():
         S="skyblue",
         D="i",
         A=1000,
-        L="jMM+c1+w1000k+f+l",
+        L="jCM+c1+w1000k+f+l",
         U=True,
         V="q",
         X="a4c",
@@ -71,7 +71,7 @@ def test_coast_aliases():
         water="skyblue",  # S
         resolution="i",  # D
         area_thresh=1000,  # A
-        map_scale="jMM+c1+w1000k+f+l",  # L
+        map_scale="jCM+c1+w1000k+f+l",  # L
         timestamp=True,  # U
         verbose="q",  # V
         xshift="a4c",  # X


### PR DESCRIPTION
As discussed in #631, this is a review and update of the documentation for the conic projections to accurately display the GMT arguments.