### PR TITLE
Bump the minimum required GMT version to 6.2.0

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -34,7 +34,7 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          conda install -c conda-forge gmt=6.2.0 \
+          conda install gmt=6.2.0 \
                         numpy pandas xarray netCDF4 packaging matplotlib
 
       # Install the package that we want to test

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -34,7 +34,7 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          conda install conda-forge/label/dev::gmt=6.2.0rc2 \
+          conda install -c conda-forge gmt=6.2.0 \
                         numpy pandas xarray netCDF4 packaging matplotlib
 
       # Install the package that we want to test

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -66,8 +66,7 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          conda install conda-forge/label/dev::gmt=6.2.0rc2 \
-                        numpy pandas xarray netCDF4 packaging \
+          conda install gmt=6.2.0 numpy pandas xarray netCDF4 packaging \
                         ipython make myst-parser \
                         sphinx sphinx-copybutton sphinx-gallery sphinx_rtd_theme
 

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -89,8 +89,7 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          conda install conda-forge/label/dev::gmt=6.2.0rc2 \
-                        numpy=${{ matrix.numpy-version }} \
+          conda install gmt=6.2.0 numpy=${{ matrix.numpy-version }} \
                         pandas xarray netCDF4 packaging \
                         ${{ matrix.optional-packages }} \
                         codecov coverage[toml] dvc ipython make \

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -62,7 +62,7 @@ Which GMT?
 PyGMT requires Generic Mapping Tools (GMT) version 6 as a minimum, which is the
 latest released version that can be found at
 the `GMT official site <https://www.generic-mapping-tools.org>`__.
-We need the latest GMT (>=6.1.1) since there are many changes being made to GMT
+We need the latest GMT (>=6.2.0) since there are many changes being made to GMT
 itself in response to the development of PyGMT, mainly the new
 `modern execution mode <https://docs.generic-mapping-tools.org/latest/cookbook/introduction.html#modern-and-classic-mode>`__.
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,12 +1,11 @@
 name: pygmt
 channels:
-    - conda-forge/label/dev
     - conda-forge
     - defaults
 dependencies:
     # Required dependencies
     - pip
-    - gmt=6.2.0rc2
+    - gmt=6.2.0
     - numpy>=1.17
     - pandas
     - xarray

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -123,7 +123,7 @@ class Session:
     """
 
     # The minimum version of GMT required
-    required_version = "6.1.1"
+    required_version = "6.2.0"
 
     @property
     def session_pointer(self):

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -750,7 +750,7 @@ def test_get_default():
     with clib.Session() as lib:
         assert lib.get_default("API_GRID_LAYOUT") in ["rows", "columns"]
         assert int(lib.get_default("API_CORES")) >= 1
-        assert Version(lib.get_default("API_VERSION")) >= Version("6.1.1")
+        assert Version(lib.get_default("API_VERSION")) >= Version("6.2.0")
 
 
 def test_get_default_fails():


### PR DESCRIPTION
**Description of proposed changes**

Bump the minimum required GMT version from 6.1.1 to 6.2.0. Also update GitHub Actions CI workflows to use GMT 6.2.0.

- [Changelog](https://docs.generic-mapping-tools.org/6.2/changes.html#new-features-in-gmt-6-2)
- [Commits](https://github.com/GenericMappingTools/gmt/compare/6.1.1...6.2.0)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Related to #1320, Supersedes #1290 and #577.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
