### PR TITLE
Improve the image size in the documentation

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -163,3 +163,13 @@ a.copybtn {
     font-weight: bold;
     font-style: italic;
 }
+
+/* Style for images and thumbnails of sphinx-gallery */
+.sphx-glr-thumbcontainer {
+    border: solid #d6d6d6 1px!important;
+    text-align: center!important;
+}
+
+.sphx-glr-single-img {
+    max-width: 80%!important;
+}

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -38,10 +38,6 @@ p {
     margin-bottom: 50px;
 }
 
-.rst-content img {
-    max-width: 80%;
-}
-
 .sidebar-title {
     margin-top: 10px;
     margin-bottom: 0px;

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -43,6 +43,7 @@ These are conference presentations about the development of PyGMT (previously
 
 .. figure:: https://img.youtube.com/vi/SSIGJEe0BIk/maxresdefault.jpg
     :target: https://www.youtube.com/watch?v=SSIGJEe0BIk
+    :width: 80%
     :align: center
     :alt: ROSES 2020 youtube video
 
@@ -54,6 +55,7 @@ These are conference presentations about the development of PyGMT (previously
 
 .. figure:: _static/agu2019-poster.jpg
    :target: https://doi.org/10.6084/m9.figshare.11320280
+   :width: 80%
    :align: center
    :alt: AGU 2019 poster on figshare
 
@@ -65,6 +67,7 @@ These are conference presentations about the development of PyGMT (previously
 
 .. figure:: _static/scipy2018-youtube-thumbnail.png
    :target: https://www.youtube.com/watch?v=6wMtfZXfTRM
+   :width: 80%
    :align: center
    :alt: SciPy youtube video
 
@@ -76,6 +79,7 @@ These are conference presentations about the development of PyGMT (previously
 
 .. figure:: _static/aogs2018-poster.jpg
    :target: https://doi.org/10.6084/m9.figshare.6399944
+   :width: 80%
    :align: center
    :alt: AOGS poster on figshare
 
@@ -87,6 +91,7 @@ These are conference presentations about the development of PyGMT (previously
 
 .. figure:: _static/scipy2017-youtube-thumbnail.png
    :target: https://www.youtube.com/watch?v=93M4How7R24
+   :width: 80%
    :align: center
    :alt: SciPy youtube video
 
@@ -98,5 +103,6 @@ These are conference presentations about the development of PyGMT (previously
 
 .. figure:: _static/agu2017-poster.jpg
    :target: https://doi.org/10.6084/m9.figshare.5662411
+   :width: 80%
    :align: center
    :alt: AGU 2017 poster on figshare


### PR DESCRIPTION
**Description of proposed changes**

See #1038 for context.

For the three different types of images, they now have different settings for max-width:

1. Images included using the `figure` directive: default to 100%, but we can customize the figure width using the `:width:` option of the `figure` directive. **Preview:** https://pygmt-git-thumbnail-gmt.vercel.app/overview.html
2. Single images included by calling `Figure.show()`: max-width is 80%. **Preview:** https://pygmt-git-thumbnail-gmt.vercel.app/gallery/maps/land_and_water.html
3. Gallery thumbnails: max-width is 100%. **Preview**: https://pygmt-git-thumbnail-gmt.vercel.app/gallery/index.html

I also add a thin box for each gallery thumbnail and center the thumbnail titles.

Fixes #1038


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
