### PR TITLE
Fix the Makefile 'distclean' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,4 @@ clean:
 	rm -rvf result_images
 
 distclean: clean
-	rm -r *.egg-info
+	rm -rvf *.egg-info


### PR DESCRIPTION
**Description of proposed changes**

Without `-f`, running `make distclean` results in an error.

```
find . -name "*.pyc" -exec rm -v {} +
find . -name "*~" -exec rm -v {} +
find . -type d -name  "__pycache__" -exec rm -rv {} +
rm -rvf build dist MANIFEST .coverage .cache .pytest_cache htmlcov coverage.xml
rm -rvf tmp-test-dir-with-unique-name
rm -rvf baseline
rm -rvf result_images
rm -r *.egg-info
rm: *.egg-info: No such file or directory
make: *** [distclean] Error 1
```

This PR changes `rm -r` to `rm -rvf`.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
