### PR TITLE
Add args_in_kwargs function

### DIFF
--- a/pygmt/helpers/__init__.py
+++ b/pygmt/helpers/__init__.py
@@ -9,4 +9,5 @@ from pygmt.helpers.utils import (
     dummy_context,
     is_nonstr_iter,
     launch_external_viewer,
+    args_in_kwargs
 )

--- a/pygmt/helpers/__init__.py
+++ b/pygmt/helpers/__init__.py
@@ -4,10 +4,10 @@ Functions, classes, decorators, and context managers to help wrap GMT modules.
 from pygmt.helpers.decorators import fmt_docstring, kwargs_to_strings, use_alias
 from pygmt.helpers.tempfile import GMTTempFile, unique_name
 from pygmt.helpers.utils import (
+    args_in_kwargs,
     build_arg_string,
     data_kind,
     dummy_context,
     is_nonstr_iter,
     launch_external_viewer,
-    args_in_kwargs
 )

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -224,21 +224,21 @@ def launch_external_viewer(fname):
 
 def args_in_kwargs(args, kwargs):
     """
-     Take a list and a dictionary, and determine if any entries in the list are
-     keys in the dictionary.
+    Take a list and a dictionary, and determine if any entries in the list are
+    keys in the dictionary.
 
-     This function is used to determine if at least one of the required arguments is
-     passed to raise a GMTInvalidInput Error.
+    This function is used to determine if at least one of the required arguments is
+    passed to raise a GMTInvalidInput Error.
 
-     Parameters
-     ----------
-     args : list
-         List of required arguments, using the GMT short-form aliases.
+    Parameters
+    ----------
+    args : list
+        List of required arguments, using the GMT short-form aliases.
 
-     kwargs : dict
-         The dictionary of kwargs is the format returned by the _preprocess
-         function of the BasePlotting class. The keys are the GMT
-         short-form aliases of the parameters.
+    kwargs : dict
+        The dictionary of kwargs is the format returned by the _preprocess
+        function of the BasePlotting class. The keys are the GMT
+        short-form aliases of the parameters.
 
     Returns
     --------

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -237,7 +237,7 @@ def args_in_kwargs(args, kwargs):
 
     kwargs : dict
         The dictionary of kwargs is the  format returned by the _preprocess
-        function in BasePlotting in base_plotting.py. The keys are the GMT
+        function of the BasePlotting class. The keys are the GMT
         short-form aliases of the parameters.
 
    Returns

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -236,7 +236,7 @@ def args_in_kwargs(args, kwargs):
         List of required arguments, using the GMT short-form aliases.
 
     kwargs : dict
-        The dictionary of kwargs is the  format returned by the _preprocess
+        The dictionary of kwargs is the format returned by the _preprocess
         function of the BasePlotting class. The keys are the GMT
         short-form aliases of the parameters.
 

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -222,6 +222,23 @@ def launch_external_viewer(fname):
         webbrowser.open_new_tab("file://{}".format(fname))
 
 def args_in_kwargs(args, kwargs):
+    """
+    Take a list and a dictionary, and determine if any entries in the list are
+    keys in the dictionary.
+
+    This function is used to determine if one of the required arguments is
+    passed to raise a GMTInvalidInput Error.
+
+    Parameters
+    ----------
+    args : list
+        List of required arguments, using the GMT short aliases.
+
+    kwargs : dict
+        The dictionary of kwargs is the  format returned by the _preprocess
+        function in BasePlotting in base_plotting.py. The keys are the GMT
+        short aliases of the parameters.
+    """
     for arg in args:
         if arg in list(kwargs.keys()):
             return True

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -233,7 +233,7 @@ def args_in_kwargs(args, kwargs):
     Parameters
     ----------
     args : list
-        List of required arguments, using the GMT short aliases.
+        List of required arguments, using the GMT short-form aliases.
 
     kwargs : dict
         The dictionary of kwargs is the  format returned by the _preprocess

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -221,6 +221,7 @@ def launch_external_viewer(fname):
     else:
         webbrowser.open_new_tab("file://{}".format(fname))
 
+
 def args_in_kwargs(args, kwargs):
     """
     Take a list and a dictionary, and determine if any entries in the list are
@@ -238,6 +239,7 @@ def args_in_kwargs(args, kwargs):
         The dictionary of kwargs is the  format returned by the _preprocess
         function in BasePlotting in base_plotting.py. The keys are the GMT
         short aliases of the parameters.
