### PR TITLE
NEP29: Set minimum required version to NumPy 1.18+

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -44,11 +44,11 @@ jobs:
           # - os: ubuntu-latest
           #   python-version: 3.7
           #   isDraft: true
-        # Pair Python 3.7 with NumPy 1.17 and Python 3.9 with NumPy 1.21
+        # Pair Python 3.7 with NumPy 1.18 and Python 3.9 with NumPy 1.21
         # Only install optional packages on Python 3.9/NumPy 1.21
         include:
           - python-version: 3.7
-            numpy-version: '1.17'
+            numpy-version: '1.18'
             optional-packages: ''
           - python-version: 3.9
             numpy-version: '1.21'

--- a/README.rst
+++ b/README.rst
@@ -229,7 +229,7 @@ Compatibility with GMT/Python/NumPy versions
       - Python
       - Numpy
     * - `v0.5.0 <https://github.com/GenericMappingTools/pygmt/milestone/8>`_ (upcoming release)
-      - `dev Documentation <https://www.pygmt.org/dev>`_
+      - `Dev Documentation <https://www.pygmt.org/dev>`_ (reflects `main branch <https://github.com/GenericMappingTools/pygmt>`_)
       - >=6.2.0
       - >=3.7
       - >=1.18
@@ -278,7 +278,3 @@ Compatibility with GMT/Python/NumPy versions
       - >=6.0.0
       - 3.6 - 3.8
       -
-
-The unstable development documentation, which reflects the
-`main branch <https://github.com/GenericMappingTools/pygmt>`_
-on GitHub, can be found at https://www.pygmt.org/dev/.

--- a/README.rst
+++ b/README.rst
@@ -228,16 +228,21 @@ Compatibility with GMT/Python/NumPy versions
       - GMT
       - Python
       - Numpy
+    * - `v0.5.0 <https://github.com/GenericMappingTools/pygmt/milestone/8>`_ (upcoming release)
+      - `dev Documentation <https://www.pygmt.org/dev>`_
+      - >=6.2.0
+      - >=3.7
+      - >=1.18
     * - `v0.4.1 <https://github.com/GenericMappingTools/pygmt/releases/tag/v0.4.1>`_ (latest release)
       - `v0.4.1 Documentation <https://www.pygmt.org/v0.4.1>`_
       - >=6.2.0
       - >=3.7
-      - >=1.17.0
+      - >=1.17
     * - `v0.4.0 <https://github.com/GenericMappingTools/pygmt/releases/tag/v0.4.0>`_
       - `v0.4.0 Documentation <https://www.pygmt.org/v0.4.0>`_
       - >=6.2.0
       - >=3.7
-      - >=1.17.0
+      - >=1.17
     * - `v0.3.1 <https://github.com/GenericMappingTools/pygmt/releases/tag/v0.3.1>`_
       - `v0.3.1 Documentation <https://www.pygmt.org/v0.3.1>`_
       - >=6.1.1
@@ -274,5 +279,6 @@ Compatibility with GMT/Python/NumPy versions
       - 3.6 - 3.8
       -
 
-The unstable development documentation, which reflects the `main branch <https://github.com/GenericMappingTools/pygmt>`_
+The unstable development documentation, which reflects the
+`main branch <https://github.com/GenericMappingTools/pygmt>`_
 on GitHub, can be found at https://www.pygmt.org/dev/.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -80,7 +80,7 @@ Dependencies
 
 PyGMT requires the following libraries to be installed:
 
-* `numpy <https://numpy.org>`__ (>= 1.17)
+* `numpy <https://numpy.org>`__ (>= 1.18)
 * `pandas <https://pandas.pydata.org>`__
 * `xarray <https://xarray.pydata.org>`__
 * `netCDF4 <https://unidata.github.io/netcdf4-python>`__

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
     # Required dependencies
     - pip
     - gmt=6.2.0
-    - numpy>=1.17
+    - numpy>=1.18
     - pandas
     - xarray
     - netCDF4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Required packages
-numpy>=1.17
+numpy>=1.18
 pandas
 xarray
 netCDF4

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ CLASSIFIERS = [
 ]
 PLATFORMS = "Any"
 PYTHON_REQUIRES = ">=3.7"
-INSTALL_REQUIRES = ["numpy>=1.17", "pandas", "xarray", "netCDF4", "packaging"]
+INSTALL_REQUIRES = ["numpy>=1.18", "pandas", "xarray", "netCDF4", "packaging"]
 # Configuration for setuptools-scm
 SETUP_REQUIRES = ["setuptools_scm"]
 USE_SCM_VERSION = {"local_scheme": "node-and-date", "fallback_version": "unknown"}


### PR DESCRIPTION
**Description of proposed changes**

Following NEP29 policy where NumPy 1.17 is to be dropped on or after 26 July 2021 (in a minor version increment, i.e. for PyGMT v0.5.0). Bumps minimum supported NumPy version to 1.18 in the setup.py, requirements.txt and environment.yml files. Also update installation documentation and set CI tests to run on NumPy 1.18.

This is in line with PyGMT's policy on [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule) at https://www.pygmt.org/v0.4.1/maintenance.html#dependencies-policy, xref #1074.

Around the PyData ecosystem, it looks like `pandas` 1.4 (https://github.com/pandas-dev/pandas/pull/41989) and `geopandas` 0.10.0 (https://github.com/geopandas/geopandas/pull/1877) will be using Numpy 1.18+ too.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
