### PR TITLE
Add alias name convention to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,7 +305,7 @@ Pull Request to lint the code automatically.
 
 When wrapping a new alias, use an underscore to separate words bridged by vowels
 (aeiou), such as `no_skip` and `z_only`. Do not use an underscore to separate
-words bridged by only consonants, such as `distcalc`, and `crossprofile`. This
+words bridged only by consonants, such as `distcalc`, and `crossprofile`. This
 convention is not applied by the code checking tools, but the PyGMT maintainers
 will comment on any pull requests as needed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,7 +219,7 @@ General guidelines for pull requests (PRs):
   do.
 * Each pull request should consist of a **small** and logical collection of changes.
 * Larger changes should be broken down into smaller components and integrated
-  separately.
+  separately. For example, break the wrapping of aliases into multiple pull requests.
 * Bug fixes should be submitted in separate PRs.
 * Use underscores for all Python (*.py) files as per [PEP8](https://www.python.org/dev/peps/pep-0008/),
   not hyphens. Directory names should also use underscores instead of hyphens.
@@ -302,6 +302,12 @@ Don't worry if you forget to do it. Our continuous integration systems will
 warn us and you can make a new commit with the formatted code.
 Even better, you can just write `/format` in the first line of any comment in a
 Pull Request to lint the code automatically.
+
+When wrapping a new alias, use an underscore to separate words bridged by vowels
+(aeiou), such as `no_skip` and `z_only`. Do not use an underscore to separate
+words bridged by only consonants, such as `distcalc`, and `crossprofile`. This
+convention is not applied by the code checking tools, but the PyGMT maintainers
+will comment on any pull requests as needed.
 
 We also use [flake8](http://flake8.pycqa.org/en/latest/) and
 [pylint](https://www.pylint.org/) to check the quality of the code and quickly catch


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a convention for when to separate words in aliases by an underscore to CONTRIBUTING.md. Originally suggested by @weiji14 in https://github.com/GenericMappingTools/pygmt/pull/1190#issuecomment-814451969.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
