### PR TITLE
CI: Install ninja to speed up building GMT source code

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -79,7 +79,9 @@ jobs:
 
       # Install build dependencies from conda-forge
       - name: Install build dependencies
-        run: conda install cmake libblas libcblas liblapack fftw gdal ghostscript libnetcdf hdf5 zlib curl pcre ipython pytest pytest-cov pytest-mpl
+        run: |
+          conda install ninja cmake libblas libcblas liblapack fftw gdal ghostscript \
+                        libnetcdf hdf5 zlib curl pcre ipython pytest pytest-cov pytest-mpl
 
       # Build and install latest GMT from GitHub
       - name: Install GMT ${{ matrix.gmt_git_ref }} branch (Linux/macOS)


### PR DESCRIPTION
**Description of proposed changes**

With the upstream PR https://github.com/GenericMappingTools/gmt/pull/4883 merged, it's possible to use ninja to build GMT, which is much faster.

We only need to install `ninja`.

Without ninja (https://github.com/GenericMappingTools/pygmt/actions/runs/612306243), building GMT takes ~3.5 minutes on Linux and ~8.5 minutes on macOS.

Now (https://github.com/GenericMappingTools/pygmt/actions/runs/612798172), it takes ~2.5 minutes on Linux and 5 minutes on macOS.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
