### PR TITLE
 Move reused ship_data import to pytest fixture in test_surface.py

### DIFF
--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -34,11 +34,10 @@ def test_surface_input_file():
     return output
 
 
-def test_surface_input_data_array():
+def test_surface_input_data_array(ship_data):
     """
     Run surface by passing in a numpy array into data.
     """
-    ship_data = load_sample_bathymetry()
     data = ship_data.values  # convert pandas.DataFrame to numpy.ndarray
     output = surface(data=data, spacing="5m", region=[245, 255, 20, 30])
     assert isinstance(output, xr.DataArray)

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -14,6 +14,14 @@ TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 TEMP_GRID = os.path.join(TEST_DATA_DIR, "tmp_grid.nc")
 
 
+@pytest.fixture(scope="module", name="ship_data")
+def fixture_ship_data():
+    """
+    Load the data from the sample bathymetry dataset.
+    """
+    return load_sample_bathymetry()
+
+
 def test_surface_input_file():
     """
     Run surface by passing in a filename.
@@ -37,11 +45,10 @@ def test_surface_input_data_array():
     return output
 
 
-def test_surface_input_xyz():
+def test_surface_input_xyz(ship_data):
     """
     Run surface by passing in x, y, z numpy.ndarrays individually.
     """
-    ship_data = load_sample_bathymetry()
     output = surface(
         x=ship_data.longitude,
         y=ship_data.latitude,
@@ -53,11 +60,10 @@ def test_surface_input_xyz():
     return output
 
 
-def test_surface_input_xy_no_z():
+def test_surface_input_xy_no_z(ship_data):
     """
     Run surface by passing in x and y, but no z.
     """
-    ship_data = load_sample_bathymetry()
     with pytest.raises(GMTInvalidInput):
         surface(
             x=ship_data.longitude,
@@ -67,22 +73,20 @@ def test_surface_input_xy_no_z():
         )
 
 
-def test_surface_wrong_kind_of_input():
+def test_surface_wrong_kind_of_input(ship_data):
     """
     Run surface using grid input that is not file/matrix/vectors.
     """
-    ship_data = load_sample_bathymetry()
     data = ship_data.bathymetry.to_xarray()  # convert pandas.Series to xarray.DataArray
     assert data_kind(data) == "grid"
     with pytest.raises(GMTInvalidInput):
         surface(data=data, spacing="5m", region=[245, 255, 20, 30])
 
 
-def test_surface_with_outfile_param():
+def test_surface_with_outfile_param(ship_data):
     """
     Run surface with the -Goutputfile.nc parameter.
     """
-    ship_data = load_sample_bathymetry()
     data = ship_data.values  # convert pandas.DataFrame to numpy.ndarray
     try:
         output = surface(
@@ -97,12 +101,11 @@ def test_surface_with_outfile_param():
     return output
 
 
-def test_surface_short_aliases():
+def test_surface_short_aliases(ship_data):
     """
     Run surface using short aliases -I for spacing, -R for region, -G for
     outfile.
     """
-    ship_data = load_sample_bathymetry()
     data = ship_data.values  # convert pandas.DataFrame to numpy.ndarray
     try:
         output = surface(data=data, I="5m", R=[245, 255, 20, 30], G=TEMP_GRID)


### PR DESCRIPTION
Similar to #1353, this pull request moves assigning the returned value from `load_sample_bathymetry()` to `ship_data` from the six separate instances in the `test_surface.py` functions to its own fixture function.

On my machine, this reduced average testing time over 5 runs from 1.68 seconds to 1.46 seconds.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
