### PR TITLE
Figure.contour: Deprecate parameter "columns" to "incols" (remove in v0.6.0)

### DIFF
--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -7,6 +7,7 @@ from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     build_arg_string,
     data_kind,
+    deprecate_parameter,
     dummy_context,
     fmt_docstring,
     kwargs_to_strings,

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -15,6 +15,7 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
+@deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
 @use_alias(
     A="annotation",
     B="frame",
@@ -30,7 +31,7 @@ from pygmt.helpers import (
     X="xshift",
     Y="yshift",
     c="panel",
-    i="columns",
+    i="incols",
     l="label",
     p="perspective",
     t="transparency",
@@ -104,6 +105,7 @@ def contour(self, x=None, y=None, z=None, data=None, **kwargs):
     {V}
     {XY}
     {c}
+    {i}
     {p}
     {t}
     """

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -129,7 +129,7 @@ def test_contour_deprecate_columns_to_incols(region):
 
     # generate dataframe
     # switch x and y from here onwards to simulate different column order
-    data = np.array([[y], [x], [z]])
+    data = np.array([y, x, z])
     data = pd.DataFrame(data=data)
 
     with pytest.warns(expected_warning=FutureWarning) as record:

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -130,11 +130,11 @@ def test_contour_deprecate_columns_to_incols(region):
     # generate dataframe
     # switch x and y from here onwards to simulate different column order
     data = np.array([[y], [x], [z]])
-    df = pd.DataFrame(data=data)
+    data = pd.DataFrame(data=data)
 
     with pytest.warns(expected_warning=FutureWarning) as record:
         fig.contour(
-            data=df,
+            data=data,
             projection="X10c",
             region=region,
             frame="a",

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -107,3 +107,34 @@ def test_contour_from_file(region):
         data=POINTS_DATA, projection="X10c", region=region, frame="af", pen="#ffcb87"
     )
     return fig
+
+
+@pytest.mark.mpl_image_compare(filename="test_contour_vec.png")
+def test_contour_deprecate_columns_to_incols(region):
+    """
+    Make sure that the old parameter "columns" is supported and it reports an
+    warning.
+
+    Modified from the test_contour_vec() test.
+    """
+    fig = Figure()
+    x, y = np.meshgrid(
+        np.linspace(region[0], region[1]), np.linspace(region[2], region[3])
+    )
+    y = x.flatten()  # switch x and y here to simulate different column order
+    x = y.flatten()
+    z = (x - 0.5 * (region[0] + region[1])) ** 2 + 4 * y ** 2
+    z = np.exp(-z / 10 ** 2 * np.log(2))
+    with pytest.warns(expected_warning=FutureWarning) as record:
+        fig.contour(
+            x=x,
+            y=y,
+            z=z,
+            projection="X10c",
+            region=region,
+            frame="a",
+            pen=True,
+            columns=[1, 0, 2],
+        )
+        assert len(record) == 1  # check that only one warning was raised
+    return fig

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -6,7 +6,6 @@ import os
 from itertools import product
 
 import numpy as np
-import pandas as pd
 import pytest
 from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput
@@ -130,7 +129,6 @@ def test_contour_deprecate_columns_to_incols(region):
     # generate dataframe
     # switch x and y from here onwards to simulate different column order
     data = np.array([y, x, z]).T
-    data = pd.DataFrame(data=data)
 
     with pytest.warns(expected_warning=FutureWarning) as record:
         fig.contour(

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -121,9 +121,11 @@ def test_contour_deprecate_columns_to_incols(region):
     x, y = np.meshgrid(
         np.linspace(region[0], region[1]), np.linspace(region[2], region[3])
     )
-    y = x.flatten()  # switch x and y here to simulate different column order
+    y = (
+        x.flatten()
+    )  # switch x and y from here onwards to simulate different column order
     x = y.flatten()
-    z = (x - 0.5 * (region[0] + region[1])) ** 2 + 4 * y ** 2
+    z = (y - 0.5 * (region[0] + region[1])) ** 2 + 4 * x ** 2
     z = np.exp(-z / 10 ** 2 * np.log(2))
     with pytest.warns(expected_warning=FutureWarning) as record:
         fig.contour(

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -129,7 +129,7 @@ def test_contour_deprecate_columns_to_incols(region):
 
     # generate dataframe
     # switch x and y from here onwards to simulate different column order
-    data = np.array([y, x, z])
+    data = np.array([y, x, z]).T
     data = pd.DataFrame(data=data)
 
     with pytest.warns(expected_warning=FutureWarning) as record:

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -6,6 +6,7 @@ import os
 from itertools import product
 
 import numpy as np
+import pandas as pd
 import pytest
 from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput
@@ -121,17 +122,19 @@ def test_contour_deprecate_columns_to_incols(region):
     x, y = np.meshgrid(
         np.linspace(region[0], region[1]), np.linspace(region[2], region[3])
     )
-    y = (
-        x.flatten()
-    )  # switch x and y from here onwards to simulate different column order
-    x = y.flatten()
-    z = (y - 0.5 * (region[0] + region[1])) ** 2 + 4 * x ** 2
+    x = x.flatten()
+    y = y.flatten()
+    z = (x - 0.5 * (region[0] + region[1])) ** 2 + 4 * y ** 2
     z = np.exp(-z / 10 ** 2 * np.log(2))
+
+    # generate dataframe
+    # switch x and y from here onwards to simulate different column order
+    data = np.array([[y], [x], [z]])
+    df = pd.DataFrame(data=data)
+
     with pytest.warns(expected_warning=FutureWarning) as record:
         fig.contour(
-            x=x,
-            y=y,
-            z=z,
+            data=df,
             projection="X10c",
             region=region,
             frame="a",


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the `incols` parameter description to Figure.contour() and adds the deprecate_parameter decorator for backward-compatibility.

Fixes #1313.

- [x] Updates tests and examples to use the new parameter name
- [x] Use the deprecate_parameter decorator for backward-compatibility
- [x] Add a test for checking 'columns' backward compatibility


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Write detailed docstrings for all functions/methods.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
