### PR TITLE
Remove xfails on grdimage test for GMT 6.2.0rc2

### DIFF
--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -1,19 +1,13 @@
 """
 Test Figure.grdimage.
 """
-import sys
-
 import numpy as np
 import pytest
 import xarray as xr
-from packaging.version import Version
-from pygmt import Figure, clib
+from pygmt import Figure
 from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers.testing import check_figures_equal
-
-with clib.Session() as _lib:
-    gmt_version = Version(_lib.info["version"])
 
 
 @pytest.fixture(scope="module", name="grid")
@@ -82,14 +76,6 @@ def test_grdimage_file():
     return fig
 
 
-@pytest.mark.skipif(
-    gmt_version <= Version("6.1.1") and sys.platform == "darwin",
-    reason="Upstream bug in GMT 6.1.1 that causes segfault on macOS",
-)
-@pytest.mark.xfail(
-    condition=gmt_version <= Version("6.1.1") and sys.platform != "darwin",
-    reason="Upstream bug in GMT 6.1.1 that causes this test to fail on Linux/Windows",
-)
 @check_figures_equal()
 @pytest.mark.parametrize(
     "shading",


### PR DESCRIPTION
**Description of proposed changes**

Since `test_grdimage_shading_xarray` runs properly in GMT 6.2.0, the expected failure (xfail) marker can be removed.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #1289, xref #668


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
