### PR TITLE
Remove mention of multiple grid inputs in grdtrack docstring

### DIFF
--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -37,10 +37,10 @@ def grdtrack(points, grid, newcolname=None, outfile=None, **kwargs):
     r"""
     Sample grids at specified (x,y) locations.
 
-    Reads one or more grid files and a table (from file or an array input; but
+    Reads a grid file and a table (from file or an array input; but
     see ``profile`` for exception) with (x,y) [or (lon,lat)] positions in the
     first two columns (more columns may be present). It interpolates the
-    grid(s) at the positions in the table and writes out the table with the
+    grid at the positions in the table and writes out the table with the
     interpolated values added as (one or more) new columns. Alternatively
     (``crossprofile``), the input is considered to be line-segments and we
     create orthogonal cross-profiles at each data point or with an equidistant


### PR DESCRIPTION
The documentation for `grdtrack` states that it can accept multiple grid inputs for `grid`. As `grid=` can't be repeated in the same function call and it doesn't accept a list of grids, this pull request changes the documentation to state that the `grdtrack` accepts a single grid.



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
