### PR TITLE
Update formatting for install bullet list

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -89,7 +89,7 @@ PyGMT requires the following libraries:
 The following are optional (but recommended) dependencies:
 
 * `IPython <https://ipython.org/>`__: For embedding the figures in Jupyter
-notebooks.
+  notebooks.
 
 
 Installing GMT and other dependencies


### PR DESCRIPTION
**Description of proposed changes**

I was getting this sphinx warning when building the docs: ```pygmt/doc/install.rst:92: WARNING: Bullet list ends without a blank line; unexpected unindent.```, which is reflected in the [published docs](https://www.pygmt.org/dev/install.html#dependencies). This PR fixes the ReST indentation for that bullet list. 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
