### PR TITLE
Improve the targets in doc/Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -23,7 +23,7 @@ all: html
 
 api:
 	@echo
-	@echo "Building API docs."
+	@echo "Generating rst source files of API documentation."
 	@echo
 	$(SPHINXAUTOGEN) -i -t _templates -o api/generated api/*.rst
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -36,10 +36,10 @@ api:
 	$(SPHINXAUTOGEN) -i -t _templates -o api/generated api/*.rst
 
 server:
-    @echo
-    @echo "Running a server on port 8009."
-    @echo "Open http://localhost:8009 in a web browser to preview the documentation."
-    @echo
+	@echo
+	@echo "Running a server on port 8009."
+	@echo "Open http://localhost:8009 in a web browser to preview the documentation."
+	@echo
 	cd $(BUILDDIR)/html && python -m http.server 8009
 
 clean:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -38,17 +38,6 @@ api:
 serve:
 	cd $(BUILDDIR)/html && python -m http.server 8009
 
-linkcheck:
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
-	@echo
-	@echo "Link check complete; look for any errors in the above output " \
-	      "or in $(BUILDDIR)/linkcheck/output.txt."
-
-doctest:
-	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
-	@echo "Testing of doctests in the sources finished; look at the " \
-	      "results in $(BUILDDIR)/doctest/output.txt."
-
 clean:
 	rm -rf $(BUILDDIR)/doctrees
 	rm -rf $(BUILDDIR)/html

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -17,8 +17,6 @@ help:
 	@echo "  html       build the HTML files from the existing rst sources"
 	@echo "  api        generate API documentation rst sources"
 	@echo "  serve      make a HTTP server"
-	@echo "  linkcheck  check all external links for integrity"
-	@echo "  doctest    run all doctests embedded in the documentation (if enabled)"
 	@echo "  clean      clean up build and generated files"
 
 all: html

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -21,6 +21,12 @@ help:
 
 all: html
 
+api:
+	@echo
+	@echo "Building API docs."
+	@echo
+	$(SPHINXAUTOGEN) -i -t _templates -o api/generated api/*.rst
+
 html: api
 	@echo
 	@echo "Building HTML files."
@@ -28,12 +34,6 @@ html: api
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
-
-api:
-	@echo
-	@echo "Building API docs."
-	@echo
-	$(SPHINXAUTOGEN) -i -t _templates -o api/generated api/*.rst
 
 server:
 	@echo

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,29 +7,21 @@ SPHINXAUTOGEN = sphinx-autogen
 BUILDDIR      = _build
 
 # Internal variables.
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees  $(SPHINXOPTS) .
+ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees  $(SPHINXOPTS) .
 
 .PHONY: help clean html linkcheck doctest api
-
-all: html
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  all        generate the complete webpage"
 	@echo "  html       make only the HTML files from the existing rst sources"
+	@echo "  api        make only the API documentation from the source codes"
+	@echo "  serve      make a HTTP server"
 	@echo "  linkcheck  check all external links for integrity"
 	@echo "  doctest    run all doctests embedded in the documentation (if enabled)"
+	@echo "  clean      clean up build and generated files"
 
-clean:
-	rm -rf $(BUILDDIR)/html
-	rm -rf $(BUILDDIR)/doctrees
-	rm -rf $(BUILDDIR)/linkcheck
-	rm -rf modules
-	rm -rf api/generated
-	rm -rf gallery
-	rm -rf tutorials
-	rm -rf projections
-	rm -rf .ipynb_checkpoints
+all: html
 
 html: api
 	@echo
@@ -45,6 +37,8 @@ api:
 	@echo
 	$(SPHINXAUTOGEN) -i -t _templates -o api/generated api/*.rst
 
+serve:
+	cd $(BUILDDIR)/html && python -m http.server 8009
 
 linkcheck:
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
@@ -54,8 +48,16 @@ linkcheck:
 
 doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
-	@echo "Testing of doctests in the sources finished, look at the " \
+	@echo "Testing of doctests in the sources finished; look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
-serve:
-	cd $(BUILDDIR)/html && python -m http.server 8009
+clean:
+	rm -rf $(BUILDDIR)/html
+	rm -rf api/generated
+	rm -rf $(BUILDDIR)/linkcheck
+	rm -rf $(BUILDDIR)/doctrees
+	rm -rf modules
+	rm -rf gallery
+	rm -rf tutorials
+	rm -rf projections
+	rm -rf .ipynb_checkpoints

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,7 +13,7 @@ ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees  $(SPHINXOPTS) .
 
 help:
 	@echo "Please use 'make <target>' where <target> is one of"
-	@echo "  all        generate the complete webpage"
+	@echo "  all        build the HTML files from the existing rst sources"
 	@echo "  api        generate rst source files of API documentation"
 	@echo "  html       build the HTML files from the existing rst sources"
 	@echo "  server     make a local HTTP server for previewing the built documentation"

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -16,8 +16,8 @@ help:
 	@echo "  all        generate the complete webpage"
 	@echo "  html       build the HTML files from the existing rst sources"
 	@echo "  api        generate API documentation rst sources"
-	@echo "  server     make a HTTP server"
-	@echo "  clean      clean up build and generated files"
+	@echo "  server     make a local HTTP server for previewing the built documentation"
+	@echo "  clean      clean up built and generated files"
 
 all: html
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,8 +14,8 @@ ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees  $(SPHINXOPTS) .
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  all        generate the complete webpage"
-	@echo "  html       build the HTML files from the existing rst sources"
 	@echo "  api        generate rst source files of API documentation"
+	@echo "  html       build the HTML files from the existing rst sources"
 	@echo "  server     make a local HTTP server for previewing the built documentation"
 	@echo "  clean      clean up built and generated files"
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -16,7 +16,7 @@ help:
 	@echo "  all        generate the complete webpage"
 	@echo "  html       build the HTML files from the existing rst sources"
 	@echo "  api        generate API documentation rst sources"
-	@echo "  serve      make a HTTP server"
+	@echo "  server     make a HTTP server"
 	@echo "  clean      clean up build and generated files"
 
 all: html
@@ -35,7 +35,7 @@ api:
 	@echo
 	$(SPHINXAUTOGEN) -i -t _templates -o api/generated api/*.rst
 
-serve:
+server:
 	cd $(BUILDDIR)/html && python -m http.server 8009
 
 clean:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -15,7 +15,7 @@ help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  all        generate the complete webpage"
 	@echo "  html       build the HTML files from the existing rst sources"
-	@echo "  api        generate API documentation rst sources"
+	@echo "  api        generate rst source files of API documentation"
 	@echo "  server     make a local HTTP server for previewing the built documentation"
 	@echo "  clean      clean up built and generated files"
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 # Internal variables.
 ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees  $(SPHINXOPTS) .
 
-.PHONY: help clean html linkcheck doctest api
+.PHONY: help clean html api
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -36,11 +36,14 @@ api:
 	$(SPHINXAUTOGEN) -i -t _templates -o api/generated api/*.rst
 
 server:
+    @echo
+    @echo "Running a server on port 8009."
+    @echo "Open http://localhost:8009 in a web browser to preview the documentation."
+    @echo
 	cd $(BUILDDIR)/html && python -m http.server 8009
 
 clean:
-	rm -rf $(BUILDDIR)/doctrees
-	rm -rf $(BUILDDIR)/html
+	rm -rf $(BUILDDIR)
 	rm -rf api/generated
 	rm -rf gallery
 	rm -rf tutorials

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 # Internal variables.
 ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees  $(SPHINXOPTS) .
 
-.PHONY: help clean html api
+.PHONY: help api html server clean
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -41,8 +41,6 @@ server:
 clean:
 	rm -rf $(BUILDDIR)/doctrees
 	rm -rf $(BUILDDIR)/html
-	rm -rf $(BUILDDIR)/linkcheck
-	rm -rf $(BUILDDIR)/doctest
 	rm -rf api/generated
 	rm -rf gallery
 	rm -rf tutorials

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -44,8 +44,6 @@ clean:
 	rm -rf $(BUILDDIR)/linkcheck
 	rm -rf $(BUILDDIR)/doctest
 	rm -rf api/generated
-	rm -rf modules
 	rm -rf gallery
 	rm -rf tutorials
 	rm -rf projections
-	rm -rf .ipynb_checkpoints

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 # Internal variables.
 ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees  $(SPHINXOPTS) .
 
-.PHONY: help api html server clean
+.PHONY: help all api html server clean
 
 help:
 	@echo "Please use 'make <target>' where <target> is one of"

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,8 +14,8 @@ ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees  $(SPHINXOPTS) .
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  all        generate the complete webpage"
-	@echo "  html       make only the HTML files from the existing rst sources"
-	@echo "  api        make only the API documentation from the source codes"
+	@echo "  html       build the HTML files from the existing rst sources"
+	@echo "  api        generate API documentation rst sources"
 	@echo "  serve      make a HTTP server"
 	@echo "  linkcheck  check all external links for integrity"
 	@echo "  doctest    run all doctests embedded in the documentation (if enabled)"
@@ -52,10 +52,11 @@ doctest:
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
 clean:
-	rm -rf $(BUILDDIR)/html
-	rm -rf api/generated
-	rm -rf $(BUILDDIR)/linkcheck
 	rm -rf $(BUILDDIR)/doctrees
+	rm -rf $(BUILDDIR)/html
+	rm -rf $(BUILDDIR)/linkcheck
+	rm -rf $(BUILDDIR)/doctest
+	rm -rf api/generated
 	rm -rf modules
 	rm -rf gallery
 	rm -rf tutorials

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -12,7 +12,7 @@ ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees  $(SPHINXOPTS) .
 .PHONY: help api html server clean
 
 help:
-	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "Please use 'make <target>' where <target> is one of"
 	@echo "  all        generate the complete webpage"
 	@echo "  api        generate rst source files of API documentation"
 	@echo "  html       build the HTML files from the existing rst sources"


### PR DESCRIPTION
**Description of proposed changes**

- `help` target
  - List information of `clean`, `api`, and `serve`
  - Tiny improvement for the `html` information
- Change the order of all the targets
  - the original order: `all`, `help`, `clean`, `html`, `api`, `linkcheck`, `doctest`, `serve`
  - the new order: `help`, `all`, `html`,  `api`, `serve`, `linkcheck`, `dotest`, `clean`.
- Tiny improvment of the `clean` target

The following are some of my thoughts on which I want your comments:
~~- [ ] Now the `all` target is the same as the `html`, so shall we remove the `all` target?~~
- [x] We have added a workflow to check links in plaintext and HTML files in #634, so do we want to remove the `linkcheck` target (originally posted in https://github.com/GenericMappingTools/pygmt/issues/914#issuecomment-780033253)?
- [x] There are `modules` and `ipynb_checkpoints` in the `clean` target, but I cannot find them after I made all the targets. So remove them?
- [x] Shall we rename the `serve` target to be `server`?

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #914


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
