### PR TITLE
Run slash command dispatch workflow on Pull Request comments only

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -6,6 +6,7 @@ on:
     # types: [created, edited]
 jobs:
   slashCommandDispatch:
+    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
       # Generate token from GenericMappingTools bot


### PR DESCRIPTION
**Description of proposed changes**

The workflow ran on every GitHub issue and pull request comments. This patch ensures that the the slash command dispatch workflow is triggered by Pull Request comments only, thereby helping to conserve some CI resources (since each slash command dispatch takes 16-20s to run).

![image](https://user-images.githubusercontent.com/23487320/116326087-c05d8280-a817-11eb-9113-8739a280e93c.png)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

References:
- https://docs.github.com/en/actions/reference/events-that-trigger-workflows#issue_comment

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
 Patches #646


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
