### PR TITLE
CI: Add GMT's bin to PATH for GMT dev tests

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -118,6 +118,10 @@ jobs:
           python setup.py sdist --formats=zip
           pip install dist/*
 
+      - name: Add GMT's bin to PATH (Linux/macOS)
+        run: echo ${GITHUB_WORKSPACE}/gmt-install-dir/bin >> $GITHUB_PATH
+        if: runner.os != 'Windows'
+
       # Run the tests
       - name: Test with pytest (Linux/macOS)
         run: make test PYTEST_EXTRA="-r P"


### PR DESCRIPTION
**Description of proposed changes**

See #874 for context.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #874.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
