### PR TITLE
Speedup Continuous Documentation using micromamba

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
-    "build:miniconda": "curl -o ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash ~/miniconda.sh -b -p $HOME/miniconda",
-    "build:pygmt": "conda env create -f environment.yml && source activate pygmt && conda install -c conda-forge -y gmt==6.1.1 && make install",
-    "build:docs": "source activate pygmt && cd doc && make all && mv _build/html ../public",
-    "build": "export PATH=$HOME/miniconda/bin:$PATH && npm run build:miniconda && npm run build:pygmt && npm run build:docs"
+    "build:micromamba": "touch ~/.bashrc && curl -Ls https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba && ./bin/micromamba shell init -s bash -p ~/micromamba",
+    "build:pygmt": "source ~/.bashrc && micromamba create --file environment.yml --yes && micromamba activate pygmt && make install",
+    "build:docs": "source ~/.bashrc && micromamba activate pygmt && cd doc && make all && mv _build/html ../public",
+    "build": "npm run build:micromamba && npm run build:pygmt && npm run build:docs"
   }
 }


### PR DESCRIPTION
**Description of proposed changes**

Related to #813.

This PR tries to speedup the Continuous Documentation using micromamba. The building is faster, but still takes ~6 minutes (compared to ~7 minutes using miniconda).


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
