### PR TITLE
Fix ModuleNotFoundError error when IPython is not installed

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -45,14 +45,11 @@ jobs:
           #   python-version: 3.7
           #   isDraft: true
         # Pair Python 3.7 with NumPy 1.17 and Python 3.9 with NumPy 1.20
-        # Only install optional packages on Python 3.9/NumPy 1.20
         include:
           - python-version: 3.7
             numpy-version: '1.17'
-            optional-packages: ''
           - python-version: 3.9
             numpy-version: '1.20'
-            optional-packages: 'ipython'
     defaults:
       run:
         shell: bash -l {0}
@@ -92,8 +89,7 @@ jobs:
           conda install -c conda-forge/label/dev gmt=6.2.0rc1
           conda install numpy=${{ matrix.numpy-version }} \
                         pandas xarray netCDF4 packaging \
-                        ${{ matrix.optional-packages }} \
-                        codecov coverage[toml] dvc make \
+                        codecov coverage[toml] dvc ipython make \
                         pytest-cov pytest-mpl pytest>=6.0 \
                         sphinx-gallery
 

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -45,11 +45,14 @@ jobs:
           #   python-version: 3.7
           #   isDraft: true
         # Pair Python 3.7 with NumPy 1.17 and Python 3.9 with NumPy 1.20
+        # Only install optional packages on Python 3.9/NumPy 1.20
         include:
           - python-version: 3.7
             numpy-version: '1.17'
+            optional-packages: ''
           - python-version: 3.9
             numpy-version: '1.20'
+            optional-packages: 'ipython'
     defaults:
       run:
         shell: bash -l {0}
@@ -89,7 +92,8 @@ jobs:
           conda install -c conda-forge/label/dev gmt=6.2.0rc1
           conda install numpy=${{ matrix.numpy-version }} \
                         pandas xarray netCDF4 packaging \
-                        codecov coverage[toml] dvc ipython make \
+                        ${{ matrix.optional-packages }} \
+                        codecov coverage[toml] dvc make \
                         pytest-cov pytest-mpl pytest>=6.0 \
                         sphinx-gallery
 

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -7,7 +7,7 @@ from tempfile import TemporaryDirectory
 
 try:
     import IPython
-except KeyError:
+except ModuleNotFoundError:
     IPython = None  # pylint: disable=invalid-name
 
 


### PR DESCRIPTION
**Description of proposed changes**

Fixes #1241.

A test is needed but currently I have no idea how to test it.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
