### PR TITLE
Fix pygmt/helpers/testing.py doctest for GMT 6.2.0rc1

### DIFF
--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -42,7 +42,7 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
     ...     fig_ref = Figure()
     ...     fig_ref.basemap(projection="X5c", region=[0, 5, 0, 5], frame=True)
     ...     fig_test = Figure()
-    ...     fig_test.basemap(projection="X5c", region=[0, 5, 0, 5], frame="af")
+    ...     fig_test.basemap(projection="X5c", region=[0, 5, 0, 5], frame=["WrStZ", "af"])
     ...     return fig_ref, fig_test
     >>> test_check_figures_equal()
     >>> assert len(os.listdir("tmp_result_images")) == 0
@@ -51,7 +51,7 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
     >>> @check_figures_equal(result_dir="tmp_result_images")
     ... def test_check_figures_unequal():
     ...     fig_ref = Figure()
-    ...     fig_ref.basemap(projection="X5c", region=[0, 5, 0, 5], frame=True)
+    ...     fig_ref.basemap(projection="X5c", region=[0, 6, 0, 6], frame=True)
     ...     fig_test = Figure()
     ...     fig_test.basemap(projection="X5c", region=[0, 3, 0, 3], frame=True)
     ...     return fig_ref, fig_test

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -42,7 +42,9 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
     ...     fig_ref = Figure()
     ...     fig_ref.basemap(projection="X5c", region=[0, 5, 0, 5], frame=True)
     ...     fig_test = Figure()
-    ...     fig_test.basemap(projection="X5c", region=[0, 5, 0, 5], frame=["WrStZ", "af"])
+    ...     fig_test.basemap(
+    ...         projection="X5c", region=[0, 5, 0, 5], frame=["WrStZ", "af"]
+    ...     )
     ...     return fig_ref, fig_test
     >>> test_check_figures_equal()
     >>> assert len(os.listdir("tmp_result_images")) == 0


### PR DESCRIPTION
**Description of proposed changes**

Update doctests in pygmt/helpers/testing.py's `check_figures_equal` function failing because of new GMT 6.2.0 themes default. Specifically caused by the change in `MAP_FRAME_AXES` from `WESNZ` to `auto` (WrStZ for Cartesian figures).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Address #1217


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
