### PR TITLE
Let 'make clean' delete .eggs and results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,11 @@ clean:
 	find . -name "*.pyc" -exec rm -v {} +
 	find . -name "*~" -exec rm -v {} +
 	find . -type d -name  "__pycache__" -exec rm -rv {} +
-	rm -rvf build dist MANIFEST .coverage .cache .pytest_cache htmlcov coverage.xml
+	rm -rvf build dist .eggs MANIFEST .coverage .cache .pytest_cache htmlcov coverage.xml
 	rm -rvf $(TESTDIR)
 	rm -rvf baseline
 	rm -rvf result_images
+	rm -rvf results
 
 distclean: clean
 	rm -rvf *.egg-info


### PR DESCRIPTION
**Description of proposed changes**

- `.eggs` is generated when building the package
- `results` is generated by `pytest --mpl --mpl-results-path=results`

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
