### PR TITLE
Remove xfail on grdtrack tests for GMT 6.2.0

### DIFF
--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -35,7 +35,7 @@ def test_grdtrack_input_dataframe_and_dataarray(dataarray):
     output = grdtrack(points=dataframe, grid=dataarray, newcolname="bathymetry")
     assert isinstance(output, pd.DataFrame)
     assert output.columns.to_list() == ["longitude", "latitude", "bathymetry"]
-    npt.assert_allclose(output.iloc[0], [-110.9536, -42.2489, -2974.656296])
+    npt.assert_allclose(output.iloc[0], [-110.9536, -42.2489, -2790.488422])
 
     return output
 
@@ -52,7 +52,7 @@ def test_grdtrack_input_csvfile_and_dataarray(dataarray):
         assert os.path.exists(path=TEMP_TRACK)  # check that outfile exists at path
 
         track = pd.read_csv(TEMP_TRACK, sep="\t", header=None, comment=">")
-        npt.assert_allclose(track.iloc[0], [-110.9536, -42.2489, -2974.656296])
+        npt.assert_allclose(track.iloc[0], [-110.9536, -42.2489, -2790.488422])
     finally:
         os.remove(path=TEMP_TRACK)
 

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -25,7 +25,6 @@ def fixture_dataarray():
     )
 
 
-@pytest.mark.xfail(reason="The reason why it fails is unclear now")
 def test_grdtrack_input_dataframe_and_dataarray(dataarray):
     """
     Run grdtrack by passing in a pandas.DataFrame and xarray.DataArray as
@@ -41,7 +40,6 @@ def test_grdtrack_input_dataframe_and_dataarray(dataarray):
     return output
 
 
-@pytest.mark.xfail(reason="The reason why it fails is unclear now")
 def test_grdtrack_input_csvfile_and_dataarray(dataarray):
     """
     Run grdtrack by passing in a csvfile and xarray.DataArray as inputs.


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/GenericMappingTools/pygmt/issues/1309 for the issue report of an upstream bug. The bug was partially fixed in https://github.com/GenericMappingTools/gmt/pull/5283, by restricting bilinear interpolation when grdtrack is applied to an xarray.DataArray.

Now the two tests pass for GMT 6.2.0.

Fixes #1309

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
