### PR TITLE
CI: Run tests in a single CI job (Ubuntu + Python 3.9) for draft PRs

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        # Is a draft PR (true or false)?
+        # Is it a draft Pull Request (true or false)?
         isDraft:
           - ${{ github.event.pull_request.draft }}
         # Only run one job (Ubuntu + Python 3.9) for draft PRs

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        # Is a draft PR (true|false)?
+        # Is a draft PR (true or false)?
         isDraft:
           - ${{ github.event.pull_request.draft }}
         # Only run one job (Ubuntu + Python 3.9) for draft PRs

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths-ignore:
       - 'doc/**'
       - '*.md'
@@ -29,6 +30,22 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        # Is a draft PR?
+        isDraft:
+          - ${{ github.event.pull_request.draft }}
+        # Only run one job (Ubuntu + Python 3.9) for draft PRs
+        exclude:
+          - os: macOS-latest
+            isDraft: true
+          - os: windows-latest
+            isDraft: true
+          - os: ubuntu-latest
+            python-version: 3.7
+            isDraft: true
+          - os: ubuntu-latest
+            python-version: 3.8
+            isDraft: true
+
     # environmental variables used in coverage
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        # Is a draft PR?
+        # Is a draft PR (true|false)?
         isDraft:
           - ${{ github.event.pull_request.draft }}
         # Only run one job (Ubuntu + Python 3.9) for draft PRs

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -58,6 +58,8 @@ It is also scheduled to run daily on the *master* branch.
 
 This is ran on every commit to the *master* and Pull Request branches.
 It is also scheduled to run daily on the *master* branch.
+In draft PRs, only one job (Ubuntu + Python latest) is triggered to
+save CI resources.
 
 On the *master* branch, the workflow also handles the documentation deployment:
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -58,8 +58,8 @@ It is also scheduled to run daily on the *master* branch.
 
 This is ran on every commit to the *master* and Pull Request branches.
 It is also scheduled to run daily on the *master* branch.
-In draft PRs, only one job (Ubuntu + Python latest) is triggered to
-save CI resources.
+In draft Pull Requests, only one job (Ubuntu + Python latest)
+is triggered to save on Continuous Integration resources.
 
 On the *master* branch, the workflow also handles the documentation deployment:
 


### PR DESCRIPTION
**Description of proposed changes**

This PR is inspired by another PR #869 from @willschlitzer.

This PR improves [the "Tests" workflow](https://github.com/GenericMappingTools/pygmt/blob/master/.github/workflows/ci_tests.yaml) to save CI resources. 

Expected behavior (see the comments below for how it actually works):

- For draft PRs: only run tests on Ubuntu + Python 3.9 (~10 minutes)
- When draft PRs are ready for review, run all CI jobs (9 jobs, 10-30 minutes)
- If converting PRs back to draft mode, pushes still only trigger one job (~10 minutes)
- After merged into master, all 9 jobs will run.


References:

1. https://github.com/asyncapi/parser-js/pull/204
2. https://github.community/t/how-to-conditionally-include-exclude-items-in-matrix-eg-based-on-branch/16853/6

Closes #869.

