### PR TITLE
Raise a warning for the use of short-form parameters when long-forms are available

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -372,17 +372,18 @@ def use_alias(**aliases):
             """
             New module that parses and replaces the registered aliases.
             """
-            for arg, alias in aliases.items():
-                if alias in kwargs and arg in kwargs:
+            for short_param, long_alias in aliases.items():
+                if long_alias in kwargs and short_param in kwargs:
                     raise GMTInvalidInput(
-                        f"Parameters in short-form ({arg}) and long-form ({alias}) can't coexist."
+                        f"Parameters in short-form ({short_param}) and "
+                        f"long-form ({long_alias}) can't coexist."
                     )
-                if alias in kwargs:
-                    kwargs[arg] = kwargs.pop(alias)
-                elif arg in kwargs:
+                if long_alias in kwargs:
+                    kwargs[short_param] = kwargs.pop(long_alias)
+                elif short_param in kwargs:
                     msg = (
-                        f"Short-form parameter ({arg}) is not recommended. "
-                        f"Use long-form parameter '{alias}' instead."
+                        f"Short-form parameter ({short_param}) is not recommended. "
+                        f"Use long-form parameter '{long_alias}' instead."
                     )
                     warnings.warn(msg, category=SyntaxWarning, stacklevel=2)
             return module_func(*args, **kwargs)

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -384,7 +384,7 @@ def use_alias(**aliases):
                         f"Short-form parameter ({arg}) is not recommended. "
                         f"Use long-form parameter '{alias}' instead."
                     )
-                    warnings.warn(msg, category=FutureWarning, stacklevel=2)
+                    warnings.warn(msg, category=SyntaxWarning, stacklevel=2)
             return module_func(*args, **kwargs)
 
         new_module.aliases = aliases

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -359,7 +359,7 @@ def use_alias(**aliases):
     Traceback (most recent call last):
       ...
     pygmt.exceptions.GMTInvalidInput:
-        Arguments in short-form (J) and long-form (projection) can't coexist
+        Parameters in short-form (J) and long-form (projection) can't coexist.
     """
 
     def alias_decorator(module_func):
@@ -375,10 +375,16 @@ def use_alias(**aliases):
             for arg, alias in aliases.items():
                 if alias in kwargs and arg in kwargs:
                     raise GMTInvalidInput(
-                        f"Arguments in short-form ({arg}) and long-form ({alias}) can't coexist"
+                        f"Parameters in short-form ({arg}) and long-form ({alias}) can't coexist."
                     )
                 if alias in kwargs:
                     kwargs[arg] = kwargs.pop(alias)
+                elif arg in kwargs:
+                    msg = (
+                        f"Short-form parameter ({arg}) is not recommended. "
+                        f"Use long-form parameter '{alias}' instead."
+                    )
+                    warnings.warn(msg, category=FutureWarning, stacklevel=2)
             return module_func(*args, **kwargs)
 
         new_module.aliases = aliases


### PR DESCRIPTION
**Description of proposed changes**

Address the comment in https://github.com/GenericMappingTools/pygmt/issues/1203#issuecomment-845350743.

When long-form parameters are available, we should recommend users not to use
the short-form parameters.

For example, running the following example:
```
import pygmt

fig = pygmt.Figure()
fig.basemap(region=[0, 10, 0, 10], B=True, J="X10c")
fig.savefig("map.pdf")
```
will raise warnings like:
```
test.py:4: FutureWarning: Short-form parameter (J) is not recommended. Use long-form parameter 'projection' instead.
  fig.basemap(region=[0, 10, 0, 10], B=True, J="X10c")
test.py:4: FutureWarning: Short-form parameter (B) is not recommended. Use long-form parameter 'frame' instead.
  fig.basemap(region=[0, 10, 0, 10], B=True, J="X10c")
```


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
