### PR TITLE
Conda install gmt dev version directly in one step instead of two

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -66,8 +66,8 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          conda install -c conda-forge/label/dev gmt=6.2.0rc1
-          conda install numpy pandas xarray netCDF4 packaging \
+          conda install conda-forge/label/dev::gmt=6.2.0rc1 \
+                        numpy pandas xarray netCDF4 packaging \
                         ipython make myst-parser \
                         sphinx sphinx-copybutton sphinx-gallery sphinx_rtd_theme
 

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -89,8 +89,8 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          conda install -c conda-forge/label/dev gmt=6.2.0rc1
-          conda install numpy=${{ matrix.numpy-version }} \
+          conda install conda-forge/label/dev::gmt=6.2.0rc1 \
+                        numpy=${{ matrix.numpy-version }} \
                         pandas xarray netCDF4 packaging \
                         ${{ matrix.optional-packages }} \
                         codecov coverage[toml] dvc ipython make \


### PR DESCRIPTION
**Description of proposed changes**

See if the dependency resolver works better if we install GMT dev and NumPy et al. directly in one `conda install` step, instead of having a two step process. Helps to resolve the conda dependency resolver issue reported in #1278.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1278 :crossed_fingers:, Patches #1218

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