+
     """
     for arg in args:
         if arg in list(kwargs.keys()):

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -243,6 +243,6 @@ def args_in_kwargs(args, kwargs):
     Returns
     --------
     bool
-        If one of the required arguments is in `kwargs`.
+        If one of the required arguments is in ``kwargs``.
     """
     return any(arg in kwargs for arg in args)

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -227,7 +227,7 @@ def args_in_kwargs(args, kwargs):
     Take a list and a dictionary, and determine if any entries in the list are
     keys in the dictionary.
 
-    This function is used to determine if one of the required arguments is
+    This function is used to determine if at least one of the required arguments is
     passed to raise a GMTInvalidInput Error.
 
     Parameters

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -238,7 +238,7 @@ def args_in_kwargs(args, kwargs):
     kwargs : dict
         The dictionary of kwargs is the  format returned by the _preprocess
         function in BasePlotting in base_plotting.py. The keys are the GMT
-        short aliases of the parameters.
+        short-form aliases of the parameters.
 
    Returns
    --------

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -227,7 +227,7 @@ def args_in_kwargs(args, kwargs):
     Take a list and a dictionary, and determine if any entries in the list are
     keys in the dictionary.
 
-    This function is used to determine if at least one of the required 
+    This function is used to determine if at least one of the required
     arguments is passed to raise a GMTInvalidInput Error.
 
     Parameters

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -240,6 +240,10 @@ def args_in_kwargs(args, kwargs):
         function in BasePlotting in base_plotting.py. The keys are the GMT
         short aliases of the parameters.
 
+   Returns
+   --------
+   bool 
+       If one of the required arguments is in `kwargs`.
     """
     for arg in args:
         if arg in list(kwargs.keys()):

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -246,6 +246,6 @@ def args_in_kwargs(args, kwargs):
        If one of the required arguments is in `kwargs`.
     """
     for arg in args:
-        if arg in list(kwargs.keys()):
+        if arg in kwargs.keys():
             return True
     return False

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -224,25 +224,25 @@ def launch_external_viewer(fname):
 
 def args_in_kwargs(args, kwargs):
     """
-    Take a list and a dictionary, and determine if any entries in the list are
-    keys in the dictionary.
+     Take a list and a dictionary, and determine if any entries in the list are
+     keys in the dictionary.
 
-    This function is used to determine if at least one of the required arguments is
-    passed to raise a GMTInvalidInput Error.
+     This function is used to determine if at least one of the required arguments is
+     passed to raise a GMTInvalidInput Error.
 
-    Parameters
-    ----------
-    args : list
-        List of required arguments, using the GMT short-form aliases.
+     Parameters
+     ----------
+     args : list
+         List of required arguments, using the GMT short-form aliases.
 
-    kwargs : dict
-        The dictionary of kwargs is the format returned by the _preprocess
-        function of the BasePlotting class. The keys are the GMT
-        short-form aliases of the parameters.
+     kwargs : dict
+         The dictionary of kwargs is the format returned by the _preprocess
+         function of the BasePlotting class. The keys are the GMT
+         short-form aliases of the parameters.
 
-   Returns
-   --------
-   bool 
-       If one of the required arguments is in `kwargs`.
+    Returns
+    --------
+    bool
+        If one of the required arguments is in `kwargs`.
     """
     return any(arg in kwargs for arg in args)

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -220,3 +220,9 @@ def launch_external_viewer(fname):
         subprocess.run(["open", fname], check=False, **run_args)
     else:
         webbrowser.open_new_tab("file://{}".format(fname))
