### PR TITLE
Add histogram gallery example

### DIFF
--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -10,15 +10,22 @@ fig = pygmt.Figure()
 
 fig.histogram(
     table="@v3206_06.txt",
+    # specify the "region" of interest [xmin, xmax, ymin, ymax]
     region=[-6000, 0, 0, 30],
+    # generate evenly spaced bins by increments of 250
     series=250,
+    # use red3 as color fill for the bars
     fill="red3",
+    # define the frame, add title and set background color to
+    # lightgray, add annotations for x and y axis
     frame=[
         'WSne+t"Histograms"+glightgray',
         'x+l"Topography (m)"',
         'y+l"Frequency"+u" %"',
     ],
+    # use a pen size of 1p to draw the outlines
     pen="1p",
+    # choose histogram type 1 = frequency_percent
     type=1,
 )
 

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -19,7 +19,7 @@ fig.histogram(
     # define the frame, add title and set background color to
     # lightgray, add annotations for x and y axis
     frame=[
-        'WSne+t"Histograms"+glightgray',
+        'WSne+t"Histogram"+glightgray',
         'x+l"Topography (m)"',
         'y+l"Frequency"+u" %"',
     ],

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -21,13 +21,13 @@ fig = pygmt.Figure()
 
 fig.histogram(
     table=data,
+    # define the frame, add title and set background color to
+    # lightgray, add annotations for x and y axis
+    frame=['WSne+t"Histogram"+glightgray', 'x+l"Elevation (m)"', 'y+l"Counts"'],
     # generate evenly spaced bins by increments of 5
     series=5,
     # use red3 as color fill for the bars
     fill="red3",
-    # define the frame, add title and set background color to
-    # lightgray, add annotations for x and y axis
-    frame=['WSne+t"Histogram"+glightgray', 'x+l"Elevation (m)"', 'y+l"Counts"'],
     # use a pen size of 1p to draw the outlines
     pen="1p",
     # choose histogram type 0 = counts [default]

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -9,10 +9,10 @@ import pygmt
 
 np.random.seed(100)
 
-# generate example topography data
-mu = 100  # mean of distribution
-sigma = 25  # standard deviation of distribution
-data = mu + sigma * np.random.randn(521)
+# generate random elevation data from a normal distribution
+mean = 100  # mean of distribution
+stddev = 25  # standard deviation of distribution
+data = mean + stddev * np.random.randn(521)
 
 fig = pygmt.Figure()
 
@@ -24,7 +24,7 @@ fig.histogram(
     fill="red3",
     # define the frame, add title and set background color to
     # lightgray, add annotations for x and y axis
-    frame=['WSne+t"Histogram"+glightgray', 'x+l"Topography (m)"', 'y+l"Counts"'],
+    frame=['WSne+t"Histogram"+glightgray', 'x+l"Elevation (m)"', 'y+l"Counts"'],
     # use a pen size of 1p to draw the outlines
     pen="1p",
     # choose histogram type 0 = counts [default]

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -2,6 +2,9 @@
 Histogram
 ---------
 The :meth:`pygmt.Figure.histogram` method can plot regular histograms.
+Using the ``series`` parameter allows to set the interval for the width of
+each bar. The type of histogram can be selected via the ``histtype``
+parameter.
 """
 
 import numpy as np

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -4,29 +4,31 @@ Histogram
 The :meth:`pygmt.Figure.histogram` method can plot regular histograms.
 """
 
+import numpy as np
 import pygmt
+
+np.random.seed(100)
+
+# generate example topography data
+mu = 100  # mean of distribution
+sigma = 25  # standard deviation of distribution
+data = mu + sigma * np.random.randn(521)
 
 fig = pygmt.Figure()
 
 fig.histogram(
-    table="@v3206_06.txt",
-    # specify the "region" of interest [xmin, xmax, ymin, ymax]
-    region=[-6000, 0, 0, 30],
-    # generate evenly spaced bins by increments of 250
-    series=250,
+    table=data,
+    # generate evenly spaced bins by increments of 5
+    series=5,
     # use red3 as color fill for the bars
     fill="red3",
     # define the frame, add title and set background color to
     # lightgray, add annotations for x and y axis
-    frame=[
-        'WSne+t"Histogram"+glightgray',
-        'x+l"Topography (m)"',
-        'y+l"Frequency"+u" %"',
-    ],
+    frame=['WSne+t"Histogram"+glightgray', 'x+l"Topography (m)"', 'y+l"Frequency"'],
     # use a pen size of 1p to draw the outlines
     pen="1p",
-    # choose histogram type 1 = frequency_percent
-    type=1,
+    # choose histogram type 1 = counts [default]
+    type=0,
 )
 
 fig.show()

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -24,10 +24,10 @@ fig.histogram(
     fill="red3",
     # define the frame, add title and set background color to
     # lightgray, add annotations for x and y axis
-    frame=['WSne+t"Histogram"+glightgray', 'x+l"Topography (m)"', 'y+l"Frequency"'],
+    frame=['WSne+t"Histogram"+glightgray', 'x+l"Topography (m)"', 'y+l"Counts"'],
     # use a pen size of 1p to draw the outlines
     pen="1p",
-    # choose histogram type 1 = counts [default]
+    # choose histogram type 0 = counts [default]
     type=0,
 )
 

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -28,7 +28,7 @@ fig.histogram(
     # use a pen size of 1p to draw the outlines
     pen="1p",
     # choose histogram type 0 = counts [default]
-    type=0,
+    histtype=0,
 )
 
 fig.show()

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -8,12 +8,18 @@ import pygmt
 
 fig = pygmt.Figure()
 
-fig.histogram(table = "@v3206_06.txt", 
-              region = [-6000,0,0,30],
-              series= 250, 
-              fill="red3", 
-              frame = ['WSne+t"Histograms"+glightgray','x+l"Topography (m)"', 'y+l"Frequency"+u" %"'], 
-              pen = "1p",
-              type = 1)
+fig.histogram(
+    table="@v3206_06.txt",
+    region=[-6000, 0, 0, 30],
+    series=250,
+    fill="red3",
+    frame=[
+        'WSne+t"Histograms"+glightgray',
+        'x+l"Topography (m)"',
+        'y+l"Frequency"+u" %"',
+    ],
+    pen="1p",
+    type=1,
+)
 
 fig.show()

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -3,8 +3,8 @@ Histogram
 ---------
 The :meth:`pygmt.Figure.histogram` method can plot regular histograms.
 Using the ``series`` parameter allows to set the interval for the width of
-each bar. The type of histogram can be selected via the ``histtype``
-parameter.
+each bar. The type of histogram (frequency count or percentage) can be
+selected via the ``histtype`` parameter.
 """
 
 import numpy as np

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -1,0 +1,19 @@
+"""
+Histogram
+---------
+The :meth:`pygmt.Figure.histogram` method can plot regular histograms.
+"""
+
+import pygmt
+
+fig = pygmt.Figure()
+
+fig.histogram(table = "@v3206_06.txt", 
+              region = [-6000,0,0,30],
+              series= 250, 
+              fill="red3", 
+              frame = ['WSne+t"Histograms"+glightgray','x+l"Topography (m)"', 'y+l"Frequency"+u" %"'], 
+              pen = "1p",
+              type = 1)
+
+fig.show()


### PR DESCRIPTION
**Description of proposed changes**

Since **histogram** is now wrapped, here's a corresponding gallery example.

**Preview** at https://pygmt-git-gallery-histogram-gmt.vercel.app/gallery/histograms/histogram.html

![Histogram gallery example](https://pygmt-git-gallery-histogram-gmt.vercel.app/_images/sphx_glr_histogram_001.png)

I guess we should also add the **v3206_06.txt** remote file to the cache data, right?


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
