### PR TITLE
Move reused data to pytest fixtures in test_grdtrack.py

### DIFF
--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -24,12 +24,14 @@ def fixture_dataarray():
         lat=slice(-49, -42), lon=slice(-118, -107)
     )
 
+
 @pytest.fixture(scope="module", name="dataframe")
 def fixture_dataframe():
     """
     Load the ocean ridge file.
     """
     return load_ocean_ridge_points()
+
 
 def test_grdtrack_input_dataframe_and_dataarray(dataarray, dataframe):
     """

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -33,6 +33,22 @@ def fixture_dataframe():
     return load_ocean_ridge_points()
 
 
+@pytest.fixture(scope="module", name="csvfile")
+def fixture_csvfile():
+    """
+    Load the csvfile.
+    """
+    return which("@ridge.txt", download="c")
+
+
+@pytest.fixture(scope="module", name="ncfile")
+def fixture_ncfile():
+    """
+    Load the ncfile.
+    """
+    return which("@earth_relief_01d", download="a")
+
+
 def test_grdtrack_input_dataframe_and_dataarray(dataarray, dataframe):
     """
     Run grdtrack by passing in a pandas.DataFrame and xarray.DataArray as
@@ -46,12 +62,10 @@ def test_grdtrack_input_dataframe_and_dataarray(dataarray, dataframe):
     return output
 
 
-def test_grdtrack_input_csvfile_and_dataarray(dataarray):
+def test_grdtrack_input_csvfile_and_dataarray(dataarray, csvfile):
     """
     Run grdtrack by passing in a csvfile and xarray.DataArray as inputs.
     """
-    csvfile = which("@ridge.txt", download="c")
-
     try:
         output = grdtrack(points=csvfile, grid=dataarray, outfile=TEMP_TRACK)
         assert output is None  # check that output is None since outfile is set
@@ -65,11 +79,10 @@ def test_grdtrack_input_csvfile_and_dataarray(dataarray):
     return output
 
 
-def test_grdtrack_input_dataframe_and_ncfile(dataframe):
+def test_grdtrack_input_dataframe_and_ncfile(dataframe, ncfile):
     """
     Run grdtrack by passing in a pandas.DataFrame and netcdf file as inputs.
     """
-    ncfile = which("@earth_relief_01d", download="a")
 
     output = grdtrack(points=dataframe, grid=ncfile, newcolname="bathymetry")
     assert isinstance(output, pd.DataFrame)
@@ -79,13 +92,10 @@ def test_grdtrack_input_dataframe_and_ncfile(dataframe):
     return output
 
 
-def test_grdtrack_input_csvfile_and_ncfile():
+def test_grdtrack_input_csvfile_and_ncfile(csvfile, ncfile):
     """
     Run grdtrack by passing in a csvfile and netcdf file as inputs.
     """
-    csvfile = which("@ridge.txt", download="c")
-    ncfile = which("@earth_relief_01d", download="a")
-
     try:
         output = grdtrack(points=csvfile, grid=ncfile, outfile=TEMP_TRACK)
         assert output is None  # check that output is None since outfile is set
@@ -131,13 +141,10 @@ def test_grdtrack_without_newcolname_setting(dataarray, dataframe):
         grdtrack(points=dataframe, grid=dataarray)
 
 
-def test_grdtrack_without_outfile_setting():
+def test_grdtrack_without_outfile_setting(csvfile, ncfile):
     """
     Run grdtrack by not passing in outfile parameter setting.
     """
-    csvfile = which("@ridge.txt", download="c")
-    ncfile = which("@earth_relief_01d", download="a")
-
     output = grdtrack(points=csvfile, grid=ncfile)
     npt.assert_allclose(output.iloc[0], [-32.2971, 37.4118, -1939.748245])
 

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -24,14 +24,18 @@ def fixture_dataarray():
         lat=slice(-49, -42), lon=slice(-118, -107)
     )
 
+@pytest.fixture(scope="module", name="dataframe")
+def fixture_dataframe():
+    """
+    Load the ocean ridge file.
+    """
+    return load_ocean_ridge_points()
 
-def test_grdtrack_input_dataframe_and_dataarray(dataarray):
+def test_grdtrack_input_dataframe_and_dataarray(dataarray, dataframe):
     """
     Run grdtrack by passing in a pandas.DataFrame and xarray.DataArray as
     inputs.
     """
-    dataframe = load_ocean_ridge_points()
-
     output = grdtrack(points=dataframe, grid=dataarray, newcolname="bathymetry")
     assert isinstance(output, pd.DataFrame)
     assert output.columns.to_list() == ["longitude", "latitude", "bathymetry"]
@@ -59,11 +63,10 @@ def test_grdtrack_input_csvfile_and_dataarray(dataarray):
     return output
 
 
-def test_grdtrack_input_dataframe_and_ncfile():
+def test_grdtrack_input_dataframe_and_ncfile(dataframe):
     """
     Run grdtrack by passing in a pandas.DataFrame and netcdf file as inputs.
     """
-    dataframe = load_ocean_ridge_points()
     ncfile = which("@earth_relief_01d", download="a")
 
     output = grdtrack(points=dataframe, grid=ncfile, newcolname="bathymetry")
@@ -94,12 +97,11 @@ def test_grdtrack_input_csvfile_and_ncfile():
     return output
 
 
-def test_grdtrack_wrong_kind_of_points_input(dataarray):
+def test_grdtrack_wrong_kind_of_points_input(dataarray, dataframe):
     """
     Run grdtrack using points input that is not a pandas.DataFrame (matrix) or
     file.
     """
-    dataframe = load_ocean_ridge_points()
     invalid_points = dataframe.longitude.to_xarray()
 
     assert data_kind(invalid_points) == "grid"
@@ -107,12 +109,11 @@ def test_grdtrack_wrong_kind_of_points_input(dataarray):
         grdtrack(points=invalid_points, grid=dataarray, newcolname="bathymetry")
 
 
-def test_grdtrack_wrong_kind_of_grid_input(dataarray):
+def test_grdtrack_wrong_kind_of_grid_input(dataarray, dataframe):
     """
     Run grdtrack using grid input that is not as xarray.DataArray (grid) or
     file.
     """
-    dataframe = load_ocean_ridge_points()
     invalid_grid = dataarray.to_dataset()
 
     assert data_kind(invalid_grid) == "matrix"
@@ -120,12 +121,10 @@ def test_grdtrack_wrong_kind_of_grid_input(dataarray):
         grdtrack(points=dataframe, grid=invalid_grid, newcolname="bathymetry")
 
 
-def test_grdtrack_without_newcolname_setting(dataarray):
+def test_grdtrack_without_newcolname_setting(dataarray, dataframe):
     """
     Run grdtrack by not passing in newcolname parameter setting.
     """
-    dataframe = load_ocean_ridge_points()
-
     with pytest.raises(GMTInvalidInput):
         grdtrack(points=dataframe, grid=dataarray)
 


### PR DESCRIPTION
Five test functions in `test_grdtrack.py` use a dataframe from `load_ocean_ridge_points()` and called it inside the test functions. This pull requests moves it to `fixture_dataframe()`. 

Over five runs of `test_grdtrack.py` on my machine, the average time for the old tests was 906 ms and the new tests averaged 658 ms.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