+
+def args_in_kwargs(args, kwargs):
+    for arg in args:
+        if arg in list(kwargs.keys()):
+            return True
+    return False

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -245,7 +245,4 @@ def args_in_kwargs(args, kwargs):
    bool 
        If one of the required arguments is in `kwargs`.
     """
-    for arg in args:
-        if arg in kwargs.keys():
-            return True
-    return False
+    return any(arg in kwargs for arg in args)

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -227,8 +227,8 @@ def args_in_kwargs(args, kwargs):
     Take a list and a dictionary, and determine if any entries in the list are
     keys in the dictionary.
 
-    This function is used to determine if at least one of the required arguments is
-    passed to raise a GMTInvalidInput Error.
+    This function is used to determine if at least one of the required 
+    arguments is passed to raise a GMTInvalidInput Error.
 
     Parameters
     ----------

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -92,11 +92,15 @@ def test_gmttempfile_read():
         assert tmpfile.read(keep_tabs=True) == "in.dat: N = 2\t<1/3>\t<2/4>\n"
 
 def test_args_in_kwargs():
+    "Test that args_in_kwargs function returns correct Boolean responses."
     kwargs = {"A":1, "B":2, "C":3}
+    # Passing list of arguments with passing values in the beginning
     passing_args_1 = ["B", "C", "D"]
-    passing_args_2 = ["D", "X", "C"]
     assert args_in_kwargs(args=passing_args_1, kwargs=kwargs) == True
+    # Passing list of arguments that starts with failing arguments
+    passing_args_2 = ["D", "X", "C"]
     assert args_in_kwargs(args=passing_args_2, kwargs=kwargs) == True
+    # Failing list of arguments
     failing_args = ["D", "E", "F"]
     assert args_in_kwargs(args=failing_args, kwargs=kwargs) == False
 

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -6,7 +6,13 @@ import os
 import numpy as np
 import pytest
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import GMTTempFile, data_kind, kwargs_to_strings, unique_name, args_in_kwargs
+from pygmt.helpers import (
+    GMTTempFile,
+    args_in_kwargs,
+    data_kind,
+    kwargs_to_strings,
+    unique_name,
+)
 
 
 @pytest.mark.parametrize(
@@ -91,9 +97,10 @@ def test_gmttempfile_read():
         assert tmpfile.read() == "in.dat: N = 2 <1/3> <2/4>\n"
         assert tmpfile.read(keep_tabs=True) == "in.dat: N = 2\t<1/3>\t<2/4>\n"
 
+
 def test_args_in_kwargs():
     "Test that args_in_kwargs function returns correct Boolean responses."
-    kwargs = {"A":1, "B":2, "C":3}
+    kwargs = {"A": 1, "B": 2, "C": 3}
     # Passing list of arguments with passing values in the beginning
     passing_args_1 = ["B", "C", "D"]
     assert args_in_kwargs(args=passing_args_1, kwargs=kwargs) == True
@@ -103,5 +110,3 @@ def test_args_in_kwargs():
     # Failing list of arguments
     failing_args = ["D", "E", "F"]
     assert args_in_kwargs(args=failing_args, kwargs=kwargs) == False
-
-

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -103,10 +103,10 @@ def test_args_in_kwargs():
     kwargs = {"A": 1, "B": 2, "C": 3}
     # Passing list of arguments with passing values in the beginning
     passing_args_1 = ["B", "C", "D"]
-    assert args_in_kwargs(args=passing_args_1, kwargs=kwargs) == True
+    assert args_in_kwargs(args=passing_args_1, kwargs=kwargs)
     # Passing list of arguments that starts with failing arguments
     passing_args_2 = ["D", "X", "C"]
-    assert args_in_kwargs(args=passing_args_2, kwargs=kwargs) == True
+    assert args_in_kwargs(args=passing_args_2, kwargs=kwargs)
     # Failing list of arguments
     failing_args = ["D", "E", "F"]
-    assert args_in_kwargs(args=failing_args, kwargs=kwargs) == False
+    assert not args_in_kwargs(args=failing_args, kwargs=kwargs)

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -6,7 +6,7 @@ import os
 import numpy as np
 import pytest
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import GMTTempFile, data_kind, kwargs_to_strings, unique_name
+from pygmt.helpers import GMTTempFile, data_kind, kwargs_to_strings, unique_name, args_in_kwargs
 
 
 @pytest.mark.parametrize(
@@ -90,3 +90,14 @@ def test_gmttempfile_read():
             ftmp.write("in.dat: N = 2\t<1/3>\t<2/4>\n")
         assert tmpfile.read() == "in.dat: N = 2 <1/3> <2/4>\n"
         assert tmpfile.read(keep_tabs=True) == "in.dat: N = 2\t<1/3>\t<2/4>\n"
+
+def test_args_in_kwargs():
+    kwargs = {"A":1, "B":2, "C":3}
+    passing_args_1 = ["B", "C", "D"]
+    passing_args_2 = ["D", "X", "C"]
+    assert args_in_kwargs(args=passing_args_1, kwargs=kwargs) == True
+    assert args_in_kwargs(args=passing_args_2, kwargs=kwargs) == True
+    failing_args = ["D", "E", "F"]
+    assert args_in_kwargs(args=failing_args, kwargs=kwargs) == False
+
+


### PR DESCRIPTION
As discussed in #787, the `args_in_kwargs` function is used to determine if at least one of the required arguments are passed to the function before the arguments are passed to the GMT API. The function takes a list of required arguments, using the GMT short name aliases, and a dictionary of the kwargs, which is the format that is returned by the _preprocess function in BasePlotting. It returns a Boolean value, with the idea that the plotting function raises the GMTInvalidInput Error if it returns `False`.