### PR TITLE
Fix bug that stops Figure.coast from plotting with only dcw

### DIFF
--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -187,10 +187,10 @@ def coast(self, **kwargs):
     {V}
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
-    if not args_in_kwargs(args=["C", "G", "S", "I", "N", "Q", "W"], kwargs=kwargs):
+    if not args_in_kwargs(args=["C", "G", "S", "I", "N", "E", "Q", "W"], kwargs=kwargs):
         raise GMTInvalidInput(
             """At least one of the following arguments must be specified:
-            lakes, land, water, rivers, borders, Q, or shorelines"""
+            lakes, land, water, rivers, borders, dcw, Q, or shorelines"""
         )
     with Session() as lib:
         lib.call_module("coast", build_arg_string(kwargs))


### PR DESCRIPTION
GMT allows coast to plot with the `-E` argument and no other colors set, but PyGMT would raise an error if `dcw` was the only argument. This is a fix for that.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #903


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
