### PR TITLE
Add projection and region to grdview docstring

### DIFF
--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -58,6 +58,7 @@ def grdview(self, grid, **kwargs):
     grid : str or xarray.DataArray
         The file name of the input relief grid or the grid loaded as a
         DataArray.
+    {R}
     {J}
     zscale/zsize : float or str
         Set z-axis scaling or z-axis size.

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -58,7 +58,12 @@ def grdview(self, grid, **kwargs):
     grid : str or xarray.DataArray
         The file name of the input relief grid or the grid loaded as a
         DataArray.
-    {R}
+    region : str or list
+        *xmin/xmax/ymin/ymax*\ [**+r**][**+u**\ *unit*].
+        Specify the :doc:`region </tutorials/regions>` of interest. When used
+        with ``perspective``, optionally append */zmin/zmax* to indicate the
+        range to use for the 3-D axes [Default is the region in the input
+        grid].
     {J}
     zscale/zsize : float or str
         Set z-axis scaling or z-axis size.

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -58,6 +58,7 @@ def grdview(self, grid, **kwargs):
     grid : str or xarray.DataArray
         The file name of the input relief grid or the grid loaded as a
         DataArray.
+    {J}
     zscale/zsize : float or str
         Set z-axis scaling or z-axis size.
     {B}


### PR DESCRIPTION
**Description of proposed changes**

The `projection` parameter is included in the list of aliases but not the docstring for grdview. This PR adds the projection description to the docstring.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
