### PR TITLE
Support passing a sequence to the spacing parameter of pygmt.info()

### DIFF
--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -7,7 +7,9 @@ from pygmt.helpers import GMTTempFile, build_arg_string, fmt_docstring, use_alia
 
 
 @fmt_docstring
-@use_alias(C="per_column", I="sequence", T="nearest_multiple", V="verbose", f="coltypes")
+@use_alias(
+    C="per_column", I="sequence", T="nearest_multiple", V="verbose", f="coltypes"
+)
 def info(table, **kwargs):
     r"""
     Get information about data tables.

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -7,7 +7,7 @@ from pygmt.helpers import GMTTempFile, build_arg_string, fmt_docstring, use_alia
 
 
 @fmt_docstring
-@use_alias(C="per_column", I="spacing", T="nearest_multiple", V="verbose", f="coltypes")
+@use_alias(C="per_column", I="sequence", T="nearest_multiple", V="verbose", f="coltypes")
 def info(table, **kwargs):
     r"""
     Get information about data tables.

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -3,13 +3,18 @@ info - Get information about data tables.
 """
 import numpy as np
 from pygmt.clib import Session
-from pygmt.helpers import GMTTempFile, build_arg_string, fmt_docstring, use_alias
+from pygmt.helpers import (
+    GMTTempFile,
+    build_arg_string,
+    fmt_docstring,
+    kwargs_to_strings,
+    use_alias,
+)
 
 
 @fmt_docstring
-@use_alias(
-    C="per_column", I="sequence", T="nearest_multiple", V="verbose", f="coltypes"
-)
+@use_alias(C="per_column", I="spacing", T="nearest_multiple", V="verbose", f="coltypes")
+@kwargs_to_strings(I="sequence")
 def info(table, **kwargs):
     r"""
     Get information about data tables.


### PR DESCRIPTION
Allow to pass a tuple to the ``spacing`` parameter as suggested in #1006.


**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
