### PR TITLE
Bump the GMT version to 6.2.0rc1 in CI

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -66,7 +66,8 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          conda install gmt=6.1.1 numpy pandas xarray netCDF4 packaging \
+          conda install -c conda-forge/label/dev gmt=6.2.0rc1
+          conda install numpy pandas xarray netCDF4 packaging \
                         ipython make myst-parser \
                         sphinx sphinx-copybutton sphinx-gallery sphinx_rtd_theme
 

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -86,7 +86,8 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          conda install gmt=6.1.1 numpy=${{ matrix.numpy-version }} \
+          conda install -c conda-forge/label/dev gmt=6.2.0rc1
+          conda install numpy=${{ matrix.numpy-version }} \
                         pandas xarray netCDF4 packaging \
                         codecov coverage[toml] dvc ipython make \
                         pytest-cov pytest-mpl pytest>=6.0 \

--- a/environment.yml
+++ b/environment.yml
@@ -1,11 +1,12 @@
 name: pygmt
 channels:
+    - conda-forge/label/dev
     - conda-forge
     - defaults
 dependencies:
     # Required dependencies
     - pip
-    - gmt=6.1.1
+    - gmt=6.2.0rc1
     - numpy>=1.17
     - pandas
     - xarray


### PR DESCRIPTION
**Description of proposed changes**

This PR bumps the GMT version used in the CI tests to 6.2.0rc1. The minimum required GMT version is still 6.1.1 and will be bumped to 6.2.0 after GMT v6.2.0 is released.

The documentation pass, and the tests fail, as expected.

#1217.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
