### PR TITLE
Add a gallery example showing individual custom symbols

### DIFF
--- a/examples/gallery/symbols/custom_symbols.py
+++ b/examples/gallery/symbols/custom_symbols.py
@@ -9,10 +9,10 @@ font = "15p,Helvetica-Bold"
 
 y = 1.25
 
-fig.plot(x=1, y=y, style="kvolcano/60p", pen=pen, color ="seagreen")
+fig.plot(x=1, y=y, style="kvolcano/60p", pen=pen, color="seagreen")
 fig.text(x=1, y=y + 1.25, text="volcano", font=font)
 
-fig.plot(x=2.5, y=y, style="kastroid/60p", pen=pen, color = "red3")
+fig.plot(x=2.5, y=y, style="kastroid/60p", pen=pen, color="red3")
 fig.text(x=2.5, y=y + 1.25, text="astroid", font=font)
 
 fig.plot(x=4, y=y, style="kflash/60p", pen=pen, color="darkorange")

--- a/examples/gallery/symbols/custom_symbols.py
+++ b/examples/gallery/symbols/custom_symbols.py
@@ -5,7 +5,7 @@ Custom symbols
 The :meth:`pygmt.Figure.plot` method can plot individual custom symbols
 by passing the corresponding symbol name together with the **k** shortcut to
 the ``style`` parameter. In total 41 custom symbols are already included of
-which the following plot shows five examplary ones. The symbols are shown
+which the following plot shows five exemplary ones. The symbols are shown
 underneath their corresponding names. For the remaining symbols see the GMT
 cookbook :gmt-docs:`cookbook/custom-symbols.html`.
 """

--- a/examples/gallery/symbols/custom_symbols.py
+++ b/examples/gallery/symbols/custom_symbols.py
@@ -1,6 +1,6 @@
 """
 Custom symbols
------------------------
+--------------
 
 The :meth:`pygmt.Figure.plot` method can plot individual custom symbols
 by passing the corresponding symbol name together with the **k** shortcut to

--- a/examples/gallery/symbols/custom_symbols.py
+++ b/examples/gallery/symbols/custom_symbols.py
@@ -6,8 +6,8 @@ The :meth:`pygmt.Figure.plot` method can plot individual custom symbols
 by passing the corresponding symbol name together with the **k** shortcut to
 the ``style`` parameter. In total 41 custom symbols are already included of
 which the following plot shows five examplary ones. The symbols are shown
