### PR TITLE
Add missing aliases to pygmt.Figure.text

### DIFF
--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -24,12 +24,17 @@ from pygmt.helpers import (
     D="offset",
     G="fill",
     N="no_clip",
+    U="timestamp",
     V="verbose",
     W="pen",
     X="xshift",
     Y="yshift",
+    a="aspatial",
     c="panel",
+    e="find",
     f="coltypes",
+    h="header",
+    i="incols",
     p="perspective",
     t="transparency",
 )
@@ -141,14 +146,19 @@ def text_(
         style = solid].
     no_clip : bool
         Do NOT clip text at map boundaries [Default is will clip].
+    {U}
     {V}
     {XY}
+    {a}
     {c}
+    {e}
     {f}
+    {h}
     {p}
     {t}
         *transparency* can also be a 1d array to set varying transparency
         for texts, but this option is only valid if using x/y/text.
+    {w}
     """
 
     # pylint: disable=too-many-locals

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -37,6 +37,7 @@ from pygmt.helpers import (
     i="incols",
     p="perspective",
     t="transparency",
+    w="wrap",
 )
 @kwargs_to_strings(
     R="sequence",

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -155,6 +155,7 @@ def text_(
     {e}
     {f}
     {h}
+    {i}
     {p}
     {t}
         *transparency* can also be a 1d array to set varying transparency


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the common options timestamp, aspatial, find, header, and wrap to the pygmt.Figure.text method.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #1445


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
