### PR TITLE
lint: Increase max-module-lines to 3000

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -293,7 +293,7 @@ indent-string='    '
 max-line-length=100
 
 # Maximum number of lines in a module.
-max-module-lines=2000
+max-module-lines=3000
 
 # List of optional constructs for which whitespace checking is disabled. `dict-
 # separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.


### PR DESCRIPTION
**Description of proposed changes**

We have these linting issues because `base_plotting.py` is too long:
```
pygmt/base_plotting.py:1:0: C0302: Too many lines in module (2047/2000) (too-many-lines)
```

The problem will be fixed in #685, but it may take some time.

This PR increases the max-module-lines to 3000 to temporarily disable the warning.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
