### PR TITLE
Add common alias panel (-c) to all plotting functions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -441,7 +441,6 @@ function-naming-style=snake_case
 good-names=i,
            j,
            k,
-           ax,
            ex,
            Run,
            _,

--- a/.pylintrc
+++ b/.pylintrc
@@ -441,6 +441,7 @@ function-naming-style=snake_case
 good-names=i,
            j,
            k,
+           ax,
            ex,
            Run,
            _,

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -60,16 +60,14 @@ COMMON_OPTIONS = {
             Shift plot origin in y-direction. Full documentation is at
             :gmt-docs:`gmt.html#xy-full`.
          """,
-    "c": r"""panel : int or list
+    "c": r"""panel : int or list or bool
             [*row*\ ,\ *col*\|\ *index*].
-            Used to advance to the selected subplot panel. Only allowed when in
-            subplot mode. Available to all plot modules. If no arguments are
-            given then we advance to the next panel in the selected order. If
-            no **panel** is given and we just entered subplot mode then the
-            first panel (top, left) is selected. Instead of *row, col* you may
-            give the one-dimensional *index* which depends on the order you set
-            via **autolabel** when the subplot was defined. **Note**: *row*,
-            *col*, and *index* all start at 0.
+            Selects a specific subplot panel. Only allowed when in subplot
+            mode. Use ``panel=True`` to advance to the next panel in the
+            selected order. Instead of *row,col* you may also give a scalar
+            value *index* which depends on the order you set via ``autolabel``
+            when the subplot was defined. **Note**: *row*, *col*, and *index*
+            all start at 0.
          """,
     "j": """\
         distcalc : str

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -60,6 +60,17 @@ COMMON_OPTIONS = {
             Shift plot origin in y-direction. Full documentation is at
             :gmt-docs:`gmt.html#xy-full`.
          """,
+    "c": r"""ax : int or list
+            [*row*\ ,\ *col*\|\ *index*].
+            Used to advance to the selected subplot panel. Only allowed when in
+            subplot mode. Available to all plot modules. If no arguments are
+            given then we advance to the next panel in the selected order. If
+            no **ax** is given and we just entered subplot mode then the first
+            panel (top, left) is selected. Instead of *row, col* you may give
+            the one-dimensional *index* which depends on the order you set via
+            **autolabel** when the subplot was defined. **Note**: *row*, *col*,
+            and *index* all start at 0.
+         """,
     "j": """\
         distcalc : str
             ``e|f|g``.

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -60,16 +60,16 @@ COMMON_OPTIONS = {
             Shift plot origin in y-direction. Full documentation is at
             :gmt-docs:`gmt.html#xy-full`.
          """,
-    "c": r"""ax : int or list
+    "c": r"""panel : int or list
             [*row*\ ,\ *col*\|\ *index*].
             Used to advance to the selected subplot panel. Only allowed when in
             subplot mode. Available to all plot modules. If no arguments are
             given then we advance to the next panel in the selected order. If
-            no **ax** is given and we just entered subplot mode then the first
-            panel (top, left) is selected. Instead of *row, col* you may give
-            the one-dimensional *index* which depends on the order you set via
-            **autolabel** when the subplot was defined. **Note**: *row*, *col*,
-            and *index* all start at 0.
+            no **panel** is given and we just entered subplot mode then the
+            first panel (top, left) is selected. Instead of *row, col* you may
+            give the one-dimensional *index* which depends on the order you set
+            via **autolabel** when the subplot was defined. **Note**: *row*,
+            *col*, and *index* all start at 0.
          """,
     "j": """\
         distcalc : str

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -72,9 +72,9 @@ def basemap(self, **kwargs):
     {t}
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
-    if not args_in_kwargs(args=["B", "L", "Td", "Tm"], kwargs=kwargs):
+    if not args_in_kwargs(args=["B", "L", "Td", "Tm", "c"], kwargs=kwargs):
         raise GMTInvalidInput(
-            "At least one of frame, map_scale, compass, or rose must be specified."
+            "At least one of frame, map_scale, compass, rose, or ax must be specified."
         )
     with Session() as lib:
         lib.call_module("basemap", build_arg_string(kwargs))

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -27,7 +27,7 @@ from pygmt.helpers import (
     V="verbose",
     X="xshift",
     Y="yshift",
-    c="ax",
+    c="panel",
     p="perspective",
     t="transparency",
 )
@@ -74,7 +74,7 @@ def basemap(self, **kwargs):
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
     if not args_in_kwargs(args=["B", "L", "Td", "Tm", "c"], kwargs=kwargs):
         raise GMTInvalidInput(
-            "At least one of frame, map_scale, compass, rose, or ax must be specified."
+            "At least one of frame, map_scale, compass, rose, or panel must be specified."
         )
     with Session() as lib:
         lib.call_module("basemap", build_arg_string(kwargs))

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -27,10 +27,11 @@ from pygmt.helpers import (
     V="verbose",
     X="xshift",
     Y="yshift",
+    c="ax",
     p="perspective",
     t="transparency",
 )
-@kwargs_to_strings(R="sequence", p="sequence")
+@kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def basemap(self, **kwargs):
     """
     Plot base maps and frames for the figure.
@@ -66,6 +67,7 @@ def basemap(self, **kwargs):
     {U}
     {V}
     {XY}
+    {c}
     {p}
     {t}
     """

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -32,10 +32,11 @@ from pygmt.helpers import (
     V="verbose",
     X="xshift",
     Y="yshift",
+    c="ax",
     p="perspective",
     t="transparency",
 )
-@kwargs_to_strings(R="sequence", p="sequence")
+@kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def coast(self, **kwargs):
     r"""
     Plot continents, shorelines, rivers, and borders on maps
@@ -182,6 +183,7 @@ def coast(self, **kwargs):
         the segment headers via **-Z**\ *code* settings.To apply different
         settings to different countries, pass a list of string arguments.
     {XY}
+    {c}
     {p}
     {t}
     {V}

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -32,7 +32,7 @@ from pygmt.helpers import (
     V="verbose",
     X="xshift",
     Y="yshift",
-    c="ax",
+    c="panel",
     p="perspective",
     t="transparency",
 )

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -20,10 +20,13 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     V="verbose",
     X="xshift",
     Y="yshift",
+    c="ax",
     p="perspective",
     t="transparency",
 )
-@kwargs_to_strings(R="sequence", G="sequence", I="sequence", p="sequence")
+@kwargs_to_strings(
+    R="sequence", G="sequence", I="sequence", c="sequence_comma", p="sequence"
+)
 def colorbar(self, **kwargs):
     """
     Plot a gray or color scale-bar on maps.
@@ -94,6 +97,7 @@ def colorbar(self, **kwargs):
         illumination.
     {V}
     {XY}
+    {c}
     {p}
     {t}
     """

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -20,7 +20,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     V="verbose",
     X="xshift",
     Y="yshift",
-    c="ax",
+    c="panel",
     p="perspective",
     t="transparency",
 )

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -30,10 +30,11 @@ from pygmt.helpers import (
     V="verbose",
     X="xshift",
     Y="yshift",
+    c="ax",
     p="perspective",
     t="transparency",
 )
-@kwargs_to_strings(R="sequence", i="sequence_comma", p="sequence")
+@kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 def contour(self, x=None, y=None, z=None, data=None, **kwargs):
     """
     Contour table data by direct triangulation.
@@ -92,6 +93,7 @@ def contour(self, x=None, y=None, z=None, data=None, **kwargs):
         separator for the two labels instead.
     {V}
     {XY}
+    {c}
     {p}
     {t}
     """

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -30,7 +30,7 @@ from pygmt.helpers import (
     V="verbose",
     X="xshift",
     Y="yshift",
-    c="ax",
+    c="panel",
     p="perspective",
     t="transparency",
 )

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -30,10 +30,13 @@ from pygmt.helpers import (
     l="label",
     X="xshift",
     Y="yshift",
+    c="ax",
     p="perspective",
     t="transparency",
 )
-@kwargs_to_strings(R="sequence", L="sequence", A="sequence_plus", p="sequence")
+@kwargs_to_strings(
+    R="sequence", L="sequence", A="sequence_plus", c="sequence_comma", p="sequence"
+)
 def grdcontour(self, grid, **kwargs):
     """
     Convert grids or images to contours and plot them on maps.
@@ -87,6 +90,7 @@ def grdcontour(self, grid, **kwargs):
     {V}
     {W}
     {XY}
+    {c}
     label : str
         Add a legend entry for the contour being plotted. Normally, the
         annotated contour is selected for the legend. You can select the

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -30,7 +30,7 @@ from pygmt.helpers import (
     l="label",
     X="xshift",
     Y="yshift",
-    c="ax",
+    c="panel",
     p="perspective",
     t="transparency",
 )

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -32,7 +32,7 @@ from pygmt.helpers import (
     X="xshift",
     Y="yshift",
     n="interpolation",
-    c="ax",
+    c="panel",
     p="perspective",
     t="transparency",
     x="cores",

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -32,11 +32,12 @@ from pygmt.helpers import (
     X="xshift",
     Y="yshift",
     n="interpolation",
+    c="ax",
     p="perspective",
     t="transparency",
     x="cores",
 )
-@kwargs_to_strings(R="sequence", p="sequence")
+@kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def grdimage(self, grid, **kwargs):
     """
     Project and plot grids or images.
@@ -151,6 +152,7 @@ def grdimage(self, grid, **kwargs):
     {R}
     {V}
     {XY}
+    {c}
     {n}
     {p}
     {t}

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -33,7 +33,7 @@ from pygmt.helpers import (
     V="verbose",
     X="xshift",
     Y="yshift",
-    c="ax",
+    c="panel",
     p="perspective",
     t="transparency",
 )

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -33,10 +33,11 @@ from pygmt.helpers import (
     V="verbose",
     X="xshift",
     Y="yshift",
+    c="ax",
     p="perspective",
     t="transparency",
 )
-@kwargs_to_strings(R="sequence", p="sequence")
+@kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def grdview(self, grid, **kwargs):
     """
     Create 3-D perspective image or surface mesh from a grid.
@@ -111,6 +112,7 @@ def grdview(self, grid, **kwargs):
 
     {V}
     {XY}
+    {c}
     {p}
     {t}
     """

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -15,7 +15,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     V="verbose",
     X="xshift",
     Y="yshift",
-    c="ax",
+    c="panel",
     p="perspective",
     t="transparency",
 )

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -15,10 +15,11 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     V="verbose",
     X="xshift",
     Y="yshift",
+    c="ax",
     p="perspective",
     t="transparency",
 )
-@kwargs_to_strings(R="sequence", p="sequence")
+@kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def image(self, imagefile, **kwargs):
     """
     Place images or EPS files on maps.
@@ -53,6 +54,7 @@ def image(self, imagefile, **kwargs):
         YIQ-transformation.
     {V}
     {XY}
+    {c}
     {p}
     {t}
     """

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -22,10 +22,11 @@ from pygmt.helpers import (
     V="verbose",
     X="xshift",
     Y="yshift",
+    c="ax",
     p="perspective",
     t="transparency",
 )
-@kwargs_to_strings(R="sequence", p="sequence")
+@kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def legend(self, spec=None, position="JTR+jTR+o0.2c", box="+gwhite+p1p", **kwargs):
     """
     Plot legends on maps.
@@ -61,6 +62,7 @@ def legend(self, spec=None, position="JTR+jTR+o0.2c", box="+gwhite+p1p", **kwarg
         using a 1 point black pen and adds a white background.
     {V}
     {XY}
+    {c}
     {p}
     {t}
     """

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -22,7 +22,7 @@ from pygmt.helpers import (
     V="verbose",
     X="xshift",
     Y="yshift",
-    c="ax",
+    c="panel",
     p="perspective",
     t="transparency",
 )

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -17,7 +17,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     V="verbose",
     X="xshift",
     Y="yshift",
-    c="ax",
+    c="panel",
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -17,9 +17,10 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     V="verbose",
     X="xshift",
     Y="yshift",
+    c="ax",
     t="transparency",
 )
-@kwargs_to_strings(R="sequence", p="sequence")
+@kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def logo(self, **kwargs):
     """
     Plot the GMT logo.
@@ -54,6 +55,7 @@ def logo(self, **kwargs):
     {U}
     {V}
     {XY}
+    {c}
     {t}
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -26,10 +26,11 @@ from pygmt.helpers import (
     V="verbose",
     X="xshift",
     Y="yshift",
+    c="ax",
     p="perspective",
     t="transparency",
 )
-@kwargs_to_strings(R="sequence", p="sequence")
+@kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def meca(
     self,  # pylint: disable=unused-argument
     spec,
@@ -124,6 +125,7 @@ def meca(
     {B}
     {V}
     {XY}
+    {c}
     {p}
     {t}
     """

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -26,7 +26,7 @@ from pygmt.helpers import (
     V="verbose",
     X="xshift",
     Y="yshift",
-    c="ax",
+    c="panel",
     p="perspective",
     t="transparency",
 )

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -38,10 +38,11 @@ from pygmt.helpers import (
     Z="zvalue",
     i="columns",
     l="label",
+    c="ax",
     p="perspective",
     t="transparency",
 )
-@kwargs_to_strings(R="sequence", i="sequence_comma", p="sequence")
+@kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 def plot(self, x=None, y=None, data=None, sizes=None, direction=None, **kwargs):
     """
     Plot lines, polygons, and symbols in 2-D.
@@ -178,6 +179,7 @@ def plot(self, x=None, y=None, data=None, sizes=None, direction=None, **kwargs):
         polygon in the input data. To apply it to the fill color, use
         ``color='+z'``. To apply it to the pen color, append **+z** to
         **pen**.
+    {c}
     columns : str or 1d array
         Choose which columns are x, y, color, and size, respectively if
         input is provided via *data*. E.g. ``columns = [0, 1]`` or

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -38,7 +38,7 @@ from pygmt.helpers import (
     Z="zvalue",
     i="columns",
     l="label",
-    c="ax",
+    c="panel",
     p="perspective",
     t="transparency",
 )

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -38,7 +38,7 @@ from pygmt.helpers import (
     Z="zvalue",
     i="columns",
     l="label",
-    c="ax",
+    c="panel",
     p="perspective",
     t="transparency",
 )

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -38,10 +38,11 @@ from pygmt.helpers import (
     Z="zvalue",
     i="columns",
     l="label",
+    c="ax",
     p="perspective",
     t="transparency",
 )
-@kwargs_to_strings(R="sequence", i="sequence_comma", p="sequence")
+@kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 def plot3d(
     self, x=None, y=None, z=None, data=None, sizes=None, direction=None, **kwargs
 ):
@@ -150,6 +151,7 @@ def plot3d(
         polygon in the input data. To apply it to the fill color, use
         ``color='+z'``. To apply it to the pen color, append **+z** to
         **pen**.
+    {c}
     label : str
         Add a legend entry for the symbol or line being plotted.
     {p}

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -28,6 +28,7 @@ from pygmt.helpers import (
     W="pen",
     X="xshift",
     Y="yshift",
+    c="ax",
     p="perspective",
     t="transparency",
 )
@@ -37,6 +38,7 @@ from pygmt.helpers import (
     angle="sequence_comma",
     font="sequence_comma",
     justify="sequence_comma",
+    c="sequence_comma",
     p="sequence",
 )
 def text_(
@@ -140,6 +142,7 @@ def text_(
         clip].
     {V}
     {XY}
+    {c}
     {p}
     {t}
     """

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -28,7 +28,7 @@ from pygmt.helpers import (
     W="pen",
     X="xshift",
     Y="yshift",
-    c="ax",
+    c="panel",
     p="perspective",
     t="transparency",
 )


### PR DESCRIPTION
**Description of proposed changes**

Used to advance to the selected subplot panel. See https://docs.generic-mapping-tools.org/6.1/gmt.html#c-full,
https://github.com/GenericMappingTools/gmt/blob/6.1.1/doc/rst/source/explain_-c_full.rst_, and https://docs.generic-mapping-tools.org/6.1/cookbook/options.html#selecting-subplot-panels-the-c-option. Needed for the `subplot` wrapper at #822 to resolve issue #20.

**Questions**:

1. ~~Just confirming that we want to go with `ax` (as with matplotlib) rather than `panel` (used by GMT). See https://github.com/GenericMappingTools/pygmt/pull/822#issuecomment-770341473.~~ Ok, going with `panel`
2. Haven't tested to see if `-c` works on `inset` (https://docs.generic-mapping-tools.org/6.1/inset.html), i.e. putting an inset in a subplot panel. If it works, then I'll add the alias to the `pygmt/src/inset.py` file.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
This can be merged before #822 to reduce the diff there.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
