### PR TITLE
Remove Jupyter Notebook notes from tutorials

### DIFF
--- a/examples/tutorials/3d_perspective_image.py
+++ b/examples/tutorials/3d_perspective_image.py
@@ -4,15 +4,6 @@ Creating a 3D perspective image
 
 Create 3-D perspective image or surface mesh from a grid
 using :meth:`pygmt.Figure.grdview`.
-
-.. note::
-
-    This tutorial assumes the use of a Python notebook, such as IPython or Jupyter Notebook.
-    To see the figures while using a Python script instead, use
-    ``fig.show(method="external")`` to display the figure in the default PDF viewer.
-
-    To save the figure, use ``fig.savefig("figname.pdf")`` where ``"figname.pdf"``
-    is the desired name and file extension for the saved figure.
 """
 # sphinx_gallery_thumbnail_number = 4
 

--- a/examples/tutorials/coastlines.py
+++ b/examples/tutorials/coastlines.py
@@ -3,15 +3,6 @@ Coastlines and borders
 ======================
 
 Plotting coastlines and borders is handled by :meth:`pygmt.Figure.coast`.
-
-.. note::
-
-    This tutorial assumes the use of a Python notebook, such as IPython or Jupyter Notebook.
-    To see the figures while using a Python script instead, use
-    ``fig.show(method="external")`` to display the figure in the default PDF viewer.
-
-    To save the figure, use ``fig.savefig("figname.pdf")`` where ``"figname.pdf"``
-    is the desired name and file extension for the saved figure.
 """
 # sphinx_gallery_thumbnail_number = 5
 

--- a/examples/tutorials/configuration.py
+++ b/examples/tutorials/configuration.py
@@ -3,15 +3,6 @@ Configuring PyGMT defaults
 ==========================
 
 Default GMT parameters can be set globally or locally using :class:`pygmt.config`.
-
-.. note::
-
-    This tutorial assumes the use of a Python notebook, such as IPython or Jupyter Notebook.
-    To see the figures while using a Python script instead, use
-    ``fig.show(method="external")`` to display the figure in the default PDF viewer.
-
-    To save the figure, use ``fig.savefig("figname.pdf")`` where ``"figname.pdf"``
-    is the desired name and file extension for the saved figure.
 """
 # sphinx_gallery_thumbnail_number = 3
 

--- a/examples/tutorials/contour_map.py
+++ b/examples/tutorials/contour_map.py
@@ -3,15 +3,6 @@ Creating a map with contour lines
 =================================
 
 Plotting a contour map is handled by :meth:`pygmt.Figure.grdcontour`.
-
-.. note::
-
-    This tutorial assumes the use of a Python notebook, such as IPython or Jupyter Notebook.
-    To see the figures while using a Python script instead, use
-    ``fig.show(method="external")`` to display the figure in the default PDF viewer.
-
-    To save the figure, use ``fig.savefig("figname.pdf")`` where ``"figname.pdf"``
-    is the desired name and file extension for the saved figure.
 """
 # sphinx_gallery_thumbnail_number = 5
 

--- a/examples/tutorials/earth_relief.py
+++ b/examples/tutorials/earth_relief.py
@@ -5,15 +5,6 @@ Plotting Earth relief
 Plotting a map of Earth relief can use the data accessed by the
 :meth:`pygmt.datasets.load_earth_relief` method. The data can then be plotted using the
 :meth:`pygmt.Figure.grdimage` method.
-
-.. note::
-
-    This tutorial assumes the use of a Python notebook, such as IPython or Jupyter Notebook.
-    To see the figures while using a Python script instead, use
-    ``fig.show(method="external")`` to display the figure in the default PDF viewer.
-
-    To save the figure, use ``fig.savefig("figname.pdf")`` where ``"figname.pdf"``
-    is the desired name and file extension for the saved figure.
 """
 # sphinx_gallery_thumbnail_number = 5
 

--- a/examples/tutorials/first_figure.py
+++ b/examples/tutorials/first_figure.py
@@ -4,16 +4,6 @@ Making your first figure
 
 Welcome to PyGMT! Here we'll cover some of basic concepts, like creating simple figures
 and naming conventions.
-
-.. note::
-
-    This tutorial assumes the use of a Python notebook, such as `IPython <https://ipython.org/>`__
-    or `JupyterLab <https://jupyter.org/>`__.
-    To see the figures while using a Python script instead, use
-    ``fig.show(method="external")`` to display the figure in the default PDF viewer.
-
-    To save the figure, use ``fig.savefig("figname.pdf")`` where ``"figname.pdf"``
-    is the desired name and file extension for the saved figure.
 """
 
 ########################################################################################

--- a/examples/tutorials/frames.py
+++ b/examples/tutorials/frames.py
@@ -4,15 +4,6 @@ Frames, ticks, titles, and labels
 
 Setting the style of the map frames, ticks, etc, is handled by the ``frame`` parameter
 that all plotting methods of :class:`pygmt.Figure`.
