### PR TITLE
Fix a warning in test_plot3d_matrix_color

### DIFF
--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -498,7 +498,7 @@ def test_plot3d_matrix_color(data, region):
         p="225/30",
         R="/".join(map(str, region)),
         J="X5i",
-        S="c0.5cc",
+        S="c0.5c",
         C="rainbow",
         i="0,1,2,2",
         B=["a", "za"],


### PR DESCRIPTION
**Description of proposed changes**

Silence the following warning:
```
[WARNING]: 0.5c not a valid number and may not be decoded properly.
```

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
