### PR TITLE
Add return statement to grdclip and grdgradient docstring

### DIFF
--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -68,10 +68,12 @@ def grdclip(grid, **kwargs):
         Set all data[i] == *old* to *new*. This is mostly useful when
         your data are known to be integer values.
     {V}
+    
     Returns
     -------
     ret: xarray.DataArray or None
         Return type depends on whether the ``outgrid`` parameter is set:
+        
         - :class:`xarray.DataArray` if ``outgrid`` is not set
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -68,12 +68,12 @@ def grdclip(grid, **kwargs):
         Set all data[i] == *old* to *new*. This is mostly useful when
         your data are known to be integer values.
     {V}
-    
+
     Returns
     -------
     ret: xarray.DataArray or None
         Return type depends on whether the ``outgrid`` parameter is set:
-        
+
         - :class:`xarray.DataArray` if ``outgrid`` is not set
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -68,6 +68,13 @@ def grdclip(grid, **kwargs):
         Set all data[i] == *old* to *new*. This is mostly useful when
         your data are known to be integer values.
     {V}
+    Returns
+    -------
+    ret: xarray.DataArray or None
+        Return type depends on whether the ``outgrid`` parameter is set:
+        - :class:`xarray.DataArray` if ``outgrid`` is not set
+        - None if ``outgrid`` is set (grid output will be stored in file set by
+          ``outgrid``)
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -92,6 +92,15 @@ def grdgradient(grid, **kwargs):
     {R}
     {V}
     {n}
+    
+    Returns
+    -------
+    ret: xarray.DataArray or None
+        Return type depends on whether the ``outgrid`` parameter is set:
+        
+        - :class:`xarray.DataArray` if ``outgrid`` is not set
+        - None if ``outgrid`` is set (grid output will be stored in file set by
+          ``outgrid``)
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         if not args_in_kwargs(args=["A", "D", "E"], kwargs=kwargs):

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -92,12 +92,12 @@ def grdgradient(grid, **kwargs):
     {R}
     {V}
     {n}
-    
+
     Returns
     -------
     ret: xarray.DataArray or None
         Return type depends on whether the ``outgrid`` parameter is set:
-        
+
         - :class:`xarray.DataArray` if ``outgrid`` is not set
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)


### PR DESCRIPTION
**Description of proposed changes**

Updated the docstring in grdclip.py to have a return statement.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1388


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [x] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
