### PR TITLE
Improve the error message when PyGMT fails to load the GMT library

### DIFF
--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -44,8 +44,7 @@ def load_libgmt():
     if error:
         raise GMTCLibNotFoundError(
             "Error loading the GMT shared library "
-            f"'{', '.join(lib_fullnames)}'.\n {error}."
-            )
+            f"{', '.join(lib_fullnames)}.\n {error}."
         )
     return libgmt
 

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -43,8 +43,8 @@ def load_libgmt():
             error = err
     if error:
         raise GMTCLibNotFoundError(
-            "Error loading the GMT shared library '{}':".format(
-                ", ".join(lib_fullnames)
+            "Error loading the GMT shared library '{}'.\n {}.".format(
+                ", ".join(lib_fullnames), error
             )
         )
     return libgmt

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -43,8 +43,8 @@ def load_libgmt():
             error = err
     if error:
         raise GMTCLibNotFoundError(
-            "Error loading the GMT shared library '{}'.\n {}.".format(
-                ", ".join(lib_fullnames), error
+            "Error loading the GMT shared library "
+            f"'{', '.join(lib_fullnames)}'.\n {error}."
             )
         )
     return libgmt


### PR DESCRIPTION
**Description of proposed changes**

When PyGMT fails to load the GMT library, it raises an error:
```
GMTCLibNotFoundError: Error loading the GMT shared library '/opt/GMT-6.1.1/lib/libgmt.dylib'.
```
However, it's still unclear why it fails.

After this PR, the error message will contain the original error
message. For example:
```
GMTCLibNotFoundError: Error loading the GMT shared library '/opt/GMT-6.1.1/lib/libgmt.dylib'.
 dlopen(/opt/GMT-6.1.1/lib/libgmt.dylib, 6): Library not loaded: @rpath/libnetcdf.15.dylib
  Referenced from: /opt/GMT-6.1.1/lib/libgmt.6.1.1.dylib
  Reason: image not found.
```

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #792.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
