### PR TITLE
Remove xfail on makecpt tests for GMT 6.2.0

### DIFF
--- a/pygmt/tests/test_makecpt.py
+++ b/pygmt/tests/test_makecpt.py
@@ -150,10 +150,6 @@ def test_makecpt_continuous(grid):
     return fig
 
 
-@pytest.mark.xfail(
-    reason="Flaky test only passes with pytest on single module"
-    "See https://github.com/GenericMappingTools/pygmt/issues/1242"
-)
 @pytest.mark.mpl_image_compare
 def test_makecpt_categorical(region):
     """
@@ -165,10 +161,6 @@ def test_makecpt_categorical(region):
     return fig
 
 
-@pytest.mark.xfail(
-    reason="Flaky test only passes with pytest on single module"
-    "See https://github.com/GenericMappingTools/pygmt/issues/1242"
-)
 @pytest.mark.mpl_image_compare
 def test_makecpt_cyclic(region):
     """


### PR DESCRIPTION
**Description of proposed changes**

The two "makecpt" flaky tests are fixed in GenericMappingTools/gmt#5280 and now pass for GMT 6.2.0.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Address #1320.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
