### PR TITLE
Remove the "full test" section from installation guide

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -159,35 +159,17 @@ from Python.
 Testing your install
 --------------------
 
-Quick check
-~~~~~~~~~~~
-
 To ensure that PyGMT and its dependencies are installed correctly, run the
 following in your Python interpreter::
 
     import pygmt
     pygmt.show_versions()
 
-Or run this in the command line::
+    fig = pygmt.Figure()
+    fig.coast(region="g", frame=True, shorelines=1)
+    fig.show()
 
-    python -c "import pygmt; pygmt.show_versions()"
-
-
-Full test (optional)
-~~~~~~~~~~~~~~~~~~~~
-
-PyGMT ships with a full test suite.
-You can run our tests after you install it but you will need a few extra
-dependencies as well (be sure to have your conda environment activated)::
-
-    conda install pytest pytest-mpl ipython
-
-Test your installation by running the following inside a Python interpreter
-(note that it may take a few minutes)::
-
-    import pygmt
-    pygmt.show_versions()
-    pygmt.test()
+If you see a global map with shorelines, then you're all set.
 
 
 Finding the GMT shared library


### PR DESCRIPTION
**Description of proposed changes**

- Remove the "Full test" section since it's no longer valid after
  migrating baseline images to dvc
- Add a simple script to test the install. If it works, at least
  we know that the coast function, GSHHG data and gs work as expected.

Fixes #1200


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
