### PR TITLE
Clarify position of deprecate_parameter decorator to be above use_alias

### DIFF
--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -173,21 +173,21 @@ When making incompatible changes, we should follow the process:
   3-12 months.
 - Remove the old usage and warning when reaching the declared version.
 
-To rename a function parameter, add the `@deprecated_parameter` decorator
-before the function definition (but after the `@use_alias` decorator if it exists).
-Here is an example:
+To rename a function parameter, add the `@deprecate_parameter` decorator near
+the top after the `@fmt_docstring` decorator but before the `@use_alias`
+decorator (if those two exists). Here is an example:
 
 ```
 @fmt_docstring
-@use_alias(J="projection", R="region", V="verbose")
-@kwargs_to_strings(R="sequence")
-@deprecate_parameter("sizes", "size", "v0.4.0", remove_version="v0.6.0")
+@deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
+@use_alias(J="projection", R="region", V="verbose", i="incols")
+@kwargs_to_strings(R="sequence", i='sequence_comma')
 def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
     pass
 ```
 
-In this case, the old parameter name `sizes` is deprecated since v0.4.0, and will be
-fully removed in v0.6.0. The new parameter name is `size`.
+In this case, the old parameter name `columns` is deprecated since v0.4.0, and
+will be fully removed in v0.6.0. The new parameter name is `incols`.
 
 
 ## Making a Release

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -505,7 +505,7 @@ def deprecate_parameter(oldname, newname, deprecate_version, remove_version):
     name, and users will receive a FutureWarning to inform them of the pending
     deprecation.
 
-    Use this decorator below the ``use_alias`` decorator.
+    Use this decorator above the ``use_alias`` decorator.
 
     Parameters
     ----------


### PR DESCRIPTION
**Description of proposed changes**

Need to move the `@deprecate_parameter` decorator to be before `@use_alias` but after `@fmt_docstring` so that the `@kwargs_to_strings` decorator can do its job properly.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

In code, it should look something like this.

```python
@fmt_docstring
@deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
@use_alias(J="projection", R="region", V="verbose", i="incols")
@kwargs_to_strings(R="sequence", i='sequence_comma')
def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
    pass
```

Explanation:

1. Rename 'columns' to 'incols' via `@deprecate_parameter`
2. Convert long alias 'incols' to GMT short alias 'i' via `@use_alias`
3. Let the list type argument `[0, 1]` be converted to str type `0,1` via `@kwargs_to_strings`
4. Pass in `-i0,1` to `lib.call_module("plot", ...)`

_Originally posted by @weiji14 in https://github.com/GenericMappingTools/pygmt/pull/1298#discussion_r640162801_

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses https://github.com/GenericMappingTools/pygmt/pull/1298#discussion_r640162801


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
