### PR TITLE
Fix two sphinx warnings for docs build

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -744,7 +744,7 @@ class Session:
         first. Use ``family='GMT_IS_DATASET|GMT_VIA_VECTOR'``.
 
         Not at all numpy dtypes are supported, only: float64, float32, int64,
-        int32, uint64, uint32, datetime64 and str_.
+        int32, uint64, uint32, datetime64 and str.
 
         .. warning::
             The numpy array must be C contiguous in memory. If it comes from a

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -734,7 +734,7 @@ class Session:
         return self[DTYPES[array.dtype.type]]
 
     def put_vector(self, dataset, column, vector):
-        """
+        r"""
         Attach a numpy 1D array as a column on a GMT dataset.
 
         Use this function to attach numpy array data to a GMT dataset and pass

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -744,7 +744,7 @@ class Session:
         first. Use ``family='GMT_IS_DATASET|GMT_VIA_VECTOR'``.
 
         Not at all numpy dtypes are supported, only: float64, float32, int64,
-        int32, uint64, uint32, datetime64 and str.
+        int32, uint64, uint32, datetime64 and str\_.
 
         .. warning::
             The numpy array must be C contiguous in memory. If it comes from a

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -56,7 +56,7 @@ def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
     {B}
     position : str
         [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\
-        **+w**\ *length*\ [**+j**\ *justify*]\ [**+al**\ \|\ **r**]\
+        **+w**\ *length*\ [**+j**\ *justify*]\ [**+al**\|\ **r**]\
         [**+o**\ *dx*\ [/*dy*]][**+l**\ [*label*]].
         Defines the reference point on the map for the vertical scale bar.
     color : str

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -56,7 +56,7 @@ def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
     {B}
     position : str
         [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\
-        **+w**\ *length*\ [**+j**\ *justify*]\ [**+al**\ |\ **r**]\
+        **+w**\ *length*\ [**+j**\ *justify*]\ [**+al**\ \|\ **r**]\
         [**+o**\ *dx*\ [/*dy*]][**+l**\ [*label*]].
         Defines the reference point on the map for the vertical scale bar.
     color : str


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes two warnings generated when building the docs:
```
pygmt/pygmt/src/wiggle.py:docstring of pygmt.src.wiggle.wiggle:54: WARNING: Inline substitution_reference start-string without end-string.
pygmt/pygmt/clib/session.py:docstring of pygmt.clib.session.Session.put_vector:9: WARNING: Unknown target name: "str".
```


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
