### PR TITLE
Add pandas to generated-members in .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -322,7 +322,7 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=
+generated-members=pandas.*
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).


### PR DESCRIPTION
**Description of proposed changes**

I am getting several pylint errors related to pandas classes on the main branch:

```
************* Module pygmt.tests.test_blockmean
pygmt/tests/test_blockmean.py:30:11: E1101: Instance of 'TextFileReader' has no 'shape' member (no-member)
pygmt/tests/test_blockmean.py:31:24: E1101: Instance of 'TextFileReader' has no 'iloc' member (no-member)
pygmt/tests/test_blockmean.py:43:24: E1101: Instance of 'TextFileReader' has no 'iloc' member (no-member)
pygmt/tests/test_blockmean.py:72:28: E1101: Instance of 'TextFileReader' has no 'iloc' member (no-member)
pygmt/tests/test_blockmean.py:82:24: E1101: Instance of 'TextFileReader' has no 'iloc' member (no-member)
************* Module pygmt.tests.test_grdtrack
pygmt/tests/test_grdtrack.py:38:24: E1101: Instance of 'TextFileReader' has no 'iloc' member (no-member)
pygmt/tests/test_grdtrack.py:72:24: E1101: Instance of 'TextFileReader' has no 'iloc' member (no-member)
************* Module pygmt.tests.test_blockmedian
pygmt/tests/test_blockmedian.py:30:11: E1101: Instance of 'TextFileReader' has no 'shape' member (no-member)
pygmt/tests/test_blockmedian.py:31:24: E1101: Instance of 'TextFileReader' has no 'iloc' member (no-member)
pygmt/tests/test_blockmedian.py:43:24: E1101: Instance of 'TextFileReader' has no 'iloc' member (no-member)
pygmt/tests/test_blockmedian.py:72:28: E1101: Instance of 'TextFileReader' has no 'iloc' member (no-member)
pygmt/tests/test_blockmedian.py:82:24: E1101: Instance of 'TextFileReader' has no 'iloc' member (no-member)
************* Module pygmt.tests.test_datasets_samples
pygmt/tests/test_datasets_samples.py:19:14: E1101: Instance of 'TextFileReader' has no 'describe' member (no-member)
pygmt/tests/test_datasets_samples.py:34:14: E1101: Instance of 'TextFileReader' has no 'describe' member (no-member)
pygmt/tests/test_datasets_samples.py:47:14: E1101: Instance of 'TextFileReader' has no 'describe' member (no-member)
************* Module pygmt.tests.test_surface
pygmt/tests/test_surface.py:47:10: E1101: Instance of 'TextFileReader' has no 'latitude' member (no-member)
pygmt/tests/test_surface.py:48:10: E1101: Instance of 'TextFileReader' has no 'bathymetry' member (no-member)
pygmt/tests/test_surface.py:64:14: E1101: Instance of 'TextFileReader' has no 'latitude' member (no-member)
```

Some internet searching suggested that adding pandas to generated-members is the appropriate solution to the problem. It solved the problem for me.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
