### PR TITLE
Bump GMT version from 6.2.0rc1 to 6.2.0rc2 in CI

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -26,7 +26,7 @@ jobs:
 
       # Install GMT
       - name: Install GMT
-        run: conda install -c conda-forge gmt=6.1.1
+        run: conda install -c conda-forge/label/dev gmt=6.2.0rc2
 
       # Download remote files
       - name: Download remote data

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -66,7 +66,7 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          conda install conda-forge/label/dev::gmt=6.2.0rc1 \
+          conda install conda-forge/label/dev::gmt=6.2.0rc2 \
                         numpy pandas xarray netCDF4 packaging \
                         ipython make myst-parser \
                         sphinx sphinx-copybutton sphinx-gallery sphinx_rtd_theme

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -52,7 +52,7 @@ jobs:
             optional-packages: ''
           - python-version: 3.9
             numpy-version: '1.20'
-            optional-packages: 'geopandas'
+            optional-packages: ''  # 'geopandas'
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -89,7 +89,7 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          conda install conda-forge/label/dev::gmt=6.2.0rc1 \
+          conda install conda-forge/label/dev::gmt=6.2.0rc2 \
                         numpy=${{ matrix.numpy-version }} \
                         pandas xarray netCDF4 packaging \
                         ${{ matrix.optional-packages }} \

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -83,7 +83,7 @@ jobs:
       # Install dependencies from conda-forge
       - name: Install dependencies
         run: |
-          conda install ninja cmake libblas libcblas liblapack fftw gdal \
+          conda install ninja cmake libblas libcblas liblapack fftw gdal=3.2 geopandas \
                         ghostscript libnetcdf hdf5 zlib curl pcre make dvc
           pip install --pre numpy pandas xarray netCDF4 packaging \
                             ipython pytest-cov pytest-mpl pytest>=6.0 sphinx-gallery

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
     # Required dependencies
     - pip
-    - gmt=6.2.0rc1
+    - gmt=6.2.0rc2
     - numpy>=1.17
     - pandas
     - xarray


### PR DESCRIPTION
**Description of proposed changes**

Second release candidate of Generic Mapping Tools v6.2.0 at https://github.com/GenericMappingTools/gmt/releases/tag/6.2.0rc2.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Note**: This PR also temporarily stops `geopandas` from being installed in the main test suite, see https://github.com/GenericMappingTools/pygmt/pull/1290#issuecomment-847495768 for the rationale.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Related to #1289, Supersedes #1218


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
