### PR TITLE
Separate tests of tutorial dataset and earth_relief dataset into two files

### DIFF
--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -1,5 +1,5 @@
 """
-Test basic functionality for loading datasets.
+Test basic functionality for loading Earth relief datasets.
 """
 import numpy as np
 import numpy.testing as npt

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -4,65 +4,8 @@ Test basic functionality for loading datasets.
 import numpy as np
 import numpy.testing as npt
 import pytest
-from pygmt.datasets import (
-    load_earth_relief,
-    load_japan_quakes,
-    load_ocean_ridge_points,
-    load_sample_bathymetry,
-    load_usgs_quakes,
-)
+from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput
-
-
-def test_japan_quakes():
-    """
-    Check that the dataset loads without errors.
-    """
-    data = load_japan_quakes()
-    assert data.shape == (115, 7)
-    summary = data.describe()
-    assert summary.loc["min", "year"] == 1987
-    assert summary.loc["max", "year"] == 1988
-    assert summary.loc["min", "month"] == 1
-    assert summary.loc["max", "month"] == 12
-    assert summary.loc["min", "day"] == 1
-    assert summary.loc["max", "day"] == 31
-
-
-def test_ocean_ridge_points():
-    """
-    Check that the @ridge.txt dataset loads without errors.
-    """
-    data = load_ocean_ridge_points()
-    assert data.shape == (4146, 2)
-    summary = data.describe()
-    assert summary.loc["min", "longitude"] == -179.9401
-    assert summary.loc["max", "longitude"] == 179.935
-    assert summary.loc["min", "latitude"] == -65.6182
-    assert summary.loc["max", "latitude"] == 86.8
-
-
-def test_sample_bathymetry():
-    """
-    Check that the @tut_ship.xyz dataset loads without errors.
-    """
-    data = load_sample_bathymetry()
-    assert data.shape == (82970, 3)
-    summary = data.describe()
-    assert summary.loc["min", "longitude"] == 245.0
-    assert summary.loc["max", "longitude"] == 254.705
-    assert summary.loc["min", "latitude"] == 20.0
-    assert summary.loc["max", "latitude"] == 29.99131
-    assert summary.loc["min", "bathymetry"] == -7708.0
-    assert summary.loc["max", "bathymetry"] == -9.0
-
-
-def test_usgs_quakes():
-    """
-    Check that the dataset loads without errors.
-    """
-    data = load_usgs_quakes()
-    assert data.shape == (1197, 22)
 
 
 def test_earth_relief_fails():

--- a/pygmt/tests/test_datasets_tutorial.py
+++ b/pygmt/tests/test_datasets_tutorial.py
@@ -1,0 +1,60 @@
+"""
+Test basic functionality for loading datasets.
+"""
+from pygmt.datasets import (
+    load_japan_quakes,
+    load_ocean_ridge_points,
+    load_sample_bathymetry,
+    load_usgs_quakes,
+)
+
+
+def test_japan_quakes():
+    """
+    Check that the dataset loads without errors.
+    """
+    data = load_japan_quakes()
+    assert data.shape == (115, 7)
+    summary = data.describe()
+    assert summary.loc["min", "year"] == 1987
+    assert summary.loc["max", "year"] == 1988
+    assert summary.loc["min", "month"] == 1
+    assert summary.loc["max", "month"] == 12
+    assert summary.loc["min", "day"] == 1
+    assert summary.loc["max", "day"] == 31
+
+
+def test_ocean_ridge_points():
+    """
+    Check that the @ridge.txt dataset loads without errors.
+    """
+    data = load_ocean_ridge_points()
+    assert data.shape == (4146, 2)
+    summary = data.describe()
+    assert summary.loc["min", "longitude"] == -179.9401
+    assert summary.loc["max", "longitude"] == 179.935
+    assert summary.loc["min", "latitude"] == -65.6182
+    assert summary.loc["max", "latitude"] == 86.8
+
+
+def test_sample_bathymetry():
+    """
+    Check that the @tut_ship.xyz dataset loads without errors.
+    """
+    data = load_sample_bathymetry()
+    assert data.shape == (82970, 3)
+    summary = data.describe()
+    assert summary.loc["min", "longitude"] == 245.0
+    assert summary.loc["max", "longitude"] == 254.705
+    assert summary.loc["min", "latitude"] == 20.0
+    assert summary.loc["max", "latitude"] == 29.99131
+    assert summary.loc["min", "bathymetry"] == -7708.0
+    assert summary.loc["max", "bathymetry"] == -9.0
+
+
+def test_usgs_quakes():
+    """
+    Check that the dataset loads without errors.
+    """
+    data = load_usgs_quakes()
+    assert data.shape == (1197, 22)

--- a/pygmt/tests/test_datasets_tutorial.py
+++ b/pygmt/tests/test_datasets_tutorial.py
@@ -1,5 +1,5 @@
 """
-Test basic functionality for loading datasets.
+Test basic functionality for loading datasets for tutorials.
 """
 from pygmt.datasets import (
     load_japan_quakes,


### PR DESCRIPTION
**Description of proposed changes**

Similar to what we're doing to other tests, we should split the tests in `test_datasets.py` into two files `test_datasets_tutorial.py` and `test_datasets_earth_relief.py`.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
