### PR TITLE
Update forum link to pygmt specific category

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: GMT Community Forum
-    url: https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a/11
+    url: https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a
     about: Please ask questions here or find answers to common problems.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: GMT Community Forum
-    url: https://forum.generic-mapping-tools.org/
+    url: https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a/11
     about: Please ask questions here or find answers to common problems.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ read it carefully.
 
 Discussion often happens in the issues and pull requests.
 In addition, there is a
-[Discourse forum](https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a/11) for
+[Discourse forum](https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a) for
 the project where you can ask questions.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,9 @@ read it carefully.
 ## How Can I Talk to You?
 
 Discussion often happens in the issues and pull requests.
-In addition, there is a [Discourse forum](https://forum.generic-mapping-tools.org)
-for the project where you can ask questions.
+In addition, there is a
+[Discourse forum](https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a/11) for
+the project where you can ask questions.
 
 
 ## Reporting a Bug

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Contacting Us
   <https://github.com/GenericMappingTools/pygmt/issues/new>`__ or comment on any
   open issue or pull request.
 * We have a `Discourse forum
-  <https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a/11>`__ where you can ask
+  <https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a>`__ where you can ask
   questions and leave comments.
 
 

--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,9 @@ Contacting Us
   <https://github.com/GenericMappingTools/pygmt>`__. Feel free to `open an issue
   <https://github.com/GenericMappingTools/pygmt/issues/new>`__ or comment on any
   open issue or pull request.
-* We have a `Discourse forum <https://forum.generic-mapping-tools.org>`__
-  where you can ask questions and leave comments.
+* We have a `Discourse forum
+  <https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a/11>`__ where you can ask
+  questions and leave comments.
 
 
 Contributing

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -10,7 +10,8 @@ Installing
     We welcome any feedback and ideas!
     Let us know by submitting
     `issues on GitHub <https://github.com/GenericMappingTools/pygmt/issues>`__
-    or by posting on our `Discourse forum <https://forum.generic-mapping-tools.org>`__.
+    or by posting on our `Discourse forum
+    <https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a/11>`__.
 
 
 Which Python?

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -11,7 +11,7 @@ Installing
     Let us know by submitting
     `issues on GitHub <https://github.com/GenericMappingTools/pygmt/issues>`__
     or by posting on our `Discourse forum
-    <https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a/11>`__.
+    <https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a>`__.
 
 
 Which Python?


### PR DESCRIPTION
**Description of proposed changes**

Update all links to the GMT forum to point to the new PyGMT-specific category, as discussed in the community meeting and as recently created by @meghanrjones.

We might want to adjust the text in the associated docs surrounding the links slightly.