### PR TITLE
Ensure proper non-dev version string when publishing to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -55,11 +55,11 @@ jobs:
     - name: Publish to Test PyPI
       uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
-        password: ${{ secrets.test_pypi_password }}
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
-        password: ${{ secrets.pypi_password }}
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -36,6 +36,7 @@ jobs:
       run: python -m pip install setuptools wheel
 
     - name: Fix up version string
+      if: !startsWith(github.ref, 'refs/tags')
       run: |
         # Change setuptools-scm local_scheme to "no-local-version" so the
         # local part of the version isn't included, making the version string

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,6 +19,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
+    if: github.repository == 'GenericMappingTools/pygmt'
 
     steps:
     - name: Checkout
@@ -35,8 +36,8 @@ jobs:
     - name: Install dependencies
       run: python -m pip install setuptools wheel
 
+    # This step is only necessary for testing purposes and for TestPyPI
     - name: Fix up version string for TestPyPI
-      # This step is only necessary for testing purposes and for TestPyPI
       if: !startsWith(github.ref, 'refs/tags')
       run: |
         # Change setuptools-scm local_scheme to "no-local-version" so the

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2.3.4
       with:
-        # fecth all history so that setuptools-scm works
+        # fetch all history so that setuptools-scm works
         fetch-depth: 0
 
     - name: Set up Python

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -38,7 +38,7 @@ jobs:
 
     # This step is only necessary for testing purposes and for TestPyPI
     - name: Fix up version string for TestPyPI
-      if: !startsWith(github.ref, 'refs/tags')
+      if: ${{ !startsWith(github.ref, 'refs/tags') }}
       run: |
         # Change setuptools-scm local_scheme to "no-local-version" so the
         # local part of the version isn't included, making the version string

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,9 +11,9 @@ on:
     types:
       - published
   # Runs for pull requests should be disabled other than for testing purposes
-  pull_request:
-    branches:
-      - master
+  #pull_request:
+  #  branches:
+  #    - master
 
 jobs:
   publish-pypi:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -35,14 +35,13 @@ jobs:
     - name: Install dependencies
       run: python -m pip install setuptools wheel
 
-    - name: Fix up version string
+    - name: Fix up version string for TestPyPI
+      # This step is only necessary for testing purposes and for TestPyPI
       if: !startsWith(github.ref, 'refs/tags')
       run: |
         # Change setuptools-scm local_scheme to "no-local-version" so the
         # local part of the version isn't included, making the version string
         # compatible with PyPI.
-        #
-        # The step is only necessary for testing purpose
         sed --in-place "s/node-and-date/no-local-version/g" setup.py
 
     - name: Build source and wheel distributions

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,9 +11,9 @@ on:
     types:
       - published
   # Runs for pull requests should be disabled other than for testing purposes
-  #pull_request:
-  #  branches:
-  #    - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   publish-pypi:


### PR DESCRIPTION
**Description of proposed changes**

Ensures that the PyPI release Github Action workflow has a proper version string like `v0.3.0` instead of `v0.3.1.dev0`. Also edit the Publish-to-PyPI workflow to only run on GenericMappingTools/pygmt and rename secrets from `*_PYPI_PASSWORD` to `*_PYPI_API_TOKEN`

Publish Publish Github Action Documentation is at https://github.com/pypa/gh-action-pypi-publish/tree/v1.4.2

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses https://github.com/GenericMappingTools/pygmt/issues/845#issuecomment-779148771, also fixes #901.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
