### PR TITLE
Add a workflow to upload baseline images as a release asset

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -29,7 +29,7 @@ assignees: ''
   - [ ] Edit the draft release notes with the finalized changelog
   - [ ] Set the tag version and release title to vX.Y.Z
   - [ ] Make a release by clicking the 'Publish Release' button, this will automatically create a tag too
-- [ ] Manually upload the pygmt-vX.Y.Z.zip file to https://zenodo.org/deposit, ensure that it is filed under the correct reserved DOI
+- [ ] Manually upload the pygmt-vX.Y.Z.zip and baseline-images.zip files to https://zenodo.org/deposit, ensure that it is filed under the correct reserved DOI
 
 **After release**:
 - [ ] Update conda-forge [pygmt-feedstock](https://github.com/conda-forge/pygmt-feedstock) [Usually done automatically by conda-forge's bot]

--- a/.github/workflows/release-baseline-images.yml
+++ b/.github/workflows/release-baseline-images.yml
@@ -31,6 +31,7 @@ jobs:
         mkdir baseline-images
         mv pygmt/tests/baseline/*.png baseline-images/
         zip -r baseline-images.zip baseline-images
+        shasum -a 256 baseline-images.zip
 
     - name: Upload baseline image as a release asset
       uses: shogo82148/actions-upload-release-asset@v1.3.0

--- a/.github/workflows/release-baseline-images.yml
+++ b/.github/workflows/release-baseline-images.yml
@@ -1,0 +1,42 @@
+# Upload the archive of baseline images as release asset
+
+name: Upload baseline images
+
+# Only run for releases
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  upload-baseline:
+    name: Upload baseline images
+    runs-on: ubuntu-latest
+    if: github.repository == 'seisman/pygmt'
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.3.4
+
+    - name: Setup data version control (DVC)
+      uses: iterative/setup-dvc@v1.0.3
+
+    - name: Pull baseline image data from dvc remote
+      run: |
+        dvc pull
+        ls -lhR pygmt/tests/baseline/
+
+    - name: Create the baseline image asset in zip format
+      run: |
+        mkdir baseline-images
+        mv pygmt/tests/baseline/*.png baseline-images/
+        zip -r baseline-images.zip baseline-images
+
+    - name: Upload baseline image as a release asset
+      uses: shogo82148/actions-upload-release-asset@v1.3.0
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: baseline-images.zip
+
+
+

--- a/.github/workflows/release-baseline-images.yml
+++ b/.github/workflows/release-baseline-images.yml
@@ -1,4 +1,4 @@
-# Upload the archive of baseline images as release asset
+# Upload the ZIP archive of baseline images as a release asset
 
 name: Upload baseline images
 
@@ -12,7 +12,7 @@ jobs:
   upload-baseline:
     name: Upload baseline images
     runs-on: ubuntu-latest
-    if: github.repository == 'seisman/pygmt'
+    if: github.repository == 'GenericMappingTools/pygmt'
 
     steps:
     - name: Checkout
@@ -37,6 +37,3 @@ jobs:
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: baseline-images.zip
-
-
-

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -138,7 +138,7 @@ There are 11 configuration files located in `.github/workflows`:
     modified, or deleted. A GitHub comment will be published that contains a summary
     table of the images that have changed along with a visual report.
 
-11. `release-baseline-images.yml` (Upload the archive of baseline images as a release asset)
+11. `release-baseline-images.yml` (Upload the ZIP archive of baseline images as a release asset)
 
 	This workflow is run to upload the ZIP archive of baseline images as a release
 	asset when a release is published.

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -32,7 +32,7 @@ A few guidelines for managing GitHub issues:
   [milestone](https://github.com/GenericMappingTools/pygmt/milestones) to issues as
   appropriate.
 * When people request to work on an open issue, either assign the issue to that person
-  and post a comment about the assignment or explain why you are not assigning the 
+  and post a comment about the assignment or explain why you are not assigning the
   issue to them and, if possible, recommend other issues for them to work on.
 * People with write access should self-assign issues and/or comment on the issues that
   they will address.
@@ -69,7 +69,7 @@ build and test the project on Linux, macOS and Windows.
 They rely on the `environment.yml` file to install required dependencies using
 conda and the `Makefile` to run the tests and checks.
 
-There are 9 configuration files located in `.github/workflows`:
+There are 11 configuration files located in `.github/workflows`:
 
 1. `style_checks.yaml` (Code lint and style checks)
 
@@ -137,6 +137,11 @@ There are 9 configuration files located in `.github/workflows`:
     This workflow is triggered in a PR when any *.png.dvc files have been added,
     modified, or deleted. A GitHub comment will be published that contains a summary
     table of the images that have changed along with a visual report.
+
+11. `release-baseline-images.yml` (Upload the archive of baseline images as a release asset)
+
+	This workflow is run to upload the ZIP archive of baseline images as a release
+	asset when a release is published.
 
 ## Continuous Documentation
 

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -140,8 +140,8 @@ There are 11 configuration files located in `.github/workflows`:
 
 11. `release-baseline-images.yml` (Upload the ZIP archive of baseline images as a release asset)
 
-	This workflow is run to upload the ZIP archive of baseline images as a release
-	asset when a release is published.
+    This workflow is run to upload the ZIP archive of baseline images as a release
+    asset when a release is published.
 
 ## Continuous Documentation
 
@@ -281,8 +281,8 @@ this new folder.
 
 ### Archiving on Zenodo
 
-Grab a zip file from the GitHub release and upload to Zenodo using the previously
-reserved DOI.
+Grab both the source code and baseline images zip files from the GitHub release page
+and upload them to Zenodo using the previously reserved DOI.
 
 ### Updating the conda package
 


### PR DESCRIPTION
**Description of proposed changes**

In this PR, a workflow is added to upload all baseline PNG images as a release
asset when a release is published.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1201.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
