### PR TITLE
Remove required description from label_placement parameter

### DIFF
--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -81,7 +81,10 @@ def contour(self, x=None, y=None, z=None, data=None, **kwargs):
     E : str
         Network information.
     label_placement : str
-        Placement of labels.
+        [**d**\|\ **f**\|\ **n**\|\ **l**\|\ **L**\|\ **x**\|\ **X**]\ *args*.
+        Control the placement of labels along the quoted lines. It supports
+        five controlling algorithms. See :gmt-docs:`contour.html#g` for
+        details.
     I : bool
         Color the triangles using CPT.
     triangular_mesh_pen : str

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -77,9 +77,9 @@ def grdcontour(self, grid, **kwargs):
     label_placement : str
         [**d**\|\ **f**\|\ **n**\|\ **l**\|\ **L**\|\ **x**\|\ **X**]\
         *args*.
-        The required parameter controls the placement of labels along the
-        quoted lines. It supports five controlling algorithms. See
-        :gmt-docs:`grdcontour.html#g` for details.
+        Control the placement of labels along the quoted lines. It supports
+        five controlling algorithms. See :gmt-docs:`grdcontour.html#g` for
+        details.
     {U}
     {V}
     {W}


### PR DESCRIPTION
**Description of proposed changes**

This PR removed the required description from the label_placement parameter in grdcontour and adds the string syntax to the contour method. See https://github.com/GenericMappingTools/gmt/pull/5647 for the corresponding fix in the GMT repository.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
