### PR TITLE
Speedup sphinx-build using parallelization

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -45,17 +45,5 @@ api:
 	@echo
 	$(SPHINXAUTOGEN) -i -t _templates -o api/generated api/*.rst
 
-
-linkcheck:
-	$(SPHINXBUILD) -b linkcheck -j auto $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
-	@echo
-	@echo "Link check complete; look for any errors in the above output " \
-	      "or in $(BUILDDIR)/linkcheck/output.txt."
-
-doctest:
-	$(SPHINXBUILD) -b doctest -j auto $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
-	@echo "Testing of doctests in the sources finished, look at the " \
-	      "results in $(BUILDDIR)/doctest/output.txt."
-
 serve:
 	cd $(BUILDDIR)/html && python -m http.server 8009

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Sphinx documentation
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -j auto
 SPHINXBUILD   = sphinx-build
 SPHINXAUTOGEN = sphinx-autogen
 BUILDDIR      = _build
@@ -31,7 +31,7 @@ html: api
 	@echo
 	@echo "Building HTML files."
 	@echo
-	$(SPHINXBUILD) -b html -j auto $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -35,7 +35,7 @@ html: api
 	@echo
 	@echo "Building HTML files."
 	@echo
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html -j auto $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
@@ -47,13 +47,13 @@ api:
 
 
 linkcheck:
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	$(SPHINXBUILD) -b linkcheck -j auto $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
 doctest:
-	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
+	$(SPHINXBUILD) -b doctest -j auto $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -17,8 +17,6 @@ help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  all        generate the complete webpage"
 	@echo "  html       make only the HTML files from the existing rst sources"
-	@echo "  linkcheck  check all external links for integrity"
-	@echo "  doctest    run all doctests embedded in the documentation (if enabled)"
 
 clean:
 	rm -rf $(BUILDDIR)/html

--- a/pygmt/tests/test_grdinfo.py
+++ b/pygmt/tests/test_grdinfo.py
@@ -10,7 +10,7 @@ from pygmt.exceptions import GMTInvalidInput
 
 def test_grdinfo():
     """
-    Make sure grd info works as expected.
+    Make sure grdinfo works as expected.
     """
     grid = load_earth_relief(registration="gridline")
     result = grdinfo(grid=grid, force_scan=0, per_column="n")


### PR DESCRIPTION
**Description of proposed changes**

Distribute sphinx-build over several processes in parallel to make building on multiprocessor machines faster. Using 'auto' which equals the number of CPUs available. This should speed up running `make html`, `make linkcheck` and `make doctest` in the 'doc/' folder and cut down on time waiting for the Vercel Continuous Documentation and Github Actions Continuous Integration steps to run.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

References:
- https://www.sphinx-doc.org/en/3.x/man/sphinx-build.html#cmdoption-sphinx-build-j.


<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #584.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
