### PR TITLE
Add how to use different colormaps for subplots

### DIFF
--- a/examples/gallery/embellishments/colorbars_multiple.py
+++ b/examples/gallery/embellishments/colorbars_multiple.py
@@ -1,0 +1,43 @@
+"""
+Multiple colormaps
+------------------
+This gallery shows how to use multiple colormaps for different subplots. To
+better understand how GMT modern mode maintain several levels of colormaps,
+please refer to :gmt-docs:`cookbook/features.html#gmt-modern-mode-hierarchical-levels`
+for details.
+"""
+import pygmt
+
+fig = pygmt.Figure()
+
+# Load Earth relief data for the entire globe and a subset region
+grid_globe = pygmt.datasets.load_earth_relief(resolution="01d")
+subset_region = [-14, 30, 35, 60]
+grid_subset = pygmt.datasets.load_earth_relief(resolution="10m", region=subset_region)
+
+# Define a 1-row, 2-column subplot layout. The overall figure dimensions is set
+# to be 15 cm wide and 8 cm high. Each subplot is automatically labelled.
+# The space between the subplots is set to be 0.5 cm.
+with fig.subplot(
+    nrows=1, ncols=2, figsize=("15c", "8c"), autolabel=True, margins="0.5c"
+):
+    # Activate the first panel so that the corlomap created by the makecpt
+    # method is a panel-level CPT
+    with fig.set_panel(panel=0):
+        pygmt.makecpt(cmap="geo", series=[-8000, 8000])
+        # "R?" means Winkel Tripel projection with map width automatically
+        # determined from the subplot width.
+        fig.grdimage(grid=grid_globe, projection="R?", region="g", frame=True)
+        fig.colorbar(frame=["a4000f2000", "x+lElevation", "y+lm"])
+    # Activate the second panel so that the corlomap created by the makecpt
+    # method is a panel-level CPT
+    with fig.set_panel(panel=1):
+        pygmt.makecpt(cmap="globe", series=[-6000, 3000])
+        # "M?" means Mercator projection with map width also automatically
+        # determined from the subplot width.
+        fig.grdimage(
+            grid=grid_subset, projection="M?", region=subset_region, frame=True
+        )
+        fig.colorbar(frame=["a2000f1000", "x+lElevation", "y+lm"])
+
+fig.show()

--- a/examples/gallery/embellishments/colorbars_multiple.py
+++ b/examples/gallery/embellishments/colorbars_multiple.py
@@ -1,7 +1,7 @@
 """
 Multiple colormaps
 ------------------
-This gallery shows how to create multiple colormaps for different subplots. To
+This gallery example shows how to create multiple colormaps for different subplots. To
 better understand how GMT modern mode maintain several levels of colormaps,
 please refer to :gmt-docs:`cookbook/features.html#gmt-modern-mode-hierarchical-levels`
 for details.
@@ -21,7 +21,7 @@ grid_subset = pygmt.datasets.load_earth_relief(resolution="10m", region=subset_r
 with fig.subplot(
     nrows=1, ncols=2, figsize=("15c", "8c"), autolabel=True, margins="0.5c"
 ):
-    # Activate the first panel so that the corlomap created by the makecpt
+    # Activate the first panel so that the colormap created by the makecpt
     # method is a panel-level CPT
     with fig.set_panel(panel=0):
         pygmt.makecpt(cmap="geo", series=[-8000, 8000])
@@ -29,7 +29,7 @@ with fig.subplot(
         # determined from the subplot width.
         fig.grdimage(grid=grid_globe, projection="R?", region="g", frame=True)
         fig.colorbar(frame=["a4000f2000", "x+lElevation", "y+lm"])
-    # Activate the second panel so that the corlomap created by the makecpt
+    # Activate the second panel so that the colormap created by the makecpt
     # method is a panel-level CPT
     with fig.set_panel(panel=1):
         pygmt.makecpt(cmap="globe", series=[-6000, 3000])

--- a/examples/gallery/embellishments/colorbars_multiple.py
+++ b/examples/gallery/embellishments/colorbars_multiple.py
@@ -1,7 +1,7 @@
 """
 Multiple colormaps
 ------------------
-This gallery shows how to use multiple colormaps for different subplots. To
+This gallery shows how to create multiple colormaps for different subplots. To
 better understand how GMT modern mode maintain several levels of colormaps,
 please refer to :gmt-docs:`cookbook/features.html#gmt-modern-mode-hierarchical-levels`
 for details.

--- a/examples/gallery/embellishments/colorbars_multiple.py
+++ b/examples/gallery/embellishments/colorbars_multiple.py
@@ -2,7 +2,7 @@
 Multiple colormaps
 ------------------
 This gallery example shows how to create multiple colormaps for different subplots. To
-better understand how GMT modern mode maintain several levels of colormaps,
+better understand how GMT modern mode maintains several levels of colormaps,
 please refer to :gmt-docs:`cookbook/features.html#gmt-modern-mode-hierarchical-levels`
 for details.
 """


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

This PR revises the example shown in https://forum.generic-mapping-tools.org/t/different-colorbars-for-subplots/1797/7 to clarify how to use different colormaps for subplots.

The regional Earth relief is chosen to be the same as the [Create a region map](https://www.pygmt.org/latest/tutorials/earth_relief.html#create-a-region-map) tutorial.

Fixes #1338


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
