### PR TITLE
Replace np.str and np.object to silence numpy 1.20 deprecation warnings

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1179,7 +1179,7 @@ class Session:
                 strings = np.apply_along_axis(
                     func1d=" ".join, axis=0, arr=string_arrays
                 )
-            strings = np.asanyarray(a=strings, dtype=np.str)
+            strings = np.asanyarray(a=strings, dtype=str)
             self.put_strings(
                 dataset, family="GMT_IS_VECTOR|GMT_IS_DUPLICATE", strings=strings
             )

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -432,7 +432,7 @@ def test_virtualfile_from_vectors():
             assert output == expected
 
 
-@pytest.mark.parametrize("dtype", [str, np.object])
+@pytest.mark.parametrize("dtype", [str, object])
 def test_virtualfile_from_vectors_one_string_or_object_column(dtype):
     """
     Test passing in one column with string or object dtype into virtual file
@@ -451,7 +451,7 @@ def test_virtualfile_from_vectors_one_string_or_object_column(dtype):
         assert output == expected
 
 
-@pytest.mark.parametrize("dtype", [str, np.object])
+@pytest.mark.parametrize("dtype", [str, object])
 def test_virtualfile_from_vectors_two_string_or_object_columns(dtype):
     """
     Test passing in two columns of string or object dtype into virtual file

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -432,7 +432,7 @@ def test_virtualfile_from_vectors():
             assert output == expected
 
 
-@pytest.mark.parametrize("dtype", [np.str, np.object])
+@pytest.mark.parametrize("dtype", [str, np.object])
 def test_virtualfile_from_vectors_one_string_or_object_column(dtype):
     """
     Test passing in one column with string or object dtype into virtual file
@@ -451,7 +451,7 @@ def test_virtualfile_from_vectors_one_string_or_object_column(dtype):
         assert output == expected
 
 
-@pytest.mark.parametrize("dtype", [np.str, np.object])
+@pytest.mark.parametrize("dtype", [str, np.object])
 def test_virtualfile_from_vectors_two_string_or_object_columns(dtype):
     """
     Test passing in two columns of string or object dtype into virtual file

--- a/pygmt/tests/test_clib_put_strings.py
+++ b/pygmt/tests/test_clib_put_strings.py
@@ -26,7 +26,7 @@ def test_put_strings():
         )
         x = np.array([1, 2, 3, 4, 5], dtype=np.int32)
         y = np.array([6, 7, 8, 9, 10], dtype=np.int32)
-        strings = np.array(["a", "bc", "defg", "hijklmn", "opqrst"], dtype=np.str)
+        strings = np.array(["a", "bc", "defg", "hijklmn", "opqrst"], dtype=str)
         lib.put_vector(dataset, column=lib["GMT_X"], vector=x)
         lib.put_vector(dataset, column=lib["GMT_Y"], vector=y)
         lib.put_strings(
@@ -62,5 +62,5 @@ def test_put_strings_fails():
             lib.put_strings(
                 dataset=None,
                 family="GMT_IS_VECTOR|GMT_IS_DUPLICATE",
-                strings=np.empty(shape=(3,), dtype=np.str),
+                strings=np.empty(shape=(3,), dtype=str),
             )


### PR DESCRIPTION
**Description of proposed changes**

- Change `np.str` to `str`

References: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #846


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
