### PR TITLE
Configure codecov project and patch status settings

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -12,7 +12,7 @@ coverage:
         if_ci_failed: failure
     patch:
       default:
-        target: 100%  # new changes should be 100% tested
+        target: 90%  # >=90% of new changes should be tested
         if_not_found: success
         if_ci_failed: failure
 

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,10 +4,15 @@ codecov:
 
 coverage:
   status:
+    project:
+      default:
+        target: auto  # increase overall coverage on each pull request
+        threshold: 0.25%  # Allow the coverage to drop by X%
+        if_not_found: success
+        if_ci_failed: failure
     patch:
       default:
-        target: '90'
-        if_no_uploads: error
+        target: 100%  # new changes should be 100% tested
         if_not_found: success
         if_ci_failed: failure
 


### PR DESCRIPTION
**Description of proposed changes**

Our draft PRs have a failure in codecov status check. It's because only one CI job (Linux) is triggered for draft PRs. Some Windows-only tests are not run, thus in draft PRs, code coverage always decreases compared to the base branch.

Even for normal PRs, as CI jobs are much faster on Linux than macOS and Windows, we always see a coverage decrease (thus a failure) until the Windows CI jobs finish.

This PR fixes the problem by configuring the codecov project and patch status.

- the project coverage must always increase compared to the base branch, but allow 0.25% drop so that the status check still pass when Windows-only tests are not run
- the patch coverage `target` is set to 100%, so that we know that all changes are covered
- `if_no_uploads` is not documented in the codecov reference, so removed.

Note: this draft PR has a -0.07% coverage decrease. As -0.07% is smaller than the threshold (-0.25%), the codecov status check still passes.


References:

- docs.codecov.io/docs/common-recipe-list
- docs.codecov.io/docs/commit-status

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
