### PR TITLE
Show test execution times in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ omit = ["*/tests/*", "*pygmt/__init__.py"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--verbose --doctest-modules --mpl --mpl-results-path=results"
+addopts = "--verbose --durations=0 --durations-min=0.2 --doctest-modules --mpl --mpl-results-path=results"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
**Description of proposed changes**

Show the slowest tests with executation times > 0.2 s (the default is 0.005 s).

Reference: https://docs.pytest.org/en/stable/usage.html#profiling-test-execution-duration


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #584


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
