### PR TITLE
Update axis label explanation in frames tutorial

### DIFF
--- a/examples/tutorials/frames.py
+++ b/examples/tutorials/frames.py
@@ -80,11 +80,11 @@ fig.show()
 #
 # Axis labels can be set by passing **x+l**\ *label* (or starting with **y** if
 # labeling the y-axis) to the ``frame`` argument of :meth:`pygmt.Figure.basemap`.
-# Axis labels will be displayed on all primary axes, which the default is all sides of
-# the figure. To designate only some of the axes as primary, an argument that
-# capitlizes only the primary axes can be passed, which is ``"WSne"`` in the example
-# below. The letters correspond with west (left), south (bottom), north (top), and
-# east (right) sides of a figure.
+# By default, all 4 map boundaries (or plot axes) are plotted with both tick marks and
+# axis labels. The axes are named as **W** (west/left), **S** (south/bottom),
+# **N** (north/top), and **E** (east/right) sides of a figure. If an upper-case axis
+# name is passed, the axis is plotted with tick marks and axis labels. A lower case
+# axis name plots only the axis and tick marks.
 #
 # The example below uses a Cartesian projection, as GMT does not allow axis labels to
 # be set for geographic maps.
@@ -93,6 +93,8 @@ fig = pygmt.Figure()
 fig.basemap(
     region=[0, 10, 0, 20],
     projection="X10c/8c",
+    # Plot axis, tick marks, and axis labels on the west/left and south/bottom axes
+    # Plot axis and tick marks on the north/top and east/right axes
     frame=["WSne", "x+lx-axis", "y+ly-axis"],
 )
 fig.show()


### PR DESCRIPTION
This improves the explanation of axis labeling in the `frame.py` tutorial.

Fixes #815


**Reminders**

- [X] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
