### PR TITLE
Let Figure.savefig recommend .eps or .pdf when .ps extension is used

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -236,11 +236,12 @@ class Figure:
 
         prefix, ext = os.path.splitext(fname)
         ext = ext[1:]  # Remove the .
-        if ext == "ps":
-            raise GMTInvalidInput(
-                "Extension '.ps' is not supported. Please use '.eps' or '.pdf' instead."
-            )
         if ext not in fmts:
+            if ext == "ps":
+                raise GMTInvalidInput(
+                    "Extension '.ps' is not supported. "
+                    "Please use '.eps' or '.pdf' instead."
+                )
             raise GMTInvalidInput(f"Unknown extension '.{ext}'.")
         fmt = fmts[ext]
         if transparent:

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -236,13 +236,17 @@ class Figure:
 
         prefix, ext = os.path.splitext(fname)
         ext = ext[1:]  # Remove the .
-        if ext not in fmts:
-            raise GMTInvalidInput("Unknown extension '.{}'".format(ext))
+        if ext == "ps":
+            raise GMTInvalidInput(
+                "Extension '.ps' is not supported. Please use '.eps' or '.pdf' instead."
+            )
+        elif ext not in fmts:
+            raise GMTInvalidInput(f"Unknown extension '.{ext}'.")
         fmt = fmts[ext]
         if transparent:
             if fmt != "g":
                 raise GMTInvalidInput(
-                    "Transparency unavailable for '{}', only for png.".format(ext)
+                    f"Transparency unavailable for '{ext}', only for png."
                 )
             fmt = fmt.upper()
         if anti_alias:

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -240,7 +240,7 @@ class Figure:
             raise GMTInvalidInput(
                 "Extension '.ps' is not supported. Please use '.eps' or '.pdf' instead."
             )
-        elif ext not in fmts:
+        if ext not in fmts:
             raise GMTInvalidInput(f"Unknown extension '.{ext}'.")
         fmt = fmts[ext]
         if transparent:

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -74,7 +74,18 @@ def test_figure_savefig_unknown_extension():
     prefix = "test_figure_savefig_unknown_extension"
     fmt = "test"
     fname = ".".join([prefix, fmt])
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTInvalidInput, match="Unknown extension '.test'."):
+        fig.savefig(fname)
+
+
+def test_figure_savefig_ps_extension():
+    """
+    Check that an error is raised when .ps is specified.
+    """
+    fig = Figure()
+    fig.basemap(region="10/70/-300/800", projection="X3c/5c", frame="af")
+    fname = "test_figure_savefig_ps_extension.ps"
+    with pytest.raises(GMTInvalidInput, match="Extension '.ps' is not supported."):
         fig.savefig(fname)
 
 

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -80,7 +80,7 @@ def test_figure_savefig_unknown_extension():
 
 def test_figure_savefig_ps_extension():
     """
-    Check that an error is raised when .ps is specified.
+    Check that an error is raised when .ps extension is specified.
     """
     fig = Figure()
     fig.basemap(region="10/70/-300/800", projection="X3c/5c", frame="af")


### PR DESCRIPTION
**Description of proposed changes**

See #300 for the discussions.

'.ps' extension is not supported. When users request a '.ps' file, the old
`Unknown extension '.ps'` error message is not clear for GMT users.

This PR changes the error message to:
```
Extension '.ps' is not supported. Please use '.eps' or '.pdf' instead.
```

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #300.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
