### PR TITLE
Update fig.text baseline images for GMT 6.2.0rc2

### DIFF
--- a/pygmt/tests/baseline/test_text_angle_30.png.dvc
+++ b/pygmt/tests/baseline/test_text_angle_30.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: ecd7b400f7421d0f9d65879f798be3aa
-  size: 5485
+- md5: a21fa8f14cf1df1e38763395a1b372b5
+  size: 5737
   path: test_text_angle_30.png

--- a/pygmt/tests/baseline/test_text_angle_font_justify_from_textfile.png.dvc
+++ b/pygmt/tests/baseline/test_text_angle_font_justify_from_textfile.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 67773d5e56bd3d8a9afda23551f24793
-  size: 14146
+- md5: c812717ca530830ca390584d4fe365eb
+  size: 9353
   path: test_text_angle_font_justify_from_textfile.png

--- a/pygmt/tests/baseline/test_text_fill.png.dvc
+++ b/pygmt/tests/baseline/test_text_fill.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 81c49d2f653288ac23937a8a91802ff3
-  size: 1918
+- md5: a58064918d13b2cb5a24c25e8302f6b5
+  size: 2001
   path: test_text_fill.png

--- a/pygmt/tests/baseline/test_text_font_bold.png.dvc
+++ b/pygmt/tests/baseline/test_text_font_bold.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 55875debfe049cc8b9fed9012ab0cde7
-  size: 1346
+- md5: f0c7a49ec4ca5b8f669c44f65394b350
+  size: 1435
   path: test_text_font_bold.png

--- a/pygmt/tests/baseline/test_text_input_multiple_filenames.png.dvc
+++ b/pygmt/tests/baseline/test_text_input_multiple_filenames.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: ad2ebff32ed5559c165767427ad974cb
-  size: 32675
+- md5: f9133bc3452f2c51d1ba595589a874e6
+  size: 28788
   path: test_text_input_multiple_filenames.png

--- a/pygmt/tests/baseline/test_text_input_remote_filename.png.dvc
+++ b/pygmt/tests/baseline/test_text_input_remote_filename.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 3dcfb0403ab740ea59b6633af1d466d3
-  size: 48909
+- md5: 25473909b2d8d9c86cd19b1682fea87e
+  size: 42700
   path: test_text_input_remote_filename.png

--- a/pygmt/tests/baseline/test_text_input_single_filename.png.dvc
+++ b/pygmt/tests/baseline/test_text_input_single_filename.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 0d4bb86bb215dc668954cd0f797b0112
-  size: 30750
+- md5: 10aca164308b4653643ac4511f8d9e02
+  size: 26937
   path: test_text_input_single_filename.png

--- a/pygmt/tests/baseline/test_text_justify_bottom_right_and_top_left.png.dvc
+++ b/pygmt/tests/baseline/test_text_justify_bottom_right_and_top_left.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: de441a55342a02fd9a72dfb4e26b1e4f
-  size: 4665
+- md5: 996c32e4a0496ba7057905670b45bf36
+  size: 4886
   path: test_text_justify_bottom_right_and_top_left.png

--- a/pygmt/tests/baseline/test_text_justify_parsed_from_textfile.png.dvc
+++ b/pygmt/tests/baseline/test_text_justify_parsed_from_textfile.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 5933108dbec4e66903180fec744128fb
-  size: 11229
+- md5: 5e2c9457993e3fde8340e69b5d1a1f5b
+  size: 10567
   path: test_text_justify_parsed_from_textfile.png

--- a/pygmt/tests/baseline/test_text_multiple_lines_of_text.png.dvc
+++ b/pygmt/tests/baseline/test_text_multiple_lines_of_text.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 680b7683044d4a4dced2fa7ef6b224f3
-  size: 6016
+- md5: f6d3dffdb9a873c414f381a1434dfccd
+  size: 6128
   path: test_text_multiple_lines_of_text.png

--- a/pygmt/tests/baseline/test_text_nonstr_text.png.dvc
+++ b/pygmt/tests/baseline/test_text_nonstr_text.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 33281f8b69dabad053c3031e17b0680b
-  size: 17998
+- md5: 182422ec2319098a82daa29d6d8009e0
+  size: 12659
   path: test_text_nonstr_text.png

--- a/pygmt/tests/baseline/test_text_pen.png.dvc
+++ b/pygmt/tests/baseline/test_text_pen.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 0fa24792c277718f44e6468a699921a0
-  size: 2469
+- md5: 3badbac89878d8144e449bfa2846b76b
+  size: 2594
   path: test_text_pen.png

--- a/pygmt/tests/baseline/test_text_position.png.dvc
+++ b/pygmt/tests/baseline/test_text_position.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 3463b1217b0d1aca2913cbcb9b0ca438
-  size: 10583
+- md5: 6c106e25a9e273e39498748e03ca85cd
+  size: 6267
   path: test_text_position.png

--- a/pygmt/tests/baseline/test_text_position_offset_with_line.png.dvc
+++ b/pygmt/tests/baseline/test_text_position_offset_with_line.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: e5645d25873e31c750e6642a63a6d47d
-  size: 11577
+- md5: fb8201292ca95fd84c2c33f933d4d066
+  size: 7213
   path: test_text_position_offset_with_line.png

--- a/pygmt/tests/baseline/test_text_round_clearance.png.dvc
+++ b/pygmt/tests/baseline/test_text_round_clearance.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: ad64e7cba2c3f776a8786fd551063489
-  size: 3558
+- md5: dc3f82e1b5889c1c7ecf7ae03d333ab3
+  size: 3643
   path: test_text_round_clearance.png

--- a/pygmt/tests/baseline/test_text_single_line_of_text.png.dvc
+++ b/pygmt/tests/baseline/test_text_single_line_of_text.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 3f3874c252ee2cefc3f9a2c29f46b8e3
-  size: 1839
+- md5: 357038279799ac60f4106107cda36f05
+  size: 1908
   path: test_text_single_line_of_text.png

--- a/pygmt/tests/baseline/test_text_transparency.png.dvc
+++ b/pygmt/tests/baseline/test_text_transparency.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: c2fd156325a40e9d875edfd6d236002e
-  size: 24535
+- md5: 0ba04d2715ef2fcdca352a47a1b4c661
+  size: 18078
   path: test_text_transparency.png

--- a/pygmt/tests/baseline/test_text_varying_transparency.png.dvc
+++ b/pygmt/tests/baseline/test_text_varying_transparency.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 5e867b4473cd9d1063ad5a08253e031c
-  size: 24775
+- md5: bd7e829612bb9168609f37e0cb54f808
+  size: 18254
   path: test_text_varying_transparency.png


### PR DESCRIPTION
**Description of proposed changes**

Fix broken tests on GMT 6.2.0rc2 for `fig.text`. This corrects the false positive passing tests due to #1242.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #1289.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
