### PR TITLE
Update fig.grd baseline images for GMT 6.2.0rc1

### DIFF
--- a/pygmt/tests/baseline/test_grd2cpt.png.dvc
+++ b/pygmt/tests/baseline/test_grd2cpt.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 0848349770986ef56d740e866ab961bc
-  size: 24843
+- md5: 305e3650aa4ed9a56bec58be3a0d752b
+  size: 22460
   path: test_grd2cpt.png

--- a/pygmt/tests/baseline/test_grdcontour.png.dvc
+++ b/pygmt/tests/baseline/test_grdcontour.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 438f13a0356e3bec8e3762180ea9c2f0
-  size: 219869
+- md5: 9366e405a1be22b4c2515f24a3acae69
+  size: 217638
   path: test_grdcontour.png

--- a/pygmt/tests/baseline/test_grdcontour_file.png.dvc
+++ b/pygmt/tests/baseline/test_grdcontour_file.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: fa2f0be00003b6a1cf8cc80da0eb824c
-  size: 102192
+- md5: 717b9f9123c7bb2bfb197a419d459288
+  size: 97067
   path: test_grdcontour_file.png

--- a/pygmt/tests/baseline/test_grdcontour_interval_file_full_opts.png.dvc
+++ b/pygmt/tests/baseline/test_grdcontour_interval_file_full_opts.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 7f655c17e068dd4860c5f97b7503a314
-  size: 38237
+- md5: 25125246f541652071fac1771e5d7e88
+  size: 33966
   path: test_grdcontour_interval_file_full_opts.png

--- a/pygmt/tests/baseline/test_grdcontour_labels.png.dvc
+++ b/pygmt/tests/baseline/test_grdcontour_labels.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 582303f039a43f271c543b78d3a3ff4b
-  size: 226135
+- md5: 03a7cc6dea35f9383cbfb2683d7b7c1b
+  size: 223421
   path: test_grdcontour_labels.png

--- a/pygmt/tests/baseline/test_grdcontour_slice.png.dvc
+++ b/pygmt/tests/baseline/test_grdcontour_slice.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: c9538960aae7cd5263bce0f6bda20090
-  size: 102143
+- md5: 48070d23c538d26eb96b5caaf440513a
+  size: 97314
   path: test_grdcontour_slice.png

--- a/pygmt/tests/test_grdfilter.py
+++ b/pygmt/tests/test_grdfilter.py
@@ -21,7 +21,7 @@ def fixture_grid():
     return load_earth_relief(registration="pixel")
 
 
-def test_grfilter_dataarray_in_dataarray_out(grid):
+def test_grdfilter_dataarray_in_dataarray_out(grid):
     """
     grdfilter an input DataArray, and output as DataArray.
     """
@@ -32,8 +32,8 @@ def test_grfilter_dataarray_in_dataarray_out(grid):
     assert result.coords["lat"].data.max() == 89.5
     assert result.coords["lon"].data.min() == -179.5
     assert result.coords["lon"].data.max() == 179.5
-    npt.assert_almost_equal(result.data.min(), -6147.47265625, decimal=2)
-    npt.assert_almost_equal(result.data.max(), 5164.1157, decimal=2)
+    npt.assert_almost_equal(result.data.min(), -6147.4907, decimal=2)
+    npt.assert_almost_equal(result.data.max(), 5164.06, decimal=2)
     assert result.sizes["lat"] == 180
     assert result.sizes["lon"] == 360
 
@@ -47,11 +47,11 @@ def test_grdfilter_dataarray_in_file_out(grid):
         assert result is None  # grdfilter returns None if output to a file
         result = grdinfo(tmpfile.name, per_column=True)
         assert (
-            result == "-180 180 -90 90 -6147.47265625 5164.11572266 1 1 360 180 1 1\n"
+            result == "-180 180 -90 90 -6147.49072266 5164.06005859 1 1 360 180 1 1\n"
         )
 
 
-def test_grfilter_file_in_dataarray_out():
+def test_grdfilter_file_in_dataarray_out():
     """
     grdfilter an input grid file, and output as DataArray.
     """


### PR DESCRIPTION
**Description of proposed changes**

Updates broken tests on GMT 6.2.0rc1 for `fig.grdcontour`, `fig.grdfilter` and `pygmt.grd2cpt`.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Note that the tests for `fig.grdfilter` are updates to the min/max values of the grid (and not baseline images). In GMT 6.1.1, the min/max values of a `grdfilter`ed `xarray.DataArray` grid was slightly different to that of a NetCDF grid by a few decimal places (see https://github.com/GenericMappingTools/pygmt/pull/809), but this appears to be fixed so that the min/max values are exactly the same in GMT 6.2.0rc1 now. This resolves #859 I think, (originally fixed upstream at https://github.com/GenericMappingTools/gmt/pull/5107).

This PR should also:

- Resolve #1172 as geographic xarray.DataArray grids should now be plotted as Geographic grids instead of Cartesian grids.
- Resolve #1177 as the `fig.grdcontour` tests doesn't crash anymore with the upstream fix at https://github.com/GenericMappingTools/gmt/pull/5100.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #1217

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
