### PR TITLE
Tiny improvements for the line tyles gallery example

### DIFF
--- a/examples/gallery/lines/linestyles.py
+++ b/examples/gallery/lines/linestyles.py
@@ -38,7 +38,9 @@ for linestyle in [
     "1p,lightblue,-.",  # dash-dotted line
     "2p,blue,..-",  # dot-dot-dashed line
     "2p,tomato,--.",  # dash-dash-dotted line
-    "2p,tomato,4_2:2p",  # A pattern of 4-point-long line segment and 2-point-gap between segment
+    # A pattern of 4-point-long line segment and 2-point-gap between segment,
+    # with pattern offset by 2 points from the origin
+    "2p,tomato,4_2:2p",
 ]:
     y -= 1  # Move the current line down
     fig.plot(x=x, y=y, pen=linestyle)


### PR DESCRIPTION
**Description of proposed changes**

Add an explaination of `:2p` for the line style `"2p,tomato,4_2:2p"` in [Line styles gallery example](https://www.pygmt.org/dev/gallery/lines/linestyles.html#sphx-glr-gallery-lines-linestyles-py)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Related to #983 and #996.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
