### PR TITLE
Update fig.basemap and pygmt.config baseline images for Ghostscript 9.54.0

### DIFF
--- a/pygmt/tests/baseline/test_basemap_winkel_tripel.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_winkel_tripel.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: b32f987475dee83c219df916a7ffb687
-  size: 62786
+- md5: 128e58b420ec614da56fd273c4f4c1ea
+  size: 62767
   path: test_basemap_winkel_tripel.png

--- a/pygmt/tests/baseline/test_config_map_grid_cross_size.png.dvc
+++ b/pygmt/tests/baseline/test_config_map_grid_cross_size.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: cd5aec2937c08cf7d94f80eb6894609a
-  size: 13246
+- md5: c154f4630cd8ec5ceaf5329fdcc6aa5c
+  size: 13550
   path: test_config_map_grid_cross_size.png

--- a/pygmt/tests/baseline/test_config_map_grid_pen.png.dvc
+++ b/pygmt/tests/baseline/test_config_map_grid_pen.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: eb591a3581ad0cc82ff08fd4aa763b8c
-  size: 13506
+- md5: 3a3423437fcc7039db04e4c1bbb779e7
+  size: 13562
   path: test_config_map_grid_pen.png

--- a/pygmt/tests/baseline/test_config_map_tick_length.png.dvc
+++ b/pygmt/tests/baseline/test_config_map_tick_length.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 2fdbc52afba87ecf8c434e4b62232455
-  size: 12664
+- md5: b20b1fd9f9e585abb5da08f3201e69ce
+  size: 12965
   path: test_config_map_tick_length.png

--- a/pygmt/tests/baseline/test_config_map_tick_pen.png.dvc
+++ b/pygmt/tests/baseline/test_config_map_tick_pen.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 380b4c6fb0245a393aeb76b5c1f6ee91
-  size: 13085
+- md5: ebc85cc6c78a30b1d55972a725b01005
+  size: 13502
   path: test_config_map_tick_pen.png


### PR DESCRIPTION
**Description of proposed changes**

Refreshed 5 baseline images on DAGsHub using ghostscript 9.54.0 instead of 9.53.3 to fix some broken tests.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1270


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
