### PR TITLE
Add common alias spacing (-I) for specifying grid increments

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -40,7 +40,7 @@ COMMON_OPTIONS = {
         color : str or 1d array
             Select color or pattern for filling of symbols or polygons. Default
             is no fill.""",
-    "I": """\
+    "I": r"""\
         spacing : str
             *xinc*\ [**+e**\|\ **n**][/\ *yinc*\ [**+e**\|\ **n**]].
             *x_inc* [and optionally *y_inc*] is the grid spacing.

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -40,6 +40,37 @@ COMMON_OPTIONS = {
         color : str or 1d array
             Select color or pattern for filling of symbols or polygons. Default
             is no fill.""",
+    "I": """\
+        spacing : str
+            *xinc*\ [**+e**\|\ **n**][/\ *yinc*\ [**+e**\|\ **n**]].
+            *x_inc* [and optionally *y_inc*] is the grid spacing.
+
+            - **Geographical (degrees) coordinates**: Optionally, append an
+              increment unit. Choose among **m** to indicate arc minutes or
+              **s** to indicate arc seconds. If one of the units **e**, **f**,
+              **k**, **M**, **n** or **u** is appended instead, the increment
+              is assumed to be given in meter, foot, km, mile, nautical mile or
+              US survey foot, respectively, and will be converted to the
+              equivalent degrees longitude at the middle latitude of the region
+              (the conversion depends on :gmt-term:`PROJ_ELLIPSOID`). If
+              *y_inc* is given but set to 0 it will be reset equal to *x_inc*;
+              otherwise it will be converted to degrees latitude.
+
+            - **All coordinates**: If **+e** is appended then the corresponding
+              max *x* (*east*) or *y* (*north*) may be slightly adjusted to fit
+              exactly the given increment [by default the increment may be
+              adjusted slightly to fit the given domain]. Finally, instead of
+              giving an increment you may specify the *number of nodes* desired
+              by appending **+n** to the supplied integer argument; the
+              increment is then recalculated from the number of nodes, the
+              *registration*, and the domain. The resulting increment value
+              depends on whether you have selected a gridline-registered or
+              pixel-registered grid; see :gmt-docs:`GMT File Formats
+              <cookbook/file-formats.html#gmt-file-formats>` for details.
+
+            **Note**: If ``region=grdfile`` is used then the grid spacing and
+            the registration have already been initialized; use ``spacing`` and
+            ``registration`` to override these values.""",
     "V": """\
         verbose : bool or str
             Select verbosity level [Default is **w**], which modulates the messages

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -40,7 +40,7 @@ COMMON_OPTIONS = {
         color : str or 1d array
             Select color or pattern for filling of symbols or polygons. Default
             is no fill.""",
-    "I": r"""\
+    "I": r"""
         spacing : str
             *xinc*\ [**+e**\|\ **n**][/\ *yinc*\ [**+e**\|\ **n**]].
             *x_inc* [and optionally *y_inc*] is the grid spacing.

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -100,10 +100,7 @@ def blockmean(table, outfile=None, **kwargs):
         elevation) values in the first three columns, or a file name to an
         ASCII data table.
 
-    spacing : str
-        *xinc*\[\ *unit*\][**+e**\|\ **n**]
-        [/*yinc*\ [*unit*][**+e**\|\ **n**]].
-        *xinc* [and optionally *yinc*] is the grid spacing.
+    {I}
 
     region : str or list
         *xmin/xmax/ymin/ymax*\[\ **+r**\][**+u**\ *unit*].
@@ -161,10 +158,7 @@ def blockmedian(table, outfile=None, **kwargs):
         elevation) values in the first three columns, or a file name to an
         ASCII data table.
 
-    spacing : str
-        *xinc*\[\ *unit*\][**+e**\|\ **n**]
-        [/*yinc*\ [*unit*][**+e**\|\ **n**]].
-        *xinc* [and optionally *yinc*] is the grid spacing.
+    {I}
 
     region : str or list
         *xmin/xmax/ymin/ymax*\[\ **+r**\][**+u**\ *unit*].

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -97,10 +97,7 @@ def grdfilter(grid, **kwargs):
         5: grid (x,y) in Mercator ``projection='m1'`` img units, *width* in km,
         Spherical distance calculation.
 
-    spacing : str
-        *xinc*\[\ *unit*\][**+e**\|\ **n**]
-        [/*yinc*\ [*unit*][**+e**\|\ **n**]].
-        *xinc* [and optionally *yinc*] is the grid spacing.
+    {I}
     nans : str or float
         **i**\|\ **p**\|\ **r**.
         Determine how NaN-values in the input grid affects the filtered output.

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -54,10 +54,7 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
     data : str or 2d array
         Either a data file name or a 2d numpy array with the tabular data.
 
-    spacing : str
-        *xinc*\[\ *unit*\][**+e**\|\ **n**]\
-        [/*yinc*\ [*unit*][**+e**\|\ **n**]].
-        *xinc* [and optionally *yinc*] is the grid spacing.
+    {I}
 
     region : str or list
         *xmin/xmax/ymin/ymax*\[**+r**][**+u**\ *unit*].


### PR DESCRIPTION
**Description of proposed changes**

Used to specify the grid spacing. See also [https://github.com/GenericMappingTools/gmt/blob/6.2.0rc1/doc/rst/source/explain_-I.rst_](https://github.com/GenericMappingTools/gmt/blob/6.2.0rc1/doc/rst/source/explain_-I.rst_)

**Preview** at https://pygmt-git-common-aliases-spacing-gmt.vercel.app/api/generated/pygmt.surface.html

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This PR expands and standardizes the spacing (-I) parameter's docstring in `blockmean`, `blockmedian`, `grdfilter` and `surface`. The `{I}` common option will also be useful for many future PyGMT modules according to  https://github.com/GenericMappingTools/pygmt/pull/1273/files#r637586300:

- [x] blockmean
- [x] blockmedian
- [ ] blockmode
- [ ] gmtbinstats
- [ ] grdblend
- [x] grdfilter (#616)
- [ ] grdlandmask (#1273)
- [ ] grdmask
- [ ] grdmath
- [ ] grdsample
- [ ] mask_common_
- [ ] nearneighbor
- [ ] sph2grd
- [ ] sphdistance
- [ ] sphinterpolate
- [ ] supplements/geodesy/earthtide
- [ ] supplements/geodesy/gpsgridder
- [ ] supplements/potential/grdgravmag3d
- [ ] supplements/potential/grdseamount
- [ ] supplements/potential/talwani3d
- [ ] supplements/spotter/grdspotter
- [ ] supplements/spotter/hotspotter
- [ ] supplements/spotter/polespotter
- [x] surface
- [ ] triangulate (#731)
- [ ] xyz2grd (#636)


<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
