### PR TITLE
Add list of aliases to grdinfo docstring

### DIFF
--- a/pygmt/src/grdinfo.py
+++ b/pygmt/src/grdinfo.py
@@ -33,6 +33,8 @@ def grdinfo(grid, **kwargs):
 
     Full option list at :gmt-docs:`grdinfo.html`
 
+    {aliases}
+
     Parameters
     ----------
     grid : str or xarray.DataArray


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the list of aliases to the [grdinfo documentation](https://www.pygmt.org/dev/api/generated/pygmt.grdinfo.html#pygmt.grdinfo). 

Preview: https://pygmt-1xwur89u9-gmt.vercel.app/api/generated/pygmt.grdinfo.html#pygmt.grdinfo

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
