### PR TITLE
Add alias 'aspatial' to methods blockmedian, info, plot, plot3d, surface

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -64,7 +64,7 @@ COMMON_OPTIONS = {
          """,
     "a": r"""
         aspatial : str
-            [*col*\ =]\ *name*\ [,...]
+            [*col*\ =]\ *name*\ [,...].
             Control how aspatial data are handled during input and output.
             Full documentation is at :gmt-docs:`gmt.html#aspatial-full`.
          """,

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -62,6 +62,12 @@ COMMON_OPTIONS = {
             Shift plot origin in y-direction. Full documentation is at
             :gmt-docs:`gmt.html#xy-full`.
          """,
+    "a": r"""
+        aspatial : str
+            [*col*\ =]\ *name*\ [,...]
+            Control how aspatial data are handled during input and output.
+            Full documentation is at :gmt-docs:`gmt.html#aspatial-full`.
+         """,
     "c": r"""
         panel : bool or int or list
             [*row,col*\|\ *index*].

--- a/pygmt/src/blockmedian.py
+++ b/pygmt/src/blockmedian.py
@@ -20,6 +20,7 @@ from pygmt.helpers import (
     I="spacing",
     R="region",
     V="verbose",
+    a="aspatial",
     f="coltypes",
     r="registration",
 )
@@ -58,6 +59,7 @@ def blockmedian(table, outfile=None, **kwargs):
         file.
 
     {V}
+    {a}
     {f}
     {r}
 

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -18,6 +18,7 @@ from pygmt.helpers import (
     I="spacing",
     T="nearest_multiple",
     V="verbose",
+    a="aspatial",
     f="coltypes",
     r="registration",
 )
@@ -62,6 +63,7 @@ def info(table, **kwargs):
         of dz and output this in the form ``[zmin, zmax, dz]``.
 
     {V}
+    {a}
     {f}
     {r}
 

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -34,6 +34,7 @@ from pygmt.helpers import (
     X="xshift",
     Y="yshift",
     Z="zvalue",
+    a="aspatial",
     i="columns",
     l="label",
     c="panel",
@@ -181,6 +182,7 @@ def plot(self, x=None, y=None, data=None, sizes=None, direction=None, **kwargs):
         polygon in the input data. To apply it to the fill color, use
         ``color='+z'``. To apply it to the pen color, append **+z** to
         ``pen``.
+    {a}
     {c}
     {f}
     columns : str or 1d array

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -34,6 +34,7 @@ from pygmt.helpers import (
     X="xshift",
     Y="yshift",
     Z="zvalue",
+    a="aspatial",
     i="columns",
     l="label",
     c="panel",
@@ -151,6 +152,7 @@ def plot3d(
         polygon in the input data. To apply it to the fill color, use
         ``color='+z'``. To apply it to the pen color, append **+z** to
         ``pen``.
+    {a}
     {c}
     {f}
     label : str

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -22,6 +22,7 @@ from pygmt.helpers import (
     R="region",
     G="outfile",
     V="verbose",
+    a="aspatial",
     f="coltypes",
     r="registration",
 )
@@ -67,6 +68,7 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
         to store the grid in.
 
     {V}
+    {a}
     {f}
     {r}
 


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the 'aspatial' alias for **-a** to the blockmedian, info, plot, plot3d, and surface methods.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #48 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
