### PR TITLE
Catch subprocess.CalledProcessError if 'gmt --show-library' fails

### DIFF
--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -116,7 +116,10 @@ def clib_full_names(env=None):
         )
         assert libfullpath.exists()
         yield str(libfullpath)
-    except (FileNotFoundError, AssertionError):  # command not found
+    except (FileNotFoundError, AssertionError, sp.CalledProcessError):
+        # the 'gmt' executable  is not found
+        # the gmt library is not found
+        # the 'gmt' executable is broken
         pass
 
     # 3. Search for DLLs in PATH by calling find_library() (Windows only)


### PR DESCRIPTION
**Description of proposed changes**

The `gmt --show-library` command may fail due to linking with a broken
library. For example, if my netcdf library is missing, running `gmt
--show-library` will report:
```
dyld: Library not loaded: /usr/local/opt/netcdf/lib/libnetcdf.18.dylib
  Referenced from: /Users/seisman/opt/GMT-master/bin/gmt
  Reason: image not found
[1]    84067 abort      gmt
```
`subprocess.check_output(["gmt", "--show-library"])` will raise the 
`CalledProcessError` exception.

This PR catches the exception.

Reference: https://docs.python.org/3/library/subprocess.html#subprocess.check_output


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
