### PR TITLE
CI: Run tests on Ubuntu + Python 3.9 only for draft PRs

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths-ignore:
       - 'doc/**'
       - '*.md'
@@ -29,6 +30,22 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        # Is a draft PR?
+        isDraft:
+          - ${{ github.event.pull_request.draft }}
+        # Only run one job (Ubuntu + Python 3.9) for draft PRs
+        exclude:
+          - os: macOS-latest
+            isDraft: true
+          - os: windows-latest
+            isDraft: true
+          - os: ubuntu-latest
+            python-version: 3.7
+            isDraft: true
+          - os: ubuntu-latest
+            python-version: 3.8
+            isDraft: true
+
     # environmental variables used in coverage
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
This PR makes changes to save CI resources:

- For draft PRs: only run tests on Ubuntu + Python 3.9 (~10 minutes)
- When draft PRs are ready for review, run all CI jobs (9 jobs, 10-30 minutes)
- If converting PRs back to draft mode, pushes still only trigger one job