### PR TITLE
Add a reference to vector types example in vector-heads-tails.py

### DIFF
--- a/examples/gallery/line/vector-heads-tails.py
+++ b/examples/gallery/line/vector-heads-tails.py
@@ -25,8 +25,9 @@ corresponding module.
 
 In the following we use the :meth:`pygmt.Figure.plot` method to plot vectors
 with individual heads and tails. We must specify the modifiers (together with
-the vector type, here ``v``) by passing the corresponding shortcuts to the
-``style`` parameter.
+the vector type, here ``v``, see also
+:doc:`Vector types documentation </gallery/line/vectors>`.) 
+by passing the corresponding shortcuts to the ``style`` parameter.
 
 """
 


### PR DESCRIPTION
I think in vector-heads-tails.py we should also have a reference to the recently deployed vector type gallery example.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Write detailed docstrings for all functions/methods.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
