### PR TITLE
Add slash command '/test-gmt-dev' to test GMT dev version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,10 @@ Fixes #
 - [ ] Write detailed docstrings for all functions/methods.
 - [ ] If adding new functionality, add an example to docstrings or tutorials.
 
-**Notes**
+**Slash Commands**
 
-- You can write `/format` in the first line of a comment to lint the code automatically
+You can write slash commands (`/command`) in the first line of a comment to perform
+specific operations. Supported slash commands are:
+
+- `/format`: format and lint the codes automatically
+- `/test-gmt-master`: run the full tests with the GMT latest codes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,5 +21,5 @@ Fixes #
 You can write slash commands (`/command`) in the first line of a comment to perform
 specific operations. Supported slash commands are:
 
-- `/format`: format and lint the codes automatically
-- `/test-gmt-master`: run the full tests with the GMT latest codes
+- `/format`: automatically format and lint the code
+- `/test-gmt-dev`: run full tests on the latest GMT development version

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -1,7 +1,7 @@
-# This workflow installs PyGMT dependencies, builds documentation and runs tests on GMT latest
+# This workflow installs PyGMT dependencies, builds documentation and runs tests on GMT dev version
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: GMT Latest Tests
+name: GMT Dev Tests
 
 on:
   # push:

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -8,6 +8,8 @@ on:
   #   branches: [ master ]
   pull_request:
     types: [review_requested, ready_for_review]
+  repository_dispatch:
+    types: [test-gmt-master-command]
   # Schedule daily tests
   schedule:
     - cron: '0 0 * * *'
@@ -36,7 +38,28 @@ jobs:
       # Checkout current git repository
       - name: Checkout
         uses: actions/checkout@v2.3.4
+        if: github.event_name != 'repository_dispatch'
         with:
+          # fecth all history so that setuptools-scm works
+          fetch-depth: 0
+
+      # Generate token from GenericMappingTools bot
+      - name: Generate token from GenericMappingTools bot
+        uses: tibdex/github-app-token@v1
+        if: github.event_name == 'repository_dispatch'
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      # Checkout the pull request branch
+      - name: Checkout
+        uses: actions/checkout@v2
+        if: github.event_name == 'repository_dispatch'
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref }}
           # fecth all history so that setuptools-scm works
           fetch-depth: 0
 
@@ -106,3 +129,12 @@ jobs:
         with:
           name: artifact-GMT-${{ matrix.gmt_git_ref }}-${{ runner.os }}
           path: tmp-test-dir-with-unique-name
+
+      - name: Add reaction
+        uses: peter-evans/create-or-update-comment@v1
+        if: github.event_name == 'repository_dispatch'
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reaction-type: hooray

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -7,7 +7,7 @@ on:
   # push:
   #   branches: [ master ]
   pull_request:
-    types: [review_requested, ready_for_review]
+    types: [ready_for_review]
   repository_dispatch:
     types: [test-gmt-master-command]
   # Schedule daily tests

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
     types: [ready_for_review]
   repository_dispatch:
-    types: [test-gmt-master-command]
+    types: [test-gmt-dev-command]
   # Schedule daily tests
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -21,6 +21,6 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           commands: |
             format
-            test-gmt-master
+            test-gmt-dev
           issue-type: pull-request
           permission: none

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -21,5 +21,6 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           commands: |
             format
+            test-gmt-master
           issue-type: pull-request
           permission: none

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -62,8 +62,8 @@ On the *master* branch, the workflow also handles the documentation deployment:
 
 2. `ci_tests_dev.yaml` (GMT Latest Tests on Linux/macOS/Windows).
 
-This is only triggered when a review is requested or re-requested on a PR.
-It is also scheduled to run daily on the *master* branch.
+This is triggered when a PR is marked as "ready for review", or using the slash
+command `/test-gmt-master`. It is also scheduled to run daily on the *master* branch.
 
 3. `cache_data.yaml` (Caches GMT remote data files needed for GitHub Actions CI)
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -63,7 +63,7 @@ On the *master* branch, the workflow also handles the documentation deployment:
 2. `ci_tests_dev.yaml` (GMT Latest Tests on Linux/macOS/Windows).
 
 This is triggered when a PR is marked as "ready for review", or using the slash
-command `/test-gmt-master`. It is also scheduled to run daily on the *master* branch.
+command `/test-gmt-dev`. It is also scheduled to run daily on the *master* branch.
 
 3. `cache_data.yaml` (Caches GMT remote data files needed for GitHub Actions CI)
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -60,7 +60,7 @@ On the *master* branch, the workflow also handles the documentation deployment:
   *master* branch onto the `dev` folder of the *gh-pages* branch.
 * Updated the `latest` documentation link to the new release.
 
