### PR TITLE
WIP: Parallelize Continuous Integration test and documentation build

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -47,7 +47,7 @@ jobs:
           find . -type f -not -path '*/\.git/*' -exec grep -Iq . {} \; -exec chmod 644 {} \;
           if [[ $(git ls-files -m) ]]; then git --no-pager diff HEAD; exit 1; fi
 
-  test:
+  install-deps:
     name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -55,10 +55,6 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, macOS-latest, windows-latest]
-    # environmental variables used in coverage
-    env:
-      OS: ${{ matrix.os }}
-      PYTHON: ${{ matrix.python-version }}
 
     steps:
       # Cancel previous runs that are not completed
@@ -124,6 +120,20 @@ jobs:
           python setup.py sdist --formats=zip
           pip install dist/*
 
+  test:
+    needs: install-deps
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    # environmental variables used in coverage
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+
+    steps:
       # Run the tests
       - name: Test with pytest
         shell: bash -l {0}
@@ -137,11 +147,6 @@ jobs:
           name: artifact-${{ runner.os }}-${{ matrix.python-version }}
           path: tmp-test-dir-with-unique-name
 
-      # Build the documentation
-      - name: Build the documentation
-        shell: bash -l {0}
-        run: make -C doc clean all
-
       # Upload coverage to Codecov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.10
@@ -149,6 +154,21 @@ jobs:
           file: ./coverage.xml # optional
           env_vars: OS,PYTHON
           fail_ci_if_error: true
+
+  docs:
+    needs: install-deps
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.9]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    steps:
+      # Build the documentation
+      - name: Build the documentation
+        shell: bash -l {0}
+        run: make -C doc clean all
 
       - name: Checkout the gh-pages branch
         uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
@@ -210,3 +230,10 @@ jobs:
           git push -fq origin gh-pages 2>&1 >/dev/null
           echo -e "\nFinished uploading generated files."
         if: (github.event_name == 'release' || github.event_name == 'push') && (matrix.os == 'ubuntu-latest') && (matrix.python-version == '3.9')
+
+  # just for blocking the merge until the parallel test and docs are successful
+  success-all-test:
+    needs: [test, docs]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All Done"


### PR DESCRIPTION
**Description of proposed changes**

Split the unit tests and documentation build into two separate and parallel paths to reduce total time spent on Continuous Integration. Also only performing documentation build on Python 3.9 only to conserve CI resources. Edit: doesn't work yet...

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

![image](https://user-images.githubusercontent.com/23487320/106411717-c78c2300-64aa-11eb-963e-64d1a2da0c39.png)

This should save an estimated ~4 min of CI time (the unit tests and docs build take about 4 min respectively, i.e. 8 mins in serial, 4 min in parallel), so the longest running Windows CI should go from ~18min to ~14min.

References:
- https://hanxiao.io/2021/01/24/Speedup-CI-Workflow-in-Github-Actions-via-Strategy-Matrix/
- See example at https://github.com/jina-ai/jina/actions/runs/507130336
- https://github.community/t/reusing-sharing-inheriting-steps-between-jobs-declarations/16851/16
- https://github.blog/changelog/2020-08-07-github-actions-composite-run-steps/

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Part of #584

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
