### PR TITLE
Fix "pandas.Dataframe" to "pandas.DataFrame" in pygmt/datasets/samples.py

### DIFF
--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -18,7 +18,7 @@ def load_japan_quakes():
 
     Returns
     -------
-    data :  pandas.DataFrame
+    data : pandas.DataFrame
         The data table. Columns are year, month, day, latitude, longitude,
         depth (in km), and magnitude of the earthquakes.
     """
@@ -49,7 +49,7 @@ def load_ocean_ridge_points():
 
     Returns
     -------
-    data :  pandas.DataFrame
+    data : pandas.DataFrame
         The data table. Columns are longitude and latitude.
     """
     fname = which("@ridge.txt", download="c")
@@ -72,7 +72,7 @@ def load_sample_bathymetry():
 
     Returns
     -------
-    data :  pandas.DataFrame
+    data : pandas.DataFrame
         The data table. Columns are longitude, latitude, and bathymetry.
     """
     fname = which("@tut_ship.xyz", download="c")

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -7,7 +7,7 @@ from pygmt.src import which
 
 def load_japan_quakes():
     """
-    Load a table of earthquakes around Japan as a pandas.Dataframe.
+    Load a table of earthquakes around Japan as a pandas.DataFrame.
 
     Data is from the NOAA NGDC database. This is the ``@tut_quakes.ngdc``
     dataset used in the GMT tutorials.
@@ -18,7 +18,7 @@ def load_japan_quakes():
 
     Returns
     -------
-    data :  pandas.Dataframe
+    data :  pandas.DataFrame
         The data table. Columns are year, month, day, latitude, longitude,
         depth (in km), and magnitude of the earthquakes.
     """
@@ -49,7 +49,7 @@ def load_ocean_ridge_points():
 
     Returns
     -------
-    data :  pandas.Dataframe
+    data :  pandas.DataFrame
         The data table. Columns are longitude and latitude.
     """
     fname = which("@ridge.txt", download="c")
@@ -72,7 +72,7 @@ def load_sample_bathymetry():
 
     Returns
     -------
-    data :  pandas.Dataframe
+    data :  pandas.DataFrame
         The data table. Columns are longitude, latitude, and bathymetry.
     """
     fname = which("@tut_ship.xyz", download="c")
@@ -84,7 +84,7 @@ def load_sample_bathymetry():
 
 def load_usgs_quakes():
     """
-    Load a table of global earthquakes form the USGS as a pandas.Dataframe.
+    Load a table of global earthquakes form the USGS as a pandas.DataFrame.
 
     This is the ``@usgs_quakes_22.txt`` dataset used in the GMT tutorials.
 
@@ -94,7 +94,7 @@ def load_usgs_quakes():
 
     Returns
     -------
-    data : pandas.Dataframe
+    data : pandas.DataFrame
         The data table. Use ``print(data.describe())`` to see the available
         columns.
     """


### PR DESCRIPTION
**Description of proposed changes**

Replace (Match case and WholeWord) "pandas.Dataframe" to "pandas.DataFrame"

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1123 



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