-
-.. note::
-
-    This tutorial assumes the use of a Python notebook, such as IPython or Jupyter Notebook.
-    To see the figures while using a Python script instead, use
-    ``fig.show(method="external")`` to display the figure in the default PDF viewer.
-
-    To save the figure, use ``fig.savefig("figname.pdf")`` where ``"figname.pdf"``
-    is the desired name and file extension for the saved figure.
 """
 # sphinx_gallery_thumbnail_number = 4
 

--- a/examples/tutorials/insets.py
+++ b/examples/tutorials/insets.py
@@ -6,15 +6,6 @@ To plot an inset figure inside another larger figure, we can use the
 :meth:`pygmt.Figure.inset` method. After a large figure has been created,
 call ``inset`` using a ``with`` statement, and new plot elements will be
 added to the inset figure instead of the larger figure.
-
-.. note::
-
-    This tutorial assumes the use of a Python notebook, such as IPython or Jupyter Notebook.
-    To see the figures while using a Python script instead, use
-    ``fig.show(method="external")`` to display the figure in the default PDF viewer.
-
-    To save the figure, use ``fig.savefig("figname.pdf")`` where ``"figname.pdf"``
-    is the desired name and file extension for the saved figure.
 """
 # sphinx_gallery_thumbnail_number = 4
 

--- a/examples/tutorials/lines.py
+++ b/examples/tutorials/lines.py
@@ -3,15 +3,6 @@ Plotting lines
 ==============
 
 Plotting lines is handled by :meth:`pygmt.Figure.plot`.
-
-.. note::
-
-    This tutorial assumes the use of a Python notebook, such as IPython or Jupyter Notebook.
-    To see the figures while using a Python script instead, use
-    ``fig.show(method="external")`` to display the figure in the default PDF viewer.
-
-    To save the figure, use ``fig.savefig("figname.pdf")`` where ``"figname.pdf"``
-    is the desired name and file extension for the saved figure.
 """
 # sphinx_gallery_thumbnail_number = 3
 

--- a/examples/tutorials/plot.py
+++ b/examples/tutorials/plot.py
@@ -7,15 +7,6 @@ packaged with GMT to try this out. PyGMT provides access to these datasets throu
 :mod:`pygmt.datasets` package. If you don't have the data files already, they are
 automatically downloaded and saved to a cache directory the first time you use them
 (usually ``~/.gmt/cache``).
-
-.. note::
-
-    This tutorial assumes the use of a Python notebook, such as IPython or Jupyter Notebook.
-    To see the figures while using a Python script instead, use
-    ``fig.show(method="external")`` to display the figure in the default PDF viewer.
-
-    To save the figure, use ``fig.savefig("figname.pdf")`` where ``"figname.pdf"``
-    is the desired name and file extension for the saved figure.
 """
 # sphinx_gallery_thumbnail_number = 3
 

--- a/examples/tutorials/regions.py
+++ b/examples/tutorials/regions.py
@@ -5,15 +5,6 @@ Setting the region
 Many of the plotting functions take the ``region`` parameter, which sets
 the area that will be shown in the figure. This tutorial covers the different types of
 inputs that it can accept.
-
-.. note::
-
-    This tutorial assumes the use of a Python notebook, such as IPython or Jupyter Notebook.
-    To see the figures while using a Python script instead, use
-    ``fig.show(method="external")`` to display the figure in the default PDF viewer.
-
-    To save the figure, use ``fig.savefig("figname.pdf")`` where ``"figname.pdf"``
-    is the desired name and file extension for the saved figure.
 """
 
 import pygmt

--- a/examples/tutorials/text.py
+++ b/examples/tutorials/text.py
@@ -4,15 +4,6 @@ Plotting text
 
 It is often useful to add annotations to a map plot. This is handled by
 :meth:`pygmt.Figure.text`.
-
-.. note::
-
-    This tutorial assumes the use of a Python notebook, such as IPython or Jupyter Notebook.
-    To see the figures while using a Python script instead, use
-    ``fig.show(method="external")`` to display the figure in the default PDF viewer.
-
-    To save the figure, use ``fig.savefig("figname.pdf")`` where ``"figname.pdf"``
-    is the desired name and file extension for the saved figure.
 """
 # sphinx_gallery_thumbnail_number = 3
 

--- a/examples/tutorials/vectors.py
+++ b/examples/tutorials/vectors.py
@@ -3,15 +3,6 @@ Plotting vectors
 ================
 
 Plotting vectors is handled by :meth:`pygmt.Figure.plot`.
-
-.. note::
-
-    This tutorial assumes the use of a Python notebook, such as IPython or Jupyter Notebook.
-    To see the figures while using a Python script instead, use
-    ``fig.show(method="external")`` to display the figure in the default PDF viewer.
-
-    To save the figure, use ``fig.savefig("figname.pdf")`` where ``"figname.pdf"``
-    is the desired name and file extension for the saved figure.
 """
 # sphinx_gallery_thumbnail_number = 6
 


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1198.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
