### PR TITLE
Fix dvc-diff workflow for multiple changes

### DIFF
--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -48,7 +48,7 @@ jobs:
       id: image-diff
       run: |
         # Get just the filename of the changed image from the report
-        awk 'NR>=7 {print $4}' report.md > diff_files.txt
+        awk 'NF==5 && NR>=7 {print $4}' report.md > diff_files.txt
 
         # Append each image to the markdown report
         echo -e "## Image diff(s)\n" >> report.md
@@ -56,7 +56,7 @@ jobs:
 
         while IFS= read -r line; do
           echo -e "- $line \n" >> report.md
-          cml-publish --title $line --md "$line" >> report.md
+          cml-publish --title $line --md "$line" >> report.md < /dev/null
         done < diff_files.txt
 
         echo -e "</details>\n" >> report.md


### PR DESCRIPTION
**Description of proposed changes**

Two problems in the original dvc-diff workflow:

1. `while` loop stops after the first iteration, so only one image is shown. The solution is adding `< /dev/null` to the `cml-publish` command (reference https://stackoverflow.com/questions/13800225/)
2. The `dvc diff --show-md master HEAD` command outputs a blank line at the end. It causes trouble because `cml-publish` will try to upload an image with an empty name. The solution is checking `NF==5` in `awk`, (i.e., checking that the **N**umber of **F**ields equals to 5).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
