### PR TITLE
Add common option aliases to COMMON_OPTIONS in decorators.py

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -198,8 +198,7 @@ COMMON_OPTIONS = {
                   **M**\ (iles), or **n**\ (autical miles) [Default is
                   (m)\ **e**\ (ter)].
                 - For projected data (**X**\|\ **Y**\|\ **D**), the unit may be
-                  **i**\ (nch), **c**\ (entimeter), or **p**\ (oint) [Default
-                  unit is set by :term:`PROJ_LENGTH_UNIT`].
+                  **i**\ (nch), **c**\ (entimeter), or **p**\ (oint).
 
             One of the following modifiers can be appended to *gap* [Default
             imposes breaks based on the absolute value of the difference
@@ -218,6 +217,7 @@ COMMON_OPTIONS = {
         [Default is 0]. Prepend **i** if only the primary input should have
         header records. Prepend **o** to control the writing of header records,
         with the following modifiers supported:
+
             - **+d** to remove existing header records.
             - **+c** to add a header comment with column names to the output
               [Default is no column names].
@@ -243,13 +243,13 @@ COMMON_OPTIONS = {
             - For :py:class:`str`: specify individual columns or column
               ranges in the format *start*\ [:*inc*]:*stop*, where *inc*
               defaults to 1 if not specified, with columns and/or column ranges
-              separated by commas (e.g., ``incols='0:2,4+l'`` to input the
+              separated by commas (e.g., ``incols="0:2,4+l"`` to input the
               first three columns followed by the log-transformed 5th column).
               To read from a given column until the end of the record, leave
               off *stop* when specifying the column range. To read trailing
               text, add the column **t**. Append the word number to **t** to
               ingest only a single word from the trailing text. Instead of
-              specifying columns, use ``incols='n'`` to simply read numerical
+              specifying columns, use ``incols="n"`` to simply read numerical
               input and skip trailing text. Optionally, append one of the
               following modifiers to any column or column range to transform
               the input columns:
@@ -298,13 +298,13 @@ COMMON_OPTIONS = {
             - For :py:class:`str`: specify individual columns or column
               ranges in the format *start*\ [:*inc*]:*stop*, where *inc*
               defaults to 1 if not specified, with columns and/or column ranges
-              separated by commas (e.g., ``outcols='0:2,4'`` to output the
+              separated by commas (e.g., ``outcols="0:2,4"`` to output the
               first three columns followed by the 5th column).
               To write from a given column until the end of the record, leave
               off *stop* when specifying the column range. To write trailing
               text, add the column **t**. Append the word number to **t** to
               write only a single word from the trailing text. Instead of
-              specifying columns, use ``outcols='n'`` to simply read numerical
+              specifying columns, use ``outcols="n"`` to simply read numerical
               input and skip trailing text. Note: if ``incols`` is also used
               then the columns given to ``outcols`` correspond to the order
               after the ``incols`` selection has taken place.
@@ -323,6 +323,23 @@ COMMON_OPTIONS = {
             Force gridline (**g**) or pixel (**p**) node registration.
             [Default is **g**\ (ridline)].
         """,
+    "s": r"""
+        skiprows : bool or str
+            [*cols*][**+a**][**+r**]
+            Suppress output for records whose *z*-value equals NaN [Default
+            outputs all records]. Optionally, supply a comma-separated list of
+            all columns or column ranges to consider for this NaN test [Default
+            only considers the third data column (i.e., *cols = 2*)]. Column
+            ranges must be given in the format *start*\ [:*inc*]:*stop*, where
+            *inc* defaults to 1 if not specified. The following modifiers are
+            supported:
+
+                - **+r** to reverse the suppression, i.e., only output the
+                  records whose *z*-value equals NaN.
+                - **+a** to suppress the output of the record if just one or
+                  more of the columns equal NaN [Default skips record only
+                  if values in all specified *cols* equal NaN].
+    """,
     "t": """\
         transparency : int or float
             Set transparency level, in [0-100] percent range.

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -102,6 +102,35 @@ COMMON_OPTIONS = {
             Control how aspatial data are handled during input and output.
             Full documentation is at :gmt-docs:`gmt.html#aspatial-full`.
          """,
+    "b": r"""
+        binary : bool or str
+            **-bi**\|\ **o**\ [*ncols*][*type*][**w**][**+l**\|\ **b**]
+            Select native binary input (using ``binary="i"``) or output
+            (using ``binary="o"``), where *ncols* is the number of data columns
+            of *type*, which must be one of:
+
+                - **c** - int8_t (1-byte signed char)
+                - **u** - uint8_t (1-byte unsigned char)
+                - **h** - int16_t (2-byte signed int)
+                - **H** - uint16_t (2-byte unsigned int)
+                - **i** - int32_t (4-byte signed int)
+                - **I** - uint32_t (4-byte unsigned int)
+                - **l** - int64_t (8-byte signed int)
+                - **L** - uint64_t (8-byte unsigned int)
+                - **f** - 4-byte single-precision float
+                - **d** - 8-byte double-precision float
+                - **x** - use to skip *ncols* anywhere in the record
+
+            For records with mixed types, append additional comma-separated
+            combinations of *ncols* *type* (no space). The following modifiers
+            are supported:
+
+                - **w** after any item to force byte-swapping.
+                - **+l**\|\ **b** to indicate that the entire data file should
+                  be read as little- or big-endian, respectively.
+
+            Full documentation is at :gmt-docs:`gmt.html#bi-full`.
+    """,
     "c": r"""
         panel : bool or int or list
             [*row,col*\|\ *index*].

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -143,13 +143,22 @@ COMMON_OPTIONS = {
     "c": r"""
         panel : bool or int or list
             [*row,col*\|\ *index*].
-            Selects a specific subplot panel. Only allowed when in subplot
+            Select a specific subplot panel. Only allowed when in subplot
             mode. Use ``panel=True`` to advance to the next panel in the
             selected order. Instead of *row,col* you may also give a scalar
             value *index* which depends on the order you set via ``autolabel``
             when the subplot was defined. **Note**: *row*, *col*, and *index*
             all start at 0.
          """,
+    "e": r"""
+        find : str
+            [**~**]\ *"pattern"* \| [**~**]/\ *regexp*/[**i**]
+            Only pass records that match the given *pattern* or regular
+            expressions [Default processes all records]. Prepend **~** to
+            the *pattern* or *regexp* to instead only pass data expressions
+            that do not match the pattern. Append **i** for case insensitive
+            matching. This does not apply to headers or segment headers.
+    """,
     "f": r"""
         coltypes : str
             [**i**\|\ **o**]\ *colinfo*.

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -201,7 +201,7 @@ COMMON_OPTIONS = {
                   **i**\ (nch), **c**\ (entimeter), or **p**\ (oint) [Default
                   unit is set by :term:`PROJ_LENGTH_UNIT`].
 
-            One of the following modifiers can be appended to *gap* [default
+            One of the following modifiers can be appended to *gap* [Default
             imposes breaks based on the absolute value of the difference
             between the current and previous value]:
 
@@ -209,6 +209,27 @@ COMMON_OPTIONS = {
                   column value must exceed *gap* for a break to be imposed.
                 - **+p** - specify that the current value minus the previous
                   value must exceed *gap* for a break to be imposed.
+    """,
+    "h": r"""
+    header : str
+        [**i**\|\ **o**][*n*][**+c**][**+d**][**+m**\ *segheader*][**+r**\
+        *remark*][**+t**\ *title*]
+        Specify that input and/or output file(s) have *n* header records
+        [Default is 0]. Prepend **i** if only the primary input should have
+        header records. Prepend **o** to control the writing of header records,
+        with the following modifiers supported:
+            - **+d** to remove existing header records.
+            - **+c** to add a header comment with column names to the output
+              [Default is no column names].
+            - **+m** to add a segment header *segheader* to the output after 
+              the header block [Default is no segment header].
+            - **+r** to add a *remark* comment to the output [Default is no
+              comment]. The *remark* string may contain \\n to indicate
+              line-breaks.
+            - **+t** to add a *title* comment to the output [Default is no
+              title]. The *title* string may contain \\n to indicate line-breaks.
+        
+        **Note**: Blank lines and lines starting with \# are always skipped.
     """,
     "i": r"""
         incols : str or 1d array
@@ -235,10 +256,10 @@ COMMON_OPTIONS = {
 
                 - **+l** to take the *log10* of the input values.
                 - **+d** to divide the input values by the factor *divisor*
-                  [default is 1].
+                  [Default is 1].
                 - **+s** to multiple the input values by the factor *scale*
-                  [default is 1].
-                - **+o** to add the given *offset* to the input values [default
+                  [Default is 1].
+                - **+o** to add the given *offset* to the input values [Default
                   is 0].""",
     "j": r"""
         distcalc : str

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -221,15 +221,15 @@ COMMON_OPTIONS = {
             - **+d** to remove existing header records.
             - **+c** to add a header comment with column names to the output
               [Default is no column names].
-            - **+m** to add a segment header *segheader* to the output after 
+            - **+m** to add a segment header *segheader* to the output after
               the header block [Default is no segment header].
             - **+r** to add a *remark* comment to the output [Default is no
               comment]. The *remark* string may contain \\n to indicate
               line-breaks.
             - **+t** to add a *title* comment to the output [Default is no
               title]. The *title* string may contain \\n to indicate line-breaks.
-        
-        **Note**: Blank lines and lines starting with \# are always skipped.
+
+        Blank lines and lines starting with \# are always skipped.
     """,
     "i": r"""
         incols : str or 1d array
@@ -285,6 +285,30 @@ COMMON_OPTIONS = {
             - **c** for bicubic [Default]
             - **l** for bilinear
             - **n** for nearest-neighbor""",
+    "o": r"""
+        outcols : str or 1d array
+            *cols*\ [,...][,\ **t**\ [*word*]]
+            Specify data columns for primary output in arbitrary order. Columns
+            can be repeated and columns not listed will be skipped [Default
+            writes all columns in order, starting with the first (i.e., column
+            0)].
+
+            - For *1d array*: specify individual columns in output order (e.g.,
+              ``outcols=[1,0]`` for the 2nd column followed by the 1st column).
+            - For :py:class:`str`: specify individual columns or column
+              ranges in the format *start*\ [:*inc*]:*stop*, where *inc*
+              defaults to 1 if not specified, with columns and/or column ranges
+              separated by commas (e.g., ``outcols='0:2,4'`` to output the
+              first three columns followed by the 5th column).
+              To write from a given column until the end of the record, leave
+              off *stop* when specifying the column range. To write trailing
+              text, add the column **t**. Append the word number to **t** to
+              write only a single word from the trailing text. Instead of
+              specifying columns, use ``outcols='n'`` to simply read numerical
+              input and skip trailing text. Note: if ``incols`` is also used
+              then the columns given to ``outcols`` correspond to the order
+              after the ``incols`` selection has taken place.
+    """,
     "p": r"""
         perspective : list or str
             [**x**\|\ **y**\|\ **z**]\ *azim*\[/*elev*\[/*zlevel*]]\

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -166,6 +166,50 @@ COMMON_OPTIONS = {
             geographical data). Full documentation is at
             :gmt-docs:`gmt.html#f-full`.
          """,
+    "g": r"""
+        gap : str or list
+            [**a**]\ **x**\|\ **y**\|\ **d**\|\ **X**\|\ **Y**\|\
+            **D**\|[*col*]\ **z**\ *gap*\ [**+n**\|\ **p**]
+            Examine the spacing between consecutive data points in order to
+            impose breaks in the line. To specify multiple critera, provide
+            a list with each item containing a string describing one set of
+            critera. Prepend **a** to specify that all the criteria must be
+            met [Default is to impose breaks if any criteria are met]. The
+            following modifiers are supported:
+
+                - **x**\|\ **X** - define a gap when there is a large enough
+                  change in the x coordinates (upper case to use projected
+                  coordinates).
+                - **y**\|\ **Y** - define a gap when there is a large enough
+                  change in the y coordinates (upper case to use projected
+                  coordinates).
+                - **d**\|\ **D** - define a gap when there is a large enough
+                  distance between coordinates (upper case to use projected
+                  coordinates).
+                - [*col*]\ **z** - define a gap when there is a large enough
+                  change in the data in column *col* [default *col* is 2 (i.e.,
+                  3rd column)].
+
+            A unit **u** may be appended to the specified *gap*:
+
+                - For geographic data (**x**\|\ **y**\|\ **d**), the unit may
+                  be arc **d**\ (egree), **m**\ (inute), and **s**\ (econd), or
+                  (m)\ **e**\ (ter), **f**\ (eet), **k**\ (ilometer),
+                  **M**\ (iles), or **n**\ (autical miles) [Default is
+                  (m)\ **e**\ (ter)].
+                - For projected data (**X**\|\ **Y**\|\ **D**), the unit may be
+                  **i**\ (nch), **c**\ (entimeter), or **p**\ (oint) [Default
+                  unit is set by :term:`PROJ_LENGTH_UNIT`].
+
+            One of the following modifiers can be appended to *gap* [default
+            imposes breaks based on the absolute value of the difference
+            between the current and previous value]:
+
+                - **+n** - specify that the previous value minus the current
+                  column value must exceed *gap* for a break to be imposed.
+                - **+p** - specify that the current value minus the previous
+                  value must exceed *gap* for a break to be imposed.
+    """,
     "i": r"""
         incols : str or 1d array
             Specify data columns for primary input in arbitrary order. Columns

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -104,7 +104,7 @@ COMMON_OPTIONS = {
          """,
     "b": r"""
         binary : bool or str
-            **i**\|\ **o**\ [*ncols*][*type*][**w**][**+l**\|\ **b**]
+            **i**\|\ **o**\ [*ncols*][*type*][**w**][**+l**\|\ **b**].
             Select native binary input (using ``binary="i"``) or output
             (using ``binary="o"``), where *ncols* is the number of data columns
             of *type*, which must be one of:
@@ -132,7 +132,7 @@ COMMON_OPTIONS = {
             Full documentation is at :gmt-docs:`gmt.html#bi-full`.""",
     "d": r"""
         nodata : str
-            **i**\|\ **o**\ *nodata*
+            **i**\|\ **o**\ *nodata*.
             Substitute specific values with NaN (for tabular data). For
             example, ``d="-9999"`` will replace all values equal to -9999 with
             NaN during input and all NaN values with -9999 during output.
@@ -150,7 +150,7 @@ COMMON_OPTIONS = {
          """,
     "e": r"""
         find : str
-            [**~**]\ *"pattern"* \| [**~**]/\ *regexp*/[**i**]
+            [**~**]\ *"pattern"* \| [**~**]/\ *regexp*/[**i**].
             Only pass records that match the given *pattern* or regular
             expressions [Default processes all records]. Prepend **~** to
             the *pattern* or *regexp* to instead only pass data expressions
@@ -165,7 +165,7 @@ COMMON_OPTIONS = {
     "g": r"""
         gap : str or list
             [**a**]\ **x**\|\ **y**\|\ **d**\|\ **X**\|\ **Y**\|\
-            **D**\|[*col*]\ **z**\ *gap*\ [**+n**\|\ **p**]
+            **D**\|[*col*]\ **z**\ *gap*\ [**+n**\|\ **p**].
             Examine the spacing between consecutive data points in order to
             impose breaks in the line. To specify multiple critera, provide
             a list with each item containing a string describing one set of
@@ -205,26 +205,27 @@ COMMON_OPTIONS = {
                 - **+p** - specify that the current value minus the previous
                   value must exceed *gap* for a break to be imposed.""",
     "h": r"""
-    header : str
-        [**i**\|\ **o**][*n*][**+c**][**+d**][**+m**\ *segheader*][**+r**\
-        *remark*][**+t**\ *title*]
-        Specify that input and/or output file(s) have *n* header records
-        [Default is 0]. Prepend **i** if only the primary input should have
-        header records. Prepend **o** to control the writing of header records,
-        with the following modifiers supported:
+        header : str
+            [**i**\|\ **o**][*n*][**+c**][**+d**][**+m**\ *segheader*][**+r**\
+            *remark*][**+t**\ *title*].
+            Specify that input and/or output file(s) have *n* header records
+            [Default is 0]. Prepend **i** if only the primary input should have
+            header records. Prepend **o** to control the writing of header
+            records, with the following modifiers supported:
 
-            - **+d** to remove existing header records.
-            - **+c** to add a header comment with column names to the output
-              [Default is no column names].
-            - **+m** to add a segment header *segheader* to the output after
-              the header block [Default is no segment header].
-            - **+r** to add a *remark* comment to the output [Default is no
-              comment]. The *remark* string may contain \\n to indicate
-              line-breaks.
-            - **+t** to add a *title* comment to the output [Default is no
-              title]. The *title* string may contain \\n to indicate line-breaks.
+                - **+d** to remove existing header records.
+                - **+c** to add a header comment with column names to the
+                  output [Default is no column names].
+                - **+m** to add a segment header *segheader* to the output
+                  after the header block [Default is no segment header].
+                - **+r** to add a *remark* comment to the output [Default is no
+                  comment]. The *remark* string may contain \\n to indicate
+                  line-breaks.
+                - **+t** to add a *title* comment to the output [Default is no
+                  title]. The *title* string may contain \\n to indicate
+                  line-breaks.
 
-        Blank lines and lines starting with \# are always skipped.""",
+            Blank lines and lines starting with \# are always skipped.""",
     "i": r"""
         incols : str or 1d array
             Specify data columns for primary input in arbitrary order. Columns
@@ -281,7 +282,7 @@ COMMON_OPTIONS = {
             - **n** for nearest-neighbor""",
     "o": r"""
         outcols : str or 1d array
-            *cols*\ [,...][,\ **t**\ [*word*]]
+            *cols*\ [,...][,\ **t**\ [*word*]].
             Specify data columns for primary output in arbitrary order. Columns
             can be repeated and columns not listed will be skipped [Default
             writes all columns in order, starting with the first (i.e., column
@@ -318,7 +319,7 @@ COMMON_OPTIONS = {
         """,
     "s": r"""
         skiprows : bool or str
-            [*cols*][**+a**][**+r**]
+            [*cols*][**+a**][**+r**].
             Suppress output for records whose *z*-value equals NaN [Default
             outputs all records]. Optionally, supply a comma-separated list of
             all columns or column ranges to consider for this NaN test [Default
@@ -342,7 +343,7 @@ COMMON_OPTIONS = {
     "w": r"""
         wrap : str
             **y**\|\ **a**\|\ **w**\|\ **d**\|\ **h**\|\ **m**\|\ **s**\|\
-            **c**\ *period*\ [/*phase*][**+c**\ *col*]
+            **c**\ *period*\ [/*phase*][**+c**\ *col*].
             Convert the input *x*-coordinate to a cyclical coordinate, or a
             different column if selected via **+c**\ *col*. The following
             cyclical coordinate transformations are supported:

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -129,8 +129,7 @@ COMMON_OPTIONS = {
                 - **+l**\|\ **b** to indicate that the entire data file should
                   be read as little- or big-endian, respectively.
 
-            Full documentation is at :gmt-docs:`gmt.html#bi-full`.
-    """,
+            Full documentation is at :gmt-docs:`gmt.html#bi-full`.""",
     "d": r"""
         nodata : str
             **i**\|\ **o**\ *nodata*
@@ -138,8 +137,7 @@ COMMON_OPTIONS = {
             example, ``d="-9999"`` will replace all values equal to -9999 with
             NaN during input and all NaN values with -9999 during output.
             Prepend **i** to the *nodata* value for input columns only. Prepend
-            **o** to the *nodata* value for output columns only.
-    """,
+            **o** to the *nodata* value for output columns only.""",
     "c": r"""
         panel : bool or int or list
             [*row,col*\|\ *index*].
@@ -157,15 +155,13 @@ COMMON_OPTIONS = {
             expressions [Default processes all records]. Prepend **~** to
             the *pattern* or *regexp* to instead only pass data expressions
             that do not match the pattern. Append **i** for case insensitive
-            matching. This does not apply to headers or segment headers.
-    """,
+            matching. This does not apply to headers or segment headers.""",
     "f": r"""
         coltypes : str
             [**i**\|\ **o**]\ *colinfo*.
             Specify data types of input and/or output columns (time or
             geographical data). Full documentation is at
-            :gmt-docs:`gmt.html#f-full`.
-         """,
+            :gmt-docs:`gmt.html#f-full`.""",
     "g": r"""
         gap : str or list
             [**a**]\ **x**\|\ **y**\|\ **d**\|\ **X**\|\ **Y**\|\
@@ -207,8 +203,7 @@ COMMON_OPTIONS = {
                 - **+n** - specify that the previous value minus the current
                   column value must exceed *gap* for a break to be imposed.
                 - **+p** - specify that the current value minus the previous
-                  value must exceed *gap* for a break to be imposed.
-    """,
+                  value must exceed *gap* for a break to be imposed.""",
     "h": r"""
     header : str
         [**i**\|\ **o**][*n*][**+c**][**+d**][**+m**\ *segheader*][**+r**\
@@ -229,8 +224,7 @@ COMMON_OPTIONS = {
             - **+t** to add a *title* comment to the output [Default is no
               title]. The *title* string may contain \\n to indicate line-breaks.
 
-        Blank lines and lines starting with \# are always skipped.
-    """,
+        Blank lines and lines starting with \# are always skipped.""",
     "i": r"""
         incols : str or 1d array
             Specify data columns for primary input in arbitrary order. Columns
@@ -307,8 +301,7 @@ COMMON_OPTIONS = {
               specifying columns, use ``outcols="n"`` to simply read numerical
               input and skip trailing text. Note: if ``incols`` is also used
               then the columns given to ``outcols`` correspond to the order
-              after the ``incols`` selection has taken place.
-    """,
+              after the ``incols`` selection has taken place.""",
     "p": r"""
         perspective : list or str
             [**x**\|\ **y**\|\ **z**]\ *azim*\[/*elev*\[/*zlevel*]]\
@@ -338,8 +331,7 @@ COMMON_OPTIONS = {
                   records whose *z*-value equals NaN.
                 - **+a** to suppress the output of the record if just one or
                   more of the columns equal NaN [Default skips record only
-                  if values in all specified *cols* equal NaN].
-    """,
+                  if values in all specified *cols* equal NaN].""",
     "t": """\
         transparency : int or float
             Set transparency level, in [0-100] percent range.
@@ -363,9 +355,8 @@ COMMON_OPTIONS = {
                 - **m** - minute cycle (second)
                 - **s** - second cycle (second)
                 - **c** - custom cycle (normalized)
-            
-            Full documentation is at :gmt-docs:`gmt.html#w-full`.
-        """,
+
+            Full documentation is at :gmt-docs:`gmt.html#w-full`.""",
     "x": r"""
         cores : bool or int
             [[**-**]\ *n*].

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -104,7 +104,7 @@ COMMON_OPTIONS = {
          """,
     "b": r"""
         binary : bool or str
-            **-bi**\|\ **o**\ [*ncols*][*type*][**w**][**+l**\|\ **b**]
+            **i**\|\ **o**\ [*ncols*][*type*][**w**][**+l**\|\ **b**]
             Select native binary input (using ``binary="i"``) or output
             (using ``binary="o"``), where *ncols* is the number of data columns
             of *type*, which must be one of:
@@ -130,6 +130,15 @@ COMMON_OPTIONS = {
                   be read as little- or big-endian, respectively.
 
             Full documentation is at :gmt-docs:`gmt.html#bi-full`.
+    """,
+    "d": r"""
+        nodata : str
+            **i**\|\ **o**\ *nodata*
+            Substitute specific values with NaN (for tabular data). For
+            example, ``d="-9999"`` will replace all values equal to -9999 with
+            NaN during input and all NaN values with -9999 during output.
+            Prepend **i** to the *nodata* value for input columns only. Prepend
+            **o** to the *nodata* value for output columns only.
     """,
     "c": r"""
         panel : bool or int or list

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -347,6 +347,25 @@ COMMON_OPTIONS = {
             Only visible when PDF or raster format output is selected.
             Only the PNG format selection adds a transparency layer
             in the image (for further processing). """,
+    "w": r"""
+        wrap : str
+            **y**\|\ **a**\|\ **w**\|\ **d**\|\ **h**\|\ **m**\|\ **s**\|\
+            **c**\ *period*\ [/*phase*][**+c**\ *col*]
+            Convert the input *x*-coordinate to a cyclical coordinate, or a
+            different column if selected via **+c**\ *col*. The following
+            cyclical coordinate transformations are supported:
+
+                - **y** - yearly cycle (normalized)
+                - **a** - annual cycle (monthly)
+                - **w** - weekly cycle (day)
+                - **d** - daily cycle (hour)
+                - **h** - hourly cycle (minute)
+                - **m** - minute cycle (second)
+                - **s** - second cycle (second)
+                - **c** - custom cycle (normalized)
+            
+            Full documentation is at :gmt-docs:`gmt.html#w-full`.
+        """,
     "x": r"""
         cores : bool or int
             [[**-**]\ *n*].

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -72,6 +72,7 @@ def _blockm(block_method, table, outfile, x, y, z, **kwargs):
     a="aspatial",
     f="coltypes",
     i="incols",
+    o="outcols",
     r="registration",
 )
 @kwargs_to_strings(R="sequence")
@@ -112,6 +113,7 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     {a}
     {i}
     {f}
+    {o}
     {r}
 
     Returns
@@ -137,6 +139,7 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     a="aspatial",
     f="coltypes",
     i="incols",
+    o="outcols",
     r="registration",
 )
 @kwargs_to_strings(R="sequence")
@@ -177,6 +180,7 @@ def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     {a}
     {f}
     {i}
+    {o}
     {r}
 
     Returns

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -74,6 +74,7 @@ def _blockm(block_method, table, outfile, x, y, z, **kwargs):
     i="incols",
     o="outcols",
     r="registration",
+    s="skiprows",
 )
 @kwargs_to_strings(R="sequence")
 def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
@@ -115,6 +116,7 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     {f}
     {o}
     {r}
+    {s}
 
     Returns
     -------
@@ -141,6 +143,7 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     i="incols",
     o="outcols",
     r="registration",
+    s="skiprows",
 )
 @kwargs_to_strings(R="sequence")
 def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
@@ -182,6 +185,7 @@ def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     {i}
     {o}
     {r}
+    {s}
 
     Returns
     -------

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -75,6 +75,7 @@ def _blockm(block_method, table, outfile, x, y, z, **kwargs):
     o="outcols",
     r="registration",
     s="skiprows",
+    w="wrap",
 )
 @kwargs_to_strings(R="sequence")
 def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
@@ -117,6 +118,7 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     {o}
     {r}
     {s}
+    {w}
 
     Returns
     -------
@@ -144,6 +146,7 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     o="outcols",
     r="registration",
     s="skiprows",
+    w="wrap",
 )
 @kwargs_to_strings(R="sequence")
 def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
@@ -186,6 +189,7 @@ def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     {o}
     {r}
     {s}
+    {w}
 
     Returns
     -------

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -22,6 +22,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     b="binary",
     c="panel",
     d="nodata",
+    e="find",
     i="columns",
     p="perspective",
 )
@@ -80,6 +81,7 @@ def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
     {b}
     {c}
     {d}
+    {e}
     columns : str or 1d array
         Choose which columns are x, y, and z, respectively if input is provided
         via *data*. E.g. ``columns = [0, 1, 2]`` or ``columns = "0,1,2"`` if

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -24,6 +24,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     d="nodata",
     e="find",
     g="gap",
+    h="header",
     i="columns",
     p="perspective",
 )
@@ -84,6 +85,7 @@ def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
     {d}
     {e}
     {g}
+    {h}
     columns : str or 1d array
         Choose which columns are x, y, and z, respectively if input is provided
         via *data*. E.g. ``columns = [0, 1, 2]`` or ``columns = "0,1,2"`` if

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -23,6 +23,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     c="panel",
     d="nodata",
     e="find",
+    g="gap",
     i="columns",
     p="perspective",
 )
@@ -82,6 +83,7 @@ def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
     {c}
     {d}
     {e}
+    {g}
     columns : str or 1d array
         Choose which columns are x, y, and z, respectively if input is provided
         via *data*. E.g. ``columns = [0, 1, 2]`` or ``columns = "0,1,2"`` if

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -19,6 +19,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     X="xshift",
     Y="yshift",
     Z="scale",
+    b="binary",
     c="panel",
     i="columns",
     p="perspective",
@@ -75,6 +76,7 @@ def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
     pen : str
         Specify outline pen attributes [Default is no outline].
     {XY}
+    {b}
     {c}
     columns : str or 1d array
         Choose which columns are x, y, and z, respectively if input is provided

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -21,6 +21,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     Z="scale",
     b="binary",
     c="panel",
+    d="nodata",
     i="columns",
     p="perspective",
 )
@@ -78,6 +79,7 @@ def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
     {XY}
     {b}
     {c}
+    {d}
     columns : str or 1d array
         Choose which columns are x, y, and z, respectively if input is provided
         via *data*. E.g. ``columns = [0, 1, 2]`` or ``columns = "0,1,2"`` if


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the following common options to COMMON_OPTIONS in pygmt/helpers/decorators.py:

- binary
- nodata
- find
- gap
- header
- outcols
- skiprows
- wrap

This is all the remaining common options from https://github.com/GenericMappingTools/pygmt/issues/48 except -l (which I would prefer having some discussion about the implementation before adding) and -: which I do not think we need to support since this can be done with `incols`. 

The common options are added to either wiggle or blockmean/blockmedian for convenience for reviewing. I did not add the common options to all the modules that accept them because these could be good first issues for the upcoming ESWN workshop, in order to have a first exercise where everyone works on a similar task.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Relates to #48 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
