### PR TITLE
Remove trailing whitespaces from examples

### DIFF
--- a/examples/gallery/embellishments/logo.py
+++ b/examples/gallery/embellishments/logo.py
@@ -2,7 +2,7 @@
 Logo
 ----
 
-The :meth:`pygmt.Figure.logo` method allows to place the GMT logo on a map.  
+The :meth:`pygmt.Figure.logo` method allows to place the GMT logo on a map.
 """
 
 import pygmt

--- a/examples/gallery/maps/borders.py
+++ b/examples/gallery/maps/borders.py
@@ -11,8 +11,8 @@ below:
 * **3** = Marine boundaries
 * **a** = All boundaries (1-3)
 
-For example, to draw national boundaries with a line thickness of 1p and black line 
-color use ``borders="1/1p,black"``. You can draw multiple boundaries by passing in 
+For example, to draw national boundaries with a line thickness of 1p and black line
+color use ``borders="1/1p,black"``. You can draw multiple boundaries by passing in
 a list to ``borders``.
 """
 import pygmt

--- a/examples/gallery/maps/land_and_water.py
+++ b/examples/gallery/maps/land_and_water.py
@@ -2,7 +2,7 @@
 Color land and water
 --------------------
 
-The ``land`` and ``water`` parameters of :meth:`pygmt.Figure.coast` specify 
+The ``land`` and ``water`` parameters of :meth:`pygmt.Figure.coast` specify
 a color to fill in the land and water masses, respectively. There are many
 :gmt-docs:`color codes in GMT <gmtcolors.html>`, including standard GMT color
 names (like ``skyblue``), R/G/B levels (like ``0/0/255``), a hex value (like

--- a/examples/gallery/symbols/datetime_inputs.py
+++ b/examples/gallery/symbols/datetime_inputs.py
@@ -8,14 +8,14 @@ Datetime inputs of the following types are supported in PyGMT:
 - :class:`pandas.DatetimeIndex`
 - :class:`xarray.DataArray`: datetimes included in a *xarray.DataArray*
 - raw datetime strings in `ISO format <https://en.wikipedia.org/wiki/ISO_8601>`__
-  (e.g. ``"YYYY-MM-DD"``, ``"YYYY-MM-DDTHH"``, and ``"YYYY-MM-DDTHH:MM:SS"``) 
+  (e.g. ``"YYYY-MM-DD"``, ``"YYYY-MM-DDTHH"``, and ``"YYYY-MM-DDTHH:MM:SS"``)
 - Python built-in :class:`datetime.datetime` and :class:`datetime.date`
 
-We can pass datetime inputs based on one of the types listed above directly to 
+We can pass datetime inputs based on one of the types listed above directly to
 the ``x`` and ``y`` parameters of e.g. the :meth:`pygmt.Figure.plot` method.
 
-The ``region`` parameter has to include the :math:`x` and :math:`y` axis limits 
-in the form [*date_min*, *date_max*, *ymin*, *ymax*]. Here *date_min* and 
+The ``region`` parameter has to include the :math:`x` and :math:`y` axis limits
+in the form [*date_min*, *date_max*, *ymin*, *ymax*]. Here *date_min* and
 *date_max* can be directly defined as datetime input.
 
 """

--- a/examples/projections/nongeo/polar.py
+++ b/examples/projections/nongeo/polar.py
@@ -3,7 +3,7 @@ Polar
 =====
 
 Polar projections allow plotting polar coordinate data (e.g. angle
-:math:`\theta` and radius *r*). 
+:math:`\theta` and radius *r*).
 
 The full syntax for polar projections is:
 


### PR DESCRIPTION
**Description of proposed changes**

This PR removes trailing whitespace from some of the examples.

p.s. I am mostly just submitting this so that the main formatting issues in the PyGMT docs can go away after a fresh build.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
