### PR TITLE
Refactor grd modules to use virtualfile_from_data

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1411,7 +1411,7 @@ class Session:
         kind = data_kind(data, x, y, z)
 
         if check_kind == "raster" and kind not in ("file", "grid"):
-            raise GMTInvalidInput(f"Unrecognized data type: {type(data)}")
+            raise GMTInvalidInput(f"Unrecognized data type for grid: {type(data)}")
         if check_kind == "vector" and kind not in ("file", "matrix", "vectors"):
             raise GMTInvalidInput(f"Unrecognized data type: {type(data)}")
 

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -4,14 +4,7 @@ grd2cpt - Create a CPT from a grid file.
 
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import (
-    build_arg_string,
-    data_kind,
-    dummy_context,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 
 @fmt_docstring
@@ -169,14 +162,8 @@ def grd2cpt(grid, **kwargs):
     """
     if "W" in kwargs and "Ww" in kwargs:
         raise GMTInvalidInput("Set only categorical or cyclic to True, not both.")
-    kind = data_kind(grid)
     with Session() as lib:
-        if kind == "file":
-            file_context = dummy_context(grid)
-        elif kind == "grid":
-            file_context = lib.virtualfile_from_grid(grid)
-        else:
-            raise GMTInvalidInput(f"Unrecognized data type: {type(grid)}")
+        file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
         with file_context as infile:
             if "H" not in kwargs.keys():  # if no output is set
                 arg_str = " ".join([infile, build_arg_string(kwargs)])

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -2,15 +2,7 @@
 grdcontour - Plot a contour figure.
 """
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import (
-    build_arg_string,
-    data_kind,
-    dummy_context,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 
 @fmt_docstring
@@ -103,14 +95,8 @@ def grdcontour(self, grid, **kwargs):
     {t}
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
-    kind = data_kind(grid, None, None)
     with Session() as lib:
-        if kind == "file":
-            file_context = dummy_context(grid)
-        elif kind == "grid":
-            file_context = lib.virtualfile_from_grid(grid)
-        else:
-            raise GMTInvalidInput("Unrecognized data type: {}".format(type(grid)))
+        file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
         with file_context as fname:
             arg_str = " ".join([fname, build_arg_string(kwargs)])
             lib.call_module("grdcontour", arg_str)

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -4,12 +4,9 @@ grdcut - Extract subregion from a grid.
 
 import xarray as xr
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     GMTTempFile,
     build_arg_string,
-    data_kind,
-    dummy_context,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
@@ -89,17 +86,9 @@ def grdcut(grid, **kwargs):
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)
     """
-    kind = data_kind(grid)
-
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            if kind == "file":
-                file_context = dummy_context(grid)
-            elif kind == "grid":
-                file_context = lib.virtualfile_from_grid(grid)
-            else:
-                raise GMTInvalidInput("Unrecognized data type: {}".format(type(grid)))
-
+            file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
             with file_context as infile:
                 if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -4,12 +4,9 @@ grdfilter - Filter a grid in the space (or time) domain.
 
 import xarray as xr
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     GMTTempFile,
     build_arg_string,
-    data_kind,
-    dummy_context,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
@@ -143,17 +140,9 @@ def grdfilter(grid, **kwargs):
     >>> grid = pygmt.datasets.load_earth_relief()
     >>> smooth_field = pygmt.grdfilter(grid=grid, filter="g600", distance="4")
     """
-    kind = data_kind(grid)
-
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            if kind == "file":
-                file_context = dummy_context(grid)
-            elif kind == "grid":
-                file_context = lib.virtualfile_from_grid(grid)
-            else:
-                raise GMTInvalidInput("Unrecognized data type: {}".format(type(grid)))
-
+            file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
             with file_context as infile:
                 if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -2,15 +2,7 @@
 grdimage - Plot grids or images.
 """
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import (
-    build_arg_string,
-    data_kind,
-    dummy_context,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 
 @fmt_docstring
@@ -157,14 +149,8 @@ def grdimage(self, grid, **kwargs):
     {x}
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
-    kind = data_kind(grid, None, None)
     with Session() as lib:
-        if kind == "file":
-            file_context = dummy_context(grid)
-        elif kind == "grid":
-            file_context = lib.virtualfile_from_grid(grid)
-        else:
-            raise GMTInvalidInput("Unrecognized data type: {}".format(type(grid)))
+        file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
         with file_context as fname:
             arg_str = " ".join([fname, build_arg_string(kwargs)])
             lib.call_module("grdimage", arg_str)

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -84,12 +84,7 @@ def grdtrack(points, grid, newcolname=None, outfile=None, **kwargs):
                 raise GMTInvalidInput(f"Unrecognized data type {type(points)}")
 
             # Store the xarray.DataArray grid in virtualfile
-            if data_kind(grid) == "grid":
-                grid_context = lib.virtualfile_from_grid(grid)
-            elif data_kind(grid) == "file":
-                grid_context = dummy_context(grid)
-            else:
-                raise GMTInvalidInput(f"Unrecognized data type {type(grid)}")
+            grid_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
 
             # Run grdtrack on the temporary (csv) points table
             # and (netcdf) grid virtualfile

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -8,7 +8,6 @@ from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     build_arg_string,
     data_kind,
-    dummy_context,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
@@ -112,14 +111,8 @@ def grdview(self, grid, **kwargs):
     {t}
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
-    kind = data_kind(grid, None, None)
     with Session() as lib:
-        if kind == "file":
-            file_context = dummy_context(grid)
-        elif kind == "grid":
-            file_context = lib.virtualfile_from_grid(grid)
-        else:
-            raise GMTInvalidInput(f"Unrecognized data type for grid: {type(grid)}")
+        file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
 
         with contextlib.ExitStack() as stack:
             if "G" in kwargs:  # deal with kwargs["G"] if drapegrid is xr.DataArray


### PR DESCRIPTION
**Description of proposed changes**

Remove duplicated code in grd2cpt, grdcontour, grdcut, grdfilter, grdimage, grdtrack, and grdview.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Will need a bit of extra thinking for parts of `grdtrack` and `grdview` (will do in a separate PR).

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
