### PR TITLE
Fix parameters section with sphinx_rtd_theme 5.x.x

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -89,6 +89,11 @@ p {
     max-width: 1000px;
 }
 
+/* Format parameters section similar to sphinx_rtd_theme v4.x.x (not grid) */
+html.writer-html5 .rst-content dl.field-list {
+    display: initial;
+}
+
 /* Remove the padding from the Parameters table */
 .rst-content table.field-list .field-name {
     padding-left: 0px;

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -89,9 +89,30 @@ p {
     max-width: 1000px;
 }
 
-/* Format parameters section similar to sphinx_rtd_theme v4.x.x (not grid) */
+/* Format parameters section similar to sphinx_rtd_theme v4.x.x (not a grid) */
 html.writer-html5 .rst-content dl.field-list {
     display: initial;
+}
+
+/* Add a grey box around parameters similar to sphinx_rtd_theme v4.x.x) */
+.rst-content dl:not(.docutils) dl dt {
+    margin-bottom: 4px;
+    border: none;
+    border-left: solid 3px #ccc;
+    background: #f0f0f0;
+    color: #555;
+}
+
+.rst-content dl:not(.docutils) dt {
+    display: table;
+    margin: 6px 0;
+    font-size: 90%;
+    line-height: normal;
+    background: #e7f2fa;
+    color: #2980B9;
+    border-top: solid 3px #6ab0de;
+    padding: 6px;
+    position: relative;
 }
 
 /* Remove the padding from the Parameters table */


### PR DESCRIPTION
**Description of proposed changes**

This PR updates style.css for the newer version of sphinx_rtd_theme. So far, the parameters section is updated to not waste so much space on the left side. It would be helpful if people point out any other issues that need addressing.

Acknowledgement to this helpful post: https://github.com/readthedocs/sphinx_rtd_theme/issues/766#issuecomment-670969609

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1151 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
