### PR TITLE
Mark two velo tests as xfail due to upstream fixes

### DIFF
--- a/pygmt/tests/test_velo.py
+++ b/pygmt/tests/test_velo.py
@@ -3,8 +3,12 @@ Tests velo.
 """
 import pandas as pd
 import pytest
-from pygmt import Figure
+from packaging.version import Version
+from pygmt import Figure, clib
 from pygmt.exceptions import GMTInvalidInput
+
+with clib.Session() as _lib:
+    gmt_version = Version(_lib.info["version"])
 
 
 @pytest.fixture(scope="module", name="dataframe")
@@ -26,6 +30,10 @@ def fixture_dataframe():
     )
 
 
+@pytest.mark.xfail(
+    condition=gmt_version > Version("6.2.0"),
+    reason="Upstream bug fixed by https://github.com/GenericMappingTools/gmt/pull/5360.",
+)
 @pytest.mark.mpl_image_compare
 def test_velo_numpy_array_numeric_only(dataframe):
     """
@@ -63,6 +71,10 @@ def test_velo_without_spec(dataframe):
         fig.velo(data=dataframe)
 
 
+@pytest.mark.xfail(
+    condition=gmt_version > Version("6.2.0"),
+    reason="Upstream bug fixed by https://github.com/GenericMappingTools/gmt/pull/5360.",
+)
 @pytest.mark.mpl_image_compare
 def test_velo_pandas_dataframe(dataframe):
     """


### PR DESCRIPTION
**Description of proposed changes**

https://github.com/GenericMappingTools/gmt/pull/5360 fixes a bug related to velo pen settings. 

Two velo tests fail due to the upstream bug fixes and are marked as "xfail".


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
