### PR TITLE
Add defaults convention to example code standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,7 +187,7 @@ When editing documentation, use the following standards to demonstrate the examp
    (two asterisks) on both sides. The argument description should be in *italicized*
    with \* (single asterisk) on both sides.
    Examples: `**+l**\ *label*` results in **+l***label*, `**05m**` results in **05m**.
-3. Optional arguments are placed wrapped with [ ] (square brackets).
+3. Optional arguments are wrapped with [ ] (square brackets).
 4. Arguments that are mutually exclusive are separated with a | (bar) to denote "or".
 5. Default arguments for parameters and configuration settings are wrapped
    with [ ] (square brackers) with the prefix "Default is". Example: [Default is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,9 @@ When editing documentation, use the following standards to demonstrate the examp
    Examples: `**+l**\ *label*` results in **+l***label*, `**05m**` results in **05m**.
 3. Optional arguments are placed wrapped with [ ] (square brackets).
 4. Arguments that are mutually exclusive are separated with a | (bar) to denote "or".
+5. Default arguments for parameters and configuration settings are placed wrapped
+   with [ ] (square brackers) with the prefix "Default is". Example: [Default is
+   **p**].
 
 ## Contributing Code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,7 @@ When editing documentation, use the following standards to demonstrate the examp
    Examples: `**+l**\ *label*` results in **+l***label*, `**05m**` results in **05m**.
 3. Optional arguments are placed wrapped with [ ] (square brackets).
 4. Arguments that are mutually exclusive are separated with a | (bar) to denote "or".
-5. Default arguments for parameters and configuration settings are placed wrapped
+5. Default arguments for parameters and configuration settings are wrapped
    with [ ] (square brackers) with the prefix "Default is". Example: [Default is
    **p**].
 


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the convention for specifying defaults in the PyGMT documentation to the contributing guidelines.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #631


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
