### PR TITLE
Move MAINTENANCE.md to documentation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,6 @@ exclude .gitignore
 exclude .pylintrc
 exclude AUTHORSHIP.md
 exclude CONTRIBUTING.md
-exclude MAINTENANCE.md
 exclude Makefile
 exclude environment.yml
 exclude package.json

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -49,4 +49,5 @@
     :caption: Reference documentation
 
     api/index.rst
-    changes.rst
+    changes.md
+    maintenance.md

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -4,30 +4,17 @@ This page contains instructions for project maintainers about how our setup work
 making releases, creating packages, etc.
 
 If you want to make a contribution to the project, see the
-[Contributing Guide](CONTRIBUTING.md) instead.
-
-## Table of Contents
-* [Onboarding Access Checklist](#onboarding-access-checklist)
-* [Branches](#branches)
-* [Reviewing and Merging Pull Requests](#reviewing-and-merging-pull-requests)
-* [Continuous Integration](#continuous-integration)
-* [Continuous Documentation](#continuous-documentation)
-* [Dependencies Policy](#dependencies-policy)
-* [Making a Release](#making-a-release)
-    - [Updating the Changelog](#updating-the-changelog)
-    - [Check the README Syntax](#check-the-readme-syntax)
-    - [Pushing to PyPI and Updating the Documentation](#pushing-to-pypi-and-updating-the-documentation)
-    - [Archiving on Zenodo](#archiving-on-zenodo)
-    - [Updating the Conda Package](#updating-the-conda-package)
+[Contributing Guide](https://github.com/GenericMappingTools/pygmt/blob/master/CONTRIBUTING.md)
+instead.
 
 ## Onboarding Access Checklist
 
-- [ ] Added to [python-maintainers](https://github.com/orgs/GenericMappingTools/teams/python-maintainers) team in the [GenericMappingTools](https://github.com/orgs/GenericMappingTools/teams/) organization on GitHub (gives 'maintain' permissions)
-- [ ] Added as collaborator on [DAGsHub](https://dagshub.com/GenericMappingTools/pygmt/settings/collaboration) (gives 'write' permission to dvc remote storage)
-- [ ] Added as moderator on [GMT forum](https://forum.generic-mapping-tools.org) (to see mod-only discussions)
-- [ ] Added as member on the [PyGMT devs Slack channel](https://pygmtdevs.slack.com) (for casual conversations)
-- [ ] Added as maintainer on [PyPI](https://pypi.org/project/pygmt/) and [Test PyPI](https://test.pypi.org/project/pygmt) [optional]
-- [ ] Added as member on [HackMD](https://hackmd.io/@pygmt) [optional]
+- Added to [python-maintainers](https://github.com/orgs/GenericMappingTools/teams/python-maintainers) team in the [GenericMappingTools](https://github.com/orgs/GenericMappingTools/teams/) organization on GitHub (gives 'maintain' permissions)
+- Added as collaborator on [DAGsHub](https://dagshub.com/GenericMappingTools/pygmt/settings/collaboration) (gives 'write' permission to dvc remote storage)
+- Added as moderator on [GMT forum](https://forum.generic-mapping-tools.org) (to see mod-only discussions)
+- Added as member on the [PyGMT devs Slack channel](https://pygmtdevs.slack.com) (for casual conversations)
+- Added as maintainer on [PyPI](https://pypi.org/project/pygmt/) and [Test PyPI](https://test.pypi.org/project/pygmt) [optional]
+- Added as member on [HackMD](https://hackmd.io/@pygmt) [optional]
 
 ## Branches
 


### PR DESCRIPTION
**Description of proposed changes**

- Move MAINTENANCE.md to the `doc` directory and rename it to "maintenance.md"
- Add "maintenance.md" to "doc/index.rst"
- Remove MANIFEST.in from `MANIFEST.in`
- Remove TOC in "maintenance.md"
- A few styling fixes
- Fix "changes.rst" to "changes.md"

Fixes #1181.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
