### PR TITLE
Cache earth_relief_05m_p used in tutorials

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  # pull_request:
+  pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  pull_request:
+  # pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -33,7 +33,7 @@ jobs:
           gmt which -Ga @earth_relief_10m_p @earth_relief_10m_g \
                         @earth_relief_30m_p @earth_relief_30m_g \
                         @earth_relief_01d_p @earth_relief_01d_g \
-                        @earth_relief_05m_g
+                        @earth_relief_05m_p @earth_relief_05m_g
           gmt which -Ga @ridge.txt @Table_5_11.txt @test.dat.nc \
                         @tut_bathy.nc @tut_quakes.ngdc @tut_ship.xyz \
                         @usgs_quakes_22.txt


### PR DESCRIPTION
**Description of proposed changes**

Some tutorials (`examples/tutorials/earth-relief.py`, `examples/tutorials/contour-map.py`,
`examples/tutorials/3d-perspective-image.py`) use `earth_relief_05m_p`.

This data is not cached, thus slows the CI.

This PR caches `earth_relief_05m_p` data.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
