### PR TITLE
Allow pygmt.which to accept a list of filenames as input

### DIFF
--- a/pygmt/src/which.py
+++ b/pygmt/src/which.py
@@ -2,11 +2,18 @@
 which - Find the full path to specified files.
 """
 from pygmt.clib import Session
-from pygmt.helpers import GMTTempFile, build_arg_string, fmt_docstring, use_alias
+from pygmt.helpers import (
+    GMTTempFile,
+    build_arg_string,
+    fmt_docstring,
+    kwargs_to_strings,
+    use_alias,
+)
 
 
 @fmt_docstring
 @use_alias(G="download", V="verbose")
+@kwargs_to_strings(fname="sequence_space")
 def which(fname, **kwargs):
     """
     Find the full path to specified files.
@@ -27,8 +34,8 @@ def which(fname, **kwargs):
 
     Parameters
     ----------
-    fname : str
-        The file name that you want to check.
+    fname : str or list
+        One or more file names of any data type (grids, tables, etc.).
     download : bool or str
         If the file is downloadable and not found, we will try to download the
         it. Use True or 'l' (default) to download to the current directory. Use
@@ -38,8 +45,8 @@ def which(fname, **kwargs):
 
     Returns
     -------
-    path : str
-        The path of the file, depending on the options used.
+    path : str or list
+        The path(s) to the file(s), depending on the options used.
 
     Raises
     ------
@@ -52,5 +59,6 @@ def which(fname, **kwargs):
             lib.call_module("which", arg_str)
         path = tmpfile.read().strip()
     if not path:
-        raise FileNotFoundError("File '{}' not found.".format(fname))
-    return path
+        _fname = fname.replace(" ", "', '")
+        raise FileNotFoundError(f"File(s) '{_fname}' not found.")
+    return path.split("\n") if "\n" in path else path

--- a/pygmt/tests/test_which.py
+++ b/pygmt/tests/test_which.py
@@ -10,7 +10,7 @@ from pygmt.helpers import unique_name
 
 def test_which():
     """
-    Make sure which returns file paths for @files correctly without errors.
+    Make sure `which` returns file paths for @files correctly without errors.
     """
     for fname in ["tut_quakes.ngdc", "tut_bathy.nc"]:
         cached_file = which(f"@{fname}", download="c")
@@ -20,7 +20,7 @@ def test_which():
 
 def test_which_multiple():
     """
-    Make sure which returns file paths for multiple @files correctly.
+    Make sure `which` returns file paths for multiple @files correctly.
     """
     filenames = ["ridge.txt", "tut_ship.xyz"]
     cached_files = which(fname=[f"@{fname}" for fname in filenames], download="c")
@@ -31,7 +31,7 @@ def test_which_multiple():
 
 def test_which_fails():
     """
-    which should fail with a FileNotFoundError.
+    Make sure `which` will fail with a FileNotFoundError.
     """
     bogus_file = unique_name()
     with pytest.raises(FileNotFoundError):

--- a/pygmt/tests/test_which.py
+++ b/pygmt/tests/test_which.py
@@ -18,6 +18,17 @@ def test_which():
         assert os.path.basename(cached_file) == fname
 
 
+def test_which_multiple():
+    """
+    Make sure which returns file paths for multiple @files correctly.
+    """
+    filenames = ["ridge.txt", "tut_ship.xyz"]
+    cached_files = which(fname=[f"@{fname}" for fname in filenames], download="c")
+    for cached_file in cached_files:
+        assert os.path.exists(cached_file)
+        assert os.path.basename(cached_file) in filenames
+
+
 def test_which_fails():
     """
     which should fail with a FileNotFoundError.
@@ -25,3 +36,5 @@ def test_which_fails():
     bogus_file = unique_name()
     with pytest.raises(FileNotFoundError):
         which(bogus_file)
+    with pytest.raises(FileNotFoundError):
+        which(fname=[f"{bogus_file}.nc", f"{bogus_file}.txt"])


### PR DESCRIPTION
**Description of proposed changes**

Let the fname parameter in `pygmt.which` accept list inputs. List of filenames are parsed using the `sequence_space` (see #325) and then passed into GMT C API as space delimited filenames. Also added a unit test to check that multi-file inputs work.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Use case for this is to download multiple files at once using `pygmt.which` without going through a for-loop, as in #1310.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses https://github.com/GenericMappingTools/pygmt/pull/1310#discussion_r642747438

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
