### PR TITLE
Fix issues in loading GMT's shared library

### DIFF
--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -84,7 +84,7 @@ def clib_names(os_name):
     elif os_name.startswith("freebsd"):  # FreeBSD
         libnames = ["libgmt.so"]
     else:
-        raise GMTOSError(f'Operating system "{os_name}" not supported.')
+        raise GMTOSError(f"Operating system '{os_name}' not supported.")
     return libnames
 
 

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -75,14 +75,12 @@ def clib_names(os_name):
     libnames : list of str
         List of possible names of GMT's shared library.
     """
-    if os_name.startswith("linux"):
+    if os_name.startswith(("linux", "freebsd")):
         libnames = ["libgmt.so"]
     elif os_name == "darwin":  # Darwin is macOS
         libnames = ["libgmt.dylib"]
     elif os_name == "win32":
         libnames = ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
-    elif os_name.startswith("freebsd"):  # FreeBSD
-        libnames = ["libgmt.so"]
     else:
         raise GMTOSError(f"Operating system '{os_name}' not supported.")
     return libnames

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -53,9 +53,7 @@ def load_libgmt(lib_fullnames=None):
             error = False
             break
         except (OSError, GMTCLibError) as err:
-            error_msg.append(
-                f"Error loading the GMT shared library '{libname}'.\n{err}"
-            )
+            error_msg.append(f"Error loading GMT shared library at '{libname}'.\n{err}")
             failing_libs.append(libname)
 
     if error:

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -46,12 +46,11 @@ def load_libgmt(lib_fullnames=None):
     failing_libs = []
     for libname in lib_fullnames:
         try:
-            if libname in failing_libs:  # libname is known to fail, so skip it
-                continue
-            libgmt = ctypes.CDLL(libname)
-            check_libgmt(libgmt)
-            error = False
-            break
+            if libname not in failing_libs:  # skip the lib if it's known to fail
+                libgmt = ctypes.CDLL(libname)
+                check_libgmt(libgmt)
+                error = False
+                break
         except (OSError, GMTCLibError) as err:
             error_msg.append(f"Error loading GMT shared library at '{libname}'.\n{err}")
             failing_libs.append(libname)

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -134,9 +134,9 @@ def test_load_libgmt_with_broken_libraries(monkeypatch):
         # The error message should contains information of both libraries
         lib_fullnames = [faked_libgmt1, faked_libgmt2]
         msg_regex = (
-            fr"Error loading the GMT shared library '{faked_libgmt1._name}'.\n"
+            fr"Error loading GMT shared library at '{faked_libgmt1._name}'.\n"
             fr"Error loading '{faked_libgmt1._name}'. Couldn't access.*\n"
-            fr"Error loading the GMT shared library '{faked_libgmt2._name}'.\n"
+            fr"Error loading GMT shared library at '{faked_libgmt2._name}'.\n"
             fr"Error loading '{faked_libgmt2._name}'. Couldn't access.*"
         )
         with pytest.raises(GMTCLibNotFoundError, match=msg_regex):
@@ -145,9 +145,9 @@ def test_load_libgmt_with_broken_libraries(monkeypatch):
         # case 2: broken library + invalid path
         lib_fullnames = [faked_libgmt1, "/invalid/path/to/libgmt.so"]
         msg_regex = (
-            fr"Error loading the GMT shared library '{faked_libgmt1._name}'.\n"
+            fr"Error loading GMT shared library at '{faked_libgmt1._name}'.\n"
             fr"Error loading '{faked_libgmt1._name}'. Couldn't access.*\n"
-            "Error loading the GMT shared library '/invalid/path/to/libgmt.so'.\n"
+            "Error loading GMT shared library at '/invalid/path/to/libgmt.so'.\n"
             "Unable to find '/invalid/path/to/libgmt.so'"
         )
         with pytest.raises(GMTCLibNotFoundError, match=msg_regex):

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -127,6 +127,9 @@ class TestLibgmtBrokenLibs:
 
     @pytest.fixture
     def mock_ctypes(self, monkeypatch):
+        """
+        Patch the ctypes.CDLL function.
+        """
         monkeypatch.setattr(ctypes, "CDLL", self._mock_ctypes_cdll_return)
 
     def test_two_broken_libraries(self, mock_ctypes):
@@ -136,6 +139,7 @@ class TestLibgmtBrokenLibs:
         Raise the GMTCLibNotFoundError exception. Error message should contain
         information of both libraries that failed to load properly.
         """
