### PR TITLE
Bump codecov-action from v1.4.0 to v1.4.1

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -140,7 +140,7 @@ jobs:
 
       # Upload coverage to Codecov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.4.0
+        uses: codecov/codecov-action@v1.4.1
         with:
           file: ./coverage.xml # optional
           env_vars: OS,PYTHON,NUMPY


### PR DESCRIPTION
**Description of proposed changes**

`codecov-action@v1.4.0` has a bug and reports:
```
Warning: Codecov 1.0.2 checksums for SHA1 failed to match.
Public checksum:   537069158a6f72b145cfe5f782dceb608d9ef594  codecov
af0dd19ee59f977bf5793cffafe116d7c248aa62  env
Uploader checksum: 537069158a6f72b145cfe5f782dceb608d9ef594  codecov
Error: Codecov failure: Bash script checksums do not match published values. Please contact security@codecov.io immediately.
Error: Codecov failed with the following error: Codecov failure: Bash script checksums do not match published values. Please contact security@codecov.io immediately.
```

See codecov/codecov-action#289 for the issue report.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
