### PR TITLE
Fix bug so that x2sys_cross accepts dataframes with NaN values

### DIFF
--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -47,6 +47,7 @@ def tempfile_from_dftrack(track, suffix):
             path_or_buf=tmpfilename,
             sep="\t",
             index=False,
+            na_rep="NaN",  # write a NaN value explicitly instead of a blank string
             date_format="%Y-%m-%dT%H:%M:%S.%fZ",
         )
         yield tmpfilename

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -75,7 +75,7 @@ def test_x2sys_cross_input_file_output_dataframe(mock_x2sys_home):
 
 def test_x2sys_cross_input_dataframe_output_dataframe(mock_x2sys_home, tracks):
     """
-    Run x2sys_cross by passing in one dataframe, and output external crossovers
+    Run x2sys_cross by passing in one dataframe, and output internal crossovers
     to a pandas.DataFrame.
     """
     with TemporaryDirectory(prefix="X2SYS", dir=os.getcwd()) as tmpdir:
@@ -127,6 +127,29 @@ def test_x2sys_cross_input_two_dataframes(mock_x2sys_home):
         assert columns[6:] == ["head_1", "head_2", "vel_1", "vel_2", "z_X", "z_M"]
         assert output.dtypes["t_1"].type == np.datetime64
         assert output.dtypes["t_2"].type == np.datetime64
+
+
+def test_x2sys_cross_input_dataframe_with_nan(mock_x2sys_home, tracks):
+    """
+    Run x2sys_cross by passing in one dataframe with NaN values, and output
+    internal crossovers to a pandas.DataFrame.
+    """
+    with TemporaryDirectory(prefix="X2SYS", dir=os.getcwd()) as tmpdir:
+        tag = os.path.basename(tmpdir)
+        x2sys_init(
+            tag=tag, fmtfile="xyz", suffix="xyzt", units=["de", "se"], force=True
+        )
+
+        tracks[0].loc[tracks[0]["z"] < -15, "z"] = np.nan  # set some values to NaN
+        output = x2sys_cross(tracks=tracks, tag=tag, coe="i")
+
+        assert isinstance(output, pd.DataFrame)
+        assert output.shape == (3, 12)
+        columns = list(output.columns)
+        assert columns[:6] == ["x", "y", "i_1", "i_2", "dist_1", "dist_2"]
+        assert columns[6:] == ["head_1", "head_2", "vel_1", "vel_2", "z_X", "z_M"]
+        assert output.dtypes["i_1"].type == np.object_
+        assert output.dtypes["i_2"].type == np.object_
 
 
 def test_x2sys_cross_input_two_filenames(mock_x2sys_home):


### PR DESCRIPTION
**Description of proposed changes**

Ensure that the NaN values properly written to the temporary track file in tempfile_from_dftrack so that GMT's `x2sys_cross` function can read it properly. Added a regression unit test to ensure that the pandas EmptyDataError doesn't occur again.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1368


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
