### PR TITLE
Add regression test for grdimage plotting an xarray.DataArray grid subset

### DIFF
--- a/pygmt/tests/baseline/test_grdimage_global_subset.png.dvc
+++ b/pygmt/tests/baseline/test_grdimage_global_subset.png.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 8f38333a67076f0125cb2d1828aa244e
+  size: 39288
+  path: test_grdimage_global_subset.png

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -154,7 +154,7 @@ def test_grdimage_global_subset(grid_360):
     GMT_GRID_IS_CARTESIAN). This is a regression test for
     https://github.com/GenericMappingTools/pygmt/issues/732.
     """
-    # Get a slice of South America and Africa only (lat=-90:31, lon -180:41)
+    # Get a slice of South America and Africa only (lat=-90:31, lon=-180:41)
     sliced_grid = grid_360[0:121, 0:221]
     assert sliced_grid.gmt.registration == 0  # gridline registration
     assert sliced_grid.gmt.gtype == 0  # Cartesian coordinate system

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -18,6 +18,18 @@ def fixture_grid():
     return load_earth_relief(registration="gridline")
 
 
+@pytest.fixture(scope="module", name="grid_360")
+def fixture_grid_360(grid):
+    """
+    Earth relief grid with longitude range from 0 to 360 (instead of -180 to
+    180).
+    """
+    _grid = grid.copy()  # get a copy of original earth_relief grid
+    _grid.encoding.pop("source")  # unlink earth_relief NetCDF source
+    _grid["lon"] = np.arange(0, 361, 1)  # convert longitude from -180:180 to 0:360
+    return _grid
+
+
 @pytest.fixture(scope="module", name="xrgrid")
 def fixture_xrgrid():
     """
@@ -128,6 +140,29 @@ def test_grdimage_over_dateline(xrgrid):
     assert xrgrid.gmt.registration == 0  # gridline registration
     xrgrid.gmt.gtype = 1  # geographic coordinate system
     fig.grdimage(grid=xrgrid, region="g", projection="A0/0/1c", V="i")
+    return fig
+
+
+@pytest.mark.mpl_image_compare
+def test_grdimage_global_subset(grid_360):
+    """
+    Ensure subsets of grids are plotted correctly on a global map.
+
+    Specifically checking that xarray.DataArray grids can wrap around the left
+    and right sides on a Mollweide projection (W) plot correctly. Note that a
+    Cartesian grid is used here instead of a Geographic grid (i.e.
+    GMT_GRID_IS_CARTESIAN). This is a regression test for
+    https://github.com/GenericMappingTools/pygmt/issues/732.
+    """
+    # Get a slice of South America and Africa only (lat=-90:31, lon -180:41)
+    sliced_grid = grid_360[0:121, 0:221]
+    assert sliced_grid.gmt.registration == 0  # gridline registration
+    assert sliced_grid.gmt.gtype == 0  # Cartesian coordinate system
+
+    fig = Figure()
+    fig.grdimage(
+        grid=sliced_grid, cmap="vik", region="g", projection="W0/3.5c", frame=True
+    )
     return fig
 
 


### PR DESCRIPTION
**Description of proposed changes**

Ensure that a sliced xarray.DataArray grid is plotted correctly on a global Mollweide projection map. This is a regression test to ensure that the bug reported in #732 does not happen in the future.

![image](https://user-images.githubusercontent.com/23487320/120417465-f95abb00-c3b2-11eb-9912-312c2234a749.png)

Cross-reference upstream issue https://github.com/GenericMappingTools/gmt/issues/5180, and PR https://github.com/GenericMappingTools/gmt/pull/5181 where the bug was fixed.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #732


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
