### PR TITLE
Add area_thresh to COMMON_OPTIONS

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -31,7 +31,8 @@ COMMON_OPTIONS = {
             [**s**\|\ **S**]][**+l**\|\ **r**][**+p**\ *percent*].
             Features with an area smaller than *min_area* in km\ :sup:`2` or of
             hierarchical level that is lower than *min_level* or higher than
-            *max_level* will not be plotted.""",
+            *max_level* will not be plotted [Default is 0/0/4 (all
+            features)].""",
     "B": r"""
         frame : bool or str or list
             Set map boundary

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -28,7 +28,7 @@ COMMON_OPTIONS = {
     "A": r"""
         area_thresh : int, float, or str
             *min_area*\ [/*min_level*/*max_level*][**+a**\[**g**\|\ **i**]\
-            [**s**\|\ **S**][**+l**\|\ **r**][**+p**\ *percent*].
+            [**s**\|\ **S**]][**+l**\|\ **r**][**+p**\ *percent*].
             Features with an area smaller than *min_area* in km\ :sup:`2` or of
             hierarchical level that is lower than *min_level* or higher than
             *max_level* will not be plotted.""",

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -26,7 +26,7 @@ COMMON_OPTIONS = {
             *projcode*\[*projparams*/]\ *width*.
             Select map :doc:`projection </projections/index>`.""",
     "A": r"""
-        area_thresh : int, float, or str
+        area_thresh : int or float or str
             *min_area*\ [/*min_level*/*max_level*][**+a**\[**g**\|\ **i**]\
             [**s**\|\ **S**]][**+l**\|\ **r**][**+p**\ *percent*].
             Features with an area smaller than *min_area* in km\ :sup:`2` or of

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -27,11 +27,11 @@ COMMON_OPTIONS = {
             Select map :doc:`projection </projections/index>`.""",
     "A": r"""
         area_thresh : int, float, or str
-        *min_area*\ [/*min_level*/*max_level*][**+a**\[**g**\|\ **i**]\
-        [**s**\|\ **S**][**+l**\|\ **r**][**+p**\ *percent*].
-        Features with an area smaller than *min_area* in km\ :sup:`2` or of
-        hierarchical level that is lower than *min_level* or higher than
-        *max_level* will not be plotted.""",
+            *min_area*\ [/*min_level*/*max_level*][**+a**\[**g**\|\ **i**]\
+            [**s**\|\ **S**][**+l**\|\ **r**][**+p**\ *percent*].
+            Features with an area smaller than *min_area* in km\ :sup:`2` or of
+            hierarchical level that is lower than *min_level* or higher than
+            *max_level* will not be plotted.""",
     "B": r"""
         frame : bool or str or list
             Set map boundary

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -25,6 +25,13 @@ COMMON_OPTIONS = {
             *Required if this is the first plot command*.
             *projcode*\[*projparams*/]\ *width*.
             Select map :doc:`projection </projections/index>`.""",
+    "A": r"""
+        area_thresh : int, float, or str
+        *min_area*\ [/*min_level*/*max_level*][**+a**\[**g**\|\ **i**]\
+        [**s**\|\ **S**][**+l**\|\ **r**][**+p**\ *percent*].
+        Features with an area smaller than *min_area* in km\ :sup:`2` or of
+        hierarchical level that is lower than *min_level* or higher than
+        *max_level* will not be plotted.""",
     "B": r"""
         frame : bool or str or list
             Set map boundary

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -65,12 +65,7 @@ def coast(self, **kwargs):
     ----------
     {J}
     {R}
-    area_thresh : int, float, or str
-        *min_area*\ [/*min_level*/*max_level*][**+a**\[**g**\|\ **i**]\
-        [**s**\|\ **S**][**+l**\|\ **r**][**+p**\ *percent*].
-        Features with an area smaller than *min_area* in km\ :sup:`2` or of
-        hierarchical level that is lower than *min_level* or higher than
-        *max_level* will not be plotted.
+    {A}
     {B}
     lakes : str or list
         *fill*\ [**+l**\|\ **+r**].


### PR DESCRIPTION
**Description of proposed changes**

While working on #1423 I recognized that the **-A** alias already implemented in ``coast`` as **area_thresh** is also used in several other modules like ``grdlandmask``, ``grdmath`` and ``gmtselect``. This PR adds **area_thresh** to the common options list.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
