### PR TITLE
Update plotting module docstrings to use parameter vs. argument

### DIFF
--- a/pygmt/src/blockmedian.py
+++ b/pygmt/src/blockmedian.py
@@ -25,7 +25,7 @@ def blockmedian(table, outfile=None, **kwargs):
     Reads arbitrarily located (x,y,z) triples [or optionally weighted
     quadruples (x,y,z,w)] from a table and writes to the output a median
     position and value for every non-empty block in a grid region defined by
-    the region and spacing arguments.
+    the ``region`` and ``spacing`` parameters.
 
     Full option list at :gmt-docs:`blockmedian.html`
 

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -76,7 +76,7 @@ def coast(self, **kwargs):
         *fill*\ [**+l**\|\ **+r**].
         Set the shade, color, or pattern for lakes and river-lakes. The
         default is the fill chosen for wet areas set by the ``water``
-        argument. Optionally, specify separate fills by appending
+        parameter. Optionally, specify separate fills by appending
         **+l** for lakes or **+r** for river-lakes, and passing multiple
         strings in a list.
     resolution : str
@@ -189,7 +189,7 @@ def coast(self, **kwargs):
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
     if not args_in_kwargs(args=["C", "G", "S", "I", "N", "E", "Q", "W"], kwargs=kwargs):
         raise GMTInvalidInput(
-            """At least one of the following arguments must be specified:
+            """At least one of the following parameters must be specified:
             lakes, land, water, rivers, borders, dcw, Q, or shorelines"""
         )
     with Session() as lib:

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -130,7 +130,7 @@ def grd2cpt(grid, **kwargs):
         the CPT alone. The truncation takes place before any resampling. See
         also :gmt-docs:`cookbook/features.html#manipulating-cpts`.
     output : str
-        Optional argument to set the file name with extension .cpt to store
+        Optional parameter to set the file name with extension .cpt to store
         the generated CPT file. If not given or False (default), saves the CPT
         as the session current CPT.
     reverse : str

--- a/pygmt/src/grdinfo.py
+++ b/pygmt/src/grdinfo.py
@@ -39,7 +39,7 @@ def grdinfo(grid, **kwargs):
     ----------
     grid : str or xarray.DataArray
         The file name of the input grid or the grid loaded as a DataArray.
-        This is the only required argument.
+        This is the only required parameter.
     {R}
     per_column : str or bool
         **n**\|\ **t**.
@@ -47,7 +47,7 @@ def grdinfo(grid, **kwargs):
         output is name *w e s n z0 z1 dx dy nx ny* [ *x0 y0 x1 y1* ]
         [ *med scale* ] [ *mean std rms* ] [ *n_nan* ] *registration gtype*.
         The data in brackets are outputted depending on the ``force_scan``
-        and ``minmax_pos`` arguments. Use **t** to place file name at the end
+        and ``minmax_pos`` parameters. Use **t** to place file name at the end
         of the output record or, **n** or ``True`` to only output numerical
         columns. The registration is either 0 (gridline) or 1 (pixel), while
         gtype is either 0 (Cartesian) or 1 (geographic). The default value is

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -165,7 +165,7 @@ def text_(
     if kind == "vectors" and text is None:
         raise GMTInvalidInput("Must provide text with x/y pairs or position")
 
-    # Build the `-F` argument in gmt text.
+    # Build the `-F` parameter in gmt text.
     if "F" not in kwargs.keys() and (
         (
             position is not None

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -165,7 +165,7 @@ def text_(
     if kind == "vectors" and text is None:
         raise GMTInvalidInput("Must provide text with x/y pairs or position")
 
-    # Build the `-F` parameter in gmt text.
+    # Build the -F option in gmt text.
     if "F" not in kwargs.keys() and (
         (
             position is not None


### PR DESCRIPTION
As discussed in #886, this pull requests updates the incorrect use of "argument" with "parameter." This pull request covers changes in the doc strings in the plotting modules.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
