### PR TITLE
Fix two warnings with pylint v2.9.3

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -213,7 +213,6 @@ def meca(
     # pylint: disable=too-many-nested-blocks
     # pylint: disable=too-many-branches
     # pylint: disable=too-many-statements
-    # pylint: disable=consider-using-dict-items
 
     def set_pointer(data_pointers, spec):
         """
@@ -295,14 +294,12 @@ def meca(
                 spec_conv = spec
 
         # set convention and focal parameters based on spec convention
-        convention_assigned = False
-        for conv in param_conventions:
+        for conv in list(param_conventions):
             if set(spec_conv.keys()) == set(param_conventions[conv]):
                 convention = conv.lower()
                 foc_params = param_conventions[conv]
-                convention_assigned = True
                 break
-        if not convention_assigned:
+        else:
             raise GMTError(
                 "Parameters in spec dictionary do not match known " "conventions."
             )

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -213,6 +213,7 @@ def meca(
     # pylint: disable=too-many-nested-blocks
     # pylint: disable=too-many-branches
     # pylint: disable=too-many-statements
+    # pylint: disable=consider-using-dict-items
 
     def set_pointer(data_pointers, spec):
         """

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -299,9 +299,9 @@ def meca(
                 convention = conv.lower()
                 foc_params = param_conventions[conv]
                 break
-        else:
+        else: # if there is no convention assigned
             raise GMTError(
-                "Parameters in spec dictionary do not match known " "conventions."
+                "Parameters in spec dictionary do not match known conventions."
             )
 
         # create a dict type pointer for easier to read code

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -299,7 +299,7 @@ def meca(
                 convention = conv.lower()
                 foc_params = param_conventions[conv]
                 break
-        else: # if there is no convention assigned
+        else:  # if there is no convention assigned
             raise GMTError(
                 "Parameters in spec dictionary do not match known conventions."
             )

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -784,8 +784,8 @@ def test_info_dict():
     with mock(ses, "GMT_Get_Default", mock_func=mock_defaults):
         # Check for an empty dictionary
         assert ses.info
-        for key in ses.info:
-            assert ses.info[key] == "bla"
+        for value in ses.info.values():
+            assert value == "bla"
     ses.destroy()
 
 


### PR DESCRIPTION
**Description of proposed changes**

Fix two warnings in the latest style checks.

- pygmt/tests/test_clib.py - iterate over values
- pygmt/src/meca.py - disable warning since a full refactoring is needed.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
