### PR TITLE
WIP: Setup poetry in pyproject.toml

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -79,7 +79,7 @@ jobs:
 
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
-        run: conda env update --file environment.yml
+        run: conda install gmt=6.1.1 make poetry
 
       # Show installed pkg information for postmortem diagnostic
       - name: List installed packages
@@ -105,9 +105,7 @@ jobs:
 
       # Install the package that we want to test
       - name: Install the package
-        run: |
-          python setup.py sdist --formats=zip
-          pip install dist/*
+        run: poetry install --extras docs
 
       # Run the tests
       - name: Test with pytest

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 *.egg-info/
 .eggs/
 MANIFEST
+poetry.lock
 
 # Unit test / coverage reports
 .cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,47 @@
+[tool.poetry]
+name = "pygmt"
+version = "0.3.1"
+description = "A Python interface for the Generic Mapping Tools"
+authors = ["The PyGMT Developers"]
+license = "BSD License"
+
+[tool.poetry.dependencies]
+myst-parser = {version = "*", optional = true}
+netCDF4 = "*"
+numpy = "*"
+packaging = "*"
+pandas = "*"
+python = "^3.7"
+sphinx = {version = "*", optional = true}
+sphinx-copybutton = {version = "*", optional = true}
+sphinx-gallery = {version = "*", optional = true}
+sphinx_rtd_theme = {version = "0.4.3", optional = true}
+xarray = "*"
+
+[tool.poetry.dev-dependencies]
+black = "*"
+blackdoc = "*"
+codecov = "*"
+coverage = {extras = ["toml"], version = "*"}
+docformatter = "*"
+flake8 = "*"
+ipython = "*"
+isort = ">=5"
+jupyter = "*"
+make = "*"
+matplotlib = "*"
+pylint = "*"
+pytest-cov = "*"
+pytest-mpl = "*"
+pytest = ">=6.0"
+
+[tool.poetry.extras]
+docs = ["myst-parser", "sphinx", "sphinx-copybutton", "sphinx-gallery", "sphinx_rtd_theme"]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.coverage.run]
 omit = ["*/tests/*", "*pygmt/__init__.py"]
 


### PR DESCRIPTION
**Description of proposed changes**

Initializing [poetry](https://python-poetry.org) to see if it can speed up the install step in our Continuous Integration.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

`conda` works in serial and can be a bit slow, while `poetry` can install things in parallel. The idea here is to use `conda` only for non-Python packages (i.e. GMT and make), and `poetry` for Python dependencies (e.g. numpy, pandas, etc).

Notes:
- Use `poetry install --no-dev` to get only the minimum required dependencies for PyGMT
- Use `poetry install` to get both minimum and development dependencies (e.g. pytest, black, codecov, etc)
- Use `poetry install --no-dev --extras docs` to install minimum and dependencies for building docs (e.g. sphinx, etc)
- Use `poetry install --extras docs` to get all of the above

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #584, may help with #690

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