+        # pylint: disable=protected-access
         lib_fullnames = [self.faked_libgmt1, self.faked_libgmt2]
         msg_regex = (
             fr"Error loading GMT shared library at '{self.faked_libgmt1._name}'.\n"
@@ -153,6 +157,7 @@ class TestLibgmtBrokenLibs:
         Raise the GMTCLibNotFoundError exception. Error message should contain
         information of one library that failed to load and one invalid path.
         """
+        # pylint: disable=protected-access
         lib_fullnames = [self.faked_libgmt1, self.invalid_path]
         msg_regex = (
             fr"Error loading GMT shared library at '{self.faked_libgmt1._name}'.\n"

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -103,7 +103,7 @@ def test_load_libgmt_with_broken_libraries(monkeypatch):
         Parameters
         ----------
         libname : str or FakedLibGMT or ctypes.CDLL
-            Path to the GMT library, a faked GMT library or a working library
+            Path to the GMT library, a faked GMT library, or a working library
             loaded as ctypes.CDLL.
 
         Return
@@ -115,7 +115,7 @@ def test_load_libgmt_with_broken_libraries(monkeypatch):
             # libname is a faked GMT library, return the faked library
             return libname
         if isinstance(libname, str):
-            # libname is an invalid library path in str type,
+            # libname is an invalid library path in string type,
             # raise OSError like the original ctypes.CDLL
             raise OSError(f"Unable to find '{libname}'")
         # libname is a loaded GMT library
@@ -123,7 +123,7 @@ def test_load_libgmt_with_broken_libraries(monkeypatch):
 
     with monkeypatch.context() as mpatch:
         # pylint: disable=protected-access
-        # mock the ctypes.CDLL using mock_ctypes_cdll_return()
+        # mock the ctypes.CDLL function using mock_ctypes_cdll_return()
         mpatch.setattr(ctypes, "CDLL", mock_ctypes_cdll_return)
 
         faked_libgmt1 = FakedLibGMT("/path/to/faked/libgmt1.so")
@@ -131,7 +131,7 @@ def test_load_libgmt_with_broken_libraries(monkeypatch):
 
         # case 1: two broken libraries
         # Raise the GMTCLibNotFoundError exception
-        # The error message should contains information of both libraries
+        # The error message should contain information of both libraries
         lib_fullnames = [faked_libgmt1, faked_libgmt2]
         msg_regex = (
             fr"Error loading GMT shared library at '{faked_libgmt1._name}'.\n"
@@ -165,7 +165,7 @@ def test_load_libgmt_with_broken_libraries(monkeypatch):
         lib_fullnames = [loaded_libgmt, faked_libgmt1, "/invalid/path/to/libgmt.so"]
         assert check_libgmt(load_libgmt(lib_fullnames=lib_fullnames)) is None
 
-        # case 6: repeated broken library + working library
+        # case 6: repeating broken libraries + working library
         lib_fullnames = [faked_libgmt1, faked_libgmt1, loaded_libgmt]
         assert check_libgmt(load_libgmt(lib_fullnames=lib_fullnames)) is None
 

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -132,7 +132,7 @@ class TestLibgmtBrokenLibs:
         """
         monkeypatch.setattr(ctypes, "CDLL", self._mock_ctypes_cdll_return)
 
-    def test_two_broken_libraries(self, mock_ctypes):
+    def test_two_broken_libraries(self, mock_ctypes):  # pylint: disable=unused-argument
         """
         Case 1: two broken libraries.
 
@@ -150,7 +150,9 @@ class TestLibgmtBrokenLibs:
         with pytest.raises(GMTCLibNotFoundError, match=msg_regex):
             load_libgmt(lib_fullnames=lib_fullnames)
 
-    def test_load_brokenlib_invalidpath(self, mock_ctypes):
+    def test_load_brokenlib_invalidpath(
+        self, mock_ctypes
+    ):  # pylint: disable=unused-argument
         """
         Case 2: broken library + invalid path.
 
@@ -168,28 +170,36 @@ class TestLibgmtBrokenLibs:
         with pytest.raises(GMTCLibNotFoundError, match=msg_regex):
             load_libgmt(lib_fullnames=lib_fullnames)
 
-    def test_brokenlib_invalidpath_workinglib(self, mock_ctypes):
+    def test_brokenlib_invalidpath_workinglib(
+        self, mock_ctypes
+    ):  # pylint: disable=unused-argument
         """
         Case 3: broken library + invalid path + working library.
         """
         lib_fullnames = [self.faked_libgmt1, self.invalid_path, self.loaded_libgmt]
         assert check_libgmt(load_libgmt(lib_fullnames=lib_fullnames)) is None
 
-    def test_invalidpath_brokenlib_workinglib(self, mock_ctypes):
+    def test_invalidpath_brokenlib_workinglib(
+        self, mock_ctypes
+    ):  # pylint: disable=unused-argument
         """
         Case 4: invalid path + broken library + working library.
         """
         lib_fullnames = [self.invalid_path, self.faked_libgmt1, self.loaded_libgmt]
         assert check_libgmt(load_libgmt(lib_fullnames=lib_fullnames)) is None
 
-    def test_workinglib_brokenlib_invalidpath(self, mock_ctypes):
+    def test_workinglib_brokenlib_invalidpath(
+        self, mock_ctypes
+    ):  # pylint: disable=unused-argument
         """
         Case 5: working library + broken library + invalid path.
         """
         lib_fullnames = [self.loaded_libgmt, self.faked_libgmt1, self.invalid_path]
         assert check_libgmt(load_libgmt(lib_fullnames=lib_fullnames)) is None
 
-    def test_brokenlib_brokenlib_workinglib(self, mock_ctypes):
+    def test_brokenlib_brokenlib_workinglib(
+        self, mock_ctypes
+    ):  # pylint: disable=unused-argument
         """
         Case 6: repeating broken libraries + working library.
         """

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -1,6 +1,7 @@
 """
 Test the functions that load libgmt.
 """
+import ctypes
 import shutil
 import subprocess
 import sys
@@ -12,15 +13,23 @@ from pygmt.clib.loading import check_libgmt, clib_full_names, clib_names, load_l
 from pygmt.exceptions import GMTCLibError, GMTCLibNotFoundError, GMTOSError
 
 
+class FakedLibGMT:  # pylint: disable=too-few-public-methods
+    """
+    Class for faking a GMT library.
+    """
+
+    def __init__(self, name):
+        self._name = name
+
+    def __str__(self):
+        return self._name
+
+
 def test_check_libgmt():
     """
     Make sure check_libgmt fails when given a bogus library.
     """
-    # create a fake library with a "_name" property
-    def libgmt():
-        pass
-
-    libgmt._name = "/path/to/libgmt.so"  # pylint: disable=protected-access
+    libgmt = FakedLibGMT("/path/to/libgmt.so")
     msg = (
         # pylint: disable=protected-access
         f"Error loading '{libgmt._name}'. "
@@ -33,6 +42,22 @@ def test_check_libgmt():
         check_libgmt(libgmt)
 
 
+def test_clib_names():
+    """
+    Make sure we get the correct library name for different OS names.
+    """
+    for linux in ["linux", "linux2", "linux3"]:
+        assert clib_names(linux) == ["libgmt.so"]
+    assert clib_names("darwin") == ["libgmt.dylib"]
+    assert clib_names("win32") == ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
+    for freebsd in ["freebsd10", "freebsd11", "freebsd12"]:
+        assert clib_names(freebsd) == ["libgmt.so"]
+    with pytest.raises(GMTOSError):
+        clib_names("meh")
+
+
+###############################################################################
+# Tests for load_libgmt
 def test_load_libgmt():
     """
     Test that loading libgmt works and doesn't crash.
@@ -64,18 +89,85 @@ def test_load_libgmt_with_a_bad_library_path(monkeypatch):
     assert check_libgmt(load_libgmt()) is None
 
 
-def test_clib_names():
+def test_load_libgmt_with_broken_libraries(monkeypatch):
     """
-    Make sure we get the correct library name for different OS names.
+    Test load_libgmt still works when a broken library is found.
     """
-    for linux in ["linux", "linux2", "linux3"]:
-        assert clib_names(linux) == ["libgmt.so"]
-    assert clib_names("darwin") == ["libgmt.dylib"]
-    assert clib_names("win32") == ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
-    for freebsd in ["freebsd10", "freebsd11", "freebsd12"]:
-        assert clib_names(freebsd) == ["libgmt.so"]
-    with pytest.raises(GMTOSError):
-        clib_names("meh")
+    # load the GMT library before mocking the ctypes.CDLL function
+    loaded_libgmt = load_libgmt()
+
+    def mock_ctypes_cdll_return(libname):
+        """
+        Mock the return value of ctypes.CDLL.
+
+        Parameters
+        ----------
+        libname : str or FakedLibGMT or ctypes.CDLL
+            Path to the GMT library, a faked GMT library or a working library
+            loaded as ctypes.CDLL.
+
+        Return
+        ------
+        object
+            Either the loaded GMT library or the faked GMT library.
+        """
+        if isinstance(libname, FakedLibGMT):
+            # libname is a faked GMT library, return the faked library
+            return libname
+        if isinstance(libname, str):
+            # libname is an invalid library path in str type,
+            # raise OSError like the original ctypes.CDLL
+            raise OSError(f"Unable to find '{libname}'")
+        # libname is a loaded GMT library
+        return loaded_libgmt
+
+    with monkeypatch.context() as mpatch:
+        # pylint: disable=protected-access
+        # mock the ctypes.CDLL using mock_ctypes_cdll_return()
+        mpatch.setattr(ctypes, "CDLL", mock_ctypes_cdll_return)
+
+        faked_libgmt1 = FakedLibGMT("/path/to/faked/libgmt1.so")
+        faked_libgmt2 = FakedLibGMT("/path/to/faked/libgmt2.so")
+
+        # case 1: two broken libraries
+        # Raise the GMTCLibNotFoundError exception
+        # The error message should contains information of both libraries
+        lib_fullnames = [faked_libgmt1, faked_libgmt2]
+        msg_regex = (
+            fr"Error loading the GMT shared library '{faked_libgmt1._name}'.\n"
+            fr"Error loading '{faked_libgmt1._name}'. Couldn't access.*\n"
+            fr"Error loading the GMT shared library '{faked_libgmt2._name}'.\n"
+            fr"Error loading '{faked_libgmt2._name}'. Couldn't access.*"
+        )
+        with pytest.raises(GMTCLibNotFoundError, match=msg_regex):
+            load_libgmt(lib_fullnames=lib_fullnames)
+
+        # case 2: broken library + invalid path
+        lib_fullnames = [faked_libgmt1, "/invalid/path/to/libgmt.so"]
+        msg_regex = (
+            fr"Error loading the GMT shared library '{faked_libgmt1._name}'.\n"
+            fr"Error loading '{faked_libgmt1._name}'. Couldn't access.*\n"
+            "Error loading the GMT shared library '/invalid/path/to/libgmt.so'.\n"
+            "Unable to find '/invalid/path/to/libgmt.so'"
+        )
+        with pytest.raises(GMTCLibNotFoundError, match=msg_regex):
+            load_libgmt(lib_fullnames=lib_fullnames)
+
+        # case 3: broken library + invalid path + working library
+        lib_fullnames = [faked_libgmt1, "/invalid/path/to/libgmt.so", loaded_libgmt]
+        assert check_libgmt(load_libgmt(lib_fullnames=lib_fullnames)) is None
+
+        # case 4: invalid path + broken library + working library
+        lib_fullnames = ["/invalid/path/to/libgmt.so", faked_libgmt1, loaded_libgmt]
+        assert check_libgmt(load_libgmt(lib_fullnames=lib_fullnames)) is None
+
+        # case 5: working library + broken library + invalid path
+        lib_fullnames = [loaded_libgmt, faked_libgmt1, "/invalid/path/to/libgmt.so"]
+        assert check_libgmt(load_libgmt(lib_fullnames=lib_fullnames)) is None
+
+        # case 6: repeated broken library + working library
+        lib_fullnames = [faked_libgmt1, faked_libgmt1, loaded_libgmt]
+        assert check_libgmt(load_libgmt(lib_fullnames=lib_fullnames)) is None
 
 
 ###############################################################################


### PR DESCRIPTION
**Description of proposed changes**

The `load_libgmt()` function still has some bugs:

https://github.com/GenericMappingTools/pygmt/blob/6a6171e3efc112f2a8a86088e24caf932149e928/pygmt/clib/loading.py#L36-L52

1. At line 45, we only catch the `OSError` exception, but `check_libgmt()` may raise `GMTCLibError` exception. So if the library paths are `["/path/to/GMT5/libgmt.so", "/path/to/GMT6/libgmt.so", "libgmt.so"]`, the `load_libgmt()` function won't be able to the working library.
2. After #702, the `clib_full_names()` function returns a list of all possible paths. Some paths may be duplicated. So, if the paths are `["invalid_path_A", "invalid_path_A", "invalid_path_B"]`, we will check `invalid_path_A` twice. 
3. The variable `error` only contains the error message of the last library path, but, each library path may fail due to different reasons.

This PR makes the following changes:

1. Catch the `GMTCLibError` error from calling `check_libgmt()` (Fixes point 1)
2. Skip a library path if it's known to fail in previous tries (Fixes point 2)
3. Improve the error message, by combine error message of all tries (Fixes point 3)
4. Add a new parameter `lib_fullnames` (default to `clib_full_names()`) to for easier testing
4. Add more tests to make sure it works.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
