### PR TITLE
Fix documentation for alias 'aspatial'

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -64,7 +64,7 @@ COMMON_OPTIONS = {
          """,
     "a": r"""
         aspatial : str
-            [*col*\ =]\ *name*\ [,...].
+            [[*col*\ =]\ *name*\ [,...]].
             Control how aspatial data are handled during input and output.
             Full documentation is at :gmt-docs:`gmt.html#aspatial-full`.
          """,

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -64,7 +64,7 @@ COMMON_OPTIONS = {
          """,
     "a": r"""
         aspatial : bool or str
-            [[*col*\ =]\ *name*\ [,...]].
+            [*col*\ =]\ *name*\ [,...].
             Control how aspatial data are handled during input and output.
             Full documentation is at :gmt-docs:`gmt.html#aspatial-full`.
          """,

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -63,7 +63,7 @@ COMMON_OPTIONS = {
             :gmt-docs:`gmt.html#xy-full`.
          """,
     "a": r"""
-        aspatial : str
+        aspatial : bool or str
             [[*col*\ =]\ *name*\ [,...]].
             Control how aspatial data are handled during input and output.
             Full documentation is at :gmt-docs:`gmt.html#aspatial-full`.

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -112,14 +112,14 @@ def plot(self, x=None, y=None, data=None, sizes=None, direction=None, **kwargs):
         Draw symmetrical error bars. Full documentation is at
         :gmt-docs:`plot.html#e`.
     connection : str
-        [**c**\|\ **n**\|\ **r**]\
+        [**c**\|\ **n**\|\ **p**]\
         [**a**\|\ **f**\|\ **s**\|\ **r**\|\ *refpoint*].
         Alter the way points are connected (by specifying a *scheme*) and
         data are grouped (by specifying a *method*). Append one of three
         line connection schemes:
 
         - **c** : Draw continuous line segments for each group [Default].
-        - **r** : Draw line segments from a reference point reset for each
+        - **p** : Draw line segments from a reference point reset for each
           group.
         - **n** : Draw networks of line segments between all points in
           each group.
@@ -138,7 +138,7 @@ def plot(self, x=None, y=None, data=None, sizes=None, direction=None, **kwargs):
           incoming segment [Default].
         - **r** : Same as **s**, but the group reference point is reset
           after each record to the previous point (this method is only
-          available with the ``connection='r'`` scheme).
+          available with the ``connection='p'`` scheme).
 
         Instead of the codes **a**\|\ **f**\|\ **s**\|\ **r** you may append
         the coordinates of a *refpoint* which will serve as a fixed external

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -112,14 +112,14 @@ def plot(self, x=None, y=None, data=None, sizes=None, direction=None, **kwargs):
         Draw symmetrical error bars. Full documentation is at
         :gmt-docs:`plot.html#e`.
     connection : str
-        [**c**\|\ **n**\|\ **p**]\
+        [**c**\|\ **n**\|\ **r**]\
         [**a**\|\ **f**\|\ **s**\|\ **r**\|\ *refpoint*].
         Alter the way points are connected (by specifying a *scheme*) and
         data are grouped (by specifying a *method*). Append one of three
         line connection schemes:
 
         - **c** : Draw continuous line segments for each group [Default].
-        - **p** : Draw line segments from a reference point reset for each
+        - **r** : Draw line segments from a reference point reset for each
           group.
         - **n** : Draw networks of line segments between all points in
           each group.
@@ -138,7 +138,7 @@ def plot(self, x=None, y=None, data=None, sizes=None, direction=None, **kwargs):
           incoming segment [Default].
         - **r** : Same as **s**, but the group reference point is reset
           after each record to the previous point (this method is only
-          available with the ``connection='p'`` scheme).
+          available with the ``connection='r'`` scheme).
 
         Instead of the codes **a**\|\ **f**\|\ **s**\|\ **r** you may append
         the coordinates of a *refpoint* which will serve as a fixed external


### PR DESCRIPTION
**Description of proposed changes**

This PR updates an error that @PaulWessel found in the ReST docs for GMT in [this PR](https://github.com/GenericMappingTools/gmt/pull/4796), in that the *cols*=*name* option for 'aspatial' is optional.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
