### PR TITLE
Use Vercel action for continuous documentation

### DIFF
--- a/.github/workflows/continuous-documentation.yml
+++ b/.github/workflows/continuous-documentation.yml
@@ -1,0 +1,95 @@
+# This workflow deploys documentation to Vercel for previewing PRs
+
+name: Continuous Documentation
+
+on:
+  pull_request:
+    paths:
+    - 'doc/**'
+    - 'examples/**'
+    - 'pygmt/**'
+    - 'README.rst'
+    - '.github/workflows/continuous-documentation.yml'
+  pull_request_target:
+    paths:
+    - 'doc/**'
+    - 'examples/**'
+    - 'pygmt/**'
+    - 'README.rst'
+    - '.github/workflows/continuous-documentation.yml'
+
+jobs:
+  vercel:
+    name: Deploy to Vercel
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+        with:
+          # fecth all history so that setuptools-scm works
+          fetch-depth: 0
+
+      # Setup Miniconda
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2.0.1
+        with:
+          activate-environment: pygmt
+          python-version: 3.9
+          channels: conda-forge
+          miniconda-version: "latest"
+
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: |
+          conda install gmt=6.1.1 numpy pandas xarray netcdf4 packaging \
+                        ipython myst-parser sphinx sphinx-copybutton \
+                        sphinx-gallery sphinx_rtd_theme=0.4.3
+
+      - name: List installed packages
+        shell: bash -l {0}
+        run: conda list
+
+      - name: Download remote data from GitHub
+        uses: dawidd6/action-download-artifact@v2.11.1
+        with:
+          workflow: cache_data.yaml
+          workflow_conclusion: success
+          name: gmt-cache
+          path: .gmt
+
+      - name: Move and list downloaded remote files
+        shell: bash -l {0}
+        run: |
+          mkdir -p ~/.gmt
+          mv .gmt/* ~/.gmt
+          # Change modification times of the two files, so GMT won't refresh it
+          touch ~/.gmt/server/gmt_data_server.txt ~/.gmt/server/gmt_hash_server.txt
+          ls -lhR ~/.gmt
+
+      - name: Install the package
+        shell: bash -l {0}
+        run: |
+          python setup.py sdist --formats=zip
+          pip install dist/*
+
+      - name: Build the documentation
+        shell: bash -l {0}
+        run: make -C doc clean all
+
+      - name: Deploy documentation to Vercel
+        uses: amondnet/vercel-action@v20.0.0
+        with:
+          # https://vercel.com/account/tokens
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          # vercel-org-id and vercel-project-id are generated using vercel CLI
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-comment: true
+          working-directory: ./doc/_build/html

--- a/.github/workflows/continuous-documentation.yml
+++ b/.github/workflows/continuous-documentation.yml
@@ -83,9 +83,15 @@ jobs:
       - name: Deploy documentation to Vercel
         uses: amondnet/vercel-action@v20.0.0
         with:
-          # https://vercel.com/account/tokens
+          # Generate a vercel token at https://vercel.com/account/tokens,
+          # and save the value in the secrets setting in the repository.
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          # vercel-org-id and vercel-project-id are generated using vercel CLI
+          # https://github.com/marketplace/actions/vercel-action#project-linking
+          # Install the Vercel CLI and run `vercel` in the project directory.
+          # After linking the repository with a Vercel project, `vercel` will
+          # create a `.vercel` directory containing both the organization (vercel-org-id)
+          # and project (vercel-project-id) id of the project.
+          # Save the values in the secrets setting in the repository.
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/continuous-documentation.yml
+++ b/.github/workflows/continuous-documentation.yml
@@ -22,6 +22,9 @@ jobs:
   vercel:
     name: Deploy to Vercel
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
       - name: Cancel Previous Runs
@@ -45,14 +48,12 @@ jobs:
           miniconda-version: "latest"
 
       - name: Install dependencies
-        shell: bash -l {0}
         run: |
           conda install gmt=6.1.1 numpy pandas xarray netcdf4 packaging \
                         ipython myst-parser sphinx sphinx-copybutton \
                         sphinx-gallery sphinx_rtd_theme=0.4.3
 
       - name: List installed packages
-        shell: bash -l {0}
         run: conda list
 
       - name: Download remote data from GitHub
@@ -64,7 +65,6 @@ jobs:
           path: .gmt
 
       - name: Move and list downloaded remote files
-        shell: bash -l {0}
         run: |
           mkdir -p ~/.gmt
           mv .gmt/* ~/.gmt
@@ -73,13 +73,11 @@ jobs:
           ls -lhR ~/.gmt
 
       - name: Install the package
-        shell: bash -l {0}
         run: |
           python setup.py sdist --formats=zip
           pip install dist/*
 
       - name: Build the documentation
-        shell: bash -l {0}
         run: make -C doc clean all
 
       - name: Deploy documentation to Vercel

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -91,8 +91,8 @@ to make it easier to preview documentation changes.
 
 ## Continuous Documentation
 
-We use the [Vercel](https://vercel.com/) service and the
-[vercel-action](https://github.com/marketplace/actions/vercel-action) action to
+We use a cloud platform service called [Vercel](https://vercel.com/) via
+[vercel-action](https://github.com/marketplace/actions/vercel-action) to
 preview changes made to our documentation website every time we make a commit
 in a pull request. The workflow `continuous-documentation.yml` builds and
 deploys the documentation to Vercel and create a comment with the latest URL

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -47,7 +47,7 @@ conda and the `Makefile` to run the tests and checks.
 
 ### GitHub Actions
 
-There are 5 configuration files located in `.github/workflows`:
+There are 6 configuration files located in `.github/workflows`:
 
 1. `style_checks.yaml` (Code lint and style checks)
 
@@ -84,16 +84,19 @@ This workflow is ran to publish wheels to PyPI and TestPyPI (for testing only).
 Archives will be pushed to TestPyPI on every commit to the *master* branch and
 tagged releases, and to PyPI for tagged releases only.
 
+6. `continuous-documentation.yml` (Deploy documentation to Vercel for preview)
+
+This workflow builds and deploys the documentation in Pull Requests to Vercel,
+to make it easier to preview documentation changes.
 
 ## Continuous Documentation
 
-We use the [Vercel for GitHub](https://github.com/apps/vercel) App to preview changes
-made to our documentation website every time we make a commit in a pull request.
-The service has a configuration file `vercel.json`, with a list of options to
-change the default behaviour at https://vercel.com/docs/configuration.
-The actual script `package.json` is used by Vercel to install the necessary packages,
-build the documentation, copy the files to a 'public' folder and deploy that to the web,
-see https://vercel.com/docs/build-step.
+We use the [Vercel](https://vercel.com/) service and the
+[vercel-action](https://github.com/marketplace/actions/vercel-action) action to
+preview changes made to our documentation website every time we make a commit
+in a pull request. The workflow `continuous-documentation.yml` builds and
+deploys the documentation to Vercel and create a comment with the latest URL
+of deployment preview.
 
 ## Making a Release
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -95,8 +95,8 @@ We use a cloud platform service called [Vercel](https://vercel.com/) via
 [vercel-action](https://github.com/marketplace/actions/vercel-action) to
 preview changes made to our documentation website every time we make a commit
 in a pull request. The workflow `continuous-documentation.yml` builds and
-deploys the documentation to Vercel and create a comment with the latest URL
-of deployment preview.
+deploys the documentation to Vercel. The vercel bot will automatically make a
+comment with a URL to preview the deployed documentation for that pull request.
 
 ## Making a Release
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,0 @@
-{
-  "scripts": {
-    "build:miniconda": "curl -o ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash ~/miniconda.sh -b -p $HOME/miniconda",
-    "build:pygmt": "conda install mamba -c conda-forge -y && mamba env create -f environment.yml && source activate pygmt && make install",
-    "build:docs": "source activate pygmt && cd doc && make all && mv _build/html ../public",
-    "build": "export PATH=$HOME/miniconda/bin:$PATH && npm run build:miniconda && npm run build:pygmt && npm run build:docs"
-  }
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,0 @@
-{
-  "github": {
-    "silent": true
-  },
-  "public": true
-}


### PR DESCRIPTION
**Description of proposed changes**

For Continous Documentation (i.e., previewing documentation in PRs), we're currently using the [Vercel App](https://github.com/apps/vercel). To make the app work, we need two configuration files in the repository root directory, `package.json` and `vercel.json`. The Vercel App works well for PyGMT, but is more challenging for GMT (https://github.com/GenericMappingTools/gmt/issues/4848#issuecomment-785391790).

This PR adds a new workflow using the [vercel-action](https://github.com/marketplace/actions/vercel-action) action.

The new Vercel action has the following pros:

1. `package.json` and `vercel.json` are no longer needed. Two fewer files in the root directory
2. The workflow is easier to understand and maintain. We just need to build the documentation as usual and run the vercel action to deploy it to vercel.
3. The old vercel app shows "View deployment" button for each build. It adds too much vertical spaces, making a PR page much longer. The new vercel action doesn't have such a problem.
![image](https://user-images.githubusercontent.com/3974108/109108900-613d9d80-7702-11eb-95b4-b314ce13606b.png)

The new Vercel action also has some cons:

1. After the first build finishes, the action creates a comment, showing the preview URL. For the following builds, the action updates the preview URL in the comment. So PR authors and maintainers will be notified once by the action. It's noisier than the old Vercel App.
![image](https://user-images.githubusercontent.com/3974108/109109231-ec1e9800-7702-11eb-97a4-51fa7a72389b.png)

2. The comment only shows the preview URL of the latest build, so it's not easy to compare the documentation of two builds. It's still possible to get old preview URLs by checking the workflow output.

3. The workflow takes ~7 minutes, slightly slower than the old Vercel App (~6 minutes).


**Notes:**

You may notice that the Vercel App also creates a comment and still show the "View deployment" buttons, even though we already remove the `package.json` and `vercel.json` files. That's simply because we still have the Vercel App installed and enabled for this repository. We should diable the Vercel App if we decide to use the new workflow.

![image](https://user-images.githubusercontent.com/3974108/109110102-7a474e00-7704-11eb-927d-910f8f89c448.png)
![image](https://user-images.githubusercontent.com/3974108/109110183-9d71fd80-7704-11eb-865a-00619fc273ab.png)

**TODO**

- [ ] Update CONTRIBUTING.md and MAINTENANCE.md

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
