### PR TITLE
Fix a bug in the "frames" tutorials

### DIFF
--- a/examples/tutorials/frames.py
+++ b/examples/tutorials/frames.py
@@ -105,6 +105,6 @@ fig.basemap(
     projection="X10c/8c",
     # Plot axis, tick marks, and axis labels on the west/left and south/bottom axes
     # Plot axis and tick marks on the north/top and east/right axes
-    frame=["af", "WSne", "x+lx-axis", "y+ly-axis"],
+    frame=["WSne", "xaf+lx-axis", "yaf+ly-axis"],
 )
 fig.show()

--- a/examples/tutorials/frames.py
+++ b/examples/tutorials/frames.py
@@ -105,6 +105,6 @@ fig.basemap(
     projection="X10c/8c",
     # Plot axis, tick marks, and axis labels on the west/left and south/bottom axes
     # Plot axis and tick marks on the north/top and east/right axes
-    frame=["WSne", "x+lx-axis", "y+ly-axis"],
+    frame=["a", "WSne", "x+lx-axis", "y+ly-axis"],
 )
 fig.show()

--- a/examples/tutorials/frames.py
+++ b/examples/tutorials/frames.py
@@ -105,6 +105,6 @@ fig.basemap(
     projection="X10c/8c",
     # Plot axis, tick marks, and axis labels on the west/left and south/bottom axes
     # Plot axis and tick marks on the north/top and east/right axes
-    frame=["a", "WSne", "x+lx-axis", "y+ly-axis"],
+    frame=["af", "WSne", "x+lx-axis", "y+ly-axis"],
 )
 fig.show()


### PR DESCRIPTION
**Description of proposed changes**
In https://www.pygmt.org/latest/tutorials/frames.html#axis-labels:
```Python
fig = pygmt.Figure()
fig.basemap(
    region=[0, 10, 0, 20],
    projection="X10c/8c",
    # Plot axis, tick marks, and axis labels on the west/left and south/bottom axes
    # Plot axis and tick marks on the north/top and east/right axes
    frame=["WSne", "x+lx-axis", "y+ly-axis"],
)
fig.show()
```
We don't have axis and tick marks on the left and right axes. See the output:
![froma-2](https://user-images.githubusercontent.com/50591376/110113345-f10fd580-7ded-11eb-9c60-392ce23e2e3f.png)

We should add `af` to the **frame** to plot set the frame automatically.
```Python
frame=["af", "WSne", "x+lx-axis", "y+ly-axis"],
```
![Screenshot from 2021-03-05 20-06-55](https://user-images.githubusercontent.com/50591376/110113659-61b6f200-7dee-11eb-8900-94aa4961faab.png)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
