### PR TITLE
Add a gallery example showing individual basic geometric symbols

### DIFF
--- a/examples/gallery/symbols/basic_symbols.py
+++ b/examples/gallery/symbols/basic_symbols.py
@@ -28,36 +28,36 @@ y = 2
 fig.plot(x=1, y=y, style="-0.9c", pen="2p,gray40")
 fig.text(x=1, y=y + 0.6, text="-", font=font)
 
-# use a plus (+) with a size of 0.9,
+# use a plus (+) with a size of 0.9 cm,
 # linewidth is set to 2p and the linecolor to "gray40"
 fig.plot(x=2, y=y, style="+0.9c", pen="2p,gray40")
 fig.text(x=2, y=y + 0.6, text="+", font=font)
 
-# use a star (a) with a size of 0.9,
+# use a star (a) with a size of 0.9 cm,
 # linewidth is set to 1p, the linecolor to "black" (default) and the
 # color fill to "darkorange"
 fig.plot(x=3, y=y, style="a0.9c", pen="1p,black", color="darkorange")
 fig.text(x=3, y=y + 0.6, text="a", font=font)
 
-# use a circle (c) with a size of 0.9,
+# use a circle (c) with a size of 0.9 cm,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "darkred"
 fig.plot(x=4, y=y, style="c0.9c", pen="1p,black", color="darkred")
 fig.text(x=4, y=y + 0.6, text="c", font=font)
 
-# use a diamond (d) with a size of 0.9,
+# use a diamond (d) with a size of 0.9 cm,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "seagreen"
 fig.plot(x=5, y=y, style="d0.9c", pen="1p,black", color="seagreen")
 fig.text(x=5, y=y + 0.6, text="d", font=font)
 
-# use a octagon (g) with a size of 0.9,
+# use a octagon (g) with a size of 0.9 cm,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "dodgerblue4"
 fig.plot(x=6, y=y, style="g0.9c", pen="1p,black", color="dodgerblue4")
 fig.text(x=6, y=y + 0.6, text="g", font=font)
 
-# use a hexagon (h) with a size of 0.9,
+# use a hexagon (h) with a size of 0.9 cm,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "lightgray"
 fig.plot(x=7, y=y, style="h0.9c", pen="1p,black", color="lightgray")
@@ -66,41 +66,41 @@ fig.text(x=7, y=y + 0.6, text="h", font=font)
 # lower row
 y = 0.5
 
-# use an inverted triangle (i) with a size of 0.9,
+# use an inverted triangle (i) with a size of 0.9 cm,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "tomato"
 fig.plot(x=1, y=y, style="i0.9c", pen="1p,black", color="tomato")
 fig.text(x=1, y=y + 0.6, text="i", font=font)
 
-# use pentagon (n) with a size of 0.9,
+# use pentagon (n) with a size of 0.9 cm,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "lightseagreen"
 fig.plot(x=2, y=y, style="n0.9c", pen="1p,black", color="lightseagreen")
 fig.text(x=2, y=y + 0.6, text="n", font=font)
 
-# use a point (p) with a size of 0.9,
+# use a point (p) with a size of 0.9 cm,
 # color fill is set to "lightseagreen"
 fig.plot(x=3, y=y, style="p0.9c", color="slateblue")
 fig.text(x=3, y=y + 0.6, text="p", font=font)
 
-# use square (s) with a size of 0.9,
+# use square (s) with a size of 0.9 cm,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "gold2"
 fig.plot(x=4, y=y, style="s0.9c", pen="1p,black", color="gold2")
 fig.text(x=4, y=y + 0.6, text="s", font=font)
 
-# use triangle (t) with a size of 0.9,
+# use triangle (t) with a size of 0.9 cm,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "magenta4"
 fig.plot(x=5, y=y, style="t0.9c", pen="1p,black", color="magenta4")
 fig.text(x=5, y=y + 0.6, text="t", font=font)
 
