### PR TITLE
NEP29: Test PyGMT on NumPy 1.21

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -44,14 +44,14 @@ jobs:
           # - os: ubuntu-latest
           #   python-version: 3.7
           #   isDraft: true
-        # Pair Python 3.7 with NumPy 1.17 and Python 3.9 with NumPy 1.20
-        # Only install optional packages on Python 3.9/NumPy 1.20
+        # Pair Python 3.7 with NumPy 1.17 and Python 3.9 with NumPy 1.21
+        # Only install optional packages on Python 3.9/NumPy 1.21
         include:
           - python-version: 3.7
             numpy-version: '1.17'
             optional-packages: ''
           - python-version: 3.9
-            numpy-version: '1.20'
+            numpy-version: '1.21'
             optional-packages: 'geopandas'
     defaults:
       run:


### PR DESCRIPTION
**Description of proposed changes**

Bumps [numpy](https://github.com/numpy/numpy) from 1.20.3 to 1.21.0 released on 23 June 2021.
- [Release notes](https://github.com/numpy/numpy/releases)
- [Changelog](https://github.com/numpy/numpy/blob/v1.21.0/doc/changelog/1.21.0-changelog.rst)
- [Commits](numpy/numpy@v1.20.3...v1.21.0)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This is in line with PyGMT's policy on [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) at https://www.pygmt.org/v0.4.0/maintenance.html#dependencies-policy, xref #1074.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
