### PR TITLE
Add 3 arc minute relief tile containing Iceland to cache

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  # pull_request:
+  pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  pull_request:
+  # pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -157,6 +157,8 @@ def download_test_data():
         "@earth_relief_10m_p",
         "@earth_relief_05m_p",
         "@earth_relief_05m_g",
+        "@earth_relief_01m_p",
+        "@earth_relief_01m_g",
         # List of tiles of 03s srtm data.
         # Names like @N35E135.earth_relief_03s_g.nc is for internal use only.
         # The naming scheme may change. DO NOT USE IT IN YOUR SCRIPTS.

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -157,8 +157,8 @@ def download_test_data():
         "@earth_relief_10m_p",
         "@earth_relief_05m_p",
         "@earth_relief_05m_g",
-        "@earth_relief_01m_p",
-        "@earth_relief_01m_g",
+        "@earth_relief_03m_p",
+        "@earth_relief_03m_g",
         # List of tiles of 03s srtm data.
         # Names like @N35E135.earth_relief_03s_g.nc is for internal use only.
         # The naming scheme may change. DO NOT USE IT IN YOUR SCRIPTS.

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -158,7 +158,6 @@ def download_test_data():
         "@earth_relief_05m_p",
         "@earth_relief_05m_g",
         "@earth_relief_03m_p",
-        "@earth_relief_03m_g",
         # List of tiles of 03s srtm data.
         # Names like @N35E135.earth_relief_03s_g.nc is for internal use only.
         # The naming scheme may change. DO NOT USE IT IN YOUR SCRIPTS.

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -157,11 +157,11 @@ def download_test_data():
         "@earth_relief_10m_p",
         "@earth_relief_05m_p",
         "@earth_relief_05m_g",
-        "@earth_relief_03m_p",
         # List of tiles of 03s srtm data.
         # Names like @N35E135.earth_relief_03s_g.nc is for internal use only.
         # The naming scheme may change. DO NOT USE IT IN YOUR SCRIPTS.
         "@N35E135.earth_relief_03s_g.nc",
+        "@N00W090.earth_relief_03m_p.nc",
         # Other cache files
         "@fractures_06.txt",
         "@ridge.txt",


### PR DESCRIPTION
**Description of proposed changes**

As discussed in #1396 this PR adds the 3 arc minute global relief data to cache.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
