### PR TITLE
Reorder plotting functions alphabetically in index

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -25,19 +25,19 @@ Plotting data and laying out the map:
     Figure.basemap
     Figure.coast
     Figure.colorbar
-    Figure.plot
-    Figure.plot3d
     Figure.contour
     Figure.grdcontour
     Figure.grdimage
     Figure.grdview
+    Figure.image
+    Figure.inset
     Figure.legend
     Figure.logo
-    Figure.image
+    Figure.meca
+    Figure.plot
+    Figure.plot3d
     Figure.shift_origin
     Figure.text
-    Figure.meca
-    Figure.inset
 
 Color palette table generation:
 


### PR DESCRIPTION
This pull request reorders the plotting functions listed in the `doc/api/index.rst` to alphabetical order.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #851


**Reminders**

- [X] Run `make format` and `make check` to make sure the code follows the style guide.
- [X] Add new public functions/methods/classes to `doc/api/index.rst`.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
