### PR TITLE
Add categorical colorbars for plot, plot3d and line colors gallery examples

### DIFF
--- a/examples/gallery/3d_plots/scatter3d.py
+++ b/examples/gallery/3d_plots/scatter3d.py
@@ -60,7 +60,7 @@ fig.plot3d(
     region=region,
     # Set frame parameters
     frame=[
-        "WsNeZ3",  # z axis label positioned on 3rd corner
+        'WsNeZ3+t"Iris flower data set"',  # z axis label positioned on 3rd corner, add title
         'xafg+l"Petal Width"',
         'yafg+l"Sepal Length"',
         'zafg+l"Petal Length"',

--- a/examples/gallery/3d_plots/scatter3d.py
+++ b/examples/gallery/3d_plots/scatter3d.py
@@ -37,7 +37,8 @@ fig = pygmt.Figure()
 # Define a colormap to be used for three categories, define the range of the
 # new discrete CPT using series=(lowest_value, highest_value, interval),
 # use color_model="+csetosa,versicolor,virginica" to write the discrete color palette
-# "cubhelix" in categorical format and add the species names as annotations
+# "cubhelix" in categorical format and add the species names as annotations for the
+# colorbar
 pygmt.makecpt(
     cmap="cubhelix", color_model="+csetosa,versicolor,virginica", series=(0, 2, 1)
 )

--- a/examples/gallery/3d_plots/scatter3d.py
+++ b/examples/gallery/3d_plots/scatter3d.py
@@ -36,11 +36,11 @@ fig = pygmt.Figure()
 
 # Define a colormap to be used for three categories, define the range of the
 # new discrete CPT using series=(lowest_value, highest_value, interval),
-# use color_model="+csetosa,versicolor,virginica" to write the discrete color palette
+# use color_model="+cSetosa,Versicolor,Virginica" to write the discrete color palette
 # "cubhelix" in categorical format and add the species names as annotations for the
 # colorbar
 pygmt.makecpt(
-    cmap="cubhelix", color_model="+csetosa,versicolor,virginica", series=(0, 2, 1)
+    cmap="cubhelix", color_model="+cSetosa,Versicolor,Virginica", series=(0, 2, 1)
 )
 
 fig.plot3d(
@@ -62,9 +62,9 @@ fig.plot3d(
     # Set frame parameters
     frame=[
         'WsNeZ3+t"Iris flower data set"',  # z axis label positioned on 3rd corner, add title
-        'xafg+l"Petal Width"',
-        'yafg+l"Sepal Length"',
-        'zafg+l"Petal Length"',
+        'xafg+l"Petal Width (cm)"',
+        'yafg+l"Sepal Length (cm)"',
+        'zafg+l"Petal Length (cm)"',
     ],
     # Set perspective to azimuth NorthWest (315°), at elevation 25°
     perspective=[315, 25],

--- a/examples/gallery/3d_plots/scatter3d.py
+++ b/examples/gallery/3d_plots/scatter3d.py
@@ -17,8 +17,13 @@ the vertical exaggeration factor.
 import pandas as pd
 import pygmt
 
-# Load sample iris data, and convert 'species' column to categorical dtype
+# Load sample iris data
 df = pd.read_csv("https://github.com/mwaskom/seaborn-data/raw/master/iris.csv")
+
+# Extract species names for colorbar legend
+species = ",".join(df.species.unique())
+
+# Convert 'species' column to categorical dtype
 df.species = df.species.astype(dtype="category")
 
 # Use pygmt.info to get region bounds (xmin, xmax, ymin, ymax, zmin, zmax)
@@ -36,9 +41,9 @@ fig = pygmt.Figure()
 
 # Define a colormap to be used for three categories, define the range of the
 # new discrete CPT using series=(lowest_value, highest_value, interval),
-# use color_model="+c" to write the discrete color palette "cubhelix" in
-# categorical format
-pygmt.makecpt(cmap="cubhelix", color_model="+c", series=(0, 3, 1))
+# use color_model="+c" + species to write the discrete color palette "cubhelix" in
+# categorical format and add the species names extracted above as annotations
+pygmt.makecpt(cmap="cubhelix", color_model="+c" + species, series=(0, 2, 1))
 
 fig.plot3d(
     # Use petal width, sepal length and petal length as x, y and z data input,
@@ -68,4 +73,8 @@ fig.plot3d(
     # Vertical exaggeration factor
     zscale=1.5,
 )
+
+# Add colorbar legend
+fig.colorbar()
+
 fig.show()

--- a/examples/gallery/3d_plots/scatter3d.py
+++ b/examples/gallery/3d_plots/scatter3d.py
@@ -17,13 +17,8 @@ the vertical exaggeration factor.
 import pandas as pd
 import pygmt
 
-# Load sample iris data
+# Load sample iris data and convert 'species' column to categorical dtype
 df = pd.read_csv("https://github.com/mwaskom/seaborn-data/raw/master/iris.csv")
-
-# Extract species names for colorbar legend
-species = ",".join(df.species.unique())
-
-# Convert 'species' column to categorical dtype
 df.species = df.species.astype(dtype="category")
 
 # Use pygmt.info to get region bounds (xmin, xmax, ymin, ymax, zmin, zmax)
@@ -41,9 +36,11 @@ fig = pygmt.Figure()
 
 # Define a colormap to be used for three categories, define the range of the
 # new discrete CPT using series=(lowest_value, highest_value, interval),
-# use color_model="+c" + species to write the discrete color palette "cubhelix" in
-# categorical format and add the species names extracted above as annotations
-pygmt.makecpt(cmap="cubhelix", color_model="+c" + species, series=(0, 2, 1))
+# use color_model="+csetosa,versicolor,virginica" to write the discrete color palette
+# "cubhelix" in categorical format and add the species names as annotations
+pygmt.makecpt(
+    cmap="cubhelix", color_model="+csetosa,versicolor,virginica", series=(0, 2, 1)
+)
 
 fig.plot3d(
     # Use petal width, sepal length and petal length as x, y and z data input,
@@ -75,6 +72,6 @@ fig.plot3d(
 )
 
 # Add colorbar legend
-fig.colorbar()
+fig.colorbar(xshift=3.1)
 
 fig.show()

--- a/examples/gallery/lines/line_custom_cpt.py
+++ b/examples/gallery/lines/line_custom_cpt.py
@@ -21,8 +21,12 @@ x = np.arange(start=20, stop=30, step=0.2)
 fig = pygmt.Figure()
 fig.basemap(frame=["WSne", "af"], region=[20, 30, -10, 10])
 
-# Create a custom CPT with the batlow CPT and 10 discrete z-values (colors)
-pygmt.makecpt(cmap="batlow", series=[0, 10, 1])
+# Create a custom CPT with the batlow CPT and 10 discrete z-values (colors),
+# use color_model="+c" + ','.join(map(str, range(1,11))) to write the color
+# palette in categorical format and add labels (1) to (10) for the colorbar legend
+pygmt.makecpt(
+    cmap="batlow", series=[0, 9, 1], color_model="+c" + ",".join(map(str, range(1, 11)))
+)
 
 # Plot 10 lines and set a different z-value for each line
 for zvalue in range(0, 10):

--- a/examples/gallery/lines/line_custom_cpt.py
+++ b/examples/gallery/lines/line_custom_cpt.py
@@ -25,7 +25,7 @@ fig.basemap(frame=["WSne", "af"], region=[20, 30, -10, 10])
 # use color_model="+c" + ','.join(map(str, range(1,11))) to write the color
 # palette in categorical format and add labels (1) to (10) for the colorbar legend
 pygmt.makecpt(
-    cmap="batlow", series=[0, 9, 1], color_model="+c" + ",".join(map(str, range(1, 11)))
+    cmap="batlow", series=[0, 9, 1], color_model="+c0-9")
 )
 
 # Plot 10 lines and set a different z-value for each line

--- a/examples/gallery/lines/line_custom_cpt.py
+++ b/examples/gallery/lines/line_custom_cpt.py
@@ -22,16 +22,15 @@ fig = pygmt.Figure()
 fig.basemap(frame=["WSne", "af"], region=[20, 30, -10, 10])
 
 # Create a custom CPT with the batlow CPT and 10 discrete z-values (colors),
-# use color_model="+c" + ','.join(map(str, range(1,11))) to write the color
-# palette in categorical format and add labels (1) to (10) for the colorbar legend
-pygmt.makecpt(
-    cmap="batlow", series=[0, 9, 1], color_model="+c0-9")
-)
+# use color_model="+c0-9" to write the color palette in categorical format and
+# add labels (0) to (9) for the colorbar legend
+pygmt.makecpt(cmap="batlow", series=[0, 9, 1], color_model="+c0-9")
 
 # Plot 10 lines and set a different z-value for each line
 for zvalue in range(0, 10):
     y = zvalue * np.sin(x)
     fig.plot(x=x, y=y, cmap=True, zvalue=zvalue, pen="thick,+z,-")
+
 # Color bar to show the custom CPT and the associated z-values
 fig.colorbar()
 fig.show()

--- a/examples/gallery/symbols/points_categorical.py
+++ b/examples/gallery/symbols/points_categorical.py
@@ -14,13 +14,8 @@ method.
 import pandas as pd
 import pygmt
 
-# Load sample penguins data
+# Load sample penguins data and convert 'species' column to categorical dtype
 df = pd.read_csv("https://github.com/mwaskom/seaborn-data/raw/master/penguins.csv")
-
-# Extract species names for colorbar legend
-species = ",".join(df.species.unique())
-
-# Convert 'species' column to categorical dtype
 df.species = df.species.astype(dtype="category")
 
 # Use pygmt.info to get region bounds (xmin, xmax, ymin, ymax)
@@ -49,9 +44,10 @@ fig.basemap(
 
 # Define a colormap to be used for three categories, define the range of the
 # new discrete CPT using series=(lowest_value, highest_value, interval),
-# use color_model="+c" + species to write the discrete color palette "inferno" in
-# categorical format and add the species names extracted above as annotations
-pygmt.makecpt(cmap="inferno", series=(0, 2, 1), color_model="+c" + species)
+# use color_model="+cAdelie,Chinstrap,Gentoo" to write the discrete color palette
+# "inferno" in categorical format and add the species names as annotations for the
+# colorbar
+pygmt.makecpt(cmap="inferno", series=(0, 2, 1), color_model="+cAdelie,Chinstrap,Gentoo")
 
 fig.plot(
     # Use bill length and bill depth as x and y data input, respectively

--- a/examples/gallery/symbols/points_categorical.py
+++ b/examples/gallery/symbols/points_categorical.py
@@ -46,7 +46,7 @@ fig.basemap(
 # new discrete CPT using series=(lowest_value, highest_value, interval),
 # use color_model="+c" to write the discrete color palette "inferno" in
 # categorical format
-pygmt.makecpt(cmap="inferno", series=(0, 3, 1), color_model="+c")
+pygmt.makecpt(cmap="inferno", series=(0, 2, 1), color_model="+c")
 
 fig.plot(
     # Use bill length and bill depth as x and y data input, respectively

--- a/examples/gallery/symbols/points_categorical.py
+++ b/examples/gallery/symbols/points_categorical.py
@@ -14,8 +14,13 @@ method.
 import pandas as pd
 import pygmt
 
-# Load sample penguins data and convert 'species' column to categorical dtype
+# Load sample penguins data
 df = pd.read_csv("https://github.com/mwaskom/seaborn-data/raw/master/penguins.csv")
+
+# Extract species names for colorbar legend
+species = ",".join(df.species.unique())
+
+# Convert 'species' column to categorical dtype
 df.species = df.species.astype(dtype="category")
 
 # Use pygmt.info to get region bounds (xmin, xmax, ymin, ymax)
@@ -44,9 +49,9 @@ fig.basemap(
 
 # Define a colormap to be used for three categories, define the range of the
 # new discrete CPT using series=(lowest_value, highest_value, interval),
-# use color_model="+c" to write the discrete color palette "inferno" in
-# categorical format
-pygmt.makecpt(cmap="inferno", series=(0, 2, 1), color_model="+c")
+# use color_model="+c" + species to write the discrete color palette "inferno" in
+# categorical format and add the species names extracted above as annotations
+pygmt.makecpt(cmap="inferno", series=(0, 2, 1), color_model="+c" + species)
 
 fig.plot(
     # Use bill length and bill depth as x and y data input, respectively
@@ -66,7 +71,7 @@ fig.plot(
     transparency=40,
 )
 
-# A colorbar displaying the different penguin species types will be added
-# once GMT 6.2.0 is released.
+# Add colorbar legend
+fig.colorbar()
 
 fig.show()


### PR DESCRIPTION
**Description of proposed changes**

As discussed in #1259 this PR fixes issues appearing during cpt creation and adds categorical colorbars to the examples.

Previews:
- https://pygmt-git-cat-update-plot-plot3d-gmt.vercel.app/gallery/symbols/points_categorical.html
- https://pygmt-git-cat-update-plot-plot3d-gmt.vercel.app/gallery/3d_plots/scatter3d.html
- https://pygmt-git-cat-update-plot-plot3d-gmt.vercel.app/gallery/lines/line_custom_cpt.html

Closes #1259.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
