### PR TITLE
Add pygmt.load_dataarray function and refactor modules that return None or xarray.dataarray

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -107,6 +107,14 @@ Crossover analysis with x2sys:
     x2sys_init
     x2sys_cross
 
+Input/output
+------------
+
+.. autosummary::
+    :toctree: generated
+
+    load_dataarray
+
 GMT Defaults
 ------------
 

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -26,6 +26,7 @@ from pkg_resources import get_distribution
 from pygmt import datasets
 from pygmt.accessors import GMTDataArrayAccessor
 from pygmt.figure import Figure, set_display
+from pygmt.io import load_dataarray
 from pygmt.session_management import begin as _begin
 from pygmt.session_management import end as _end
 from pygmt.src import (

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -4,9 +4,9 @@ load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
-import xarray as xr
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import kwargs_to_strings
+from pygmt.io import load_dataarray
 from pygmt.src import grdcut, which
 
 
@@ -133,9 +133,7 @@ def load_earth_relief(resolution="01d", region=None, registration=None, use_srtm
                 f"'region' is required for Earth relief resolution '{resolution}'."
             )
         fname = which(f"@earth_relief_{resolution}{reg}", download="a")
-        with xr.open_dataarray(fname, engine="netcdf4") as dataarray:
-            grid = dataarray.load()
-            _ = grid.gmt  # load GMTDataArray accessor information
+        grid = load_dataarray(fname, engine="netcdf4")
     else:
         grid = grdcut(f"@{earth_relief_prefix}{resolution}{reg}", region=region)
 

--- a/pygmt/io.py
+++ b/pygmt/io.py
@@ -9,8 +9,8 @@ def load_dataarray(filename_or_obj, **kwargs):
     Open, load into memory, and close a DataArray from a file or file-like
     object containing a single data variable.
 
-    This is a thin wrapper around :py:meth:`xarray.open_dataarray`. It differs
-    from :py:meth:`xarray.open_dataarray` in that it loads the DataArray into
+    This is a thin wrapper around :py:func:`xarray.open_dataarray`. It differs
+    from :py:func:`xarray.open_dataarray` in that it loads the DataArray into
     memory, gets GMT specific metadata about the grid via
     :py:meth:`GMTDataArrayAccessor`, closes the file, and returns the
     DataArray. In contrast, :py:func:`xarray.open_dataarray` keeps the file

--- a/pygmt/io.py
+++ b/pygmt/io.py
@@ -1,5 +1,5 @@
 """
-PyGMT i/o utilities.
+PyGMT input/output (I/O) utilities.
 """
 import xarray as xr
 

--- a/pygmt/io.py
+++ b/pygmt/io.py
@@ -13,14 +13,14 @@ def load_dataarray(filename_or_obj, **kwargs):
     from :py:meth:`xarray.open_dataarray` in that it loads the DataArray into
     memory, gets GMT specific metadata about the grid via
     :py:meth:`GMTDataArrayAccessor`, closes the file, and returns the
-    DataArray. In contrast, :py:meth:`xarray.open_dataarray` keeps the file
+    DataArray. In contrast, :py:func:`xarray.open_dataarray` keeps the file
     handle open and lazy loads its contents. All parameters are passed directly
-    to :py:meth:`xarray.open_dataarray`. See that documentation for further
+    to :py:func:`xarray.open_dataarray`. See that documentation for further
     details.
 
     Parameters
     ----------
-    filename_or_obj : str or Path or file-like or DataStore
+    filename_or_obj : str or pathlib.Path or file-like or DataStore
         Strings and Path objects are interpreted as a path to a netCDF file
         or an OpenDAP URL and opened with python-netCDF4, unless the filename
         ends with .gz, in which case the file is gunzipped and opened with

--- a/pygmt/io.py
+++ b/pygmt/io.py
@@ -10,11 +10,13 @@ def load_dataarray(filename_or_obj, **kwargs):
     object containing a single data variable.
 
     This is a thin wrapper around :py:meth:`xarray.open_dataarray`. It differs
-    from `open_dataarray` in that it loads the DataArray into memory, gets GMT
-    specific metadata about the grid via :meth:`GMTDataArrayAccessor`, closes
-    the file, and returns the DataArray. In contrast, `open_dataarray` keeps
-    the file handle open and lazy loads its contents. All parameters are passed
-    directly to `open_dataarray`. See that documentation for further details.
+    from :py:meth:`xarray.open_dataarray` in that it loads the DataArray into
+    memory, gets GMT specific metadata about the grid via
+    :py:meth:`GMTDataArrayAccessor`, closes the file, and returns the
+    DataArray. In contrast, :py:meth:`xarray.open_dataarray` keeps the file
+    handle open and lazy loads its contents. All parameters are passed directly
+    to :py:meth:`xarray.open_dataarray`. See that documentation for further
+    details.
 
     Parameters
     ----------

--- a/pygmt/io.py
+++ b/pygmt/io.py
@@ -1,0 +1,36 @@
+"""
+PyGMT i/o utilities.
+"""
+import xarray as xr
+
+
+def process_output_grid(grid_name, tmpfile_name):
+    """
+    Processes the output from the GMT API to return an xarray.DataArray if
+    ``grid_name`` matches ``tmpfile_name`` and return None if it does not.
+
+    Parameters
+    ----------
+    grid_name : str
+        The name of the output netCDF file with extension .nc to store the grid
+        in.
+    tmpfile_name : str
+        The name attribute from a GMTTempFile instance.
+
+    Returns
+    -------
+    ret: xarray.DataArray or None
+        Return type depends on whether the ``outgrid`` parameter is set:
+
+        - :class:`xarray.DataArray` if ``outgrid`` is not set
+        - None if ``outgrid`` is set (grid output will be stored in file set by
+          ``outgrid``)
+    """
+    if grid_name == tmpfile_name:  # Implies user did not set outgrid, return DataArray
+        with xr.open_dataarray(grid_name) as dataarray:
+            result = dataarray.load()
+            _ = result.gmt  # load GMTDataArray accessor information
+    else:
+        result = None  # Implies user set an outgrid, return None
+
+    return result

--- a/pygmt/io.py
+++ b/pygmt/io.py
@@ -37,7 +37,7 @@ def load_datagrid(filename_or_obj, **kwargs):
     if "cache" in kwargs:
         raise TypeError("cache has no effect in this context")
 
-    with xr.open_dataarray(grid_name, **kwargs) as dataarray:
+    with xr.open_dataarray(filename_or_obj, **kwargs) as dataarray:
         result = dataarray.load()
         _ = result.gmt  # load GMTDataArray accessor information
 

--- a/pygmt/io.py
+++ b/pygmt/io.py
@@ -4,7 +4,7 @@ PyGMT input/output (I/O) utilities.
 import xarray as xr
 
 
-def load_datagrid(filename_or_obj, **kwargs):
+def load_dataarray(filename_or_obj, **kwargs):
     """
     Open, load into memory, and close a DataArray from a file or file-like
     object containing a single data variable.

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -10,7 +10,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.io import process_output_grid
+from pygmt.io import load_datagrid
 
 
 @fmt_docstring
@@ -88,4 +88,4 @@ def grdclip(grid, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("grdclip", arg_str)
 
-        return process_output_grid(outgrid, tmpfile.name)
+        return load_datagrid(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -10,7 +10,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.io import load_datagrid
+from pygmt.io import load_dataarray
 
 
 @fmt_docstring
@@ -88,4 +88,4 @@ def grdclip(grid, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("grdclip", arg_str)
 
-        return load_datagrid(outgrid) if outgrid == tmpfile.name else None
+        return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -2,7 +2,6 @@
 grdclip - Change the range and extremes of grid values.
 """
 
-import xarray as xr
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,
@@ -11,6 +10,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
+from pygmt.io import process_output_grid
 
 
 @fmt_docstring
@@ -88,11 +88,4 @@ def grdclip(grid, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("grdclip", arg_str)
 
-        if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
-            with xr.open_dataarray(outgrid) as dataarray:
-                result = dataarray.load()
-                _ = result.gmt  # load GMTDataArray accessor information
-        else:
-            result = None  # if user sets an outgrid, return None
-
-        return result
+        return process_output_grid(outgrid, tmpfile.name)

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -2,7 +2,6 @@
 grdcut - Extract subregion from a grid.
 """
 
-import xarray as xr
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,
@@ -11,6 +10,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
+from pygmt.io import process_output_grid
 
 
 @fmt_docstring
@@ -98,11 +98,4 @@ def grdcut(grid, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("grdcut", arg_str)
 
-        if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
-            with xr.open_dataarray(outgrid) as dataarray:
-                result = dataarray.load()
-                _ = result.gmt  # load GMTDataArray accessor information
-        else:
-            result = None  # if user sets an outgrid, return None
-
-        return result
+        return process_output_grid(outgrid, tmpfile.name)

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -10,7 +10,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.io import process_output_grid
+from pygmt.io import load_dataarray
 
 
 @fmt_docstring
@@ -98,4 +98,4 @@ def grdcut(grid, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("grdcut", arg_str)
 
-        return process_output_grid(outgrid, tmpfile.name)
+        return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -11,7 +11,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.io import process_output_grid
+from pygmt.io import load_dataarray
 
 
 @fmt_docstring
@@ -75,4 +75,4 @@ def grdfill(grid, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("grdfill", arg_str)
 
-        return process_output_grid(outgrid, tmpfile.name)
+        return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -2,7 +2,6 @@
 grdfill - Fill blank areas from a grid.
 """
 
-import xarray as xr
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -12,6 +11,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
+from pygmt.io import process_output_grid
 
 
 @fmt_docstring
@@ -75,11 +75,4 @@ def grdfill(grid, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("grdfill", arg_str)
 
-        if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
-            with xr.open_dataarray(outgrid) as dataarray:
-                result = dataarray.load()
-                _ = result.gmt  # load GMTDataArray accessor information
-        else:
-            result = None  # if user sets an outgrid, return None
-
-        return result
+        return process_output_grid(outgrid, tmpfile.name)

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -2,7 +2,6 @@
 grdfilter - Filter a grid in the space (or time) domain.
 """
 
-import xarray as xr
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,
@@ -11,6 +10,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
+from pygmt.io import process_output_grid
 
 
 @fmt_docstring
@@ -151,11 +151,4 @@ def grdfilter(grid, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("grdfilter", arg_str)
 
-        if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
-            with xr.open_dataarray(outgrid) as dataarray:
-                result = dataarray.load()
-                _ = result.gmt  # load GMTDataArray accessor information
-        else:
-            result = None  # if user sets an outgrid, return None
-
-        return result
+        return process_output_grid(outgrid, tmpfile.name)

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -10,7 +10,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.io import process_output_grid
+from pygmt.io import load_dataarray
 
 
 @fmt_docstring
@@ -151,4 +151,4 @@ def grdfilter(grid, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("grdfilter", arg_str)
 
-        return process_output_grid(outgrid, tmpfile.name)
+        return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -2,7 +2,6 @@
 grdgradient - Compute directional gradients from a grid.
 """
 
-import xarray as xr
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -13,6 +12,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
+from pygmt.io import process_output_grid
 
 
 @fmt_docstring
@@ -117,11 +117,4 @@ def grdgradient(grid, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("grdgradient", arg_str)
 
-        if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
-            with xr.open_dataarray(outgrid) as dataarray:
-                result = dataarray.load()
-                _ = result.gmt  # load GMTDataArray accessor information
-        else:
-            result = None  # if user sets an outgrid, return None
-
-        return result
+        return process_output_grid(outgrid, tmpfile.name)

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -12,7 +12,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.io import process_output_grid
+from pygmt.io import load_dataarray
 
 
 @fmt_docstring
@@ -117,4 +117,4 @@ def grdgradient(grid, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("grdgradient", arg_str)
 
-        return process_output_grid(outgrid, tmpfile.name)
+        return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -2,7 +2,6 @@
 grdlandmask - Create a "wet-dry" mask grid from shoreline data base
 """
 
-import xarray as xr
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -12,6 +11,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
+from pygmt.io import process_output_grid
 
 
 @fmt_docstring
@@ -68,11 +68,4 @@ def grdlandmask(**kwargs):
             arg_str = build_arg_string(kwargs)
             lib.call_module("grdlandmask", arg_str)
 
-        if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
-            with xr.open_dataarray(outgrid) as dataarray:
-                result = dataarray.load()
-                _ = result.gmt  # load GMTDataArray accessor information
-        else:
-            result = None  # if user sets an outgrid, return None
-
-        return result
+        return process_output_grid(outgrid, tmpfile.name)

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -11,7 +11,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.io import process_output_grid
+from pygmt.io import load_dataarray
 
 
 @fmt_docstring
@@ -68,4 +68,4 @@ def grdlandmask(**kwargs):
             arg_str = build_arg_string(kwargs)
             lib.call_module("grdlandmask", arg_str)
 
-        return process_output_grid(outgrid, tmpfile.name)
+        return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -2,7 +2,6 @@
 grdproject - Forward and inverse map transformation of grids.
 """
 
-import xarray as xr
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -12,6 +11,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
+from pygmt.io import load_dataarray
 
 
 @fmt_docstring
@@ -83,11 +83,4 @@ def grdproject(grid, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("grdproject", arg_str)
 
-        if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
-            with xr.open_dataarray(outgrid) as dataarray:
-                result = dataarray.load()
-                _ = result.gmt  # load GMTDataArray accessor information
-        else:
-            result = None  # if user sets an outgrid, return None
-
-        return result
+        return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -2,7 +2,6 @@
 grdsample - Resample a grid onto a new lattice
 """
 
-import xarray as xr
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,
@@ -11,6 +10,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
+from pygmt.io import process_output_grid
 
 
 @fmt_docstring
@@ -85,11 +85,4 @@ def grdsample(grid, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("grdsample", arg_str)
 
-        if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
-            with xr.open_dataarray(outgrid) as dataarray:
-                result = dataarray.load()
-                _ = result.gmt  # load GMTDataArray accessor information
-        else:
-            result = None  # if user sets an outgrid, return None
-
-        return result
+        return process_output_grid(outgrid, tmpfile.name)

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -10,7 +10,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.io import process_output_grid
+from pygmt.io import load_dataarray
 
 
 @fmt_docstring
@@ -85,4 +85,4 @@ def grdsample(grid, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("grdsample", arg_str)
 
-        return process_output_grid(outgrid, tmpfile.name)
+        return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -13,7 +13,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.io import process_output_grid
+from pygmt.io import load_dataarray
 
 
 @fmt_docstring
@@ -99,4 +99,4 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module(module="surface", args=arg_str)
 
-        return process_output_grid(outfile, tmpfile.name)
+        return load_dataarray(outfile) if outfile == tmpfile.name else None

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -2,7 +2,6 @@
 surface - Grids table data using adjustable tension continuous curvature
 splines.
 """
-import xarray as xr
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -14,6 +13,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
+from pygmt.io import process_output_grid
 
 
 @fmt_docstring
@@ -99,11 +99,4 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module(module="surface", args=arg_str)
 
-        if outfile == tmpfile.name:  # if user did not set outfile, return DataArray
-            with xr.open_dataarray(outfile) as dataarray:
-                result = dataarray.load()
-                _ = result.gmt  # load GMTDataArray accessor information
-        elif outfile != tmpfile.name:  # if user sets an outfile, return None
-            result = None
-
-    return result
+        return process_output_grid(outfile, tmpfile.name)

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -1,7 +1,6 @@
 """
 xyz2grd - Convert data table to a grid.
 """
-import xarray as xr
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,
@@ -10,6 +9,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
+from pygmt.io import process_output_grid
 
 
 @fmt_docstring
@@ -64,11 +64,4 @@ def xyz2grd(table, **kwargs):
                 arg_str = " ".join([infile, arg_str])
                 lib.call_module("xyz2grd", arg_str)
 
-        if outgrid == tmpfile.name:  # if user did not set outgrid, return DataArray
-            with xr.open_dataarray(outgrid) as dataarray:
-                result = dataarray.load()
-                _ = result.gmt  # load GMTDataArray accessor information
-        else:
-            result = None  # if user sets an outgrid, return None
-
-        return result
+        return process_output_grid(outgrid, tmpfile.name)

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -9,7 +9,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.io import process_output_grid
+from pygmt.io import load_dataarray
 
 
 @fmt_docstring
@@ -64,4 +64,4 @@ def xyz2grd(table, **kwargs):
                 arg_str = " ".join([infile, arg_str])
                 lib.call_module("xyz2grd", arg_str)
 
-        return process_output_grid(outgrid, tmpfile.name)
+        return load_dataarray(outgrid) if outgrid == tmpfile.name else None


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a new pygmt/io.py module that holds process_output_grid, which returns an xarray.DataArray or None depending on whether outgrid matches tmpfile.name.

It replaces duplicate code with the new function.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1400 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
