### PR TITLE
Let GMT skip refreshing the server data files

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -89,7 +89,9 @@ jobs:
         run: |
           mkdir -p ~/.gmt
           mv .gmt/* ~/.gmt
-          ls -lh ~/.gmt
+          # Change modification times of the two files, so GMT won't refresh it
+          touch ~/.gmt/server/gmt_data_server.txt ~/.gmt/server/gmt_hash_server.txt
+          ls -lhR ~/.gmt
 
       # Install the package that we want to test
       - name: Install the package

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -108,7 +108,9 @@ jobs:
         run: |
           mkdir -p ~/.gmt
           mv .gmt/* ~/.gmt
-          ls -lh ~/.gmt
+          # Change modification times of the two files, so GMT won't refresh it
+          touch ~/.gmt/server/gmt_data_server.txt ~/.gmt/server/gmt_hash_server.txt
+          ls -lhR ~/.gmt
 
       # Install the package that we want to test
       - name: Install the package


### PR DESCRIPTION
**Description of proposed changes**

The GMT caches and remote data are cached in GitHub Actions by the
`cache_data.yaml` workflow, because the Linux and Windows agents can't
connect to the GMT's data server. The "Cache data" workflow is run weekly.

When GMT needs to access a remote file, it first checks if `~/.gmt/server/gmt_data_server.txt`
is older than 1 day. If yes, then GMT downloads the newer version of the file
from the GMT data server. As the Linux and Windwos agents have network connection
issues, the tests are slower due to the internet connection.

In this PR, we run the `touch` command to update the modification times of the
GMT's two server files, so that GMT won't try to refresh it.

This PR should decrease the CI time by 10 s on Linux and Windows, 
but we can't test it.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
