### PR TITLE
Update Figure.meca 'offset' alias to match GMT 6.2.0rc1 syntax

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -99,7 +99,7 @@ def data_format_code(convention, component="full"):
     R="region",
     J="projection",
     B="frame",
-    C="offset",
+    A="offset",
     N="no_clip",
     V="verbose",
     X="xshift",
@@ -334,8 +334,8 @@ def meca(
                 if arg is None:
                     spec.append(0)
                 else:
-                    if "C" not in kwargs:
-                        kwargs["C"] = True
+                    if "A" not in kwargs:
+                        kwargs["A"] = True
                     spec.append(arg)
 
         # or assemble the 2D array for the case of lists as values
@@ -389,8 +389,8 @@ def meca(
                     if arg is None:
                         row.append(0)
                     else:
-                        if "C" not in kwargs:
-                            kwargs["C"] = True
+                        if "A" not in kwargs:
+                            kwargs["A"] = True
                         row.append(arg[index])
                 spec_array.append(row)
             spec = spec_array
@@ -435,8 +435,8 @@ def meca(
                     if arg is None:
                         row.append(0)
                     else:
-                        if "C" not in kwargs:
-                            kwargs["C"] = True
+                        if "A" not in kwargs:
+                            kwargs["A"] = True
                         row.append(arg[index])
                 spec_array.append(row)
             spec = spec_array

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -98,8 +98,8 @@ def data_format_code(convention, component="full"):
 @use_alias(
     R="region",
     J="projection",
-    B="frame",
     A="offset",
+    B="frame",
     N="no_clip",
     V="verbose",
     X="xshift",


### PR DESCRIPTION
**Description of proposed changes**

`meca` in GMT <=6.1.1 used **-C** option for offset.
Since https://github.com/GenericMappingTools/gmt/pull/4873, the **-C** option is used
to specify the CPT of the compressional part, and the old **-C** option is
renamed to **-A**, although it's still backward-compatible.

This PR changes the 'offset' alias from **C** to **A**, to match the GMT 6.2.0rc1
syntax.

Fixes #1094.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