-# use cross (x) with a size of 0.9,
+# use cross (x) with a size of 0.9 cm,
 # linewidth is set to 2p and the linecolor to "gray40"
 fig.plot(x=6, y=y, style="x0.9c", pen="2p,gray40")
 fig.text(x=6, y=y + 0.6, text="x", font=font)
 
-# use a dash in y direction (y) with a size of 0.9,
+# use a dash in y direction (y) with a size of 0.9 cm,
 # linewidth is set to 2p and the linecolor to "gray40"
 fig.plot(x=7, y=y, style="y0.9c", pen="2p,gray40")
 fig.text(x=7, y=y + 0.6, text="y", font=font)

--- a/examples/gallery/symbols/basic_symbols.py
+++ b/examples/gallery/symbols/basic_symbols.py
@@ -3,7 +3,8 @@ Basic geometric symbols
 -----------------------
 
 The :meth:`pygmt.Figure.plot` method can plot individual geometric symbols
-by passing the corresponding shortcuts to the ``style`` parameter. 
+by passing the corresponding shortcuts to the ``style`` parameter. The 14 basic
+geometric symbols are shown underneath their corresponding shortcut codes.
 """
 
 import pygmt

--- a/examples/gallery/symbols/basic_symbols.py
+++ b/examples/gallery/symbols/basic_symbols.py
@@ -5,6 +5,11 @@ Basic geometric symbols
 The :meth:`pygmt.Figure.plot` method can plot individual geometric symbols
 by passing the corresponding shortcuts to the ``style`` parameter. The 14 basic
 geometric symbols are shown underneath their corresponding shortcut codes.
+Four symbols (**-**, **+**, **x** and **y**) are line-symbols only for which we
+can adjust the linewidth via the ``pen`` parameter. The point symbol (**p**)
+only takes a color fill which we can define via the ``color`` parameter. For the
+remaining symbols we may define linewidth as well as a color fill.
+
 """
 
 import pygmt

--- a/examples/gallery/symbols/basic_symbols.py
+++ b/examples/gallery/symbols/basic_symbols.py
@@ -11,7 +11,7 @@ import pygmt
 fig = pygmt.Figure()
 fig.basemap(region=[0, 8, 0, 3], projection="x3c", frame=True)
 
-# define fontstlye for annotations
+# define fontstyle for annotations
 font = "30p,Helvetica-Bold"
 
 # upper row

--- a/examples/gallery/symbols/basic_symbols.py
+++ b/examples/gallery/symbols/basic_symbols.py
@@ -8,7 +8,7 @@ geometric symbols are shown underneath their corresponding shortcut codes.
 Four symbols (**-**, **+**, **x** and **y**) are line-symbols only for which we
 can adjust the linewidth via the ``pen`` parameter. The point symbol (**p**)
 only takes a color fill which we can define via the ``color`` parameter. For the
