### PR TITLE
Format equation in surface docstring

### DIFF
--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -26,9 +26,9 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
     Surface reads randomly-spaced (x,y,z) triples and produces gridded values
     z(x,y) by solving:
 
-    .. math::    (1 - T)\nabla^2(z)+t\nabla(z) = 0
+    .. math::    (1 - t)\nabla^2(z)+t\nabla(z) = 0
 
-    where :math:`T` is a tension factor between 0 and 1, and :math:`\nabla`
+    where :math:`t` is a tension factor between 0 and 1, and :math:`\nabla`
     indicates the Laplacian operator.
 
     Takes a matrix, xyz triples, or a file name as input.

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -26,14 +26,14 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
     Surface reads randomly-spaced (x,y,z) triples and produces gridded values
     z(x,y) by solving:
 
-        (1 - T) * L (L (z)) + T * L (z) = 0
+    .. math::    (1 - T)\nabla^2(z)+t\nabla(z) = 0
 
-    where T is a tension factor between 0 and 1, and L indicates the Laplacian
-    operator.
+    where :math:`T` is a tension factor between 0 and 1, and :math:`\nabla`
+    indicates the Laplacian operator.
 
     Takes a matrix, xyz triples, or a file name as input.
 
-    Must provide either *data* or *x*, *y*, and *z*.
+    Must provide either ``data`` or ``x``, ``y``, and ``z``.
 
     Full option list at :gmt-docs:`surface.html`
 
@@ -64,10 +64,11 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
     Returns
     -------
     ret: xarray.DataArray or None
-        Return type depends on whether the outfile (G) parameter is set:
+        Return type depends on whether the ``outfile`` parameter is set:
 
-        - xarray.DataArray if outfile (G) is not set
-        - None if outfile (G) is set (grid output will be stored in outfile)
+        - :class:`xarray.DataArray`: if ``outfile`` is not set
+        - None if ``outfile`` is set (grid output will be stored in file set by
+          ``outfile``)
     """
     kind = data_kind(data, x, y, z)
     if kind == "vectors" and z is None:


### PR DESCRIPTION
**Description of proposed changes**

This pull request formats the gridding equation in the [pygmt.surface documentation](https://www.pygmt.org/dev/api/generated/pygmt.surface.html) using sphinx's math support.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
