### PR TITLE
Remove nbsphinx extension

### DIFF
--- a/doc/_templates/breadcrumbs.html
+++ b/doc/_templates/breadcrumbs.html
@@ -1,5 +1,4 @@
-{# Extend the RTD template to include "Edit on GitHub" and option to download
-   notebook generated pages from nbsphinx #}
+{# Extend the RTD template to include "Edit on GitHub" #}
 {% extends "!breadcrumbs.html" %}
 
 
@@ -25,10 +24,6 @@
                 <a href="https://github.com/{{ github_repo }}/edit/{{ github_version }}/{{ doc_path }}/{{ pagename }}{{ suffix }}"
                    class="fa fa-github"> Improve this page</a>
             {% endif %}
-        {% endif %}
-        {% if suffix == ".ipynb" %}
-            <a href="https://github.com/{{ github_repo }}/raw/{{ github_version }}/{{ doc_path }}/{{ pagename }}{{ suffix }}"
-               class="fa fa-download"> Download notebook</a>
         {% endif %}
     </li>
 {% endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,7 +26,6 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
-    "nbsphinx",
     "sphinx_gallery.gen_gallery",
     "sphinx_copybutton",
 ]

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,6 @@ dependencies:
     - jupyter
     - make
     - matplotlib
-    - nbsphinx
     - pylint
     - pytest-cov
     - pytest-mpl


### PR DESCRIPTION
**Description of proposed changes**

This PR removes the ``nbsphinx`` extension because it is no longer needed after #268 and produces unnecessary warnings about duplicate files. 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #920 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
