### PR TITLE
Unpin sphinx_rtd_theme from 0.5.1

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           conda install gmt=6.1.1 numpy pandas xarray netCDF4 packaging \
                         ipython make myst-parser \
-                        sphinx sphinx-copybutton sphinx-gallery sphinx_rtd_theme=0.5.2
+                        sphinx sphinx-copybutton sphinx-gallery sphinx_rtd_theme
 
       # Show installed pkg information for postmortem diagnostic
       - name: List installed packages

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           conda install gmt=6.1.1 numpy pandas xarray netCDF4 packaging \
                         ipython make myst-parser \
-                        sphinx sphinx-copybutton sphinx-gallery sphinx_rtd_theme=0.5.1
+                        sphinx sphinx-copybutton sphinx-gallery sphinx_rtd_theme=0.5.2
 
       # Show installed pkg information for postmortem diagnostic
       - name: List installed packages

--- a/environment.yml
+++ b/environment.yml
@@ -32,4 +32,4 @@ dependencies:
     - sphinx
     - sphinx-copybutton
     - sphinx-gallery
-    - sphinx_rtd_theme=0.5.1
+    - sphinx_rtd_theme=0.5.2

--- a/environment.yml
+++ b/environment.yml
@@ -32,4 +32,4 @@ dependencies:
     - sphinx
     - sphinx-copybutton
     - sphinx-gallery
-    - sphinx_rtd_theme=0.5.2
+    - sphinx_rtd_theme


### PR DESCRIPTION
**Description of proposed changes**

This PR unpins sphinx_rtd_theme so that 0.5.2 will be used when available on conda-forge, which has docutils pinned at 0.16. 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Relates to #1176


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
