### PR TITLE
Remove the unused psconvert test test_psconvert_int_options

### DIFF
--- a/pygmt/tests/test_psconvert.py
+++ b/pygmt/tests/test_psconvert.py
@@ -38,18 +38,6 @@ def test_psconvert_twice():
     os.remove(fname)
 
 
-def test_psconvert_int_options():
-    """
-    psconvert handles integer options well.
-    """
-    fig = Figure()
-    fig.basemap(R="10/70/-3/8", J="X4i/3i", B="a")
-    prefix = "test_psconvert_int_options"
-    fig.psconvert(F=prefix, E=100, T="g", I=True)
-    assert os.path.exists(prefix + ".png")
-    os.remove(prefix + ".png")
-
-
 def test_psconvert_aliases():
     """
     Use the aliases to make sure they work.


### PR DESCRIPTION
**Description of proposed changes**

The test 'test_psconvert_int_options' failed recently due to the recent
upstream changes. The changes should be backward compatible, but actually it
isn't (see https://github.com/GenericMappingTools/gmt/issues/5624 for the bug
report).

For the GMT dev versions, the `-I` option should be replaced by `-N+i`.
However, as the docstring says, the test `test_psconvert_int_options ` 
checks "psconvert handles integer options well".
We already have many tests that pass an interger as arguments, and psconvert
is not special.

So this test is useless and can be removed.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
