### PR TITLE
Redirect users to the forum if they have questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,9 @@
 ---
 name: Bug report
 about: Report a problem/bug to help us improve
+title: ''
+labels: bug
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: GMT Community Forum
+    url: https://forum.generic-mapping-tools.org/
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: GMT Community Forum
     url: https://forum.generic-mapping-tools.org/
-    about: Please ask and answer questions here.
+    about: Please ask questions here or find answers to common problems.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,9 @@
 ---
 name: Feature request
 about: Request the addition of a new feature/functionality
+title: ''
+labels: feature request
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -1,8 +1,8 @@
 ---
 name: PyGMT release checklist
 about: Checklist for a new PyGMT release.
-title: 'Release PyGMT x.x.x'
-labels: 'maintenance'
+title: Release PyGMT x.x.x
+labels: maintenance
 assignees: ''
 
 ---


### PR DESCRIPTION
Changes in this PR:

1. Add automatic labels ("bug", or "feature request") to issue templates
2. Add "config.yml" to redirect users to the forum if they have questions (configuration file from  https://github.com/GenericMappingTools/gmt/pull/2386)

Preview:

![image](https://user-images.githubusercontent.com/3974108/107159316-30691480-695d-11eb-9678-ba9060b77763.png)


Reference: https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser