### PR TITLE
Open figures using the associated application on Windows

### DIFF
--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -1,6 +1,7 @@
 """
 Utilities and common tasks for wrapping the GMT modules.
 """
+import os
 import shutil
 import subprocess
 import sys
@@ -195,8 +196,9 @@ def launch_external_viewer(fname):
     """
     Open a file in an external viewer program.
 
-    Uses the ``xdg-open`` command on Linux, the ``open`` command on macOS, and
-    the default web browser on other systems.
+    Uses the ``xdg-open`` command on Linux, the ``open`` command on macOS, the
+    associated application on Windows, and the default web browser on other
+    systems.
 
     Parameters
     ----------
@@ -214,8 +216,10 @@ def launch_external_viewer(fname):
         subprocess.run(["xdg-open", fname], check=False, **run_args)
     elif os_name == "darwin":  # Darwin is macOS
         subprocess.run(["open", fname], check=False, **run_args)
+    elif os_name == "win32":
+        os.startfile(fname)  # pylint: disable=no-member
     else:
-        webbrowser.open_new_tab("file://{}".format(fname))
+        webbrowser.open_new_tab(f"file://{fname}")
 
 
 def args_in_kwargs(args, kwargs):


### PR DESCRIPTION
**Description of proposed changes**

This PR improves the `launch_external_viewer` function to open images
using the associated application (just like double-click the images) on
Windows.

The implementation is done by calling the
[`os.startfile`](docs.python.org/3/library/os.html#os.startfile) function.

`os.startfile` is only available on Windows, so need to disable the pylint
error `no-member`.

The code was originally written in #528 by @leouieda, re-used in #529, 
but I'd like to open this PR separately so that changes in #529 can be 
smaller.

BTW, the function is not tested at all because we can't open GUI programs 
in CI machines.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
