### PR TITLE
Disable pylint 2.8 consider-using-with refactoring suggestion

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -79,7 +79,9 @@ class Figure:
 
     def __init__(self):
         self._name = unique_name()
-        self._preview_dir = TemporaryDirectory(prefix=self._name + "-preview-")
+        self._preview_dir = TemporaryDirectory(  # pylint: disable=consider-using-with
+            prefix=f"{self._name}-preview-"
+        )
         self._activate_figure()
 
     def __del__(self):
@@ -375,7 +377,7 @@ class Figure:
             If ``as_bytes=False``, this is the file name of the preview image
             file. Else, it is the file content loaded as a bytes string.
         """
-        fname = os.path.join(self._preview_dir.name, "{}.{}".format(self._name, fmt))
+        fname = os.path.join(self._preview_dir.name, f"{self._name}.{fmt}")
         self.savefig(fname, dpi=dpi, **kwargs)
         if as_bytes:
             with open(fname, "rb") as image:


### PR DESCRIPTION
**Description of proposed changes**

Each pygmt.Figure instance has an associated directory that holds temporary preview PNG and/or PDF figure files. It's not easy to use a with-statement since TemporaryDirectory is called in the `__init__` function of the Figure class, so the pylint recommendation is simply disabled here.

Alternatively, I have considered moving the TemporaryDirectory call to be in the `_preview` function, that is, each preview call would generate a new temporary folder that immediately gets destroyed, but that will affect non-inline (i.e. external) previews (read: more work).

FYI I've traced the `self._preview_dir` variable back to commit 4148951d15db8e0a1241971b2b5d6490bb7694de, for those who want to know the context of why the TemporaryDirectory thing was designed this way.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes a problem with the Style Checks workflow.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
