### PR TITLE
Add affiliation and ORCID to AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,10 +8,10 @@ Manoa.
 The following people have contributed code to the project (alphabetical by name)
 and are considered the "PyGMT Developers":
 
-* [Michael Grund](https://github.com/michaelgrund) | [0000-0001-8759-2018](https://orcid.org/0000-0001-8759-2018)
-* [Wei Ji Leong](https://github.com/weiji14)
-* [Tyler Newton](http://www.tnewton.com/)
-* [William Schlitzer](https://github.com/willschlitzer) | [0000-0002-5843-2282](https://orcid.org/0000-0002-5843-2282)
 * [Dongdong Tian](https://seisman.info/) | Department of Earth and Environmental Sciences, Michigan State University, East Lansing, MI, USA | [0000-0001-7967-1197](https://orcid.org/0000-0001-7967-1197)
-* [Liam Toney](https://liam.earth/) | Alaska Volcano Observatory and Wilson Alaska Technical Center, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK, USA | [0000-0003-0167-9433](https://orcid.org/0000-0003-0167-9433)
 * [Leonardo Uieda](http://www.leouieda.com/)
+* [Liam Toney](https://liam.earth/) | Alaska Volcano Observatory and Wilson Alaska Technical Center, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK, USA | [0000-0003-0167-9433](https://orcid.org/0000-0003-0167-9433)
+* [Michael Grund](https://github.com/michaelgrund) | [0000-0001-8759-2018](https://orcid.org/0000-0001-8759-2018)
+* [Tyler Newton](http://www.tnewton.com/)
+* [Wei Ji Leong](https://github.com/weiji14)
+* [William Schlitzer](https://github.com/willschlitzer) | [0000-0002-5843-2282](https://orcid.org/0000-0002-5843-2282)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,5 +13,5 @@ and are considered the "PyGMT Developers":
 * [Tyler Newton](http://www.tnewton.com/)
 * [William Schlitzer](https://github.com/willschlitzer) | [0000-0002-5843-2282](https://orcid.org/0000-0002-5843-2282)
 * [Dongdong Tian](https://seisman.info/) | Department of Earth and Environmental Sciences, Michigan State University, East Lansing, MI, USA | [0000-0001-7967-1197](https://orcid.org/0000-0001-7967-1197)
-* [Liam Toney](https://liam.earth/) | Alaska Volcano Observatory and Wilson Alaska Technical Center, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, Alaska, USA | [0000-0003-0167-9433](https://orcid.org/0000-0003-0167-9433)
+* [Liam Toney](https://liam.earth/) | Alaska Volcano Observatory and Wilson Alaska Technical Center, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK, USA | [0000-0003-0167-9433](https://orcid.org/0000-0003-0167-9433)
 * [Leonardo Uieda](http://www.leouieda.com/)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,9 +8,9 @@ Manoa.
 The following people have contributed code to the project (alphabetical by name)
 and are considered the "PyGMT Developers":
 
-* [Dongdong Tian](https://seisman.info/) | Department of Earth and Environmental Sciences, Michigan State University, East Lansing, MI, USA | [0000-0001-7967-1197](https://orcid.org/0000-0001-7967-1197)
+* [Dongdong Tian](https://seisman.info/) | [0000-0001-7967-1197](https://orcid.org/0000-0001-7967-1197) | Department of Earth and Environmental Sciences, Michigan State University, East Lansing, MI, USA
 * [Leonardo Uieda](http://www.leouieda.com/)
-* [Liam Toney](https://liam.earth/) | Alaska Volcano Observatory and Wilson Alaska Technical Center, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK, USA | [0000-0003-0167-9433](https://orcid.org/0000-0003-0167-9433)
+* [Liam Toney](https://liam.earth/) | [0000-0003-0167-9433](https://orcid.org/0000-0003-0167-9433) | Alaska Volcano Observatory and Wilson Alaska Technical Center, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK, USA
 * [Michael Grund](https://github.com/michaelgrund) | [0000-0001-8759-2018](https://orcid.org/0000-0001-8759-2018)
 * [Tyler Newton](http://www.tnewton.com/)
 * [Wei Ji Leong](https://github.com/weiji14)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,7 +9,7 @@ The following people have contributed code to the project (alphabetical by name)
 and are considered to be "PyGMT Developers":
 
 * [Dongdong Tian](https://seisman.info/) | [0000-0001-7967-1197](https://orcid.org/0000-0001-7967-1197) | Department of Earth and Environmental Sciences, Michigan State University, East Lansing, MI, USA
- * [Leonardo Uieda](http://www.leouieda.com/) | [0000-0001-6123-9515](https://orcid.org/0000-0001-6123-9515) | Department of Earth, Ocean and Ecological Sciences, University of Liverpool, Liverpool, United Kingdom
+* [Leonardo Uieda](http://www.leouieda.com/) | [0000-0001-6123-9515](https://orcid.org/0000-0001-6123-9515) | Department of Earth, Ocean and Ecological Sciences, University of Liverpool, Liverpool, United Kingdom
 * [Liam Toney](https://liam.earth/) | [0000-0003-0167-9433](https://orcid.org/0000-0003-0167-9433) | Alaska Volcano Observatory and Wilson Alaska Technical Center, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK, USA
 * [Malte Ziebarth](https://github.com/mjziebarth) | [0000-0002-5190-4478](https://orcid.org/0000-0002-5190-4478) | GFZ German Research Centre for Geosciences, Potsdam, Germany
 * [Michael Grund](https://github.com/michaelgrund) | [0000-0001-8759-2018](https://orcid.org/0000-0001-8759-2018)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,6 +12,6 @@ and are considered the "PyGMT Developers":
 * [Wei Ji Leong](https://github.com/weiji14)
 * [Tyler Newton](http://www.tnewton.com/)
 * [William Schlitzer](https://github.com/willschlitzer) | [0000-0002-5843-2282](https://orcid.org/0000-0002-5843-2282)
-* [Dongdong Tian](https://seisman.info/)
+* [Dongdong Tian](https://seisman.info/) | Department of Earth and Environmental Sciences, Michigan State University, East Lansing, MI, USA | [0000-0001-7967-1197](https://orcid.org/0000-0001-7967-1197)
 * [Liam Toney](https://liam.earth/) | Alaska Volcano Observatory and Wilson Alaska Technical Center, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, Alaska, USA | [0000-0003-0167-9433](https://orcid.org/0000-0003-0167-9433)
 * [Leonardo Uieda](http://www.leouieda.com/)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,7 +5,7 @@ during [an NSF funded postdoc](http://www.leouieda.com/blog/hawaii-gmt-postdoc.h
 with [Paul Wessel](http://www.soest.hawaii.edu/wessel) at the University of Hawaii at
 Manoa.
 
-The following people have contributed code to the project (alphabetical by last name)
+The following people have contributed code to the project (alphabetical by name)
 and are considered the "PyGMT Developers":
 
 * [Michael Grund](https://github.com/michaelgrund) | [0000-0001-8759-2018](https://orcid.org/0000-0001-8759-2018)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,6 +11,7 @@ and are considered to be "PyGMT Developers":
 * [Dongdong Tian](https://seisman.info/) | [0000-0001-7967-1197](https://orcid.org/0000-0001-7967-1197) | Department of Earth and Environmental Sciences, Michigan State University, East Lansing, MI, USA
 * [Leonardo Uieda](http://www.leouieda.com/)
 * [Liam Toney](https://liam.earth/) | [0000-0003-0167-9433](https://orcid.org/0000-0003-0167-9433) | Alaska Volcano Observatory and Wilson Alaska Technical Center, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK, USA
+* [Malte Ziebarth](https://github.com/mjziebarth) | [0000-0002-5190-4478](https://orcid.org/0000-0002-5190-4478) | GFZ German Research Centre for Geosciences, Potsdam, Germany
 * [Michael Grund](https://github.com/michaelgrund) | [0000-0001-8759-2018](https://orcid.org/0000-0001-8759-2018)
 * [Tyler Newton](http://www.tnewton.com/)
 * [Wei Ji Leong](https://github.com/weiji14)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,6 +13,6 @@ and are considered to be "PyGMT Developers":
 * [Liam Toney](https://liam.earth/) | [0000-0003-0167-9433](https://orcid.org/0000-0003-0167-9433) | Alaska Volcano Observatory and Wilson Alaska Technical Center, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK, USA
 * [Malte Ziebarth](https://github.com/mjziebarth) | [0000-0002-5190-4478](https://orcid.org/0000-0002-5190-4478) | GFZ German Research Centre for Geosciences, Potsdam, Germany
 * [Michael Grund](https://github.com/michaelgrund) | [0000-0001-8759-2018](https://orcid.org/0000-0001-8759-2018)
-* [Tyler Newton](http://www.tnewton.com/)
+* [Tyler Newton](http://www.tnewton.com/) | [0000-0002-1560-6553](https://orcid.org/0000-0002-1560-6553) | Department of Earth Sciences, University of Oregon, Eugene, OR, USA
 * [Wei Ji Leong](https://github.com/weiji14) | [0000-0003-2354-1988](https://orcid.org/0000-0003-2354-1988) | Antarctic Research Centre, Victoria University of Wellington, Wellington, New Zealand
 * [William Schlitzer](https://github.com/willschlitzer) | [0000-0002-5843-2282](https://orcid.org/0000-0002-5843-2282)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,8 +5,8 @@ during [an NSF funded postdoc](http://www.leouieda.com/blog/hawaii-gmt-postdoc.h
 with [Paul Wessel](http://www.soest.hawaii.edu/wessel) at the University of Hawaii at
 Manoa.
 
-The following people have contributed code to the project (alphabetical by name)
-and are considered to be "PyGMT Developers":
+The following people have contributed code and/or documentation to the project
+(alphabetical by name) and are considered to be "PyGMT Developers":
 
 * [Dongdong Tian](https://seisman.info/) | [0000-0001-7967-1197](https://orcid.org/0000-0001-7967-1197) | Department of Earth and Environmental Sciences, Michigan State University, East Lansing, MI, USA
 * [Leonardo Uieda](http://www.leouieda.com/) | [0000-0001-6123-9515](https://orcid.org/0000-0001-6123-9515) | Department of Earth, Ocean and Ecological Sciences, University of Liverpool, Liverpool, United Kingdom

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,4 +15,4 @@ and are considered to be "PyGMT Developers":
 * [Michael Grund](https://github.com/michaelgrund) | [0000-0001-8759-2018](https://orcid.org/0000-0001-8759-2018)
 * [Tyler Newton](http://www.tnewton.com/) | [0000-0002-1560-6553](https://orcid.org/0000-0002-1560-6553) | Department of Earth Sciences, University of Oregon, Eugene, OR, USA
 * [Wei Ji Leong](https://github.com/weiji14) | [0000-0003-2354-1988](https://orcid.org/0000-0003-2354-1988) | Antarctic Research Centre, Victoria University of Wellington, Wellington, New Zealand
-* [William Schlitzer](https://github.com/willschlitzer) | [0000-0002-5843-2282](https://orcid.org/0000-0002-5843-2282)
+* [William Schlitzer](https://github.com/willschlitzer) | [0000-0002-5843-2282](https://orcid.org/0000-0002-5843-2282) | Unaffiliated

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,7 +6,7 @@ with [Paul Wessel](http://www.soest.hawaii.edu/wessel) at the University of Hawa
 Manoa.
 
 The following people have contributed code to the project (alphabetical by name)
-and are considered the "PyGMT Developers":
+and are considered to be "PyGMT Developers":
 
 * [Dongdong Tian](https://seisman.info/) | [0000-0001-7967-1197](https://orcid.org/0000-0001-7967-1197) | Department of Earth and Environmental Sciences, Michigan State University, East Lansing, MI, USA
 * [Leonardo Uieda](http://www.leouieda.com/)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,7 +8,7 @@ Manoa.
 The following people have contributed code to the project (alphabetical by last name)
 and are considered the "PyGMT Developers":
 
-* [Michael Grund](https://github.com/michaelgrund)
+* [Michael Grund](https://github.com/michaelgrund) | [0000-0001-8759-2018](https://orcid.org/0000-0001-8759-2018)
 * [Wei Ji Leong](https://github.com/weiji14)
 * [Tyler Newton](http://www.tnewton.com/)
 * [William Schlitzer](https://github.com/willschlitzer) | [0000-0002-5843-2282](https://orcid.org/0000-0002-5843-2282)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,5 +13,5 @@ and are considered the "PyGMT Developers":
 * [Tyler Newton](http://www.tnewton.com/)
 * [William Schlitzer](https://github.com/willschlitzer)
 * [Dongdong Tian](https://seisman.info/)
-* [Liam Toney](https://liam.earth/)
+* [Liam Toney](https://liam.earth/) | Alaska Volcano Observatory and Wilson Alaska Technical Center, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, Alaska, USA | [0000-0003-0167-9433](https://orcid.org/0000-0003-0167-9433)
 * [Leonardo Uieda](http://www.leouieda.com/)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,7 +11,7 @@ and are considered the "PyGMT Developers":
 * [Michael Grund](https://github.com/michaelgrund)
 * [Wei Ji Leong](https://github.com/weiji14)
 * [Tyler Newton](http://www.tnewton.com/)
-* [William Schlitzer](https://github.com/willschlitzer)
+* [William Schlitzer](https://github.com/willschlitzer) | [0000-0002-5843-2282](https://orcid.org/0000-0002-5843-2282)
 * [Dongdong Tian](https://seisman.info/)
 * [Liam Toney](https://liam.earth/) | Alaska Volcano Observatory and Wilson Alaska Technical Center, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, Alaska, USA | [0000-0003-0167-9433](https://orcid.org/0000-0003-0167-9433)
 * [Leonardo Uieda](http://www.leouieda.com/)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,5 +14,5 @@ and are considered to be "PyGMT Developers":
 * [Malte Ziebarth](https://github.com/mjziebarth) | [0000-0002-5190-4478](https://orcid.org/0000-0002-5190-4478) | GFZ German Research Centre for Geosciences, Potsdam, Germany
 * [Michael Grund](https://github.com/michaelgrund) | [0000-0001-8759-2018](https://orcid.org/0000-0001-8759-2018)
 * [Tyler Newton](http://www.tnewton.com/)
-* [Wei Ji Leong](https://github.com/weiji14)
+* [Wei Ji Leong](https://github.com/weiji14) | [0000-0003-2354-1988](https://orcid.org/0000-0003-2354-1988) | Antarctic Research Centre, Victoria University of Wellington, Wellington, New Zealand
 * [William Schlitzer](https://github.com/willschlitzer) | [0000-0002-5843-2282](https://orcid.org/0000-0002-5843-2282)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,7 +9,7 @@ The following people have contributed code to the project (alphabetical by name)
 and are considered to be "PyGMT Developers":
 
 * [Dongdong Tian](https://seisman.info/) | [0000-0001-7967-1197](https://orcid.org/0000-0001-7967-1197) | Department of Earth and Environmental Sciences, Michigan State University, East Lansing, MI, USA
-* [Leonardo Uieda](http://www.leouieda.com/)
+ * [Leonardo Uieda](http://www.leouieda.com/) | [0000-0001-6123-9515](https://orcid.org/0000-0001-6123-9515) | Department of Earth, Ocean and Ecological Sciences, University of Liverpool, Liverpool, United Kingdom
 * [Liam Toney](https://liam.earth/) | [0000-0003-0167-9433](https://orcid.org/0000-0003-0167-9433) | Alaska Volcano Observatory and Wilson Alaska Technical Center, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK, USA
 * [Malte Ziebarth](https://github.com/mjziebarth) | [0000-0002-5190-4478](https://orcid.org/0000-0002-5190-4478) | GFZ German Research Centre for Geosciences, Potsdam, Germany
 * [Michael Grund](https://github.com/michaelgrund) | [0000-0001-8759-2018](https://orcid.org/0000-0001-8759-2018)

--- a/AUTHORSHIP.md
+++ b/AUTHORSHIP.md
@@ -36,9 +36,9 @@ be invited to be an author on the Zenodo archive of new releases.
 To be included as an author, you *must* add the following to the `AUTHORS.md`
 file of the repository:
 
-1. Full name
-2. Affiliation (if omitted, we will use "Unaffiliated")
-3. ORCID (optional)
+1. Full name (and a link to your website or GitHub page)
+2. [ORCID](https://orcid.org) (optional)
+3. Affiliation (if omitted, we will use "Unaffiliated")
 
 The order of authors will be defined by the number of commits to the repository
 (`git shortlog -sne`). The order can also be changed on a case-by-case basis.
@@ -54,18 +54,21 @@ there are a few options:
 ## Scientific publications (papers)
 
 We aim to write academic papers for most of our software packages. Ideally, we
-will publish updated papers for major changes or significant new components of the
-package.
+will publish updated papers for major changes or significant new components of
+the package.
 
 To be included as an author on the paper, you *must* satisfy the following
 criteria:
 
-1. Have made multiple and regular contributions to the repository, or the GMT repository, in numerous facets, such as wrapping functions, testing, and/or writing documentation.
-2. Have made non-coding contributions, including project administration and decision making.
+1. Have made multiple and regular contributions to the repository, or the GMT
+   repository, in numerous facets, such as wrapping functions, testing, and/or
+   writing documentation.
+2. Have made non-coding contributions, including project administration and
+   decision making.
 3. Have participated in the writing and reviewing of the paper.
-2. Add your full name, affiliation, and (optionally) ORCID to the paper. These
+4. Add your full name, affiliation, and (optionally) ORCID to the paper. These
    can be submitted on pull requests to the corresponding paper repository.
-3. Write and/or read and review the manuscript in a timely manner and provide
+5. Write and/or read and review the manuscript in a timely manner and provide
    comments on the paper (even if it's just an "OK", but preferably more).
 
 The order of authors will be defined by the number of commits made since the


### PR DESCRIPTION
**Description of proposed changes**

Add affiliation and ORCID to `AUTHORS.md`, in light of #726. Others can jump on this PR to add their info too.