### PR TITLE
Improve the error message for loading a old version of the GMT library

### DIFF
--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -151,5 +151,10 @@ def check_libgmt(libgmt):
     functions = ["Create_Session", "Get_Enum", "Call_Module", "Destroy_Session"]
     for func in functions:
         if not hasattr(libgmt, "GMT_" + func):
-            msg = f"Error loading libgmt. Couldn't access function GMT_{func}."
+            # pylint: disable=protected-access
+            msg = (
+                f"Error loading '{libgmt._name}'. "
+                f"Couldn't access function GMT_{func}. "
+                "Maybe loading an old version of the GMT shared library."
+            )
             raise GMTCLibError(msg)

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -153,8 +153,9 @@ def check_libgmt(libgmt):
         if not hasattr(libgmt, "GMT_" + func):
             # pylint: disable=protected-access
             msg = (
-                f"Error loading '{libgmt._name}'. "
-                f"Couldn't access function GMT_{func}. "
-                "Maybe loading an old version of the GMT shared library."
+                f"Error loading '{libgmt._name}'. Couldn't access function GMT_{func}. "
+                "Ensure that you have installed an up-to-date GMT version 6 library. "
+                "Please set the environment variable 'GMT_LIBRARY_PATH' to the "
+                "directory of the GMT 6 library."
             )
             raise GMTCLibError(msg)

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -19,9 +19,12 @@ def test_check_libgmt():
 
     libgmt._name = "/path/to/libgmt.so"  # pylint: disable=protected-access
     msg = (
-        f"Error loading '{libgmt._name}'. "  # pylint: disable=protected-access
+        # pylint: disable=protected-access
+        f"Error loading '{libgmt._name}'. "
         "Couldn't access function GMT_Create_Session. "
-        "Maybe loading an old version of the GMT shared library."
+        "Ensure that you have installed an up-to-date GMT version 6 library. "
+        "Please set the environment variable 'GMT_LIBRARY_PATH' to the "
+        "directory of the GMT 6 library."
     )
     with pytest.raises(GMTCLibError, match=msg):
         check_libgmt(libgmt)

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -13,8 +13,18 @@ def test_check_libgmt():
     """
     Make sure check_libgmt fails when given a bogus library.
     """
-    with pytest.raises(GMTCLibError):
-        check_libgmt(dict())
+    # create a fake library with a "_name" property
+    def libgmt():
+        pass
+
+    libgmt._name = "/path/to/libgmt.so"  # pylint: disable=protected-access
+    msg = (
+        f"Error loading '{libgmt._name}'. "  # pylint: disable=protected-access
+        "Couldn't access function GMT_Create_Session. "
+        "Maybe loading an old version of the GMT shared library."
+    )
+    with pytest.raises(GMTCLibError, match=msg):
+        check_libgmt(libgmt)
 
 
 def test_load_libgmt():


### PR DESCRIPTION
**Description of proposed changes**

See the [forum post](https://forum.generic-mapping-tools.org/t/getting-pygmt-running-in-jupyter/1329) for context. 

When multiple GMT versions are installed, PyGMT may incorrectly load the old version (e.g., GMT 5.4.5) and reports that it can't access a function `GMT_xxx`. As shown in the forum post, the error message is not helpful at all. 

In this PR, we improve the error message:

1. Show the library name `libgmt._name` (name or full path, depending on how the library was loaded) in the error message
2. Mention that the possible cause is PyGMT is loading an old version of the GMT library

Now the error message is:
```
GMTCLibError: Error loading '/path/to/libgmt.so'. Couldn't access function GMT_Create_Session. Maybe loading an old version of the GMT shared library.
```

The test `test_check_libgmt` is also updated to check the improve message.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
