### PR TITLE
plot: Fix 'columns' to 'incols' in docstrings

### DIFF
--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -80,7 +80,7 @@ def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
     data : str or {table-like}
         Pass in either a file name to an ASCII data table, a 2D
         {table-classes}.
-        Use parameter ``columns`` to choose which columns are x, y, color, and
+        Use parameter ``incols`` to choose which columns are x, y, color, and
         size, respectively.
     size : 1d array
         The size of the data points in units specified using ``style``.


### PR DESCRIPTION
**Description of proposed changes**

parameter `columns` has been renamed to `incols`.




**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
