### PR TITLE
Add alias annotation (A) to Figure.contour()

### DIFF
--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -62,7 +62,7 @@ def contour(self, x=None, y=None, z=None, data=None, **kwargs):
         contours specified in ``interval``.
 
         - Specify a fixed annotation interval *annot_int* or a
-          single annotation level +\ *annot_int* .
+          single annotation level +\ *annot_int*.
     {B}
     levels : str
         Contour file or level(s)

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -57,7 +57,7 @@ def contour(self, x=None, y=None, z=None, data=None, **kwargs):
         Either a data file name or a 2d numpy array with the tabular data.
     {J}
     {R}
-    annotation : str,  int, or list
+    annotation : str or int
         Specify or disable annotated contour levels, modifies annotated
         contours specified in ``interval``.
 

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -16,35 +16,34 @@ from pygmt.helpers import (
 
 @fmt_docstring
 @use_alias(
-    R="region",
-    J="projection",
+    A="annotation",
     B="frame",
-    S="skip",
+    C="levels",
     G="label_placement",
-    W="pen",
+    J="projection",
     L="triangular_mesh_pen",
     N="no_clip",
-    i="columns",
-    l="label",
-    C="levels",
+    R="region",
+    S="skip",
     V="verbose",
+    W="pen",
     X="xshift",
     Y="yshift",
     c="panel",
+    i="columns",
+    l="label",
     p="perspective",
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 def contour(self, x=None, y=None, z=None, data=None, **kwargs):
-    """
+    r"""
     Contour table data by direct triangulation.
 
     Takes a matrix, (x,y,z) pairs, or a file name as input and plots lines,
     polygons, or symbols at those locations on a map.
 
     Must provide either *data* or *x*, *y*, and *z*.
-
-    [TODO: Insert more documentation]
 
     Full option list at :gmt-docs:`contour.html`
 
@@ -58,10 +57,12 @@ def contour(self, x=None, y=None, z=None, data=None, **kwargs):
         Either a data file name or a 2d numpy array with the tabular data.
     {J}
     {R}
-    A : bool or str
-        ``'[m|p|x|y]'``
-        By default, geographic line segments are drawn as great circle
-        arcs. To draw them as straight lines, use *A*.
+    annotation : str,  int, or list
+        Specify or disable annotated contour levels, modifies annotated
+        contours specified in ``interval``.
+
+        - Specify a fixed annotation interval *annot_int* or a
+          single annotation level +\ *annot_int* .
     {B}
     levels : str
         Contour file or level(s)


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This PR fixes the description of the **A** option for ```pygmt.Figure.contour``` in the [PyGMT docs](https://www.pygmt.org/dev/api/generated/pygmt.Figure.contour.html#pygmt.Figure.contour) and adds the ```annotation``` alias for **A**. It also reorders the arguments to the ```use_alias``` decorator to be alphabetical in similarity to the other modules (some modules list **R** and **J** first but most seem to use strict alphabetical order independent of required versus optional arguments). 
<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #879 


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
