### PR TITLE
Add incols to COMMON_OPTIONS, blockmean, and blockmedian

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -118,6 +118,36 @@ COMMON_OPTIONS = {
             geographical data). Full documentation is at
             :gmt-docs:`gmt.html#f-full`.
          """,
+    "i": r"""
+        incols : str or 1d array
+            Specify data columns for primary input in arbitrary order. Columns
+            can be repeated and columns not listed will be skipped [Default
+            reads all columns in order, starting with the first (i.e., column
+            0)].
+
+            - For *1d array*: specify individual columns in input order (e.g.,
+              ``incols=[1,0]`` for the 2nd column followed by the 1st column).
+            - For :py:class:`str`: specify individual columns or column
+              ranges in the format *start*\ [:*inc*]:*stop*, where *inc*
+              defaults to 1 if not specified, with columns and/or column ranges
+              separated by commas (e.g., ``incols='0:2,4+l'`` to input the
+              first three columns followed by the log-transformed 5th column).
+              To read from a given column until the end of the record, leave
+              off *stop* when specifying the column range. To read trailing
+              text, add the column **t**. Append the word number to **t** to
+              ingest only a single word from the trailing text. Instead of
+              specifying columns, use ``incols='n'`` to simply read numerical
+              input and skip trailing text. Optionally, append one of the
+              following modifiers to any column or column range to transform
+              the input columns:
+
+                - **+l** to take the *log10* of the input values.
+                - **+d** to divide the input values by the factor *divisor*
+                  [default is 1].
+                - **+s** to multiple the input values by the factor *scale*
+                  [default is 1].
+                - **+o** to add the given *offset* to the input values [default
+                  is 0].""",
     "j": r"""
         distcalc : str
             **e**\|\ **f**\|\ **g**.

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -69,6 +69,7 @@ def _blockm(block_method, table, outfile, **kwargs):
     V="verbose",
     a="aspatial",
     f="coltypes",
+    i="incols",
     r="registration",
 )
 @kwargs_to_strings(R="sequence")
@@ -103,6 +104,7 @@ def blockmean(table, outfile=None, **kwargs):
 
     {V}
     {a}
+    {i}
     {f}
     {r}
 
@@ -126,6 +128,7 @@ def blockmean(table, outfile=None, **kwargs):
     V="verbose",
     a="aspatial",
     f="coltypes",
+    i="incols",
     r="registration",
 )
 @kwargs_to_strings(R="sequence")
@@ -161,6 +164,7 @@ def blockmedian(table, outfile=None, **kwargs):
     {V}
     {a}
     {f}
+    {i}
     {r}
 
     Returns


### PR DESCRIPTION
**Description of proposed changes**

This PR adds `incols` to `COMMON_OPTIONS` in decorators.py. The current version includes the full information from the GMT docs, but opinions are welcome if others think that 'Full documentation is at :gmt-docs:`gmt.html#the-i-option`' would be better than a complete description.

I added the alias to the pygmt/src/blockm.py methods to make reviewing easier, so that the description for incols can be reviewed using the vercel preview. I didn't add the common option to any other methods in order to keep the diff small.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #48.
Relates to #764 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
