### PR TITLE
Remove xfails on solar and velo tests for GMT 6.2.0rc2

### DIFF
--- a/pygmt/tests/test_solar.py
+++ b/pygmt/tests/test_solar.py
@@ -112,10 +112,6 @@ def test_invalid_datetime():
         )
 
 
-@pytest.mark.xfail(
-    reason="Flaky test only passes with pytest on single module"
-    "See https://github.com/GenericMappingTools/pygmt/issues/1242"
-)
 @pytest.mark.mpl_image_compare(filename="test_solar_set_terminator_datetime.png")
 def test_solar_default_terminator():
     """

--- a/pygmt/tests/test_velo.py
+++ b/pygmt/tests/test_velo.py
@@ -26,10 +26,6 @@ def fixture_dataframe():
     )
 
 
-@pytest.mark.xfail(
-    reason="Flaky test only passes with pytest on single module"
-    "See https://github.com/GenericMappingTools/pygmt/issues/1242"
-)
 @pytest.mark.mpl_image_compare
 def test_velo_numpy_array_numeric_only(dataframe):
     """
@@ -67,10 +63,6 @@ def test_velo_without_spec(dataframe):
         fig.velo(data=dataframe)
 
 
-@pytest.mark.xfail(
-    reason="Flaky test only passes with pytest on single module"
-    "See https://github.com/GenericMappingTools/pygmt/issues/1242"
-)
 @pytest.mark.mpl_image_compare
 def test_velo_pandas_dataframe(dataframe):
     """


### PR DESCRIPTION
Per #1289, this removes the `xfail` decorators from 2 tests that are no longer needed.



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
