### PR TITLE
Explicitly exclude unnecessary files in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,13 @@
+prune doc*
+prune examples*
+prune .github*
 exclude AUTHORSHIP.md
 exclude CONTRIBUTING.md
 exclude MAINTENANCE.md
-exclude MANIFEST.in
 exclude Makefile
 exclude environment.yml
 exclude package.json
 exclude requirements.txt
 exclude vercel.json
+exclude .gitignore
+exclude .pylintrc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 exclude AUTHORSHIP.md
+exclude CONTRIBUTING.md
 exclude MAINTENANCE.md
 exclude MANIFEST.in
 exclude Makefile

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,8 @@
-include README.rst
-include LICENSE.txt
-include CODE_OF_CONDUCT.md
-include CONTRIBUTING.md
-include AUTHORS.md
-recursive-include pygmt/tests/data *
-recursive-include pygmt/tests/baseline *
+exclude AUTHORSHIP.md
+exclude MAINTENANCE.md
+exclude MANIFEST.in
+exclude Makefile
+exclude environment.yml
+exclude package.json
+exclude requirements.txt
+exclude vercel.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
+prune .github*
 prune doc*
 prune examples*
-prune .github*
+exclude .gitignore
+exclude .pylintrc
 exclude AUTHORSHIP.md
 exclude CONTRIBUTING.md
 exclude MAINTENANCE.md
@@ -9,5 +11,3 @@ exclude environment.yml
 exclude package.json
 exclude requirements.txt
 exclude vercel.json
-exclude .gitignore
-exclude .pylintrc


### PR DESCRIPTION
**Description of proposed changes**

In #695, we switched our version manager from [versioneer](https://github.com/python-versioneer/python-versioneer) to [setuptools-scm](https://github.com/pypa/setuptools_scm).

When building source distributions (**sdist**), the default behavior was only including files as listed in [Python packaging guide](https://packaging.python.org/guides/using-manifest-in/). However, setuptools_scm's behavior is to include all files tracked by git (see https://github.com/pypa/setuptools_scm#file-finders-hook-makes-most-of-manifestin-unnecessary), and it seems there is no way to disable it (https://github.com/pypa/setuptools_scm/issues/516).

So, instead of listing files that should be included in the source distributions, now we need to explicitly exclude some files from the source distributions.

Here is the list of files in pygmt v0.2.1 (https://pypi.org/project/pygmt/0.2.1/#files):
```
AUTHORS.md
CODE_OF_CONDUCT.md
CONTRIBUTING.md
LICENSE.txt
MANIFEST.in
PKG-INFO
README.rst
pygmt
pygmt.egg-info
setup.cfg
setup.py
versioneer.py
```

Here is the list of files using the `MANIFEST.in` file in this PR:
```
AUTHORS.md
CODE_OF_CONDUCT.md
LICENSE.txt
MANIFEST.in
PKG-INFO
README.rst
pygmt
pygmt.egg-info
pyproject.toml
setup.cfg
setup.py
```

You can run `python setup.py sdist` to build source distributions and check the tarball in the `dist` directory. 


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #904.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
