### PR TITLE
Remove xfails and workarounds for datetime inputs into pygmt.info

### DIFF
--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -64,10 +64,6 @@ def test_info_numpy_array_time_column():
     assert output == expected_output
 
 
-@pytest.mark.xfail(
-    reason="UNIX timestamps returned instead of ISO datetime, should work on GMT 6.2.0 "
-    "after https://github.com/GenericMappingTools/gmt/issues/4241 is resolved",
-)
 def test_info_pandas_dataframe_time_column():
     """
     Make sure info works on pandas.DataFrame inputs with a time column.
@@ -85,10 +81,6 @@ def test_info_pandas_dataframe_time_column():
     assert output == expected_output
 
 
-@pytest.mark.xfail(
-    reason="UNIX timestamp returned instead of ISO datetime, should work on GMT 6.2.0 "
-    "after https://github.com/GenericMappingTools/gmt/issues/4241 is resolved",
-)
 def test_info_xarray_dataset_time_column():
     """
     Make sure info works on xarray.Dataset 1D inputs with a time column.

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -55,9 +55,7 @@ def test_info_numpy_array_time_column():
     Make sure info works on a numpy.ndarray input with a datetime type.
     """
     table = pd.date_range(start="2020-01-01", periods=5).to_numpy()
-    # Please remove coltypes="0T" workaround after
-    # https://github.com/GenericMappingTools/gmt/issues/4241 is resolved
-    output = info(table=table, coltypes="0T")
+    output = info(table=table)
     expected_output = (
         "<vector memory>: N = 5 <2020-01-01T00:00:00/2020-01-05T00:00:00>\n"
     )
@@ -135,9 +133,7 @@ def test_info_per_column_with_time_inputs():
     Make sure the per_column option works with time inputs.
     """
     table = pd.date_range(start="2020-01-01", periods=5).to_numpy()
-    # Please remove coltypes="0T" workaround after
-    # https://github.com/GenericMappingTools/gmt/issues/4241 is resolved
-    output = info(table=table, per_column=True, coltypes="0T")
+    output = info(table=table, per_column=True)
     npt.assert_equal(
         actual=output, desired=["2020-01-01T00:00:00", "2020-01-05T00:00:00"]
     )


### PR DESCRIPTION
**Description of proposed changes**

Previously in GMT 6.1.1, UNIX timestamps are returned instead of ISO datetime, and the workaround was to use `coltypes=0T` (i.e. `-f=0T`) in `pygmt.info`. The upstream bug has been fixed at https://github.com/GenericMappingTools/gmt/issues/4241 and https://github.com/GenericMappingTools/gmt/pull/4849, and is available in GMT 6.2.0rc1, so the workarounds can be removed.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #597


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
