### PR TITLE
Update GMT argument in the cylindric projections gallery to doc standards

### DIFF
--- a/examples/projections/cyl/cyl_cassini.py
+++ b/examples/projections/cyl/cyl_cassini.py
@@ -11,7 +11,10 @@ meridian. It is best suited for mapping regions of north-south extent. The centr
 meridian, each meridian 90° away, and equator are straight lines; all other meridians
 and parallels are complex curves.
 
-``Clon0/lat0/width``: ``lon0`` and ``lat0`` specifies the projection center.
+**c**\ *lon0/lat0*\ */scale* or **C**\ *lon0/lat0*\ */width*
+
+The projection is set with **c** or **C**. The projection center is set by *lon0/lat0*,
+and the figure size is set with *scale* or *width*.
 """
 import pygmt
 

--- a/examples/projections/cyl/cyl_equal_area.py
+++ b/examples/projections/cyl/cyl_equal_area.py
@@ -6,8 +6,10 @@ This cylindrical projection is actually several projections, depending on what
 latitude is selected as the standard parallel. However, they are all equal area and
 hence non-conformal. All meridians and parallels are straight lines.
 
-``Ylon0/lat0/width``: Give central meridian ``lon0``, the standard parallel ``lat0``,
-and the figure ``width``.
+**y**\ *lon0/lat0*\ */scale* or **Y**\ *lon0/lat0*\ */width*
+
+The projection is set with **y** or **Y**. The projection center is set by *lon0/lat0*,
+and the figure size is set with *scale* or *width*.
 """
 import pygmt
 

--- a/examples/projections/cyl/cyl_equidistant.py
+++ b/examples/projections/cyl/cyl_equidistant.py
@@ -6,7 +6,10 @@ This simple cylindrical projection is really a linear scaling of longitudes and
 latitudes. The most common form is the Plate Carrée projection, where the scaling of
 longitudes and latitudes is the same. All meridians and parallels are straight lines.
 
-``Qwidth``: Give the figure ``width``.
+**q**\ */scale* or **Q**\ */width*
+
+The projection is set with **q** or **Q**, and the figure size is set
+with *scale* or *width*.
 """
 import pygmt
 

--- a/examples/projections/cyl/cyl_equidistant.py
+++ b/examples/projections/cyl/cyl_equidistant.py
@@ -6,7 +6,7 @@ This simple cylindrical projection is really a linear scaling of longitudes and
 latitudes. The most common form is the Plate Carrée projection, where the scaling of
 longitudes and latitudes is the same. All meridians and parallels are straight lines.
 
-**q**\ */scale* or **Q**\ */width*
+**q**\ *scale* or **Q**\ *width*
 
 The projection is set with **q** or **Q**, and the figure size is set
 with *scale* or *width*.

--- a/examples/projections/cyl/cyl_mercator.py
+++ b/examples/projections/cyl/cyl_mercator.py
@@ -12,8 +12,11 @@ keep this constant course for the entire voyage. The Mercator projection has bee
 extensively for world maps in which the distortion towards the polar regions grows
 rather large.
 
-``M[lon0/][lat0/]width``: Give central meridian ``lon0`` (optional) and
-standard parallel ``lat0`` (optional).
+**m**\ [*lon0[/lat0]*]\ */scale* or **M**\ [*lon0*][*/lat0*]\ */width*
+
+The projection is set with **m** or **M**. The central meridian is set with the
+option *lon0* and the standard parallel is set with the option *lat0*.
+The figure size is set with *scale* or *width*.
 """
 import pygmt
 

