### PR TITLE
Do NOT fail CI if codecov runs into errors during upload

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -134,7 +134,7 @@ jobs:
         with:
           file: ./coverage.xml # optional
           env_vars: OS,PYTHON
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
       - name: Checkout the gh-pages branch
         uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b


### PR DESCRIPTION
**Description of proposed changes**

The codecov githb action is very unstable recently, and makes most of
our CI jobs failed.

This PR sets `fail_ci_if_error` to `false` (the default behavior of
codecov), so that even if codecov fails in uploading the coverage
reports, the CI jobs still pass.

Actually, if the codecov upload fails, we will see that codecov
checks fail, but at least we know that all tests still pass.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
