### PR TITLE
Revise pygmt development installation instructions

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -80,7 +80,7 @@ Now we can create a new conda environment with Python and all our dependencies i
 
      conda create --name pygmt python=3.9 pip numpy pandas xarray netcdf4 packaging gmt
 
-Activate the environment by running::
+Activate the environment by running the following (**do not forget this step!**))::
 
     conda activate pygmt
 
@@ -91,28 +91,61 @@ affect your default installation.
 Installing PyGMT
 ----------------
 
-Now that you have GMT installed and your conda environment activated, you can
-use ``conda`` to install the latest release of PyGMT from `conda-forge <https://anaconda.org/conda-forge/pygmt>`__::
+Now that you have GMT installed and your conda virtual environment activated, you can
+install PyGMT using any of the following methods:
+
+Using conda (recommended)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This installs the latest stable release of PyGMT from
+`conda-forge <https://anaconda.org/conda-forge/pygmt>`__::
 
     conda install pygmt
 
-or use ``pip`` to install from `PyPI <https://pypi.org/project/pygmt>`__::
+Using pip
+~~~~~~~~~
+
+This installs the latest stable release from
+`PyPI <https://pypi.org/project/pygmt>`__::
 
     pip install pygmt
 
-Alternatively, you can install the development version from the GitHub repository::
+Alternatively, you can install the latest development version from
+`TestPyPI <https://test.pypi.org/project/pygmt>`__::
 
-    pip install https://github.com/GenericMappingTools/pygmt/archive/master.zip
+    pip install --pre --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple pygmt
 
-This will allow you to use the ``pygmt`` library from Python.
+or from PyGMT's GitHub repository (slower as it downloads the whole archive)::
+
+    pip install git+https://github.com/GenericMappingTools/pygmt.git#egg=pygmt
+
+Any of the above methods (conda/pip) should allow you to use the ``pygmt``
+library from Python.
 
 
 Testing your install
 --------------------
 
+Quick check
+~~~~~~~~~~~
+
+To ensure that PyGMT and its depedencies are installed correctly, run the
+following in your Python interpreter::
+
+    import pygmt
+    pygmt.show_versions()
+
+Or run this in the command line::
+
+    python -c "import pygmt; pygmt.show_versions()
+
+
+Full test (optional)
+~~~~~~~~~~~~~~~~~~~~
+
 PyGMT ships with a full test suite.
-You can run our tests after you install it but you will need a few extra dependencies as
-well (be sure to have your conda env activated)::
+You can run our tests after you install it but you will need a few extra
+dependencies as well (be sure to have your conda environment activated)::
 
     conda install pytest pytest-mpl ipython
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -170,7 +170,7 @@ following in your Python interpreter::
 
 Or run this in the command line::
 
-    python -c "import pygmt; pygmt.show_versions()
+    python -c "import pygmt; pygmt.show_versions()"
 
 
 Full test (optional)

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -14,11 +14,38 @@ Installing
     <https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a>`__.
 
 
+Quickstart
+----------
+
+The fastest way to install PyGMT is with the
+`conda <https://docs.conda.io/projects/conda/en/latest/user-guide/index.html>`__
+package manager which takes care of setting up a virtual environment, as well
+as the installation of GMT and all the dependencies PyGMT depends on::
+
+    conda create --name pygmt --channel conda-forge pygmt
+
+To activate the virtual environment, you can do::
+
+    conda activate pygmt
+
+After this, check that everything works by running the following in a Python
+interpreter. If you are using Jupyter, make sure you have connected to the
+'pygmt' kernel before running the below::
+
+    import pygmt
+    pygmt.show_versions()
+
+You are now ready to make you first figure!
+Start by looking at the tutorials on our sidebar, good luck!
+
+The sections below provide a more detailed, step by step instructions to
+installing and testing PyGMT for those who may have a slightly different setup.
+
 Which Python?
 -------------
 
