### PR TITLE
Update colorbar, inset, legend and logo baseline images for GMT 6.2.0

### DIFF
--- a/pygmt/tests/baseline/test_colorbar_box.png.dvc
+++ b/pygmt/tests/baseline/test_colorbar_box.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 5bd7bba7139b23c1c63dd7ed053a5b88
-  size: 1388
+- md5: 554a83b4f34c4470e2e2aba765860e84
+  size: 1450
   path: test_colorbar_box.png

--- a/pygmt/tests/baseline/test_inset_aliases.png.dvc
+++ b/pygmt/tests/baseline/test_inset_aliases.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 62d6aec510780889e6f1d25a8c564ff0
-  size: 29626
+- md5: e70a202d0e548835276809936db1db98
+  size: 29870
   path: test_inset_aliases.png

--- a/pygmt/tests/baseline/test_inset_context_manager.png.dvc
+++ b/pygmt/tests/baseline/test_inset_context_manager.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 43c2c1d0c58d4fd2b24d3ca059cc5e35
-  size: 10477
+- md5: 5748eda7fde2e3ee4dbe3ff94d82ba7f
+  size: 10486
   path: test_inset_context_manager.png

--- a/pygmt/tests/baseline/test_legend_position.png.dvc
+++ b/pygmt/tests/baseline/test_legend_position.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 4306da978112fb27dde184d63ec440ee
-  size: 24826
+- md5: 84d9a3ca57ed3a1e4aa826d05d20518c
+  size: 24875
   path: test_legend_position.png

--- a/pygmt/tests/baseline/test_logo_on_a_map.png.dvc
+++ b/pygmt/tests/baseline/test_logo_on_a_map.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 57c3747cb7d2ed978e473d0f161ca3a6
-  size: 70993
+- md5: 2c9c6a32042a171e4fa34df5f8eccdf4
+  size: 70884
   path: test_logo_on_a_map.png

--- a/pygmt/tests/baseline/test_plot3d_matrix_color.png.dvc
+++ b/pygmt/tests/baseline/test_plot3d_matrix_color.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: d08eaf4bf196c8680a3b7c0d8f4259a7
+- md5: 9b1e94da314923794dca11d20ae3e5df
   size: 24071
   path: test_plot3d_matrix_color.png

--- a/pygmt/tests/baseline/test_plot3d_matrix_color.png.dvc
+++ b/pygmt/tests/baseline/test_plot3d_matrix_color.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 9b1e94da314923794dca11d20ae3e5df
+- md5: d08eaf4bf196c8680a3b7c0d8f4259a7
   size: 24071
   path: test_plot3d_matrix_color.png

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -2,6 +2,7 @@
 Tests plot3d.
 """
 import os
+import sys
 
 import numpy as np
 import pytest
@@ -372,6 +373,10 @@ def test_plot3d_matrix(data, region):
     return fig
 
 
+@pytest.mark.xfail(
+    condition=sys.platform == "win32",
+    reason="Wrong plot generated on Windows due to incorrect -i parameter parsing",
+)
 @pytest.mark.mpl_image_compare
 def test_plot3d_matrix_color(data, region):
     """


### PR DESCRIPTION
**Description of proposed changes**

Fix five broken tests on GMT 6.2.0 for fig.colorbar, fig.inset, fig.legend and fig.logo. Differences are mainly due to a different pen thickness setting. Also marking a `test_plot3d_matrix_color` as xfail on Windows due to incorrect `-i` parameter parsing.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #1320


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
