### PR TITLE
Pin pylint to 2.6.0

### DIFF
--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install packages
         run: |
-          pip install black blackdoc docformatter flake8 pylint isort
+          pip install black blackdoc docformatter flake8 pylint==2.6.0 isort
           sudo apt-get install dos2unix
 
       - name: Formatting check (black, blackdoc, docformatter, flake8 and isort)


### PR DESCRIPTION
**Description of proposed changes**

Temporary fix for `AttributeError: module 'pylint.checkers.utils' has no attribute 'is_call_of_name'`. Workaround https://github.com/PyCQA/pylint/issues/4096.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
