### PR TITLE
Add the link for standard GMT color names in GMT docs

### DIFF
--- a/examples/gallery/maps/land_and_water.py
+++ b/examples/gallery/maps/land_and_water.py
@@ -3,9 +3,10 @@ Color land and water
 --------------------
 
 The ``land`` and ``water`` parameters of :meth:`pygmt.Figure.coast` specify a color to
-fill in the land and water masses, respectively. You can use
-:gmt-docs:`standard GMT color names <gmtcolors.html#list-of-colors>`
-or give a hex value (like ``#333333``).
+fill in the land and water masses, respectively. There are many
+:gmt-docs:`color codes in GMT <gmtcolors.html>`, e.g., standard GMT color
+names (like ``skyblue``), R/G/B (like ``0/0/255``), a hex value (like ``#333333``),
+graylevel (like ``50``).
 """
 import pygmt
 

--- a/examples/gallery/maps/land_and_water.py
+++ b/examples/gallery/maps/land_and_water.py
@@ -4,9 +4,9 @@ Color land and water
 
 The ``land`` and ``water`` parameters of :meth:`pygmt.Figure.coast` specify a color to
 fill in the land and water masses, respectively. There are many
-:gmt-docs:`color codes in GMT <gmtcolors.html>`, e.g., standard GMT color
-names (like ``skyblue``), R/G/B (like ``0/0/255``), a hex value (like ``#333333``),
-graylevel (like ``50``).
+:gmt-docs:`color codes in GMT <gmtcolors.html>`, including standard GMT color
+names (like ``skyblue``), R/G/B levels (like ``0/0/255``), a hex value (like
+``#333333``), and a graylevel (like ``50``).
 """
 import pygmt
 

--- a/examples/gallery/maps/land_and_water.py
+++ b/examples/gallery/maps/land_and_water.py
@@ -2,8 +2,8 @@
 Color land and water
 --------------------
 
-The ``land`` and ``water`` parameters of :meth:`pygmt.Figure.coast` specify a color to
-fill in the land and water masses, respectively. There are many
+The ``land`` and ``water`` parameters of :meth:`pygmt.Figure.coast` specify 
+a color to fill in the land and water masses, respectively. There are many
 :gmt-docs:`color codes in GMT <gmtcolors.html>`, including standard GMT color
 names (like ``skyblue``), R/G/B levels (like ``0/0/255``), a hex value (like
 ``#333333``), and a graylevel (like ``50``).

--- a/examples/gallery/maps/land_and_water.py
+++ b/examples/gallery/maps/land_and_water.py
@@ -3,8 +3,9 @@ Color land and water
 --------------------
 
 The ``land`` and ``water`` parameters of :meth:`pygmt.Figure.coast` specify a color to
-fill in the land and water masses, respectively. You can use standard GMT color names or
-give a hex value (like ``#333333``).
+fill in the land and water masses, respectively. You can use
+:gmt-docs:`standard GMT color names <gmtcolors.html#list-of-colors>`
+or give a hex value (like ``#333333``).
 """
 import pygmt
 


### PR DESCRIPTION
**Description of proposed changes**

Add the link of GMT DOC to standard GMT color names.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Related to #983 and #996.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