-remaining symbols we may define linewidth as well as a color fill.
+remaining symbols we may define a linewidth as well as a color fill.
 
 """
 

--- a/examples/gallery/symbols/basic_symbols.py
+++ b/examples/gallery/symbols/basic_symbols.py
@@ -20,50 +20,43 @@ y = 2
 
 # use a dash in x direction (-) with a size of 0.9 cm,
 # linewidth is set to 2p and the linecolor to "gray40"
-x = 1
-fig.plot(x=x, y=y, style="-0.9c", pen="2p,gray40")
-fig.text(x=x, y=y + 0.6, text="-", font=font)
+fig.plot(x=1, y=y, style="-0.9c", pen="2p,gray40")
+fig.text(x=1, y=y + 0.6, text="-", font=font)
 
 # use a plus (+) with a size of 0.9,
 # linewidth is set to 2p and the linecolor to "gray40"
-x += 1
-fig.plot(x=x, y=y, style="+0.9c", pen="2p,gray40")
-fig.text(x=x, y=y + 0.6, text="+", font=font)
+fig.plot(x=2, y=y, style="+0.9c", pen="2p,gray40")
+fig.text(x=2, y=y + 0.6, text="+", font=font)
 
 # use a star (a) with a size of 0.9,
 # linewidth is set to 1p, the linecolor to "black" (default) and the
 # color fill to "darkorange"
-x += 1
 fig.plot(x=3, y=y, style="a0.9c", pen="1p,black", color="darkorange")
-fig.text(x=x, y=y + 0.6, text="a", font=font)
+fig.text(x=3, y=y + 0.6, text="a", font=font)
 
 # use a circle (c) with a size of 0.9,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "darkred"
-x += 1
 fig.plot(x=4, y=y, style="c0.9c", pen="1p,black", color="darkred")
-fig.text(x=x, y=y + 0.6, text="c", font=font)
+fig.text(x=4, y=y + 0.6, text="c", font=font)
 
 # use a diamond (d) with a size of 0.9,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "seagreen"
-x += 1
 fig.plot(x=5, y=y, style="d0.9c", pen="1p,black", color="seagreen")
-fig.text(x=x, y=y + 0.6, text="d", font=font)
+fig.text(x=5, y=y + 0.6, text="d", font=font)
 
 # use a octagon (g) with a size of 0.9,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "dodgerblue4"
-x += 1
 fig.plot(x=6, y=y, style="g0.9c", pen="1p,black", color="dodgerblue4")
-fig.text(x=x, y=y + 0.6, text="g", font=font)
+fig.text(x=6, y=y + 0.6, text="g", font=font)
 
 # use a hexagon (h) with a size of 0.9,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "lightgray"
-x += 1
 fig.plot(x=7, y=y, style="h0.9c", pen="1p,black", color="lightgray")
-fig.text(x=x, y=y + 0.6, text="h", font=font)
+fig.text(x=7, y=y + 0.6, text="h", font=font)
 
 # lower row
 y = 0.5
@@ -71,47 +64,40 @@ y = 0.5
 # use an inverted triangle (i) with a size of 0.9,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "tomato"
-x = 1
-fig.plot(x=x, y=y, style="i0.9c", pen="1p,black", color="tomato")
-fig.text(x=x, y=y + 0.6, text="i", font=font)
+fig.plot(x=1, y=y, style="i0.9c", pen="1p,black", color="tomato")
+fig.text(x=1, y=y + 0.6, text="i", font=font)
 
 # use pentagon (n) with a size of 0.9,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "lightseagreen"
-x += 1
-fig.plot(x=x, y=y, style="n0.9c", pen="1p,black", color="lightseagreen")
-fig.text(x=x, y=y + 0.6, text="n", font=font)
+fig.plot(x=2, y=y, style="n0.9c", pen="1p,black", color="lightseagreen")
+fig.text(x=2, y=y + 0.6, text="n", font=font)
 
 # use a point (p) with a size of 0.9,
 # color fill is set to "lightseagreen"
-x += 1
 fig.plot(x=3, y=y, style="p0.9c", color="slateblue")
-fig.text(x=x, y=y + 0.6, text="p", font=font)
+fig.text(x=3, y=y + 0.6, text="p", font=font)
 
 # use square (s) with a size of 0.9,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "gold2"
-x += 1
 fig.plot(x=4, y=y, style="s0.9c", pen="1p,black", color="gold2")
-fig.text(x=x, y=y + 0.6, text="s", font=font)
+fig.text(x=4, y=y + 0.6, text="s", font=font)
 
 # use triangle (t) with a size of 0.9,
 # linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "magenta4"
-x += 1
 fig.plot(x=5, y=y, style="t0.9c", pen="1p,black", color="magenta4")
-fig.text(x=x, y=y + 0.6, text="t", font=font)
+fig.text(x=5, y=y + 0.6, text="t", font=font)
 
 # use cross (x) with a size of 0.9,
 # linewidth is set to 2p and the linecolor to "gray40"
-x += 1
 fig.plot(x=6, y=y, style="x0.9c", pen="2p,gray40")
-fig.text(x=x, y=y + 0.6, text="x", font=font)
+fig.text(x=6, y=y + 0.6, text="x", font=font)
 
 # use a dash in y direction (y) with a size of 0.9,
 # linewidth is set to 2p and the linecolor to "gray40"
-x += 1
 fig.plot(x=7, y=y, style="y0.9c", pen="2p,gray40")
-fig.text(x=x, y=y + 0.6, text="y", font=font)
+fig.text(x=7, y=y + 0.6, text="y", font=font)
 
 fig.show()

--- a/examples/gallery/symbols/basic_symbols.py
+++ b/examples/gallery/symbols/basic_symbols.py
@@ -1,0 +1,116 @@
+"""
+Basic geometric symbols
+-----------------------
+
+The :meth:`pygmt.Figure.plot` method can plot individual geometric symbols
+by passing the corresponding shortcuts to the ``style`` parameter. 
+"""
+
+import pygmt
+
+fig = pygmt.Figure()
+fig.basemap(region=[0, 8, 0, 3], projection="x3c", frame=True)
+
+#define fontstlye for annotations
+font="30p,Helvetica-Bold"
+
+# upper row
+y = 2 
+
+# use a dash in x direction (-) with a size of 2 cm,
+# linewidth is set to 4p and the linecolor to "gray40" 
+x = 1
+fig.plot(x = x, y = y, style="-2c", pen="4p,gray40")
+fig.text(x = x, y = y + 0.6, text= "-", font = font)
+
+# use a plus (+) with a size of 2 cm,
+# linewidth is set to 4p and the linecolor to "gray40" 
+x +=1
+fig.plot(x = x, y = y, style="+2c", pen="4p,gray40")
+fig.text(x = x, y = y + 0.6, text= "+", font = font)
+
+# use a star (a) with a size of 2 cm,
+# linewidth is set to 2p, the linecolor to "black" (default) and the 
+# color fill to "darkorange"
+x +=1
+fig.plot(x = 3, y = y, style="a2c", pen="2p,black", color = "darkorange")
+fig.text(x = x, y = y + 0.6, text= "a", font = font)
+
+# use a circle (c) with a size of 2 cm,
+# linewidth is set to 2p, the linecolor to "black" and the 
+# color fill to "darkred"
+x +=1
+fig.plot(x = 4, y = y, style="c2c", pen="2p,black", color = "darkred")
+fig.text(x = x, y = y + 0.6, text= "c", font = font)
+
+# use a diamond (d) with a size of 2 cm,
+# linewidth is set to 2p, the linecolor to "black" and the 
+# color fill to "seagreen"
+x +=1
+fig.plot(x = 5, y = y, style="d2c", pen="2p,black", color = "seagreen")
+fig.text(x = x, y = y + 0.6, text= "d", font = font)
+
+# use a octagon (g) with a size of 2 cm,
+# linewidth is set to 2p, the linecolor to "black" and the 
+# color fill to "dodgerblue4"
+x +=1
+fig.plot(x = 6, y = y, style="g2c", pen="2p,black", color = "dodgerblue4")
+fig.text(x = x, y = y + 0.6, text= "g", font = font)
+
+# use a hexagon (h) with a size of 2 cm,
+# linewidth is set to 2p, the linecolor to "black" and the 
+# color fill to "lightgray"
+x +=1
+fig.plot(x = 7, y = y, style="h2c", pen="2p,black", color = "lightgray")
+fig.text(x = x, y = y + 0.6, text= "h", font = font)
+
+# lower row
+y = 0.5 
+
+# use an inverted triangle (i) with a size of 2 cm,
+# linewidth is set to 2p, the linecolor to "black" and the 
+# color fill to "tomato"
+x = 1
+fig.plot(x = x, y = y, style="i2c", pen="2p,black", color="tomato")
+fig.text(x = x, y = y + 0.6, text= "i", font = font)
+
+# use pentagon (n) with a size of 2 cm,
+# linewidth is set to 2p, the linecolor to "black" and the 
+# color fill to "lightseagreen"
+x +=1
+fig.plot(x = x, y = y, style="n2c", pen="2p,black", color = "lightseagreen")
+fig.text(x = x, y = y + 0.6, text= "n", font = font)
+
+# use a point (p) with a size of 2 cm,
+# color fill is set to "lightseagreen"
+x +=1
+fig.plot(x = 3, y = y, style="p2c", color = "slateblue")
+fig.text(x = x, y = y + 0.6, text= "p", font = font)
+
+# use square (s) with a size of 2 cm,
+# linewidth is set to 2p, the linecolor to "black" and the 
+# color fill to "gold2"
+x +=1
+fig.plot(x = 4, y = y, style="s2c", pen="2p,black", color = "gold2")
+fig.text(x = x, y = y + 0.6, text= "s", font = font)
+
+# use triangle (t) with a size of 2 cm,
+# linewidth is set to 2p, the linecolor to "black" and the 
+# color fill to "magenta4"
+x +=1
+fig.plot(x = 5, y = y, style="t2c", pen="2p,black", color = "magenta4")
+fig.text(x = x, y = y + 0.6, text= "t", font = font)
+
+# use cross (x) with a size of 2 cm,
+# linewidth is set to 4p and the linecolor to "gray40" 
+x +=1
+fig.plot(x = 6, y = y, style="x2c", pen="4p,gray40")
+fig.text(x = x, y = y + 0.6, text= "x", font = font)
+
+# use a dash in y direction (y) with a size of 2 cm,
+# linewidth is set to 4p and the linecolor to "gray40" 
+x +=1
+fig.plot(x = 7, y = y, style="y2c", pen="4p,gray40")
+fig.text(x = x, y = y + 0.6, text= "y", font = font)
+
+fig.show()

--- a/examples/gallery/symbols/basic_symbols.py
+++ b/examples/gallery/symbols/basic_symbols.py
@@ -10,108 +10,108 @@ geometric symbols are shown underneath their corresponding shortcut codes.
 import pygmt
 
 fig = pygmt.Figure()
-fig.basemap(region=[0, 8, 0, 3], projection="x3c", frame=True)
+fig.basemap(region=[0, 8, 0, 3], projection="X12c/4c", frame=True)
 
-# define fontstyle for annotations
-font = "30p,Helvetica-Bold"
+# define fontstlye for annotations
+font = "15p,Helvetica-Bold"
 
 # upper row
 y = 2
 
-# use a dash in x direction (-) with a size of 2 cm,
-# linewidth is set to 4p and the linecolor to "gray40"
+# use a dash in x direction (-) with a size of 0.9 cm,
+# linewidth is set to 2p and the linecolor to "gray40"
 x = 1
-fig.plot(x=x, y=y, style="-2c", pen="4p,gray40")
+fig.plot(x=x, y=y, style="-0.9c", pen="2p,gray40")
 fig.text(x=x, y=y + 0.6, text="-", font=font)
 
-# use a plus (+) with a size of 2 cm,
-# linewidth is set to 4p and the linecolor to "gray40"
+# use a plus (+) with a size of 0.9,
+# linewidth is set to 2p and the linecolor to "gray40"
 x += 1
-fig.plot(x=x, y=y, style="+2c", pen="4p,gray40")
+fig.plot(x=x, y=y, style="+0.9c", pen="2p,gray40")
 fig.text(x=x, y=y + 0.6, text="+", font=font)
 
-# use a star (a) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" (default) and the
+# use a star (a) with a size of 0.9,
+# linewidth is set to 1p, the linecolor to "black" (default) and the
 # color fill to "darkorange"
 x += 1
-fig.plot(x=3, y=y, style="a2c", pen="2p,black", color="darkorange")
+fig.plot(x=3, y=y, style="a0.9c", pen="1p,black", color="darkorange")
 fig.text(x=x, y=y + 0.6, text="a", font=font)
 
-# use a circle (c) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the
+# use a circle (c) with a size of 0.9,
+# linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "darkred"
 x += 1
-fig.plot(x=4, y=y, style="c2c", pen="2p,black", color="darkred")
+fig.plot(x=4, y=y, style="c0.9c", pen="1p,black", color="darkred")
 fig.text(x=x, y=y + 0.6, text="c", font=font)
 
-# use a diamond (d) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the
+# use a diamond (d) with a size of 0.9,
+# linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "seagreen"
 x += 1
-fig.plot(x=5, y=y, style="d2c", pen="2p,black", color="seagreen")
+fig.plot(x=5, y=y, style="d0.9c", pen="1p,black", color="seagreen")
 fig.text(x=x, y=y + 0.6, text="d", font=font)
 
-# use a octagon (g) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the
+# use a octagon (g) with a size of 0.9,
+# linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "dodgerblue4"
 x += 1
-fig.plot(x=6, y=y, style="g2c", pen="2p,black", color="dodgerblue4")
+fig.plot(x=6, y=y, style="g0.9c", pen="1p,black", color="dodgerblue4")
 fig.text(x=x, y=y + 0.6, text="g", font=font)
 
-# use a hexagon (h) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the
+# use a hexagon (h) with a size of 0.9,
+# linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "lightgray"
 x += 1
-fig.plot(x=7, y=y, style="h2c", pen="2p,black", color="lightgray")
+fig.plot(x=7, y=y, style="h0.9c", pen="1p,black", color="lightgray")
 fig.text(x=x, y=y + 0.6, text="h", font=font)
 
 # lower row
 y = 0.5
 
-# use an inverted triangle (i) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the
+# use an inverted triangle (i) with a size of 0.9,
+# linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "tomato"
 x = 1
-fig.plot(x=x, y=y, style="i2c", pen="2p,black", color="tomato")
+fig.plot(x=x, y=y, style="i0.9c", pen="1p,black", color="tomato")
 fig.text(x=x, y=y + 0.6, text="i", font=font)
 
-# use pentagon (n) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the
+# use pentagon (n) with a size of 0.9,
+# linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "lightseagreen"
 x += 1
-fig.plot(x=x, y=y, style="n2c", pen="2p,black", color="lightseagreen")
+fig.plot(x=x, y=y, style="n0.9c", pen="1p,black", color="lightseagreen")
 fig.text(x=x, y=y + 0.6, text="n", font=font)
 
-# use a point (p) with a size of 2 cm,
+# use a point (p) with a size of 0.9,
 # color fill is set to "lightseagreen"
 x += 1
-fig.plot(x=3, y=y, style="p2c", color="slateblue")
+fig.plot(x=3, y=y, style="p0.9c", color="slateblue")
 fig.text(x=x, y=y + 0.6, text="p", font=font)
 
-# use square (s) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the
+# use square (s) with a size of 0.9,
+# linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "gold2"
 x += 1
-fig.plot(x=4, y=y, style="s2c", pen="2p,black", color="gold2")
+fig.plot(x=4, y=y, style="s0.9c", pen="1p,black", color="gold2")
 fig.text(x=x, y=y + 0.6, text="s", font=font)
 
-# use triangle (t) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the
+# use triangle (t) with a size of 0.9,
+# linewidth is set to 1p, the linecolor to "black" and the
 # color fill to "magenta4"
 x += 1
-fig.plot(x=5, y=y, style="t2c", pen="2p,black", color="magenta4")
+fig.plot(x=5, y=y, style="t0.9c", pen="1p,black", color="magenta4")
 fig.text(x=x, y=y + 0.6, text="t", font=font)
 
-# use cross (x) with a size of 2 cm,
-# linewidth is set to 4p and the linecolor to "gray40"
+# use cross (x) with a size of 0.9,
+# linewidth is set to 2p and the linecolor to "gray40"
 x += 1
-fig.plot(x=6, y=y, style="x2c", pen="4p,gray40")
+fig.plot(x=6, y=y, style="x0.9c", pen="2p,gray40")
 fig.text(x=x, y=y + 0.6, text="x", font=font)
 
-# use a dash in y direction (y) with a size of 2 cm,
-# linewidth is set to 4p and the linecolor to "gray40"
+# use a dash in y direction (y) with a size of 0.9,
+# linewidth is set to 2p and the linecolor to "gray40"
 x += 1
-fig.plot(x=7, y=y, style="y2c", pen="4p,gray40")
+fig.plot(x=7, y=y, style="y0.9c", pen="2p,gray40")
 fig.text(x=x, y=y + 0.6, text="y", font=font)
 
 fig.show()

--- a/examples/gallery/symbols/basic_symbols.py
+++ b/examples/gallery/symbols/basic_symbols.py
@@ -11,106 +11,106 @@ import pygmt
 fig = pygmt.Figure()
 fig.basemap(region=[0, 8, 0, 3], projection="x3c", frame=True)
 
-#define fontstlye for annotations
-font="30p,Helvetica-Bold"
+# define fontstlye for annotations
+font = "30p,Helvetica-Bold"
 
 # upper row
-y = 2 
+y = 2
 
 # use a dash in x direction (-) with a size of 2 cm,
-# linewidth is set to 4p and the linecolor to "gray40" 
+# linewidth is set to 4p and the linecolor to "gray40"
 x = 1
-fig.plot(x = x, y = y, style="-2c", pen="4p,gray40")
-fig.text(x = x, y = y + 0.6, text= "-", font = font)
+fig.plot(x=x, y=y, style="-2c", pen="4p,gray40")
+fig.text(x=x, y=y + 0.6, text="-", font=font)
 
 # use a plus (+) with a size of 2 cm,
-# linewidth is set to 4p and the linecolor to "gray40" 
-x +=1
-fig.plot(x = x, y = y, style="+2c", pen="4p,gray40")
-fig.text(x = x, y = y + 0.6, text= "+", font = font)
+# linewidth is set to 4p and the linecolor to "gray40"
+x += 1
+fig.plot(x=x, y=y, style="+2c", pen="4p,gray40")
+fig.text(x=x, y=y + 0.6, text="+", font=font)
 
 # use a star (a) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" (default) and the 
+# linewidth is set to 2p, the linecolor to "black" (default) and the
 # color fill to "darkorange"
-x +=1
-fig.plot(x = 3, y = y, style="a2c", pen="2p,black", color = "darkorange")
-fig.text(x = x, y = y + 0.6, text= "a", font = font)
+x += 1
+fig.plot(x=3, y=y, style="a2c", pen="2p,black", color="darkorange")
+fig.text(x=x, y=y + 0.6, text="a", font=font)
 
 # use a circle (c) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the 
+# linewidth is set to 2p, the linecolor to "black" and the
 # color fill to "darkred"
-x +=1
-fig.plot(x = 4, y = y, style="c2c", pen="2p,black", color = "darkred")
-fig.text(x = x, y = y + 0.6, text= "c", font = font)
+x += 1
+fig.plot(x=4, y=y, style="c2c", pen="2p,black", color="darkred")
+fig.text(x=x, y=y + 0.6, text="c", font=font)
 
 # use a diamond (d) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the 
+# linewidth is set to 2p, the linecolor to "black" and the
 # color fill to "seagreen"
-x +=1
-fig.plot(x = 5, y = y, style="d2c", pen="2p,black", color = "seagreen")
-fig.text(x = x, y = y + 0.6, text= "d", font = font)
+x += 1
+fig.plot(x=5, y=y, style="d2c", pen="2p,black", color="seagreen")
+fig.text(x=x, y=y + 0.6, text="d", font=font)
 
 # use a octagon (g) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the 
+# linewidth is set to 2p, the linecolor to "black" and the
 # color fill to "dodgerblue4"
-x +=1
-fig.plot(x = 6, y = y, style="g2c", pen="2p,black", color = "dodgerblue4")
-fig.text(x = x, y = y + 0.6, text= "g", font = font)
+x += 1
+fig.plot(x=6, y=y, style="g2c", pen="2p,black", color="dodgerblue4")
+fig.text(x=x, y=y + 0.6, text="g", font=font)
 
 # use a hexagon (h) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the 
+# linewidth is set to 2p, the linecolor to "black" and the
 # color fill to "lightgray"
-x +=1
-fig.plot(x = 7, y = y, style="h2c", pen="2p,black", color = "lightgray")
-fig.text(x = x, y = y + 0.6, text= "h", font = font)
+x += 1
+fig.plot(x=7, y=y, style="h2c", pen="2p,black", color="lightgray")
+fig.text(x=x, y=y + 0.6, text="h", font=font)
 
 # lower row
-y = 0.5 
+y = 0.5
 
 # use an inverted triangle (i) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the 
+# linewidth is set to 2p, the linecolor to "black" and the
 # color fill to "tomato"
 x = 1
-fig.plot(x = x, y = y, style="i2c", pen="2p,black", color="tomato")
-fig.text(x = x, y = y + 0.6, text= "i", font = font)
+fig.plot(x=x, y=y, style="i2c", pen="2p,black", color="tomato")
+fig.text(x=x, y=y + 0.6, text="i", font=font)
 
 # use pentagon (n) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the 
+# linewidth is set to 2p, the linecolor to "black" and the
 # color fill to "lightseagreen"
-x +=1
-fig.plot(x = x, y = y, style="n2c", pen="2p,black", color = "lightseagreen")
-fig.text(x = x, y = y + 0.6, text= "n", font = font)
+x += 1
+fig.plot(x=x, y=y, style="n2c", pen="2p,black", color="lightseagreen")
+fig.text(x=x, y=y + 0.6, text="n", font=font)
 
 # use a point (p) with a size of 2 cm,
 # color fill is set to "lightseagreen"
-x +=1
-fig.plot(x = 3, y = y, style="p2c", color = "slateblue")
-fig.text(x = x, y = y + 0.6, text= "p", font = font)
+x += 1
+fig.plot(x=3, y=y, style="p2c", color="slateblue")
+fig.text(x=x, y=y + 0.6, text="p", font=font)
 
 # use square (s) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the 
+# linewidth is set to 2p, the linecolor to "black" and the
 # color fill to "gold2"
-x +=1
-fig.plot(x = 4, y = y, style="s2c", pen="2p,black", color = "gold2")
-fig.text(x = x, y = y + 0.6, text= "s", font = font)
+x += 1
+fig.plot(x=4, y=y, style="s2c", pen="2p,black", color="gold2")
+fig.text(x=x, y=y + 0.6, text="s", font=font)
 
 # use triangle (t) with a size of 2 cm,
-# linewidth is set to 2p, the linecolor to "black" and the 
+# linewidth is set to 2p, the linecolor to "black" and the
 # color fill to "magenta4"
-x +=1
-fig.plot(x = 5, y = y, style="t2c", pen="2p,black", color = "magenta4")
-fig.text(x = x, y = y + 0.6, text= "t", font = font)
+x += 1
+fig.plot(x=5, y=y, style="t2c", pen="2p,black", color="magenta4")
+fig.text(x=x, y=y + 0.6, text="t", font=font)
 
 # use cross (x) with a size of 2 cm,
-# linewidth is set to 4p and the linecolor to "gray40" 
-x +=1
-fig.plot(x = 6, y = y, style="x2c", pen="4p,gray40")
-fig.text(x = x, y = y + 0.6, text= "x", font = font)
+# linewidth is set to 4p and the linecolor to "gray40"
+x += 1
+fig.plot(x=6, y=y, style="x2c", pen="4p,gray40")
+fig.text(x=x, y=y + 0.6, text="x", font=font)
 
 # use a dash in y direction (y) with a size of 2 cm,
-# linewidth is set to 4p and the linecolor to "gray40" 
-x +=1
-fig.plot(x = 7, y = y, style="y2c", pen="4p,gray40")
-fig.text(x = x, y = y + 0.6, text= "y", font = font)
+# linewidth is set to 4p and the linecolor to "gray40"
+x += 1
+fig.plot(x=7, y=y, style="y2c", pen="4p,gray40")
+fig.text(x=x, y=y + 0.6, text="y", font=font)
 
 fig.show()


### PR DESCRIPTION
**Description of proposed changes**

As mentioned in #1193 so far we have no gallery example in which all basic symbols are shown. This PR adds such an example to the gallery.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Write detailed docstrings for all functions/methods.
- [x] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
