### PR TITLE
Add a gallery example for logo

### DIFF
--- a/examples/gallery/plot/logo.py
+++ b/examples/gallery/plot/logo.py
@@ -12,8 +12,8 @@ import pygmt
 fig = pygmt.Figure()
 fig.basemap(region=[0, 10, 0, 2], projection="X6c", frame=True)
 
-# add the GMT logo in the upper right corner of the current map, 
+# add the GMT logo in the upper right corner of the current map,
 # scaled up to be 3 cm wide and offset by 0.3 cm from the border
-fig.logo(position = "jTR+o0.3c/0.3c+w3c") 
+fig.logo(position="jTR+o0.3c/0.3c+w3c")
 
 fig.show()

--- a/examples/gallery/plot/logo.py
+++ b/examples/gallery/plot/logo.py
@@ -1,0 +1,19 @@
+"""
+Logo
+----
+
+The :meth:`pygmt.Figure.logo` method allows to place the GMT logo on a map.  
+
+For more advanced options, see the full option list at :gmt-docs:`logo.html`.
+"""
+
+import pygmt
+
+fig = pygmt.Figure()
+fig.basemap(region=[0, 10, 0, 2], projection="X6c", frame=True)
+
+# add the GMT logo in the upper right corner of the current map, 
+# scaled up to be 3 cm wide and offset by 0.3 cm from the border
+fig.logo(position = "jTR+o0.3c/0.3c+w3c") 
+
+fig.show()

--- a/examples/gallery/plot/logo.py
+++ b/examples/gallery/plot/logo.py
@@ -3,8 +3,6 @@ Logo
 ----
 
 The :meth:`pygmt.Figure.logo` method allows to place the GMT logo on a map.  
-
-For more advanced options, see the full option list at :gmt-docs:`logo.html`.
 """
 
 import pygmt

--- a/examples/gallery/plot/logo.py
+++ b/examples/gallery/plot/logo.py
@@ -12,10 +12,9 @@ import pygmt
 fig = pygmt.Figure()
 fig.basemap(region=[0, 10, 0, 2], projection="X6c", frame=True)
 
-# add the GMT logo in the upper right corner of the current map,
-# scaled up to be 3 cm wide and offset by 0.3 cm from the border
-#  scaled up to be 3 cm wide and offset by 0.3 cm from the vertical border
-# and 0.6 cm from the horizontal border
+# add the GMT logo in the Top Right corner of the current map,
+# scaled up to be 3 cm wide and offset by 0.3 cm in X direction
+# and 0.6 cm in Y direction.
 fig.logo(position="jTR+o0.3c/0.6c+w3c")
 
 fig.show()

--- a/examples/gallery/plot/logo.py
+++ b/examples/gallery/plot/logo.py
@@ -14,6 +14,8 @@ fig.basemap(region=[0, 10, 0, 2], projection="X6c", frame=True)
 
 # add the GMT logo in the upper right corner of the current map,
 # scaled up to be 3 cm wide and offset by 0.3 cm from the border
-fig.logo(position="jTR+o0.3c/0.3c+w3c")
+#  scaled up to be 3 cm wide and offset by 0.3 cm from the vertical border
+# and 0.6 cm from the horizontal border
+fig.logo(position="jTR+o0.3c/0.6c+w3c")
 
 fig.show()


### PR DESCRIPTION
Here's a gallery example for the ``logo`` method for which a simple showcase was missing so far.

