### PR TITLE
Clarify that the "transparency" parameter in plot/plot3d/text can be 1d array 

### DIFF
--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -203,7 +203,7 @@ def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
     {p}
     {t}
         *transparency* can also be a 1d array to set varying transparency
-        for symbols.
+        for symbols, but it is only valid if using x/y.
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
 

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -204,7 +204,7 @@ def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
     {p}
     {t}
         *transparency* can also be a 1d array to set varying transparency
-        for symbols, but it is only valid if using x/y.
+        for symbols, but this option is only valid if using x/y.
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
 

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -168,7 +168,7 @@ def plot3d(
     {p}
     {t}
         *transparency* can also be a 1d array to set varying transparency
-        for symbols, but it is only valid if using x/y.
+        for symbols, but this option is only valid if using x/y.
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
 

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -168,7 +168,7 @@ def plot3d(
     {p}
     {t}
         *transparency* can also be a 1d array to set varying transparency
-        for symbols, but this option is only valid if using x/y.
+        for symbols, but this option is only valid if using x/y/z.
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
 

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -167,7 +167,7 @@ def plot3d(
     {p}
     {t}
         *transparency* can also be a 1d array to set varying transparency
-        for symbols.
+        for symbols, but it is only valid if using x/y.
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
 

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -147,6 +147,8 @@ def text_(
     {f}
     {p}
     {t}
+        *transparency* can also be a 1d array to set varying transparency
+        for symbols, but this option is only valid if using x/y.
     """
 
     # pylint: disable=too-many-locals

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -148,7 +148,7 @@ def text_(
     {p}
     {t}
         *transparency* can also be a 1d array to set varying transparency
-        for symbols, but this option is only valid if using x/y.
+        for texts, but this option is only valid if using x/y.
     """
 
     # pylint: disable=too-many-locals

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -148,7 +148,7 @@ def text_(
     {p}
     {t}
         *transparency* can also be a 1d array to set varying transparency
-        for texts, but this option is only valid if using x/y.
+        for texts, but this option is only valid if using x/y/text.
     """
 
     # pylint: disable=too-many-locals

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -91,10 +91,10 @@ def test_plot_fail_no_data(data):
         )
 
 
-def test_plot_fail_color_size_intensity(data):
+def test_plot_fail_1d_array_with_data(data):
     """
-    Should raise an exception if array color, size and intensity are used with
-    matrix.
+    Should raise an exception if array color, size, intensity and transparency
+    are used with matrix.
     """
     fig = Figure()
     kwargs = dict(data=data, region=region, projection="X10c", frame="afg")
@@ -104,6 +104,8 @@ def test_plot_fail_color_size_intensity(data):
         fig.plot(style="cc", size=data[:, 2], color="red", **kwargs)
     with pytest.raises(GMTInvalidInput):
         fig.plot(style="c0.2c", color="red", intensity=data[:, 2], **kwargs)
+    with pytest.raises(GMTInvalidInput):
+        fig.plot(style="c0.2c", color="red", transparency=data[:, 2] * 100, **kwargs)
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -108,10 +108,10 @@ def test_plot3d_fail_no_data(data, region):
         )
 
 
-def test_plot3d_fail_color_size_intensity(data, region):
+def test_plot3d_fail_1d_array_with_data(data, region):
     """
-    Should raise an exception if array color, size and intensity are used with
-    matrix.
+    Should raise an exception if array color, size, intensity and transparency
+    are used with matrix.
     """
     fig = Figure()
     kwargs = dict(data=data, region=region, projection="X10c", frame="afg")
@@ -121,6 +121,8 @@ def test_plot3d_fail_color_size_intensity(data, region):
         fig.plot3d(style="cc", size=data[:, 2], color="red", **kwargs)
     with pytest.raises(GMTInvalidInput):
         fig.plot3d(style="cc", intensity=data[:, 2], color="red", **kwargs)
+    with pytest.raises(GMTInvalidInput):
+        fig.plot3d(style="cc", color="red", transparency=data[:, 2] * 100, **kwargs)
 
 
 @pytest.mark.mpl_image_compare


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1098 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
