### PR TITLE
Remove the extra period from the copyright information in the footer

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -117,7 +117,7 @@ master_doc = "index"
 # General information about the project
 year = datetime.date.today().year
 project = "PyGMT"
-copyright = f"2017-{year}, The PyGMT Developers."  # pylint: disable=redefined-builtin
+copyright = f"2017-{year}, The PyGMT Developers"  # pylint: disable=redefined-builtin
 if len(__version__.split("+")) > 1 or __version__ == "unknown":
     version = "dev"
 else:


### PR DESCRIPTION
**Removed the extra period that was at the footer of the PyGMT dev documentation.**
<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1152 



