### PR TITLE
Changes to speed up Earth relief and regions tutorials

### DIFF
--- a/examples/tutorials/earth-relief.py
+++ b/examples/tutorials/earth-relief.py
@@ -21,8 +21,9 @@ import pygmt
 
 ########################################################################################
 # Load sample Earth relief data for the entire globe at a resolution of 30 arc minutes.
-# The other available resolutions are show at :gmt-docs:`datasets/remote-data.html#global-earth-relief-grids`.
-grid = pygmt.datasets.load_earth_relief(resolution="30m")
+# The other available resolutions are show
+# at :gmt-docs:`datasets/remote-data.html#global-earth-relief-grids`.
+grid = pygmt.datasets.load_earth_relief(resolution="30m", registration="gridline")
 
 ########################################################################################
 # Create a plot
@@ -95,8 +96,8 @@ fig.show()
 #
 # In addition to providing global data, the ``region`` argument for
 # :meth:`pygmt.datasets.load_earth_relief` can be used to provide data for a specific
-# area. The ``region`` argument is required for resolutions at 5 arc minutes or higher, and
-# accepts a list (as in the example below) or a string. The geographic ranges are
+# area. The ``region`` argument is required for resolutions at 5 arc minutes or higher,
+# and accepts a list (as in the example below) or a string. The geographic ranges are
 # passed as *xmin*/*xmax*/*ymin*/*ymax*.
 #
 # The example below uses data with a 5 arc minute resolution, and plots it on a

--- a/examples/tutorials/regions.py
+++ b/examples/tutorials/regions.py
@@ -96,9 +96,8 @@ fig = pygmt.Figure()
 fig.coast(
     region="d",
     projection="Cyl_stere/12c",
-    land="lightgray",
+    land="darkgray",
     water="white",
-    borders="1/0.5p",
     shorelines="1/0.5p",
     frame="ag",
 )
@@ -115,9 +114,8 @@ fig = pygmt.Figure()
 fig.coast(
     region="g",
     projection="Cyl_stere/12c",
-    land="lightgray",
+    land="darkgray",
     water="white",
-    borders="1/0.5p",
     shorelines="1/0.5p",
     frame="ag",
 )


### PR DESCRIPTION
Makes the changes suggested for `regions.py` and `earth-relief.py` to reduce the time to generate the tutorials. This PR removes the internal national borders in `regions.py` and changes the land color to dark gray. It also changes the `registration` for the loaded Earth relief grid to "gridline" because that is the cached version.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #825


**Reminders**

- [X] Run `make format` and `make check` to make sure the code follows the style guide.


**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
