### PR TITLE
Improve the docstring of the pygmt package

### DIFF
--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -1,8 +1,8 @@
 # pylint: disable=missing-docstring
 #
-# PyGMT is a library for processing geospatial and geophysical data and making 
-# publication quality maps and figures. It provides a Pythonic interface for 
-# the Generic Mapping Tools (GMT), a command-line program widely used in the 
+# PyGMT is a library for processing geospatial and geophysical data and making
+# publication quality maps and figures. It provides a Pythonic interface for
+# the Generic Mapping Tools (GMT), a command-line program widely used in the
 # Earth Sciences.
 
 import atexit as _atexit

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -1,17 +1,17 @@
-# pylint: disable=missing-docstring
-#
-# PyGMT is a library for processing geospatial and geophysical data and making
-# publication quality maps and figures. It provides a Pythonic interface for
-# the Generic Mapping Tools (GMT), a command-line program widely used in the
-# Earth Sciences.
-#
-# Main Features
-# -------------
-# Here are just a few of the things that PyGMT does well:
-#   - Easy handling of all kinds of geospatial data including gridded and
-#     raster data.
-#   - Allows plotting of a large spectrum of objects on maps including lines,
-#     vectors, polygons, and symbols (pre-defined and customized)
+"""
+PyGMT is a library for processing geospatial and geophysical data and making
+publication quality maps and figures. It provides a Pythonic interface for the
+Generic Mapping Tools (GMT), a command-line program widely used in the Earth
+Sciences.
+
+Main Features
+-------------
+Here are just a few of the things that PyGMT does well:
+  - Easy handling of all kinds of geospatial data including gridded and
+    raster data.
+  - Allows plotting of a large spectrum of objects on maps including lines,
+    vectors, polygons, and symbols (pre-defined and customized)
+"""
 
 import atexit as _atexit
 

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -12,7 +12,7 @@ Here are just a few of the things that PyGMT does well:
 
   - Easy handling of individual types of data like Cartesian, geographic, or
     time-series data.
-  - Processing of (geo)spatial data including gridding, filtering, masking
+  - Processing of (geo)spatial data including gridding, filtering, and masking
   - Allows plotting of a large spectrum of objects on figures including
     lines, vectors, polygons, and symbols (pre-defined and customized)
   - Generate publication-quality illustrations and make animations

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -1,11 +1,9 @@
 # pylint: disable=missing-docstring
 #
-# The main API for PyGMT.
-#
-# All of PyGMT is operated on a "modern mode session" (new to GMT6). When you
-# import the pygmt library, a new session will be started automatically. The
-# session will be closed when the current Python process terminates. Thus, the
-# Python API does not expose the `gmt begin` and `gmt end` commands.
+# PyGMT is a library for processing geospatial and geophysical data and making 
+# publication quality maps and figures. It provides a Pythonic interface for 
+# the Generic Mapping Tools (GMT), a command-line program widely used in the 
+# Earth Sciences.
 
 import atexit as _atexit
 

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -4,6 +4,14 @@
 # publication quality maps and figures. It provides a Pythonic interface for
 # the Generic Mapping Tools (GMT), a command-line program widely used in the
 # Earth Sciences.
+#
+# Main Features
+# -------------
+# Here are just a few of the things that PyGMT does well:
+#   - Easy handling of all kinds of geospatial data including gridded and raster
+#     data.
+#   - Allows plotting of a large spectrum of objects on maps including lines,
+#     vectors, polygons, and symbols (pre-defined and customized)
 
 import atexit as _atexit
 

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -9,6 +9,7 @@ display in Jupyter notebooks.
 Main Features
 -------------
 Here are just a few of the things that PyGMT does well:
+
   - Easy handling of individual types of data like cartesian, geographic, or
     time-series data.
   - Processing of (geo)spatial data including gridding, filtering, masking

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -9,8 +9,8 @@ Main Features
 Here are just a few of the things that PyGMT does well:
   - Easy handling of all kinds of geospatial data including gridded and
     raster data.
-  - Allows plotting of a large spectrum of objects on maps including lines,
-    vectors, polygons, and symbols (pre-defined and customized)
+  - Allows plotting of a large spectrum of objects on figures including
+    lines, vectors, polygons, and symbols (pre-defined and customized)
 """
 
 import atexit as _atexit

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -10,7 +10,7 @@ Main Features
 -------------
 Here are just a few of the things that PyGMT does well:
 
-  - Easy handling of individual types of data like cartesian, geographic, or
+  - Easy handling of individual types of data like Cartesian, geographic, or
     time-series data.
   - Processing of (geo)spatial data including gridding, filtering, masking
   - Allows plotting of a large spectrum of objects on figures including

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -2,15 +2,19 @@
 PyGMT is a library for processing geospatial and geophysical data and making
 publication quality maps and figures. It provides a Pythonic interface for the
 Generic Mapping Tools (GMT), a command-line program widely used in the Earth
-Sciences.
+Sciences. Besides making GMT more accessible to new users, PyGMT aims to
+provide integration with the PyData ecosystem as well as support for rich
+display in Jupyter notebooks.
 
 Main Features
 -------------
 Here are just a few of the things that PyGMT does well:
-  - Easy handling of all kinds of geospatial data including gridded and
-    raster data.
+  - Easy handling of individual types of data like cartesian, geographic, or
+    time-series data.
+  - Processing of (geo)spatial data including gridding, filtering, masking
   - Allows plotting of a large spectrum of objects on figures including
     lines, vectors, polygons, and symbols (pre-defined and customized)
+  - Generate publication-quality illustrations and make animations
 """
 
 import atexit as _atexit

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -8,8 +8,8 @@
 # Main Features
 # -------------
 # Here are just a few of the things that PyGMT does well:
-#   - Easy handling of all kinds of geospatial data including gridded and raster
-#     data.
+#   - Easy handling of all kinds of geospatial data including gridded and
+#     raster data.
 #   - Allows plotting of a large spectrum of objects on maps including lines,
 #     vectors, polygons, and symbols (pre-defined and customized)
 


### PR DESCRIPTION
Based on #1012, here's a first suggestion (partly influced by the pandas docstring) for improving the docstring which is displayed when running ``import pygmt``  followed by ``help(pygmt)``. Open for discussions, improvements and other ideas.

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
