### PR TITLE
Add missing aliases to pygmt.Figure.image.py

### DIFF
--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -12,6 +12,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     D="position",
     F="box",
     M="monochrome",
+    U="timestamp",
     V="verbose",
     X="xshift",
     Y="yshift",
@@ -54,6 +55,7 @@ def image(self, imagefile, **kwargs):
     monochrome : bool
         Convert color image to monochrome grayshades using the (television)
         YIQ-transformation.
+    {U}
     {V}
     {XY}
     {c}


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the common timestamp option to the pygmt.Figure.image method.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #1445


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