-You'll need **Python 3.7 or greater** to run PyGMT. Older Python versions may
-work, but there is no guarantee that PyGMT will work as expected.
+PyGMT is tested to run on **Python 3.7 or greater**. Older Python versions may
+work, but there is no guarantee that PyGMT will behave as expected.
 
 We recommend using the `Anaconda <https://www.anaconda.com/distribution>`__
 Python distribution to ensure you have all dependencies installed and the

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -17,12 +17,12 @@ Installing
 Which Python?
 -------------
 
-You'll need **Python 3.7 or greater** to run PyGMT. Old Python versions may
-work, but there is no guarantee that PyGMT will work as expected with old versions.
+You'll need **Python 3.7 or greater** to run PyGMT. Older Python versions may
+work, but there is no guarantee that PyGMT will work as expected.
 
-We recommend using the `Anaconda <https://www.anaconda.com/distribution>`__ Python
-distribution to ensure you have all dependencies installed and the ``conda``
-package manager available.
+We recommend using the `Anaconda <https://www.anaconda.com/distribution>`__
+Python distribution to ensure you have all dependencies installed and the
+``conda`` package manager available.
 Installing Anaconda does not require administrative rights to your computer and
 doesn't interfere with any other Python installations in your system.
 
@@ -30,18 +30,19 @@ doesn't interfere with any other Python installations in your system.
 Which GMT?
 ----------
 
-PyGMT requires Generic Mapping Tools (GMT) version 6 as a minimum, which is the latest
-released version that can be found at
+PyGMT requires Generic Mapping Tools (GMT) version 6 as a minimum, which is the
+latest released version that can be found at
 the `GMT official site <https://www.generic-mapping-tools.org>`__.
-We need the latest GMT (>=6.1.1) since there are many changes being made to GMT itself in
-response to the development of PyGMT, mainly the new
+We need the latest GMT (>=6.1.1) since there are many changes being made to GMT
+itself in response to the development of PyGMT, mainly the new
 `modern execution mode <https://docs.generic-mapping-tools.org/latest/cookbook/introduction.html#modern-and-classic-mode>`__.
 
-Compiled conda packages of GMT for Linux, macOS and Windows are provided through
-`conda-forge <https://anaconda.org/conda-forge/gmt>`__.
+Compiled conda packages of GMT for Linux, macOS and Windows are provided
+through `conda-forge <https://anaconda.org/conda-forge/gmt>`__.
 Advanced users can also
 `build GMT from source <https://github.com/GenericMappingTools/gmt/blob/master/BUILDING.md>`__
-instead, which is not so recommended but we would love to get feedback from anyone who tries.
+instead, which is not so recommended but we would love to get feedback from
+anyone who tries.
 
 We recommend following the instructions further on to install GMT 6.
 
@@ -58,25 +59,27 @@ PyGMT requires the following libraries:
 
 The following are optional (but recommended) dependencies:
 
-* `IPython <https://ipython.org/>`__: For embedding the figures in Jupyter notebooks.
+* `IPython <https://ipython.org/>`__: For embedding the figures in Jupyter
+notebooks.
 
 
 Installing GMT and other dependencies
 -------------------------------------
 
-Before installing PyGMT, we must install GMT itself along with the other dependencies.
-The easiest way to do this is using the ``conda`` package manager.
+Before installing PyGMT, we must install GMT itself along with the other
+dependencies. The easiest way to do this is via the ``conda`` package manager.
 We recommend working in an isolated
 `conda environment <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__
-to avoid issues with competing versions of its dependencies.
+to avoid issues with conflicting versions of dependencies.
 
 First, we must configure conda to get packages from the
 `conda-forge channel <https://conda-forge.org/>`__::
 
     conda config --prepend channels conda-forge
 
