### PR TITLE
Add GMTInvalidInput Error for Figure.coast

### DIFF
--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -16,6 +16,7 @@ from pygmt.helpers import (
     is_nonstr_iter,
     kwargs_to_strings,
     use_alias,
+    args_in_kwargs
 )
 
 
@@ -147,7 +148,7 @@ class BasePlotting:
 
         """
         kwargs = self._preprocess(**kwargs)
-        if not any(arg in kwargs for arg in ["C", "G", "S", "I", "N", "Q", "W"]):
+        if not args_in_kwargs(args=["C", "G", "S", "I", "N", "Q", "W"], kwargs=kwargs):
             raise GMTInvalidInput(
                 """At least one of the following arguments must be specified:
                 C, land, water, rivers, borders, Q, or shorelines"""

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -141,15 +141,7 @@ class BasePlotting:
 
         """
         kwargs = self._preprocess(**kwargs)
-        if not (
-            "C" in kwargs
-            or "G" in kwargs
-            or "S" in kwargs
-            or "I" in kwargs
-            or "N" in kwargs
-            or "Q" in kwargs
-            or "W" in kwargs
-        ):
+        if not any(arg in kwargs for arg in ["C", "G", "S", "I", "N", "Q", "W"]):
             raise GMTInvalidInput(
                 """At least one of the following arguments must be specified:
                 C, land, water, rivers, borders, Q, or shorelines"""

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -9,6 +9,7 @@ import pandas as pd
 from pygmt.clib import Session
 from pygmt.exceptions import GMTError, GMTInvalidInput
 from pygmt.helpers import (
+    args_in_kwargs,
     build_arg_string,
     data_kind,
     dummy_context,
@@ -16,7 +17,6 @@ from pygmt.helpers import (
     is_nonstr_iter,
     kwargs_to_strings,
     use_alias,
-    args_in_kwargs
 )
 
 

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -151,8 +151,8 @@ class BasePlotting:
             or "W" in kwargs
         ):
             raise GMTInvalidInput(
-                """At least one of the following arguments must be specified: C, land, 
-                water, rivers, borders, Q, or shorelines"""
+                """At least one of the following arguments must be specified:
+                C, land, water, rivers, borders, Q, or shorelines"""
             )
         with Session() as lib:
             lib.call_module("coast", build_arg_string(kwargs))

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -151,7 +151,7 @@ class BasePlotting:
         if not args_in_kwargs(args=["C", "G", "S", "I", "N", "Q", "W"], kwargs=kwargs):
             raise GMTInvalidInput(
                 """At least one of the following arguments must be specified:
-                C, land, water, rivers, borders, Q, or shorelines"""
+                lakes, land, water, rivers, borders, Q, or shorelines"""
             )
         with Session() as lib:
             lib.call_module("coast", build_arg_string(kwargs))

--- a/pygmt/base_plotting.py
+++ b/pygmt/base_plotting.py
@@ -141,6 +141,19 @@ class BasePlotting:
 
         """
         kwargs = self._preprocess(**kwargs)
+        if not (
+            "C" in kwargs
+            or "G" in kwargs
+            or "S" in kwargs
+            or "I" in kwargs
+            or "N" in kwargs
+            or "Q" in kwargs
+            or "W" in kwargs
+        ):
+            raise GMTInvalidInput(
+                """At least one of the following arguments must be specified: C, land, 
+                water, rivers, borders, Q, or shorelines"""
+            )
         with Session() as lib:
             lib.call_module("coast", build_arg_string(kwargs))
 

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -103,7 +103,7 @@ def test_coast_required_args():
     fig = Figure()
     with pytest.raises(GMTInvalidInput):
         fig.coast(region="EG")
-        
+
 
 @check_figures_equal()
 def test_coast_dcw_single():

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -93,6 +93,7 @@ def test_coast_world_mercator():
     )
     return fig
 
+
 def test_coast_required_args():
     "Test if fig.coast fails when not given required arguments"
     fig = Figure()

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -3,6 +3,7 @@ Tests for coast
 """
 import pytest
 from pygmt import Figure
+from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers.testing import check_figures_equal
 
 
@@ -91,3 +92,9 @@ def test_coast_world_mercator():
         water="white",
     )
     return fig
+
+def test_coast_required_args():
+    "Test if fig.coast fails when not given required arguments"
+    fig = Figure()
+    with pytest.raises(GMTInvalidInput):
+        fig.coast(region="EG")


### PR DESCRIPTION
Currently, Figure.coast returns a GMTCLibError if the required arguments are not included. The error lists the GMT argument names instead of the PyGMT argument names. I added an if statement that will raise a GMTInvalidInput Error if the conditions aren't met and a test.

I left ~~`C` and~~ `Q` as is because they do not have an alias on the PyGMT master branch yet.