-underneath their corresponding names. For the remaining symbols see
-:gmt-docs:`cookbook/custom-symbols.html`
+underneath their corresponding names. For the remaining symbols see the GMT
+cookbook :gmt-docs:`cookbook/custom-symbols.html`.
 """
 
 import pygmt
@@ -21,18 +21,28 @@ font = "15p,Helvetica-Bold"
 
 y = 1.25
 
+# use the volcano symbol with a size of 60p,
+# fill color is set to "seagreen"
 fig.plot(x=1, y=y, style="kvolcano/60p", pen=pen, color="seagreen")
 fig.text(x=1, y=y + 1.25, text="volcano", font=font)
 
+# use the astroid symbol with a size of 60p,
+# fill color is set to "red3"
 fig.plot(x=2.5, y=y, style="kastroid/60p", pen=pen, color="red3")
 fig.text(x=2.5, y=y + 1.25, text="astroid", font=font)
 
+# use the flash symbol with a size of 60p,
+# fill color is set to "darkorange"
 fig.plot(x=4, y=y, style="kflash/60p", pen=pen, color="darkorange")
 fig.text(x=4, y=y + 1.25, text="flash", font=font)
 
+# use the star4 symbol with a size of 60p,
+# fill color is set to "dodgerblue4"
 fig.plot(x=5.5, y=y, style="kstar4/60p", pen=pen, color="dodgerblue4")
 fig.text(x=5.5, y=y + 1.25, text="star4", font=font)
 
+# use the hurricane symbol with a size of 60p,
+# fill color is set to "magenta4"
 fig.plot(x=7, y=y, style="khurricane/60p", pen=pen, color="magenta4")
 fig.text(x=7, y=y + 1.25, text="hurricane", font=font)
 

--- a/examples/gallery/symbols/custom_symbols.py
+++ b/examples/gallery/symbols/custom_symbols.py
@@ -19,31 +19,29 @@ fig.basemap(region=[0, 8, 0, 3], projection="X12c/4c", frame=True)
 pen = "1p,black"
 font = "15p,Helvetica-Bold"
 
-y = 1.25
-
 # use the volcano symbol with a size of 1.5c,
 # fill color is set to "seagreen"
-fig.plot(x=1, y=y, style="kvolcano/1.5c", pen=pen, color="seagreen")
-fig.text(x=1, y=y + 1.25, text="volcano", font=font)
+fig.plot(x=1, y=1.25, style="kvolcano/1.5c", pen=pen, color="seagreen")
+fig.text(x=1, y=2.5, text="volcano", font=font)
 
 # use the astroid symbol with a size of 1.5c,
 # fill color is set to "red3"
-fig.plot(x=2.5, y=y, style="kastroid/1.5c", pen=pen, color="red3")
-fig.text(x=2.5, y=y + 1.25, text="astroid", font=font)
+fig.plot(x=2.5, y=1.25, style="kastroid/1.5c", pen=pen, color="red3")
+fig.text(x=2.5, y=2.5, text="astroid", font=font)
 
 # use the flash symbol with a size of 1.5c,
 # fill color is set to "darkorange"
-fig.plot(x=4, y=y, style="kflash/1.5c", pen=pen, color="darkorange")
-fig.text(x=4, y=y + 1.25, text="flash", font=font)
+fig.plot(x=4, y=1.25, style="kflash/1.5c", pen=pen, color="darkorange")
+fig.text(x=4, y=2.5, text="flash", font=font)
 
 # use the star4 symbol with a size of 1.5c,
 # fill color is set to "dodgerblue4"
-fig.plot(x=5.5, y=y, style="kstar4/1.5c", pen=pen, color="dodgerblue4")
-fig.text(x=5.5, y=y + 1.25, text="star4", font=font)
+fig.plot(x=5.5, y=1.25, style="kstar4/1.5c", pen=pen, color="dodgerblue4")
+fig.text(x=5.5, y=2.5, text="star4", font=font)
 
 # use the hurricane symbol with a size of 1.5c,
 # fill color is set to "magenta4"
-fig.plot(x=7, y=y, style="khurricane/1.5c", pen=pen, color="magenta4")
-fig.text(x=7, y=y + 1.25, text="hurricane", font=font)
+fig.plot(x=7, y=1.25, style="khurricane/1.5c", pen=pen, color="magenta4")
+fig.text(x=7, y=2.5, text="hurricane", font=font)
 
 fig.show()

--- a/examples/gallery/symbols/custom_symbols.py
+++ b/examples/gallery/symbols/custom_symbols.py
@@ -1,0 +1,27 @@
+import pygmt
+
+fig = pygmt.Figure()
+fig.basemap(region=[0, 8, 0, 3], projection="X12c/4c", frame=True)
+
+# define pen and fontstlye for annotations
+pen = "1p,black"
+font = "15p,Helvetica-Bold"
+
+y = 1.25
+
+fig.plot(x=1, y=y, style="kvolcano/60p", pen=pen, color ="seagreen")
+fig.text(x=1, y=y + 1.25, text="volcano", font=font)
+
+fig.plot(x=2.5, y=y, style="kastroid/60p", pen=pen, color = "red3")
+fig.text(x=2.5, y=y + 1.25, text="astroid", font=font)
+
+fig.plot(x=4, y=y, style="kflash/60p", pen=pen, color="darkorange")
+fig.text(x=4, y=y + 1.25, text="flash", font=font)
+
+fig.plot(x=5.5, y=y, style="kstar4/60p", pen=pen, color="dodgerblue4")
+fig.text(x=5.5, y=y + 1.25, text="star4", font=font)
+
+fig.plot(x=7, y=y, style="khurricane/60p", pen=pen, color="magenta4")
+fig.text(x=7, y=y + 1.25, text="hurricane", font=font)
+
+fig.show()

--- a/examples/gallery/symbols/custom_symbols.py
+++ b/examples/gallery/symbols/custom_symbols.py
@@ -21,29 +21,29 @@ font = "15p,Helvetica-Bold"
 
 y = 1.25
 
-# use the volcano symbol with a size of 60p,
+# use the volcano symbol with a size of 1.5c,
 # fill color is set to "seagreen"
-fig.plot(x=1, y=y, style="kvolcano/60p", pen=pen, color="seagreen")
+fig.plot(x=1, y=y, style="kvolcano/1.5c", pen=pen, color="seagreen")
 fig.text(x=1, y=y + 1.25, text="volcano", font=font)
 
-# use the astroid symbol with a size of 60p,
+# use the astroid symbol with a size of 1.5c,
 # fill color is set to "red3"
-fig.plot(x=2.5, y=y, style="kastroid/60p", pen=pen, color="red3")
+fig.plot(x=2.5, y=y, style="kastroid/1.5c", pen=pen, color="red3")
 fig.text(x=2.5, y=y + 1.25, text="astroid", font=font)
 
-# use the flash symbol with a size of 60p,
+# use the flash symbol with a size of 1.5c,
 # fill color is set to "darkorange"
-fig.plot(x=4, y=y, style="kflash/60p", pen=pen, color="darkorange")
+fig.plot(x=4, y=y, style="kflash/1.5c", pen=pen, color="darkorange")
 fig.text(x=4, y=y + 1.25, text="flash", font=font)
 
-# use the star4 symbol with a size of 60p,
+# use the star4 symbol with a size of 1.5c,
 # fill color is set to "dodgerblue4"
-fig.plot(x=5.5, y=y, style="kstar4/60p", pen=pen, color="dodgerblue4")
+fig.plot(x=5.5, y=y, style="kstar4/1.5c", pen=pen, color="dodgerblue4")
 fig.text(x=5.5, y=y + 1.25, text="star4", font=font)
 
-# use the hurricane symbol with a size of 60p,
+# use the hurricane symbol with a size of 1.5c,
 # fill color is set to "magenta4"
-fig.plot(x=7, y=y, style="khurricane/60p", pen=pen, color="magenta4")
+fig.plot(x=7, y=y, style="khurricane/1.5c", pen=pen, color="magenta4")
 fig.text(x=7, y=y + 1.25, text="hurricane", font=font)
 
 fig.show()

--- a/examples/gallery/symbols/custom_symbols.py
+++ b/examples/gallery/symbols/custom_symbols.py
@@ -1,3 +1,15 @@
+"""
+Custom symbols
+-----------------------
+
+The :meth:`pygmt.Figure.plot` method can plot individual custom symbols
+by passing the corresponding symbol name together with the **k** shortcut to
+the ``style`` parameter. In total 41 custom symbols are already included of
+which the following plot shows five examplary ones. The symbols are shown
+underneath their corresponding names. For the remaining symbols see
+:gmt-docs:`cookbook/custom-symbols.html`
+"""
+
 import pygmt
 
 fig = pygmt.Figure()


### PR DESCRIPTION
**Description of proposed changes**

So far we have no gallery example in which custom symbols are shown. This PR adds such an example to the gallery. Since the number of custom symbols coming with GMT is huge (https://docs.generic-mapping-tools.org/latest/cookbook/custom-symbols.html) I think we should focus only on a subset of them.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