-Now we can create a new conda environment with Python and all our dependencies installed
-(we'll call it ``pygmt`` but you can change it to whatever you want)::
+Now we can create a new conda environment with Python and all our dependencies
+installed (we'll call it ``pygmt`` but feel free to change it to whatever you
+want)::
 
      conda create --name pygmt python=3.9 pip numpy pandas xarray netcdf4 packaging gmt
 
@@ -84,15 +87,15 @@ Activate the environment by running the following (**do not forget this step!**)
 
     conda activate pygmt
 
-From now on, all commands will take place inside the conda virtual environment and won't
-affect your default installation.
+From now on, all commands will take place inside the conda virtual environment
+called 'pygmt' and won't affect your default 'base' installation.
 
 
 Installing PyGMT
 ----------------
 
-Now that you have GMT installed and your conda virtual environment activated, you can
-install PyGMT using any of the following methods:
+Now that you have GMT installed and your conda virtual environment activated,
+you can install PyGMT using any of the following methods:
 
 Using conda (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -165,9 +168,9 @@ This can happen if you have multiple versions of GMT installed.
 
 You can tell PyGMT exactly where to look for ``libgmt`` by setting the
 ``GMT_LIBRARY_PATH`` environment variable.
-This should be set to the directory where ``libgmt.so``, ``libgmt.dylib`` or ``gmt.dll``
-can be found for Linux, macOS and Windows respectively.
-e.g. in a terminal run::
+This should be set to the directory where ``libgmt.so``, ``libgmt.dylib`` or
+``gmt.dll`` can be found for Linux, macOS and Windows respectively.
+e.g. on a command line, run::
 
     # Linux/macOS
     export GMT_LIBRARY_PATH=$HOME/anaconda3/envs/pygmt/lib

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -29,8 +29,7 @@ To activate the virtual environment, you can do::
     conda activate pygmt
 
 After this, check that everything works by running the following in a Python
-interpreter. If you are using Jupyter, make sure you have connected to the
-'pygmt' kernel before running the below::
+interpreter (e.g. in a Jupyter notebook)::
 
     import pygmt
     pygmt.show_versions()
@@ -38,8 +37,11 @@ interpreter. If you are using Jupyter, make sure you have connected to the
 You are now ready to make you first figure!
 Start by looking at the tutorials on our sidebar, good luck!
 
-The sections below provide a more detailed, step by step instructions to
-installing and testing PyGMT for those who may have a slightly different setup.
+.. note::
+
+    The sections below provide more detailed, step by step instructions to
+    installing and testing PyGMT for those who may have a slightly different
+    setup.
 
 Which Python?
 -------------
@@ -110,7 +112,7 @@ want)::
 
      conda create --name pygmt python=3.9 pip numpy pandas xarray netcdf4 packaging gmt
 
-Activate the environment by running the following (**do not forget this step!**))::
+Activate the environment by running the following (**do not forget this step!**)::
 
     conda activate pygmt
 
@@ -145,7 +147,8 @@ Alternatively, you can install the latest development version from
 
     pip install --pre --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple pygmt
 
-or from PyGMT's GitHub repository (slower as it downloads the whole archive)::
+or from PyGMT's `GitHub repository <https://github.com/GenericMappingTools/pygmt>`__ 
+(slower as it downloads the whole archive)::
 
     pip install git+https://github.com/GenericMappingTools/pygmt.git#egg=pygmt
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ PLATFORMS = "Any"
 INSTALL_REQUIRES = ["numpy", "pandas", "xarray", "netCDF4", "packaging"]
 # Configuration for setuptools-scm
 SETUP_REQUIRES = ["setuptools_scm"]
-USE_SCM_VERSION = {"local_scheme": "node-and-date"}
+USE_SCM_VERSION = {"local_scheme": "node-and-date", "fallback_version": "unknown"}
 
 if __name__ == "__main__":
     setup(


### PR DESCRIPTION
**Description of proposed changes**

Ensure that users can install the development version of PyGMT without getting a `LookupError`. Also update instructions on installing pygmt from conda/pip. Some changes include:

- Added a quickstart section so people can get up and running quicker!
- Split some things up into subsections to be clearer
- Point out what are recommended or optional steps

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Live preview is at https://pygmt-git-fix-pip-install-dev.gmt.vercel.app/install.html

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #856


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
