### PR TITLE
Replace argument with parameter in coastlines tutorial

### DIFF
--- a/examples/tutorials/coastlines.py
+++ b/examples/tutorials/coastlines.py
@@ -83,6 +83,6 @@ fig.show()
 # CSS):
 
 fig = pygmt.Figure()
-fig.basemap(region="g", projection="W10c", frame=True)
+fig.basemap(region="g", projection="W15c", frame=True)
 fig.coast(land="#666666", water="skyblue")
 fig.show()

--- a/examples/tutorials/coastlines.py
+++ b/examples/tutorials/coastlines.py
@@ -21,7 +21,7 @@ import pygmt
 # Shorelines
 # ----------
 #
-# Use the ``shorelines`` argument to plot only the shorelines:
+# Use the ``shorelines`` parameter to plot only the shorelines:
 
 fig = pygmt.Figure()
 fig.basemap(region="g", projection="W15c", frame=True)

--- a/examples/tutorials/coastlines.py
+++ b/examples/tutorials/coastlines.py
@@ -83,6 +83,6 @@ fig.show()
 # CSS):
 
 fig = pygmt.Figure()
-fig.basemap(region="g", projection="W10i", frame=True)
+fig.basemap(region="g", projection="W10c", frame=True)
 fig.coast(land="#666666", water="skyblue")
 fig.show()

--- a/examples/tutorials/coastlines.py
+++ b/examples/tutorials/coastlines.py
@@ -78,7 +78,7 @@ fig.show()
 # Land and water
 # --------------
 #
-# Use the ``land`` and ``water`` arguments to specify a fill color for land and water
+# Use the ``land`` and ``water`` parameters to specify a fill color for land and water
 # bodies. The colors can be given by name or hex codes (like the ones used in HTML and
 # CSS):
 


### PR DESCRIPTION
**Description of proposed changes**

Found further passages in the coastlines tutorial where "argument"  is incorrectly used. It's replaced by "parameter" in this PR.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
