### PR TITLE
CI: Add srtm_tiles.nc to cache data

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  # pull_request:
+  pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  pull_request:
+  # pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -40,6 +40,8 @@ jobs:
           # The naming scheme may change.
           # DO NOT USE IT IN SCRIPTS.
           gmt which -Ga @N35E135.earth_relief_03s_g.nc
+          # @srtm_tiles.nc is needed for 03s and 01s relief data
+          gmt which -Ga @srtm_tiles.nc
           gmt which -Ga @ridge.txt @Table_5_11.txt @test.dat.nc \
                         @tut_bathy.nc @tut_quakes.ngdc @tut_ship.xyz \
                         @usgs_quakes_22.txt


### PR DESCRIPTION
**Description of proposed changes**

GMT needs the srtm_tiles.nc file to know if a tile is on land or in ocean,
when using 01s and 03s earth relief data.

Without this file, sometimes CI jobs may fail (e.g., https://github.com/GenericMappingTools/pygmt/pull/1084/checks?check_run_id=2156130407)

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
