### PR TITLE
Add alias 'registration' to methods blockmean, info, grdfilter, surface

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -111,11 +111,12 @@ COMMON_OPTIONS = {
             the viewpoint. Default is [180, 90]. Full documentation is at
             :gmt-docs:`gmt.html#perspective-full`.
         """,
-    "registration": r"""
+    "r": r"""
         registration : str
             **g**\|\ **p**.
-            Force output grid to be gridline (g) or pixel (p) node registered.
-            Default is gridline (g).""",
+            Force gridline (**g**) or pixel (**p**) node registration.
+            [Default is **g**\ (ridline)].
+        """,
     "t": """\
         transparency : int or float
             Set transparency level, in [0-100] percent range.

--- a/pygmt/src/blockmedian.py
+++ b/pygmt/src/blockmedian.py
@@ -16,7 +16,13 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
-@use_alias(I="spacing", R="region", V="verbose", f="coltypes")
+@use_alias(
+    I="spacing",
+    R="region",
+    V="verbose",
+    f="coltypes",
+    r="registration",
+)
 @kwargs_to_strings(R="sequence")
 def blockmedian(table, outfile=None, **kwargs):
     r"""
@@ -53,6 +59,7 @@ def blockmedian(table, outfile=None, **kwargs):
 
     {V}
     {f}
+    {r}
 
     Returns
     -------

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -24,6 +24,7 @@ from pygmt.helpers import (
     T="toggle",
     V="verbose",
     f="coltypes",
+    r="registration",
 )
 @kwargs_to_strings(R="sequence")
 def grdfilter(grid, **kwargs):
@@ -110,6 +111,7 @@ def grdfilter(grid, **kwargs):
         input grid].
     {V}
     {f}
+    {r}
 
     Returns
     -------

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -13,7 +13,14 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
-@use_alias(C="per_column", I="spacing", T="nearest_multiple", V="verbose", f="coltypes")
+@use_alias(
+    C="per_column",
+    I="spacing",
+    T="nearest_multiple",
+    V="verbose",
+    f="coltypes",
+    r="registration",
+)
 @kwargs_to_strings(I="sequence")
 def info(table, **kwargs):
     r"""
@@ -56,6 +63,7 @@ def info(table, **kwargs):
 
     {V}
     {f}
+    {r}
 
     Returns
     -------

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -17,7 +17,14 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
-@use_alias(I="spacing", R="region", G="outfile", V="verbose", f="coltypes")
+@use_alias(
+    I="spacing",
+    R="region",
+    G="outfile",
+    V="verbose",
+    f="coltypes",
+    r="registration",
+)
 @kwargs_to_strings(R="sequence")
 def surface(x=None, y=None, z=None, data=None, **kwargs):
     r"""
@@ -61,6 +68,7 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
 
     {V}
     {f}
+    {r}
 
     Returns
     -------


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes the format of the registration alias in `pygmt/helpers/decorators.py` and adds the alias to the wrapped modules that support the **-r** common option. It also revises the description for the **-r** option slightly, since some modules that support **-r** do not involve output grids.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