-2. `ci_tests_dev.yaml` (GMT Latest Tests on Linux/macOS/Windows).
+2. `ci_tests_dev.yaml` (GMT Dev Tests on Linux/macOS/Windows).
 
 This is triggered when a PR is marked as "ready for review", or using the slash
 command `/test-gmt-dev`. It is also scheduled to run daily on the *master* branch.

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ PyGMT
 .. image:: https://github.com/GenericMappingTools/pygmt/workflows/Tests/badge.svg
     :alt: GitHub Actions Tests status
     :target: https://github.com/GenericMappingTools/pygmt/actions?query=workflow%3ATests
-.. image:: https://github.com/GenericMappingTools/pygmt/workflows/GMT%20Latest%20Tests/badge.svg
-    :alt: GitHub Actions GMT Latest Tests status
+.. image:: https://github.com/GenericMappingTools/pygmt/workflows/GMT%20Dev%20Tests/badge.svg
+    :alt: GitHub Actions GMT Dev Tests status
     :target: https://github.com/GenericMappingTools/pygmt/actions?query=workflow%3A%22GMT+Latest+Tests%22
 .. image:: https://img.shields.io/codecov/c/github/GenericMappingTools/pygmt/master.svg?style=flat-square
     :alt: Test coverage status


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the slash command `/test-gmt-dev` which can trigger the [GMT Dev Tests](https://github.com/GenericMappingTools/pygmt/blob/master/.github/workflows/ci_tests_dev.yaml) workflow. So we can test GMT master branch anytime, without requesting reviews from other maintainers or teams (Also fixes #828).

As you may know/remember, the slash command can only read the configurations in the master branch, so we can't test this PR unless we merge it into the master branch.

To test this PR, I forked the PyGMT repository to my own account (https://github.com/seisman/pygmt), and made changes directly to my own master branch.

If you [compare my master branch and the PyGMT master branch](https://github.com/GenericMappingTools/pygmt/compare/master...seisman:master), you will see my master branch is 2 commits ahead of PyGMT master branch. The two commits are:

- https://github.com/seisman/pygmt/commit/11446e2b13ae503f6eeb1a9c0a5bee43262434a7: This commit is the same as the only commit in this PR 
- https://github.com/seisman/pygmt/commit/37f83e4caaca2fb94f053b6f0ce2cca88814ae51: The slash command uses the GenericMappingTools bot to generate a token, which is not available in my own fork. So I have to use my own token instead. This commit is necessary in my own fork for testing purposes.

To confirm that everything works well, I opened an example PR in my own fork (https://github.com/seisman/pygmt/pull/2). Please go to that PR to see how it works.

**TODO:**

- [x] Remove `review_requested` condition from the workflow, so that we can run the GMT Latest Tests workflow by marking it "ready for review", or using the slash command `/test-gmt-dev` (done in 4a22c59aa2b3e04b4f018c13c1b5dc8d4e28dae9)
- [x] Update the [pull request template] (https://github.com/GenericMappingTools/pygmt/blob/master/.github/PULL_REQUEST_TEMPLATE.md) (done in 8620bab3fe1c00d9c0ff1e89b403b3a2a3e5f26b)
- [x] Update contributing guide or maintenance guide (done in ef31c150dabb74fa83f22aff7a0aae9dc2c40da6)

**Known issues:**

The "GMT Latest Tests" triggered by `/test-gmt-master` won't show the workflow status in the status summary page (like the screenshot below), so we have to go the the "Actions" page to find the testing results.
![image](https://user-images.githubusercontent.com/3974108/106424285-ec8f8000-642f-11eb-8a58-b03eb36114a3.png)


Note: you may find the following status page in PR https://github.com/seisman/pygmt/pull/2. These "GMT Latest Tests" status were triggered by "mark it ready for review", not by the slash command `/test-gmt-master`.
![image](https://user-images.githubusercontent.com/3974108/106424373-0f219900-6430-11eb-96e3-3b43548d9516.png)

One possible solution is: when the workflow is triggered by slash commands, we can let the workflow leave a comment saying that "The workflow is running at https://github.com/GenericMappingTools/pygmt/actions/runs/XXXXX"



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #828.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Notes**

- You can write `/format` in the first line of a comment to lint the code automatically
