### PR TITLE
Adding more links from API docs to user guide close#1048

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -17,7 +17,8 @@ COMMON_OPTIONS = {
         region : str or list
             *Required if this is the first plot command*.
             *xmin/xmax/ymin/ymax*\ [**+r**][**+u**\ *unit*].
-            Specify the region of interest.""",
+            Specify the region of interest.
+            Select map :doc:`region </tutorials/regions>`.""",
     "J": r"""
         projection : str
             *Required if this is the first plot command*.
@@ -25,7 +26,9 @@ COMMON_OPTIONS = {
             Select map :doc:`projection </projections/index>`.""",
     "B": r"""
         frame : bool or str or list
-            Set map boundary frame and axes attributes.""",
+            Set map boundary frame and axes attributes.
+            Select map :doc:`frame </tutorials/frames>`.
+            """,
     "U": """\
         timestamp : bool or str
             Draw GMT time stamp logo on plot.""",
@@ -202,10 +205,14 @@ def fmt_docstring(module_func):
         *Required if this is the first plot command*.
         *xmin/xmax/ymin/ymax*\ [**+r**][**+u**\ *unit*].
         Specify the region of interest.
+        Select map :doc:`region </tutorials/regions>`.
     projection : str
         *Required if this is the first plot command*.
         *projcode*\[*projparams*/]\ *width*.
         Select map :doc:`projection </projections/index>`.
+    frame : bool or str or list
+        Set map boundary frame and axes attributes.
+        Select map :doc:`frame </tutorials/frames>`.
     <BLANKLINE>
     **Aliases:**
     <BLANKLINE>


### PR DESCRIPTION
Added:
    R (region) - user guide doc reference is /tutorials/regions; generated page is https://www.pygmt.org/dev/tutorials/regions.html
    B (frame) - user guide doc reference is /tutorials/frames; generated page is https://www.pygmt.org/dev/tutorials/frames.html

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
