### PR TITLE
Add tomli as a dependency in GMT Dev Tests

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -86,7 +86,8 @@ jobs:
           conda install ninja cmake libblas libcblas liblapack fftw gdal geopandas \
                         ghostscript libnetcdf hdf5 zlib curl pcre make dvc
           pip install --verbose --pre numpy pandas xarray netCDF4 packaging \
-                            ipython pytest-cov pytest-mpl pytest>=6.0 sphinx-gallery
+                            ipython pytest-cov pytest-mpl pytest>=6.0 sphinx-gallery \
+                            toml
           conda list
           pip list
 

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -87,6 +87,8 @@ jobs:
                         ghostscript libnetcdf hdf5 zlib curl pcre make dvc
           pip install --verbose --pre numpy pandas xarray netCDF4 packaging \
                             ipython pytest-cov pytest-mpl pytest>=6.0 sphinx-gallery
+          conda list
+          pip list
 
       # Build and install latest GMT from GitHub
       - name: Install GMT ${{ matrix.gmt_git_ref }} branch (Linux/macOS)

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -6,7 +6,7 @@ on:
   # push:
   #   branches: [ master ]
   pull_request:
-    types: [ready_for_review]
+    types: [synchronize, ready_for_review]
     paths-ignore:
       - 'doc/**'
       - 'examples/**'
@@ -85,7 +85,7 @@ jobs:
         run: |
           conda install ninja cmake libblas libcblas liblapack fftw gdal geopandas \
                         ghostscript libnetcdf hdf5 zlib curl pcre make dvc
-          pip install --pre numpy pandas xarray netCDF4 packaging \
+          pip install --verbose --pre numpy pandas xarray netCDF4 packaging \
                             ipython pytest-cov pytest-mpl pytest>=6.0 sphinx-gallery
 
       # Build and install latest GMT from GitHub

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -87,7 +87,7 @@ jobs:
                         ghostscript libnetcdf hdf5 zlib curl pcre make dvc
           pip install --verbose --pre numpy pandas xarray netCDF4 packaging \
                             ipython pytest-cov pytest-mpl pytest>=6.0 sphinx-gallery \
-                            toml
+                            tomli
           conda list
           pip list
 

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -6,7 +6,7 @@ on:
   # push:
   #   branches: [ main ]
   pull_request:
-    types: [synchronize, ready_for_review]
+    types: [ready_for_review]
     paths-ignore:
       - 'doc/**'
       - 'examples/**'
@@ -85,11 +85,9 @@ jobs:
         run: |
           conda install ninja cmake libblas libcblas liblapack fftw gdal geopandas \
                         ghostscript libnetcdf hdf5 zlib curl pcre make dvc
-          pip install --verbose --pre numpy pandas xarray netCDF4 packaging \
+          pip install --pre numpy pandas xarray netCDF4 packaging \
                             ipython pytest-cov pytest-mpl pytest>=6.0 sphinx-gallery \
                             tomli
-          conda list
-          pip list
 
       # Build and install latest GMT from GitHub
       - name: Install GMT ${{ matrix.gmt_git_ref }} branch (Linux/macOS)


### PR DESCRIPTION
**Description of proposed changes**

Adding `tomli` to fix the GMT Dev Tests breakages reported in #1392. This is a temporary measure until `pytest-cov` releases a new version > 2.12.1 to incorporate the dependency fix in https://github.com/pytest-dev/pytest-cov/pull/410.

~~While looking into #1392, I noticed that the `pip install --pre ...` command in `ci_tests_dev.yaml` doesn't seem to produce any output in the GitHub Actions log (see e.g. https://github.com/GenericMappingTools/pygmt/runs/3206665246?check_suite_focus=true#step:7:4). So are the `pip` packages actually being installed? Not sure if this is a bug introduced after #1105, so am investigating here.~~ Edit: ok, using `pip list` at 0a8ab3d99ed784fa39e1b1198edbe2326efa23cf shows that the pip packages are indeed installed.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1392


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
