### PR TITLE
Let load_earth_relief() support 'region' argument for all resolutions

### DIFF
--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -1,6 +1,6 @@
 """
 Function to download the Earth relief datasets from the GMT data server, and
-load as DataArray.
+load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
@@ -12,7 +12,7 @@ from pygmt.src import grdcut, which
 
 @kwargs_to_strings(region="sequence")
 def load_earth_relief(resolution="01d", region=None, registration=None):
-    """
+    r"""
     Load Earth relief grids (topography and bathymetry) in various resolutions.
 
     The grids are downloaded to a user data directory
@@ -21,8 +21,11 @@ def load_earth_relief(resolution="01d", region=None, registration=None):
     So you'll need an internet connection the first time around.
 
     These grids can also be accessed by passing in the file name
-    ``'@earth_relief_rru[_reg]'`` to any grid plotting/processing function.
-    Refer to :gmt-docs:`datasets/remote-data.html` for more details.
+    **@earth_relief**\_\ *res*\[_\ *reg*] to any grid plotting/processing
+    function. *res* is the grid resolution (see below), and *reg* is grid
+    registration type (**p** for pixel registration or *g* for gridline
+    registration). Refer to :gmt-docs:`datasets/remote-data.html` for more
+    details.
 
     Parameters
     ----------
@@ -35,7 +38,7 @@ def load_earth_relief(resolution="01d", region=None, registration=None):
 
     region : str or list
         The subregion of the grid to load. Required for Earth relief grids with
-        resolutions <= 05m.
+        resolutions higher than 5 arc-minute (i.e., ``05m``).
 
     registration : str
         Grid registration type. Either ``pixel`` for pixel registration or
@@ -45,14 +48,15 @@ def load_earth_relief(resolution="01d", region=None, registration=None):
 
     Returns
     -------
-    grid : xarray.DataArray
+    grid : :class:`xarray.DataArray`
         The Earth relief grid. Coordinates are latitude and longitude in
         degrees. Relief is in meters.
 
     Notes
     -----
-    The DataArray doesn's support slice operation, for Earth relief data with
-    resolutions higher than "05m", which are stored as smaller tiles.
+    The :class:`xarray.DataArray` grid doesn't support slice operation, for
+    Earth relief data with resolutions higher than "05m", which are stored as
+    smaller tiles.
 
     Examples
     --------

--- a/pygmt/tests/test_datasets.py
+++ b/pygmt/tests/test_datasets.py
@@ -93,8 +93,14 @@ def test_earth_relief_01d_with_region():
     """
     Test loading low-resolution earth relief with 'region'.
     """
-    with pytest.raises(NotImplementedError):
-        load_earth_relief("01d", region=[0, 180, 0, 90])
+    data = load_earth_relief(
+        resolution="01d", region=[-10, 10, -5, 5], registration="gridline"
+    )
+    assert data.shape == (11, 21)
+    npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
+    npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
+    npt.assert_allclose(data.min(), -5145)
+    npt.assert_allclose(data.max(), 805.5)
 
 
 def test_earth_relief_30m():


### PR DESCRIPTION
**Description of proposed changes**

In #542, we extended the `load_earth_relief()` function to support all resolutions, and also allow `region` argument for high-resolution grids (>=05m). We had some discussions (https://github.com/GenericMappingTools/pygmt/pull/542#discussion_r459217054) and decided not to allow `region` for low-resolution grids (<=06m), due to a known issue of xr.DataArray slice operation (https://github.com/GenericMappingTools/pygmt/issues/524#issuecomment-662274140).

However, I feel that it's a wrong decision to disallow `region` for low-resolution grids, because xr.DataArray slice operation (https://github.com/GenericMappingTools/pygmt/issues/524#issuecomment-662274140) is not commonly used, especially for the GMT's earth relief data, and we have `grdcut` to do slice operation.

In this PR, we allow `load_earth_relief()` function to accept the `region` argument for all grid resolutions. 

Fixes #870.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
