### PR TITLE
Disable pull_request_target for the vercel action

### DIFF
--- a/.github/workflows/continuous-documentation.yml
+++ b/.github/workflows/continuous-documentation.yml
@@ -10,13 +10,6 @@ on:
     - 'pygmt/**'
     - 'README.rst'
     - '.github/workflows/continuous-documentation.yml'
-  pull_request_target:
-    paths:
-    - 'doc/**'
-    - 'examples/**'
-    - 'pygmt/**'
-    - 'README.rst'
-    - '.github/workflows/continuous-documentation.yml'
 
 jobs:
   vercel:


### PR DESCRIPTION
**Description of proposed changes**

`pull_request` and `pull_request_target` are similar and two CI jobs are
triggered.

This is not what we want. This PR disables the `pull_request_target`
event.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes an issue in #964.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
