### PR TITLE
Improve documentation for +r option in the regions tutorial

### DIFF
--- a/examples/tutorials/regions.py
+++ b/examples/tutorials/regions.py
@@ -27,7 +27,7 @@ import pygmt
 
 fig = pygmt.Figure()
 fig.coast(
-    # Sets the x-range from 10E to 20E and the y-range to 35N to 45N
+    # Set the x-range from 10E to 20E and the y-range to 35N to 45N
     region="10/20/35/45",
     # Set projection to Mercator, and the figure size to 15 centimeters
     projection="M15c",
@@ -46,12 +46,12 @@ fig.show()
 
 ########################################################################################
 #
-# The coordinates can be passed to ``region`` as a list, in the form
-# of [*xmin*,\ *xmax*,\ *ymin*,\ *ymax*].
+# The coordinates can be passed to ``region`` as a list, in the form of
+# [*xmin*,\ *xmax*,\ *ymin*,\ *ymax*].
 
 fig = pygmt.Figure()
 fig.coast(
-    # Sets the x-range from 10E to 20E and the y-range to 35N to 45N
+    # Set the x-range from 10E to 20E and the y-range to 35N to 45N
     region=[10, 20, 35, 45],
     projection="M12c",
     land="lightgray",
@@ -71,7 +71,7 @@ fig.show()
 
 fig = pygmt.Figure()
 fig.coast(
-    # Sets the bottom-left corner as 10E, 35N and the top-right corner as 20E, 45N
+    # Set the bottom-left corner as 10E, 35N and the top-right corner as 20E, 45N
     region="10/35/20/45+r",
     projection="M12c",
     land="lightgray",
@@ -133,7 +133,7 @@ fig.show()
 
 fig = pygmt.Figure()
 fig.coast(
-    # Sets the figure region to encompass Japan with the ISO code "JP"
+    # Set the figure region to encompass Japan with the ISO code "JP"
     region="JP",
     projection="M12c",
     land="lightgray",
@@ -147,14 +147,13 @@ fig.show()
 ########################################################################################
 #
 # The area encompassed by the ISO code can be expanded by appending **+r**\ *increment*
-# to the ISO code. The *increment* unit is in degrees, and if only value is added it
-# expands the range of the region in all directions. Using **+r** rounds to the nearest
-# increment.
+# to the ISO code. The *increment* unit is in degrees, and if only one value is added it
+# expands the range of the region in all directions. Using **+r** expands the
+# final region boundaries to be multiples of *increment* .
 
 fig = pygmt.Figure()
 fig.coast(
-    # Expands the region setting outside the range of Japan by 3 degrees in all
-    # directions
+    # Expand the region boundaries to be multiples of 3 degrees in all directions
     region="JP+r3",
     projection="M12c",
     land="lightgray",
@@ -172,7 +171,7 @@ fig.show()
 
 fig = pygmt.Figure()
 fig.coast(
-    # Expands the region setting outside the range of Japan by 3 degrees on the x-axis
+    # Expand the region boundaries to be multiples of 3 degrees on the x-axis
     # and 5 degrees on the y-axis.
     region="JP+r3/5",
     projection="M12c",
@@ -193,7 +192,7 @@ fig.show()
 
 fig = pygmt.Figure()
 fig.coast(
-    # Expands the region setting outside the range of Japan by 3 degrees to the west,
+    # Expand the region boundaries to be multiples of 3 degrees to the west,
     # 5 degrees to the east, 7 degrees to the south, and 9 degrees to the north.
     region="JP+r3/5/7/9",
     projection="M12c",
@@ -212,7 +211,7 @@ fig.show()
 
 fig = pygmt.Figure()
 fig.coast(
-    # Expands the region setting outside the range of Japan by 3 degrees in all
+    # Expand the region setting outside the range of Japan by 3 degrees in all
     # directions, without rounding to the nearest increment.
     region="JP+R3",
     projection="M12c",
@@ -226,13 +225,13 @@ fig.show()
 
 ########################################################################################
 #
-# The ``region`` increment can be appended with **+e**, which expand the bounding box
-# by at least 25% beyond the increment.
+# The ``region`` increment can be appended with **+e**, which is like **+r** and
+# expands the final region boundaries to be multiples of *increment*. However,
+# it ensures that the bounding box extends by at least 0.25 times the increment.
 
 fig = pygmt.Figure()
 fig.coast(
-    # Expands the region setting outside the range of Japan by 3 degrees in all
-    # directions, without rounding to the nearest increment.
+    # Expand the region boundaries to be multiples of 3 degrees in all directions
     region="JP+e3",
     projection="M12c",
     land="lightgray",


### PR DESCRIPTION
**Description of proposed changes**

The `+rincrement` option in the [tutorial for ISO code](https://www.pygmt.org/latest/tutorials/regions.html#iso-code) may mislead some new GMT users (originally posted in https://github.com/GenericMappingTools/pygmt/issues/983#issuecomment-791920354).

----

`+r` option in [GMT DOC](https://docs.generic-mapping-tools.org/latest/cookbook/options.html#data-domain-or-map-region-the-r-option)
> Append +r to modify exact bounding box coordinates obtained from the polygon(s): Append inc, xinc/yinc, or winc/einc/sinc/ninc to adjust the final region boundaries to be multiples of these steps [default is no adjustment]. Alternatively, use +R to extend the region outward by adding these increments instead, or +e which is like +r but it ensures that the bounding box extends by at least 0.25 times the increment [no extension]. As an example, -RFR+r1 will select the national bounding box of France rounded to nearest integer degree.

Take `JP` as an example:
```Python
import pygmt
fig = pygmt.Figure()
fig.coast(
    region="JP",
    projection="M12c",
    land="lightgray",
)
print(fig.region)
```
Output:
```
[122.938515 145.820877  20.528774  45.523136]
```

Use `[+r|R|e[incs]]` option: 
- `JP+R1`: [121.938515 146.820877  19.528774  46.523136]
- `JP+R2`: [120.938515 147.820877  18.528774  47.523136]
- `JP+R3`: [119.938515 148.820877  17.528774  48.523136]
- `JP+r1`: [122. 146.  20.  46.]
- `JP+r2`: [122. 146.  20.  46.]
- `JP+r3`: [120. 147.  18.  48.]
- `JP+e1`: [122. 147.  20.  46.]
- `JP+e2`: [122. 148.  20.  48.]
- `JP+e3`: [120. 147.  18.  48.]

We can see:
- `+Rinc` extends the region outward by **adding these increments** (using `+R3`, `119.938515` = `122.938515` - `3`)
- `+rinc` adjusts the final region boundaries to be **multiples of these steps** (using `+r3`, `120`, `147`, `18`, `48` are multiples of 3)
- `+einc` is similar to `+rinc` (final region boundaries to be **multiples of these steps**), but it ensures that the bounding box extends by **at least 0.25 times the increment**. So, `+e1` adjusts `145.820877` to be `147` instead of `146` by `+r1` since `146-145.820877=0.18` < `0.25*1`. `+e2` adjusts `145.820877` to be `148`, `45.523136` to be `48` for the same reason.

---


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Related to #983 and #996.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
