### PR TITLE
Fix sphinx warning in datetime tutorial

### DIFF
--- a/examples/tutorials/date_time_charts.py
+++ b/examples/tutorials/date_time_charts.py
@@ -177,7 +177,7 @@ fig.show()
 
 ########################################################################################
 # Using :class:`xarray.DataArray`
-# ------------------------------
+# -------------------------------
 #
 # In this example, instead of using a :func:`pandas.date_range`, ``x`` is initialized
 # as a list of :class:`xarray.DataArray` objects. This object provides a wrapper around
@@ -204,7 +204,7 @@ fig.show()
 
 ###############################################################################
 # Using :class:`numpy.datetime64`
-# ------------------------------
+# -------------------------------
 # In this example, instead of using a :func:`pd.date_range`, ``x`` is initialized
 # as an ``np.array`` object. Similar to :class:`xarray.DataArray` this wraps the
 # dataset before passing it as a paramater. However, ``np.array`` objects use less


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes title underline lengths in two lines that cause sphinx warnings:

```
pygmt/doc/tutorials/date_time_charts.rst:335: WARNING: Title underline too short.
pygmt/doc/tutorials/date_time_charts.rst:387: WARNING: Title underline too short.
```

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