--- a/examples/projections/cyl/cyl_miller.py
+++ b/examples/projections/cyl/cyl_miller.py
@@ -11,7 +11,7 @@ singular poles; the result was then divided by 0.8.
 
 **j**\ [*lon0/*]\ */scale* or **J**\ [*lon0/*]\ */width*
 
-The projection is set with **y** or **Y**. The central meridian is set by the
+The projection is set with **j** or **J**. The central meridian is set by the
 optional *lon0*, and the figure size is set with *scale* or *width*.
 """
 import pygmt

--- a/examples/projections/cyl/cyl_miller.py
+++ b/examples/projections/cyl/cyl_miller.py
@@ -9,7 +9,10 @@ Mercator and other cylindrical projections. Specifically, Miller spaced the para
 by using Mercator’s formula with 0.8 times the actual latitude, thus avoiding the
 singular poles; the result was then divided by 0.8.
 
-``J[lon0/]width``: Give the optional central meridian ``lon0`` and the figure ``width``.
+**j**\ [*lon0/*]\ */scale* or **J**\ [*lon0/*]\ */width*
+
+The projection is set with **y** or **Y**. The central meridian is set by the
+optional *lon0*, and the figure size is set with *scale* or *width*.
 """
 import pygmt
 

--- a/examples/projections/cyl/cyl_stereographic.py
+++ b/examples/projections/cyl/cyl_stereographic.py
@@ -10,8 +10,8 @@ perspective projections, projecting the sphere onto a cylinder in the direction 
 antipodal point on the equator. The cylinder crosses the sphere at two standard
 parallels, equidistant from the equator.
 
-**cyl_stere/**\ [*lon0/*]\ [*lat0/*]*\ *scale*
-or **Cyl_stere/**\ [*lon0/*]\ [*lat0/*]*\ *width*
+**cyl_stere/**\ [*lon0/*]\ [*lat0/*]\ *scale*
+or **Cyl_stere/**\ [*lon0/*]\ [*lat0/*]\ *width*
 The projection is set with **cyl_stere** or **Cyl_stere**. The central meridian is set
 by the optional *lon0*, and the figure size is set with *scale* or *width*.
 

--- a/examples/projections/cyl/cyl_stereographic.py
+++ b/examples/projections/cyl/cyl_stereographic.py
@@ -10,9 +10,12 @@ perspective projections, projecting the sphere onto a cylinder in the direction 
 antipodal point on the equator. The cylinder crosses the sphere at two standard
 parallels, equidistant from the equator.
 
-``Cyl_stere/[lon0/][lat0/]width``: Give central meridian ``lon0`` (optional) and
-standard parallel ``lat0`` (optional). The standard parallel is typically one of these
-(but can be any value):
+**cyl_stere/**\ [*lon0/*]\ [*lat0/*]*\ *scale*
+or **Cyl_stere/**\ [*lon0/*]\ [*lat0/*]*\ *width*
+The projection is set with **cyl_stere** or **Cyl_stere**. The central meridian is set
+by the optional *lon0*, and the figure size is set with *scale* or *width*.
+
+The standard parallel is typically one of these (but can be any value):
 
 * 66.159467 - Miller's modified Gall
 * 55 - Kamenetskiy's First

--- a/examples/projections/cyl/cyl_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_transverse_mercator.py
@@ -10,7 +10,7 @@ straight lines; other parallels and meridians are complex curves.
 
 **t**\ *lon0/*\ [*lat0/*\ ]\ *scale*or **T**\ *lon0/*\ [*lat0/*\ ]\ *width*
 
-The projection is set with **cyl_stere** or **Cyl_stere**. The central meridian is set
+The projection is set with **t** or **T**. The central meridian is set
 by  *lon0*, the latitude of the origin is set by the optional *lat0*, and the figure
 size is set with *scale* or *width*.
 """

--- a/examples/projections/cyl/cyl_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_transverse_mercator.py
@@ -8,8 +8,11 @@ distortion increases away from the central meridian and goes to infinity at 90°
 center. The central meridian, each meridian 90° away from the center, and equator are
 straight lines; other parallels and meridians are complex curves.
 
-``T[lon0/][lat0/]width``: Give central meridian ``lon0``, the latitude of the
-origin ``lat0`` (optional), and the figure width.
+**t**\ *lon0/*\ [*lat0/*\ ]\ *scale*or **T**\ *lon0/*\ [*lat0/*\ ]\ *width*
+
+The projection is set with **cyl_stere** or **Cyl_stere**. The central meridian is set
+by  *lon0*, the latitude of the origin is set by the optional *lat0*, and the figure
+size is set with *scale* or *width*.
 """
 import pygmt
 

--- a/examples/projections/cyl/cyl_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_transverse_mercator.py
@@ -8,7 +8,7 @@ distortion increases away from the central meridian and goes to infinity at 90°
 center. The central meridian, each meridian 90° away from the center, and equator are
 straight lines; other parallels and meridians are complex curves.
 
-**t**\ *lon0/*\ [*lat0/*\ ]\ *scale*or **T**\ *lon0/*\ [*lat0/*\ ]\ *width*
+**t**\ *lon0/*\ [*lat0/*\ ]\ *scale* or **T**\ *lon0/*\ [*lat0/*\ ]\ *width*
 
 The projection is set with **t** or **T**. The central meridian is set
 by  *lon0*, the latitude of the origin is set by the optional *lat0*, and the figure

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -14,7 +14,7 @@ not a tangent projection like the transverse Mercator above. The scale only vari
 1 part in 1,000 from true scale at equator. The ellipsoidal projection expressions are
 accurate for map areas that extend less than 10 away from the central meridian.
 
-**u**\ *UTM Zone/scale* or **U**\ *UTM Zone/width*
+**u**\ *zone/scale* or **U**\ *zone/width*
 
 the projection is set with *u* or *U*. *UTM Zone* sets the zone for the figure, and
 the figure size is set wtih *scale* or *width*.

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -14,7 +14,10 @@ not a tangent projection like the transverse Mercator above. The scale only vari
 1 part in 1,000 from true scale at equator. The ellipsoidal projection expressions are
 accurate for map areas that extend less than 10 away from the central meridian.
 
-``U[UTM Zone/][lat0/]width``: Give UTM Zone ``UTM Zone``, and the figure width.
+**u**\ *UTM Zone/scale* or **U**\ *UTM Zone/width*
+
+the projection is set with *u* or *U*. *UTM Zone* sets the zone for the figure, and
+the figure size is set wtih *scale* or *width*.
 """
 import pygmt
 

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -16,7 +16,7 @@ accurate for map areas that extend less than 10 away from the central meridian.
 
 **u**\ *zone/scale* or **U**\ *zone/width*
 
-the projection is set with *u* or *U*. *zone* sets the zone for the figure, and
+the projection is set with **u** or **U**. *zone* sets the zone for the figure, and
 the figure size is set wtih *scale* or *width*.
 """
 import pygmt

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -16,7 +16,7 @@ accurate for map areas that extend less than 10 away from the central meridian.
 
 **u**\ *zone/scale* or **U**\ *zone/width*
 
-the projection is set with *u* or *U*. *UTM Zone* sets the zone for the figure, and
+the projection is set with *u* or *U*. *zone* sets the zone for the figure, and
 the figure size is set wtih *scale* or *width*.
 """
 import pygmt


### PR DESCRIPTION
As discussed in #631, this is a review and update of the documentation for the cylindric projections to accurately display the GMT arguments.