### PR TITLE
Add tests for tempfile_from_geojson()

### DIFF
--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -129,7 +129,7 @@ def test_tempfile_from_geojson():
         geometry=[polygon, linestring],
     )
     with tempfile_from_geojson(gdf) as geojson_string:
-        assert type(geojson_string) == str
+        assert isinstance(geojson_string, str)
         with open(geojson_string) as tmpfile:
             assert os.path.basename(tmpfile.name).startswith("pygmt-")
             assert os.path.basename(tmpfile.name).endswith(".gmt")
@@ -142,7 +142,7 @@ def test_tempfile_from_geojson_no_geodataframe():
     """
     linestring = shapely.geometry.LineString([(20, 15), (30, 15)])
     with tempfile_from_geojson(linestring) as geojson_string:
-        assert type(geojson_string) == str
+        assert isinstance(geojson_string, str)
         with open(geojson_string) as tmpfile:
             assert os.path.basename(tmpfile.name).startswith("pygmt-")
             assert os.path.basename(tmpfile.name).endswith(".gmt")

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -3,19 +3,19 @@ Tests the helper functions/classes/etc used in wrapping GMT.
 """
 import os
 
+import geopandas as gpd
 import numpy as np
 import pytest
-from pygmt.exceptions import GMTInvalidInput
 import shapely.geometry
+from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     GMTTempFile,
     args_in_kwargs,
     data_kind,
     kwargs_to_strings,
+    tempfile_from_geojson,
     unique_name,
-    tempfile_from_geojson
 )
-import geopandas as gpd
 
 
 @pytest.mark.parametrize(
@@ -117,6 +117,7 @@ def test_args_in_kwargs():
     failing_args = ["D", "E", "F"]
     assert not args_in_kwargs(args=failing_args, kwargs=kwargs)
 
+
 def test_tempfile_from_geojson():
     """
     Test tempfile_from_geojson works when passed a geopandas GeoDataFrame.
@@ -133,9 +134,11 @@ def test_tempfile_from_geojson():
             assert os.path.basename(tmpfile.name).startswith("pygmt-")
             assert os.path.basename(tmpfile.name).endswith(".gmt")
 
+
 def test_tempfile_from_geojson_no_geodataframe():
     """
-    Test tempfile_from_geojson when passed data not in a geopandas GeoDataFrame format.
+    Test tempfile_from_geojson when passed data not in a geopandas GeoDataFrame
+    format.
     """
     linestring = shapely.geometry.LineString([(20, 15), (30, 15)])
     with tempfile_from_geojson(linestring) as geojson_string:


### PR DESCRIPTION
This pull requests adds two tests to `test_helpers.py` that test `tempfile_from_geojson()`


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
