### PR TITLE
Move description for -l common option to pygmt/helpers/decorators.py

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -163,6 +163,9 @@ COMMON_OPTIONS = {
             (:gmt-term:`PROJ_MEAN_RADIUS`), and the specification of latitude type
             (:gmt-term:`PROJ_AUX_LATITUDE`). Geodesic distance calculations is also
             controlled by method (:gmt-term:`PROJ_GEODESIC`).""",
+    "l": r"""
+        label : str
+        Add a legend entry for the symbol or line being plotted.""",
     "n": r"""
         interpolation : str
             [**b**\|\ **c**\|\ **l**\|\ **n**][**+a**][**+b**\ *BC*][**+c**][**+t**\ *threshold*].

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -119,8 +119,7 @@ def histogram(self, table, **kwargs):
     {XY}
     {U}
     {V}
-    label : str
-        Add a legend entry for the symbol or line being plotted.
+    {l}
     {p}
     {t}
     """

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -194,9 +194,7 @@ def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
     {c}
     {f}
     {i}
-    label : str
-        Add a legend entry for the symbol or line being plotted.
-
+    {l}
     {p}
     {t}
         *transparency* can also be a 1d array to set varying transparency

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -164,8 +164,7 @@ def plot3d(
     {c}
     {f}
     {i}
-    label : str
-        Add a legend entry for the symbol or line being plotted.
+    {l}
     {p}
     {t}
         *transparency* can also be a 1d array to set varying transparency


### PR DESCRIPTION
**Description of proposed changes**

This PR moves the description for the -l common option to pygmt/helpers/decorators.py for three methods that use the same description. Note that the alias used for PyGMT (label) is different than that for core GMT and GMT.jl (legend).


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
