### PR TITLE
Figure.rose: Deprecate parameter "columns" to "incols" (remove in v0.6.0)

### DIFF
--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -3,7 +3,13 @@ rose - Plot windrose diagrams or polar histograms.
 """
 
 from pygmt.clib import Session
-from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias, deprecate_parameter
+from pygmt.helpers import (
+    build_arg_string,
+    deprecate_parameter,
+    fmt_docstring,
+    kwargs_to_strings,
+    use_alias,
+)
 
 
 @fmt_docstring

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -3,10 +3,11 @@ rose - Plot windrose diagrams or polar histograms.
 """
 
 from pygmt.clib import Session
-from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias, deprecate_parameter
 
 
 @fmt_docstring
+@deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
 @use_alias(
     A="sector",
     B="frame",
@@ -108,12 +109,6 @@ def rose(self, length=None, azimuth=None, data=None, **kwargs):
          consideration, set them all to unity with ``scale = 'u'``
          [Default is no scaling].
 
-    columns : str or 1d array
-         Select input columns and transformations. E.g. choose
-         ``columns = [1, 0]`` or ``columns = '1,0'`` if the length values
-         are stored in the second column and the direction (azimuth)
-         values in the first one. Note: zero-based indexing is used.
-
     color : str
          Selects shade, color or pattern for filling the sectors [Default
          is no fill].
@@ -186,6 +181,7 @@ def rose(self, length=None, azimuth=None, data=None, **kwargs):
     {V}
     {XY}
     {c}
+    {i}
     {p}
     {t}
     """

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -36,7 +36,7 @@ from pygmt.helpers import (
     X="xshift",
     Y="yshift",
     Z="scale",
-    i="columns",
+    i="incols",
     c="panel",
     p="perspective",
     t="transparency",

--- a/pygmt/tests/test_rose.py
+++ b/pygmt/tests/test_rose.py
@@ -193,7 +193,7 @@ def test_rose_bools(data_fractures_compilation):
 @pytest.mark.mpl_image_compare(filename="test_rose_bools.png")
 def test_rose_deprecate_columns_to_incols(data_fractures_compilation):
     """
-    Make sure that the old parameter "columns" is supported and it reports an
+    Make sure that the old parameter "columns" is supported and it reports a
     warning.
 
     Modified from the test_rose_bools() test.

--- a/pygmt/tests/test_rose.py
+++ b/pygmt/tests/test_rose.py
@@ -38,7 +38,7 @@ def test_rose_data_file(data_fractures_compilation):
         diameter="5.5c",
         color="blue",
         frame=["x0.2g0.2", "y30g30", "+glightgray"],
-        columns=[1, 0],
+        incols=[1, 0],
         pen="1p",
         norm="",
         scale=0.4,
@@ -129,7 +129,7 @@ def test_rose_plot_with_transparency(data_fractures_compilation):
         diameter="5.5c",
         color="blue",
         frame=["x0.2g0.2", "y30g30", "+glightgray"],
-        columns=[1, 0],
+        incols=[1, 0],
         pen="1p",
         norm=True,
         scale=0.4,
@@ -151,7 +151,7 @@ def test_rose_no_sectors(data_fractures_compilation):
     fig.rose(
         data=data_fractures_compilation,
         region=[0, 500, 0, 360],
-        columns="1,0",
+        incols="1,0",
         diameter="10c",
         labels="180/0/90/270",
         frame=["xg100", "yg45", "+t'Windrose diagram'"],
@@ -176,7 +176,7 @@ def test_rose_bools(data_fractures_compilation):
         data=data_fractures_compilation,
         region=[0, 1, 0, 360],
         sector=10,
-        columns=[1, 0],
+        incols=[1, 0],
         diameter="10c",
         frame=["x0.2g0.2", "y30g30", "+glightgray"],
         color="red3",
@@ -187,4 +187,33 @@ def test_rose_bools(data_fractures_compilation):
         no_scale=True,
         shift=False,
     )
+    return fig
+
+
+@pytest.mark.mpl_image_compare(filename="test_rose_bools.png")
+def test_rose_deprecate_columns_to_incols(data_fractures_compilation):
+    """
+    Make sure that the old parameter "columns" is supported and it reports an
+    warning.
+
+    Modified from the test_rose_bools() test.
+    """
+    fig = Figure()
+    with pytest.warns(expected_warning=FutureWarning) as record:
+        fig.rose(
+            data=data_fractures_compilation,
+            region=[0, 1, 0, 360],
+            sector=10,
+            columns=[1, 0],
+            diameter="10c",
+            frame=["x0.2g0.2", "y30g30", "+glightgray"],
+            color="red3",
+            pen="1p",
+            orientation=False,
+            norm=True,
+            vectors=True,
+            no_scale=True,
+            shift=False,
+        )
+        assert len(record) == 1  # check that only one warning was raised
     return fig


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the deprecate_parameter decorator for backward-compatibility to Figure.rose().

- [x] Updates tests and examples to use the new parameter name
- [x] Use the deprecate_parameter decorator for backward-compatibility
- [x] Add a test for checking 'columns' backward compatibility


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Write detailed docstrings for all functions/methods.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
