### PR TITLE
Change references from "master" branch to "main" branch

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -2,13 +2,13 @@
 ########################################################################################
 # Comment to be posted to on first time issues
 newIssueWelcomeComment: |
-  👋 Thanks for opening your first issue here! Please make sure you filled out the template with as much detail as possible. You might also want to take a look at our [contributing guidelines](https://github.com/GenericMappingTools/pygmt/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/GenericMappingTools/pygmt/blob/master/CODE_OF_CONDUCT.md).
+  👋 Thanks for opening your first issue here! Please make sure you filled out the template with as much detail as possible. You might also want to take a look at our [contributing guidelines](https://github.com/GenericMappingTools/pygmt/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/GenericMappingTools/pygmt/blob/main/CODE_OF_CONDUCT.md).
 
 # Comment to be posted to on PRs from first time contributors in your repository
 newPRWelcomeComment: |
   💖 Thanks for opening this pull request! 💖
 
-  Please make sure you read our [contributing guidelines](https://github.com/GenericMappingTools/pygmt/blob/master/CONTRIBUTING.md) and abide by our [code of conduct](https://github.com/GenericMappingTools/pygmt/blob/master/CODE_OF_CONDUCT.md).
+  Please make sure you read our [contributing guidelines](https://github.com/GenericMappingTools/pygmt/blob/main/CONTRIBUTING.md) and abide by our [code of conduct](https://github.com/GenericMappingTools/pygmt/blob/main/CODE_OF_CONDUCT.md).
 
   A few things to keep in mind:
 

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -4,7 +4,7 @@ name: Docs
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths-ignore:
@@ -114,7 +114,7 @@ jobs:
 
       - name: Push the built HTML to gh-pages
         run: |
-          # Detect if this is a release or from the master branch
+          # Detect if this is a release or from the main branch
           if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
               # Get the tag name without the "refs/tags/" part
               version="${GITHUB_REF#refs/*/}"

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -4,7 +4,7 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths-ignore:

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -23,7 +23,7 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  test_gmt_main:
+  test_gmt_dev:
     name: ${{ matrix.os }} - GMT ${{ matrix.gmt_git_ref }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -4,7 +4,7 @@ name: GMT Dev Tests
 
 on:
   # push:
-  #   branches: [ master ]
+  #   branches: [ main ]
   pull_request:
     types: [ready_for_review]
     paths-ignore:
@@ -23,7 +23,7 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  test_gmt_master:
+  test_gmt_main:
     name: ${{ matrix.os }} - GMT ${{ matrix.gmt_git_ref }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -31,7 +31,7 @@ jobs:
       matrix:
         python-version: [3.9]
         os: [ubuntu-latest, macOS-11.0, windows-latest]
-        gmt_git_ref: [master]
+        gmt_git_ref: [main]
     defaults:
       run:
         shell: bash -l {0}
@@ -90,7 +90,7 @@ jobs:
 
       # Build and install latest GMT from GitHub
       - name: Install GMT ${{ matrix.gmt_git_ref }} branch (Linux/macOS)
-        run: curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/build-gmt.sh | bash
+        run: curl https://raw.githubusercontent.com/GenericMappingTools/gmt/main/ci/build-gmt.sh | bash
         env:
           GMT_GIT_REF: ${{ matrix.gmt_git_ref }}
           GMT_INSTALL_DIR: ${{ github.workspace }}/gmt-install-dir

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         python-version: [3.9]
         os: [ubuntu-latest, macOS-11.0, windows-latest]
-        gmt_git_ref: [main]
+        gmt_git_ref: [master]
     defaults:
       run:
         shell: bash -l {0}
@@ -90,7 +90,7 @@ jobs:
 
       # Build and install latest GMT from GitHub
       - name: Install GMT ${{ matrix.gmt_git_ref }} branch (Linux/macOS)
-        run: curl https://raw.githubusercontent.com/GenericMappingTools/gmt/main/ci/build-gmt.sh | bash
+        run: curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/build-gmt.sh | bash
         env:
           GMT_GIT_REF: ${{ matrix.gmt_git_ref }}
           GMT_INSTALL_DIR: ${{ github.workspace }}/gmt-install-dir

--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         echo -e "## Summary of changed images\n" > report.md
         echo -e "This is an auto-generated report of images that have changed on the DVC remote\n" >> report.md
-        dvc diff --show-md master HEAD >> report.md
+        dvc diff --show-md main HEAD >> report.md
 
         # Get just the filename of the added and modified image from the report
         awk 'NF==5 && NR>=7 && $2=="added" {print $4}' report.md > added_files.txt
@@ -68,8 +68,8 @@ jobs:
           cml-publish --title $line --md "$line" >> modified_images_new.md < /dev/null
         done < modified_files.txt
 
-        # Pull images in the master branch from cloud storage
-        git checkout master
+        # Pull images in the main branch from cloud storage
+        git checkout main
         dvc pull --remote upstream
         # Upload old images
         while IFS= read -r line; do

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,18 +2,18 @@
 
 name: Publish to PyPI
 
-# Only run for pushes to the master branch and releases.
+# Only run for pushes to the main branch and releases.
 on:
   push:
     branches:
-      - master
+      - main
   release:
     types:
       - published
   # Runs for pull requests should be disabled other than for testing purposes
   #pull_request:
   #  branches:
-  #    - master
+  #    - main
 
 jobs:
   publish-pypi:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,13 +4,13 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5.15.0
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -2,7 +2,7 @@ name: Style Checks
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
   # Schedule daily tests
   schedule:

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ PyGMT
 .. image:: https://github.com/GenericMappingTools/pygmt/workflows/GMT%20Dev%20Tests/badge.svg
     :alt: GitHub Actions GMT Dev Tests status
     :target: https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_dev.yaml
-.. image:: https://img.shields.io/codecov/c/github/GenericMappingTools/pygmt/master.svg?style=flat-square
+.. image:: https://img.shields.io/codecov/c/github/GenericMappingTools/pygmt/main.svg?style=flat-square
     :alt: Test coverage status
     :target: https://codecov.io/gh/GenericMappingTools/pygmt
 .. image:: https://img.shields.io/pypi/pyversions/pygmt.svg?style=flat-square
@@ -110,14 +110,14 @@ Code of conduct
 +++++++++++++++
 
 Please note that this project is released with a `Contributor Code of Conduct
-<https://github.com/GenericMappingTools/pygmt/blob/master/CODE_OF_CONDUCT.md>`__.
+<https://github.com/GenericMappingTools/pygmt/blob/main/CODE_OF_CONDUCT.md>`__.
 By participating in this project you agree to abide by its terms.
 
 Contributing Guidelines
 +++++++++++++++++++++++
 
 Please read our `Contributing Guide
-<https://github.com/GenericMappingTools/pygmt/blob/master/CONTRIBUTING.md>`__ to
+<https://github.com/GenericMappingTools/pygmt/blob/main/CONTRIBUTING.md>`__ to
 see how you can help and give feedback.
 
 Imposter syndrome disclaimer
@@ -148,7 +148,7 @@ Citing PyGMT
 ------------
 
 PyGMT is a community developed project. See the
-`AUTHORS.md <https://github.com/GenericMappingTools/pygmt/blob/master/AUTHORS.md>`__
+`AUTHORS.md <https://github.com/GenericMappingTools/pygmt/blob/main/AUTHORS.md>`__
 file on GitHub for a list of the people involved and a definition of the term "PyGMT
 Developers". Feel free to cite our work in your research using the following BibTeX:
 
@@ -190,7 +190,7 @@ License
 
 PyGMT is free software: you can redistribute it and/or modify it under the terms of
 the **BSD 3-clause License**. A copy of this license is provided in
-`LICENSE.txt <https://github.com/GenericMappingTools/pygmt/blob/master/LICENSE.txt>`__.
+`LICENSE.txt <https://github.com/GenericMappingTools/pygmt/blob/main/LICENSE.txt>`__.
 
 
 Support
@@ -218,7 +218,7 @@ Other Python wrappers for GMT:
 Documentation for other versions
 --------------------------------
 
-* `Development <https://www.pygmt.org/dev>`__ (reflects the *master* branch on
+* `Development <https://www.pygmt.org/dev>`__ (reflects the *main* branch on
   GitHub)
 * `Latest release <https://www.pygmt.org/latest>`__
 * `v0.4.0 <https://www.pygmt.org/v0.4.0>`__

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -32,7 +32,7 @@
 
 
 {% block sidebartitle %}
-    <a href="{{ pathto(master_doc) }}"><h2 class="sidebar-title">{{ project }}</h2></a>
+    <a href="{{ pathto(main_doc) }}"><h2 class="sidebar-title">{{ project }}</h2></a>
 
     {% if theme_display_version %}
         {%- set nav_version = version %}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -32,7 +32,7 @@
 
 
 {% block sidebartitle %}
-    <a href="{{ pathto(main_doc) }}"><h2 class="sidebar-title">{{ project }}</h2></a>
+    <a href="{{ pathto(root_doc) }}"><h2 class="sidebar-title">{{ project }}</h2></a>
 
     {% if theme_display_version %}
         {%- set nav_version = version %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -114,7 +114,7 @@ source_suffix = ".rst"
 needs_sphinx = "1.8"
 # The encoding of source files.
 source_encoding = "utf-8-sig"
-main_doc = "index"
+root_doc = "index"
 
 # General information about the project
 year = datetime.date.today().year

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -114,7 +114,7 @@ source_suffix = ".rst"
 needs_sphinx = "1.8"
 # The encoding of source files.
 source_encoding = "utf-8-sig"
-master_doc = "index"
+main_doc = "index"
 
 # General information about the project
 year = datetime.date.today().year

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -164,11 +164,11 @@ html_context = {
     "menu_links": [
         (
             '<i class="fa fa-gavel fa-fw"></i> Code of Conduct',
-            f"{repository_url}/blob/master/CODE_OF_CONDUCT.md",
+            f"{repository_url}/blob/main/CODE_OF_CONDUCT.md",
         ),
         (
             '<i class="fa fa-book fa-fw"></i> License',
-            f"{repository_url}/blob/master/LICENSE.txt",
+            f"{repository_url}/blob/main/LICENSE.txt",
         ),
         (
             '<i class="fa fa-comment fa-fw"></i> Contact',
@@ -187,6 +187,6 @@ html_context = {
         zip(sphinx_gallery_conf["gallery_dirs"], sphinx_gallery_conf["examples_dirs"])
     ),
     "github_repo": repository,
-    "github_version": "master",
+    "github_version": "main",
     "commit": commit_link,
 }

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -7,7 +7,7 @@ The project is hosted at the
 
 The goal is to maintain a diverse community that's pleasant for everyone.
 **Please be considerate and respectful of others**. Everyone must abide by our
-[Code of Conduct](https://github.com/GenericMappingTools/pygmt/blob/master/CODE_OF_CONDUCT.md)
+[Code of Conduct](https://github.com/GenericMappingTools/pygmt/blob/main/CODE_OF_CONDUCT.md)
 and we encourage all to read it carefully.
 
 ## Ways to Contribute
@@ -169,7 +169,7 @@ Every change made goes through a pull request, even our own, so that our
 [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration)
 services have a chance to check that the code is up to standards and passes all
 our tests.
-This way, the *master* branch is always stable.
+This way, the *main* branch is always stable.
 
 General guidelines for making a Pull Request (PR):
 
@@ -255,10 +255,10 @@ conda activate pygmt
 
 You'll need to do this every time you start a new terminal.
 
-See the [`environment.yml`](https://github.com/GenericMappingTools/pygmt/blob/master/environment.yml)
+See the [`environment.yml`](https://github.com/GenericMappingTools/pygmt/blob/main/environment.yml)
 file for the list of dependencies and the environment name.
 
-We have a [`Makefile`](https://github.com/GenericMappingTools/pygmt/blob/master/Makefile)
+We have a [`Makefile`](https://github.com/GenericMappingTools/pygmt/blob/main/Makefile)
 that provides commands for installing, running the tests and coverage analysis,
 running linters, etc. If you don't want to use `make`, open the `Makefile` and
 copy the commands you want to run.
@@ -307,7 +307,7 @@ will comment on any pull requests as needed.
 We also use [flake8](http://flake8.pycqa.org/en/latest/) and
 [pylint](https://www.pylint.org/) to check the quality of the code and quickly catch
 common errors.
-The [`Makefile`](https://github.com/GenericMappingTools/pygmt/blob/master/Makefile)
+The [`Makefile`](https://github.com/GenericMappingTools/pygmt/blob/main/Makefile)
 contains rules for running both checks:
 
 ```bash

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -95,7 +95,7 @@ to make changes to our codebase. Every change made goes through a pull request, 
 our own, so that our
 [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration)
 services have a chance to check that the code is up to standards and passes all
-our tests. This way, the *master* branch is always stable.
+our tests. This way, the *main* branch is always stable.
 
 #### General Guidelines for Making a Pull Request (PR):
 
@@ -170,7 +170,7 @@ It will make your life a lot easier!
 
 The repository includes a conda environment file `environment.yml` with the
 specification for all development requirements to build and test the project.
-See the [`environment.yml`](https://github.com/GenericMappingTools/pygmt/blob/master/environment.yml)
+See the [`environment.yml`](https://github.com/GenericMappingTools/pygmt/blob/main/environment.yml)
 file for the list of dependencies and the environment name (`pygmt`).
 Once you have forked and cloned the repository to your local machine, you can
 use this file to create an isolated environment on which you can work.

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -189,7 +189,7 @@ conda activate pygmt
 ```
 
 
-We have a [`Makefile`](https://github.com/GenericMappingTools/pygmt/blob/master/Makefile)
+We have a [`Makefile`](https://github.com/GenericMappingTools/pygmt/blob/main/Makefile)
 that provides commands for installing, running the tests and coverage analysis,
 running linters, etc. If you don't want to use `make`, open the `Makefile` and
 copy the commands you want to run.

--- a/doc/external_resources.md
+++ b/doc/external_resources.md
@@ -2,9 +2,9 @@
 
 Below is a curated collection of external PyGMT resources.
 
-*To add your contribution to this collection, follow [these instructions](https://github.com/GenericMappingTools/pygmt/blob/master/CONTRIBUTING.md#editing-the-documentation)
+*To add your contribution to this collection, follow [these instructions](https://github.com/GenericMappingTools/pygmt/blob/main/CONTRIBUTING.md#editing-the-documentation)
 to submit a pull request with your recommended addition to the
-[External Resources file](https://github.com/GenericMappingTools/pygmt/blob/master/doc/external_resources.md).*
+[External Resources file](https://github.com/GenericMappingTools/pygmt/blob/main/doc/external_resources.md).*
 
 ---
 

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -4,7 +4,7 @@ This page contains instructions for project maintainers about how our setup work
 making releases, creating packages, etc.
 
 If you want to make a contribution to the project, see the
-[Contributing Guide](https://github.com/GenericMappingTools/pygmt/blob/master/CONTRIBUTING.md)
+[Contributing Guide](https://github.com/GenericMappingTools/pygmt/blob/main/CONTRIBUTING.md)
 instead.
 
 ## Onboarding Access Checklist
@@ -18,9 +18,9 @@ instead.
 
 ## Branches
 
-* *master*: Always tested and ready to become a new version. Don't push directly to this
+* *main*: Always tested and ready to become a new version. Don't push directly to this
   branch. Make a new branch and submit a pull request instead.
-* *gh-pages*: Holds the HTML documentation and is served by GitHub. Pages for the master
+* *gh-pages*: Holds the HTML documentation and is served by GitHub. Pages for the main
   branch are in the `dev` folder. Pages for each release are in their own folders.
   **Automatically updated by GitHub Actions** so you shouldn't have to make commits here.
 
@@ -57,7 +57,7 @@ This means that all commits will be collapsed into one.
 The main advantages of this are:
 
 * Eliminates experimental commits or commits to undo previous changes.
-* Makes sure every commit on master passes the tests and has a defined purpose.
+* Makes sure every commit on main passes the tests and has a defined purpose.
 * The maintainer writes the final commit message, so we can make sure it's good and
   descriptive.
 
@@ -73,13 +73,13 @@ There are 11 configuration files located in `.github/workflows`:
 
 1. `style_checks.yaml` (Code lint and style checks)
 
-   This is run on every commit to the *master* and Pull Request branches.
-   It is also scheduled to run daily on the *master* branch.
+   This is run on every commit to the *main* and Pull Request branches.
+   It is also scheduled to run daily on the *main* branch.
 
 2. `ci_tests.yaml` (Tests on Linux/macOS/Windows)
 
-   This is run on every commit to the *master* and Pull Request branches.
-   It is also scheduled to run daily on the *master* branch.
+   This is run on every commit to the *main* and Pull Request branches.
+   It is also scheduled to run daily on the *main* branch.
    In draft Pull Requests, only two jobs on Linux are triggered to save on
    Continuous Integration resources:
 
@@ -89,22 +89,22 @@ There are 11 configuration files located in `.github/workflows`:
 
 3. `ci_docs.yml` (Build documentation on Linux/macOS/Windows)
 
-   This is run on every commit to the *master* and Pull Request branches.
+   This is run on every commit to the *main* and Pull Request branches.
    In draft Pull Requests, only the job on Linux is triggered to save on
    Continuous Integration resources.
 
-   On the *master* branch, the workflow also handles the documentation
+   On the *main* branch, the workflow also handles the documentation
    deployment:
 
    * Updating the development documentation by pushing the built HTML pages
-     from the *master* branch onto the `dev` folder of the *gh-pages* branch.
+     from the *main* branch onto the `dev` folder of the *gh-pages* branch.
    * Updating the `latest` documentation link to the new release.
 
 4. `ci_tests_dev.yaml` (GMT Dev Tests on Linux/macOS/Windows).
 
    This is triggered when a PR is marked as "ready for review", or using the
    slash command `/test-gmt-dev`. It is also scheduled to run daily on the
-   *master* branch.
+   *main* branch.
 
 5. `cache_data.yaml` (Caches GMT remote data files needed for GitHub Actions CI)
 
@@ -115,13 +115,13 @@ There are 11 configuration files located in `.github/workflows`:
 6. `publish-to-pypi.yml` (Publish wheels to PyPI and TestPyPI)
 
    This workflow is run to publish wheels to PyPI and TestPyPI (for testing only).
-   Archives will be pushed to TestPyPI on every commit to the *master* branch
+   Archives will be pushed to TestPyPI on every commit to the *main* branch
    and tagged releases, and to PyPI for tagged releases only.
 
 7. `release-drafter.yml` (Drafts the next release notes)
 
     This workflow is run to update the next releases notes as pull requests are
-    merged into master.
+    merged into main.
 
 8. `check-links.yml` (Check links in the repository and website)
 
@@ -222,7 +222,7 @@ There are a few steps that still must be done manually, though.
 
 The Release Drafter GitHub Action will automatically keep a draft changelog at
 https://github.com/GenericMappingTools/pygmt/releases, adding a new entry
-every time a Pull Request (with a proper label) is merged into the master branch.
+every time a Pull Request (with a proper label) is merged into the main branch.
 This release drafter tool has two configuration files, one for the GitHub Action
 at .github/workflows/release-drafter.yml, and one for the changelog template
 at .github/release-drafter.yml. Configuration settings can be found at
@@ -305,5 +305,5 @@ If changes need to be done manually, you can:
    from the PyPI "Download files" section.
 3. Add or remove any new dependencies (most are probably only `run` dependencies).
 4. Make a new branch, commit, and push the changes **to your personal fork**.
-5. Create a PR against the original feedstock master.
+5. Create a PR against the original feedstock main.
 6. Once the CI tests pass, merge the PR or ask a maintainer to do so.

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -57,7 +57,7 @@ This means that all commits will be collapsed into one.
 The main advantages of this are:
 
 * Eliminates experimental commits or commits to undo previous changes.
-* Makes sure every commit on main passes the tests and has a defined purpose.
+* Makes sure every commit on the main branch passes the tests and has a defined purpose.
 * The maintainer writes the final commit message, so we can make sure it's good and
   descriptive.
 
@@ -121,7 +121,7 @@ There are 11 configuration files located in `.github/workflows`:
 7. `release-drafter.yml` (Drafts the next release notes)
 
     This workflow is run to update the next releases notes as pull requests are
-    merged into main.
+    merged into the main branch.
 
 8. `check-links.yml` (Check links in the repository and website)
 


### PR DESCRIPTION
As discussed in #1356, PyGMT is changing its default branch from "master" to "main". This pull request changes the references to "master" in the CI job files, maintenance.md, and the README.

Fixes #1356

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
