### PR TITLE
Clarify interplay of spacing and per_column in info

### DIFF
--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -54,9 +54,11 @@ def info(table, **kwargs):
         Report the min/max values per column in separate columns.
     spacing : str
         [**b**\|\ **p**\|\ **f**\|\ **s**]\ *dx*\[/*dy*\[/*dz*...]].
-        Report the min/max of the first n columns to the nearest multiple of
-        the provided increments and output results in the form
-        ``[w, e, s, n]``.
+        Compute the min/max values of the first n columns to the nearest
+        multiple of the provided increments [default is 2 columns]. By default,
+        output results in the form ``[w, e, s, n]``, unless ``per_column`` is
+        set in which case we output each min and max value in separate output
+        columns.
     nearest_multiple : str
         **dz**\[\ **+c**\ *col*].
         Report the min/max of the first (0'th) column to the nearest multiple


### PR DESCRIPTION
**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

https://github.com/GenericMappingTools/gmt/pull/5014 fixed the unclear interplay of **-I** (**spacing**) and **-C** (**per_column**) in the `info` method. This PR updates the corresponding documentation in PyGMT.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1035 

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
