### PR TITLE
Explicitly use netcdf4 engine in xarray.open_dataarray to read grd files

### DIFF
--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -133,7 +133,7 @@ def load_earth_relief(resolution="01d", region=None, registration=None, use_srtm
                 f"'region' is required for Earth relief resolution '{resolution}'."
             )
         fname = which(f"@earth_relief_{resolution}{reg}", download="a")
-        with xr.open_dataarray(fname) as dataarray:
+        with xr.open_dataarray(fname, engine="netcdf4") as dataarray:
             grid = dataarray.load()
             _ = grid.gmt  # load GMTDataArray accessor information
     else:

--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -24,7 +24,7 @@ def test_accessor_pixel_geographic():
     and a gtype value of 0 when using Cartesian coordinates.
     """
     fname = which(fname="@earth_relief_01d_p", download="a")
-    grid = xr.open_dataarray(fname)
+    grid = xr.open_dataarray(fname, engine="netcdf4")
     assert grid.gmt.registration == 1  # pixel registration
     assert grid.gmt.gtype == 1  # geographic coordinate type
 

--- a/pygmt/tests/test_clib_put_matrix.py
+++ b/pygmt/tests/test_clib_put_matrix.py
@@ -92,7 +92,7 @@ def test_put_matrix_grid():
                 npt.assert_allclose(newdata, data)
 
             # Save the data to a netCDF grid and check that xarray can load it
-            with GMTTempFile() as tmp_grid:
+            with GMTTempFile(suffix=".nc") as tmp_grid:
                 lib.write_data(
                     "GMT_IS_MATRIX",
                     "GMT_IS_SURFACE",


### PR DESCRIPTION
**Description of proposed changes**

Using `xr.open_datarray(..., engine="netcdf4")` to read *.grd files, especially for the `load_earth_relief` function. Needed for `xarray` v0.18 due to backend API changes.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1262


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
