### PR TITLE
Set __commit__ to an empty string for non-dev releases

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -151,7 +151,9 @@ html_theme_options = {}
 repository = "GenericMappingTools/pygmt"
 repository_url = "https://github.com/GenericMappingTools/pygmt"
 if __commit__:
-    commit_link = f'<a href="{repository_url}/commit/{ __commit__ }">{ __commit__[:8] }</a>'
+    commit_link = (
+        f'<a href="{repository_url}/commit/{ __commit__ }">{ __commit__[:8] }</a>'
+    )
 else:
     commit_link = ""
 html_context = {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -155,7 +155,9 @@ if __commit__:
         f'<a href="{repository_url}/commit/{ __commit__ }">{ __commit__[:8] }</a>'
     )
 else:
-    commit_link = ""
+    commit_link = (
+        f'<a href="{repository_url}/releases/tag/{ __version__ }">{ __version__ }</a>'
+    )
 html_context = {
     "menu_links": [
         (

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -150,7 +150,10 @@ html_theme = "sphinx_rtd_theme"
 html_theme_options = {}
 repository = "GenericMappingTools/pygmt"
 repository_url = "https://github.com/GenericMappingTools/pygmt"
-commit_link = f'<a href="{repository_url}/commit/{ __commit__ }">{ __commit__[:8] }</a>'
+if __commit__:
+    commit_link = f'<a href="{repository_url}/commit/{ __commit__ }">{ __commit__[:8] }</a>'
+else:
+    commit_link = ""
 html_context = {
     "menu_links": [
         (

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -47,7 +47,7 @@ from pygmt.src import (
 
 # Get semantic version through setuptools-scm
 __version__ = f'v{get_distribution("pygmt").version}'  # e.g. v0.1.2.dev3+g0ab3cd78
-__commit__ = __version__.split("+g")[-1]  # 0ab3cd78
+__commit__ = __version__.split("+g")[-1] if "+g" in __version__ else ""  # 0ab3cd78
 
 # Start our global modern mode session
 _begin()


### PR DESCRIPTION
**Description of proposed changes**

For non-dev versions, `__version__` is a string like `v0.3.1`, without commit hashes. In this case, we should set `__commit__` to `""`.

When `__commit__` is empty, the "Revision xxx" in the documentation footer won't show, so this PR also fixes #1171.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
