### PR TITLE
Figure.plot: Deprecate parameter "sizes" to "size" (remove in v0.6.0)

### DIFF
--- a/examples/gallery/symbols/points_categorical.py
+++ b/examples/gallery/symbols/points_categorical.py
@@ -53,7 +53,7 @@ fig.plot(
     x=df.bill_length_mm,
     y=df.bill_depth_mm,
     # Vary each symbol size according to another feature (body mass, scaled by 7.5*10e-5)
-    sizes=df.body_mass_g * 7.5e-5,
+    size=df.body_mass_g * 7.5e-5,
     # Points colored by categorical number code
     color=df.species.cat.codes.astype(int),
     # Use colormap created by makecpt

--- a/examples/gallery/symbols/scatter.py
+++ b/examples/gallery/symbols/scatter.py
@@ -23,13 +23,13 @@ fig.basemap(
 )
 for color in ["gray73", "darkorange", "slateblue"]:
     x, y = np.random.rand(2, n)  # random X and Y data in [0,1]
-    sizes = np.random.rand(n) * 0.5  # random size [0,0.5], in cm
+    size = np.random.rand(n) * 0.5  # random size [0,0.5], in cm
     # plot data points as circles (style="c"), with different sizes
     fig.plot(
         x=x,
         y=y,
         style="c",
-        sizes=sizes,
+        size=size,
         color=color,
         # Set the legend label,
         # and set the symbol size to be 0.25 cm (+S0.25c) in legend

--- a/examples/tutorials/plot.py
+++ b/examples/tutorials/plot.py
@@ -63,7 +63,7 @@ fig.show()
 
 ########################################################################################
 # Notice that we didn't include the size in the ``style`` parameter this time, just the
-# symbol ``c`` (circles) and the unit ``c`` (centimeter). So in this case, the sizes
+# symbol ``c`` (circles) and the unit ``c`` (centimeter). So in this case, the size
 # will be interpreted as being in centimeters.
 #
 # We can also map the colors of the markers to the depths by passing an array to the

--- a/examples/tutorials/plot.py
+++ b/examples/tutorials/plot.py
@@ -45,7 +45,7 @@ fig.show()
 # parameter controls the outline of the symbols and the ``color`` parameter controls the fill.
 #
 # We can map the size of the circles to the earthquake magnitude by passing an array to
-# the ``sizes`` parameter. Because the magnitude is on a logarithmic scale, it helps to
+# the ``size`` parameter. Because the magnitude is on a logarithmic scale, it helps to
 # show the differences by scaling the values using a power law.
 
 fig = pygmt.Figure()
@@ -54,7 +54,7 @@ fig.coast(land="black", water="skyblue")
 fig.plot(
     x=data.longitude,
     y=data.latitude,
-    sizes=0.02 * (2 ** data.magnitude),
+    size=0.02 * (2 ** data.magnitude),
     style="cc",
     color="white",
     pen="black",
@@ -82,7 +82,7 @@ pygmt.makecpt(cmap="viridis", series=[data.depth_km.min(), data.depth_km.max()])
 fig.plot(
     x=data.longitude,
     y=data.latitude,
-    sizes=0.02 * 2 ** data.magnitude,
+    size=0.02 * 2 ** data.magnitude,
     color=data.depth_km,
     cmap=True,
     style="cc",

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -43,7 +43,7 @@ from pygmt.helpers import (
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
-def plot(self, x=None, y=None, data=None, sizes=None, direction=None, **kwargs):
+def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
     r"""
     Plot lines, polygons, and symbols in 2-D.
 
@@ -78,7 +78,7 @@ def plot(self, x=None, y=None, data=None, sizes=None, direction=None, **kwargs):
         Either a data file name or a 2d numpy array with the tabular data.
         Use parameter ``columns`` to choose which columns are x, y, color,
         and size, respectively.
-    sizes : 1d array
+    size : 1d array
         The sizes of the data points in units specified using ``style``.
         Only valid if using ``x``/``y``.
     direction : list of two 1d arrays
@@ -215,12 +215,12 @@ def plot(self, x=None, y=None, data=None, sizes=None, direction=None, **kwargs):
             )
         extra_arrays.append(kwargs["G"])
         del kwargs["G"]
-    if sizes is not None:
+    if size is not None:
         if kind != "vectors":
             raise GMTInvalidInput(
                 "Can't use arrays for sizes if data is matrix or file."
             )
-        extra_arrays.append(sizes)
+        extra_arrays.append(size)
 
     for flag in ["I", "t"]:
         if flag in kwargs and is_nonstr_iter(kwargs[flag]):

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -81,7 +81,7 @@ def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
         Use parameter ``columns`` to choose which columns are x, y, color,
         and size, respectively.
     size : 1d array
-        The sizes of the data points in units specified using ``style``.
+        The size of the data points in units specified using ``style``.
         Only valid if using ``x``/``y``.
     direction : list of two 1d arrays
         If plotting vectors (using ``style='V'`` or ``style='v'``), then
@@ -220,7 +220,7 @@ def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
     if size is not None:
         if kind != "vectors":
             raise GMTInvalidInput(
-                "Can't use arrays for sizes if data is matrix or file."
+                "Can't use arrays for 'size' if data is a matrix or file."
             )
         extra_arrays.append(size)
 

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -6,6 +6,7 @@ from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     build_arg_string,
     data_kind,
+    deprecate_parameter,
     fmt_docstring,
     is_nonstr_iter,
     kwargs_to_strings,
@@ -43,6 +44,7 @@ from pygmt.helpers import (
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
+@deprecate_parameter("sizes", "size", "v0.4.0", remove_version="v0.6.0")
 def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
     r"""
     Plot lines, polygons, and symbols in 2-D.

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -4,7 +4,6 @@ Tests plot.
 """
 import datetime
 import os
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -458,7 +457,7 @@ def test_plot_deprecate_sizes_to_size(data, region):
     Modified from the test_plot_sizes() test.
     """
     fig = Figure()
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(expected_warning=FutureWarning) as record:
         fig.plot(
             x=data[:, 0],
             y=data[:, 1],
@@ -469,6 +468,5 @@ def test_plot_deprecate_sizes_to_size(data, region):
             color="blue",
             frame="af",
         )
-        assert len(w) == 1
-        assert issubclass(w[0].category, FutureWarning)
+        assert len(record) == 1  # check that only one warning was raised
     return fig

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -4,6 +4,7 @@ Tests plot.
 """
 import datetime
 import os
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -445,4 +446,29 @@ def test_plot_datetime():
     x = [datetime.date(2018, 1, 1), datetime.datetime(2019, 1, 1)]
     y = [8.5, 9.5]
     fig.plot(x, y, style="i0.2c", pen="1p")
+    return fig
+
+
+@pytest.mark.mpl_image_compare(filename="test_plot_sizes.png")
+def test_plot_deprecate_sizes_to_size(data, region):
+    """
+    Make sure that the old parameter "sizes" is supported and it reports an
+    warning.
+
+    Modified from the test_plot_sizes() test.
+    """
+    fig = Figure()
+    with warnings.catch_warnings(record=True) as w:
+        fig.plot(
+            x=data[:, 0],
+            y=data[:, 1],
+            sizes=0.5 * data[:, 2],
+            region=region,
+            projection="X10c",
+            style="cc",
+            color="blue",
+            frame="af",
+        )
+        assert len(w) == 1
+        assert issubclass(w[0].category, FutureWarning)
     return fig

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -93,7 +93,7 @@ def test_plot_fail_no_data(data):
 
 def test_plot_fail_color_size_intensity(data):
     """
-    Should raise an exception if array color, sizes and intensity are used with
+    Should raise an exception if array color, size and intensity are used with
     matrix.
     """
     fig = Figure()
@@ -101,7 +101,7 @@ def test_plot_fail_color_size_intensity(data):
     with pytest.raises(GMTInvalidInput):
         fig.plot(style="c0.2c", color=data[:, 2], **kwargs)
     with pytest.raises(GMTInvalidInput):
-        fig.plot(style="cc", sizes=data[:, 2], color="red", **kwargs)
+        fig.plot(style="cc", size=data[:, 2], color="red", **kwargs)
     with pytest.raises(GMTInvalidInput):
         fig.plot(style="c0.2c", color="red", intensity=data[:, 2], **kwargs)
 
@@ -152,7 +152,7 @@ def test_plot_sizes(data, region):
     fig.plot(
         x=data[:, 0],
         y=data[:, 1],
-        sizes=0.5 * data[:, 2],
+        size=0.5 * data[:, 2],
         region=region,
         projection="X10c",
         style="cc",
@@ -172,7 +172,7 @@ def test_plot_colors_sizes(data, region):
         x=data[:, 0],
         y=data[:, 1],
         color=data[:, 2],
-        sizes=0.5 * data[:, 2],
+        size=0.5 * data[:, 2],
         region=region,
         projection="X10c",
         style="cc",
@@ -193,7 +193,7 @@ def test_plot_colors_sizes_proj(data, region):
         x=data[:, 0],
         y=data[:, 1],
         color=data[:, 2],
-        sizes=0.5 * data[:, 2],
+        size=0.5 * data[:, 2],
         style="cc",
         cmap="copper",
     )
@@ -288,7 +288,7 @@ def test_plot_sizes_colors_transparencies():
         frame=True,
         style="cc",
         color=color,
-        sizes=size,
+        size=size,
         cmap="gray",
         transparency=transparency,
     )


### PR DESCRIPTION
**Description of proposed changes**

- Rename the parameter `sizes` to `size` in Figure.plot()
- Updates tests and examples to use the new parameter name
- Use the deprecate_parameter decorator for backward-compatibility
- Add a test for checking 'sizes' backward compatibility

Address #1118.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
