### PR TITLE
Figure.plot: Deprecate parameter "columns" to "incols" (remove in v0.6.0)

### DIFF
--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -193,12 +193,7 @@ def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
     {a}
     {c}
     {f}
-    incols : str or 1d array
-        Choose which columns are x, y, color, and size, respectively if
-        input is provided via *data*. E.g. ``incols = [0, 1]`` or
-        ``incols = '0,1'`` if the *x* values are stored in the first
-        column and *y* values in the second one. Note: zero-based
-        indexing is used.
+    {i}
     label : str
         Add a legend entry for the symbol or line being plotted.
 

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -36,7 +36,7 @@ from pygmt.helpers import (
     Y="yshift",
     Z="zvalue",
     a="aspatial",
-    i="columns",
+    i="incols",
     l="label",
     c="panel",
     f="coltypes",
@@ -45,6 +45,7 @@ from pygmt.helpers import (
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 @deprecate_parameter("sizes", "size", "v0.4.0", remove_version="v0.6.0")
+@deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
 def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
     r"""
     Plot lines, polygons, and symbols in 2-D.
@@ -192,10 +193,10 @@ def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
     {a}
     {c}
     {f}
-    columns : str or 1d array
+    incols : str or 1d array
         Choose which columns are x, y, color, and size, respectively if
-        input is provided via *data*. E.g. ``columns = [0, 1]`` or
-        ``columns = '0,1'`` if the *x* values are stored in the first
+        input is provided via *data*. E.g. ``incols = [0, 1]`` or
+        ``incols = '0,1'`` if the *x* values are stored in the first
         column and *y* values in the second one. Note: zero-based
         indexing is used.
     label : str

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -15,6 +15,8 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
+@deprecate_parameter("sizes", "size", "v0.4.0", remove_version="v0.6.0")
+@deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
 @use_alias(
     A="straight_line",
     B="frame",
@@ -44,8 +46,6 @@ from pygmt.helpers import (
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
-@deprecate_parameter("sizes", "size", "v0.4.0", remove_version="v0.6.0")
-@deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
 def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
     r"""
     Plot lines, polygons, and symbols in 2-D.

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -309,8 +309,8 @@ def test_plot_matrix(data):
         projection="M15c",
         style="cc",
         color="#aaaaaa",
-        B="a",
-        columns="0,1,2+s0.005",
+        frame="a",
+        incols="0,1,2+s0.005",
     )
     return fig
 
@@ -327,7 +327,7 @@ def test_plot_matrix_color(data):
         projection="X10c",
         style="c0.5c",
         cmap="rainbow",
-        B="a",
+        frame="a",
     )
     return fig
 
@@ -345,7 +345,7 @@ def test_plot_from_file(region):
         style="d1c",
         color="yellow",
         frame=True,
-        columns=[0, 1],
+        incols=[0, 1],
     )
     return fig
 
@@ -453,7 +453,7 @@ def test_plot_datetime():
 @pytest.mark.mpl_image_compare(filename="test_plot_sizes.png")
 def test_plot_deprecate_sizes_to_size(data, region):
     """
-    Make sure that the old parameter "sizes" is supported and it reports an
+    Make sure that the old parameter "sizes" is supported and it reports a
     warning.
 
     Modified from the test_plot_sizes() test.
@@ -469,6 +469,29 @@ def test_plot_deprecate_sizes_to_size(data, region):
             style="cc",
             color="blue",
             frame="af",
+        )
+        assert len(record) == 1  # check that only one warning was raised
+    return fig
+
+
+@pytest.mark.mpl_image_compare(filename="test_plot_from_file.png")
+def test_plot_deprecate_columns_to_incols(region):
+    """
+    Make sure that the old parameter "columns" is supported and it reports a
+    warning.
+
+    Modified from the test_plot_from_file() test.
+    """
+    fig = Figure()
+    with pytest.warns(expected_warning=FutureWarning) as record:
+        fig.plot(
+            data=POINTS_DATA,
+            region=region,
+            projection="X10c",
+            style="d1c",
+            color="yellow",
+            frame=True,
+            columns=[0, 1],
         )
         assert len(record) == 1  # check that only one warning was raised
     return fig


### PR DESCRIPTION
**Description of proposed changes**

As discussed in #764, this PR replaces the **columns** parameter by **incols** for  Figure.plot().

- [x] Rename the parameter `columns` to `incols` in Figure.plot()
- [x] Updates tests and examples to use the new parameter name
- [x] Use the deprecate_parameter decorator for backward-compatibility
- [x] Add a test for checking 'columns' backward compatibility


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Write detailed docstrings for all functions/methods.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
