### PR TITLE
Add missing aliases to pygmt.Figure.rose

### DIFF
--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -36,10 +36,16 @@ from pygmt.helpers import (
     X="xshift",
     Y="yshift",
     Z="scale",
+    b="binary",
+    d="nodata",
+    e="find",
+    g="gap",
+    h="header",
     i="incols",
     c="panel",
     p="perspective",
     t="transparency",
+    w="wrap",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 def rose(self, length=None, azimuth=None, data=None, **kwargs):
@@ -186,10 +192,16 @@ def rose(self, length=None, azimuth=None, data=None, **kwargs):
     {U}
     {V}
     {XY}
+    {b}
     {c}
+    {d}
+    {e}
+    {g}
+    {h}
     {i}
     {p}
     {t}
+    {w}
     """
 
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access

--- a/test_file.txt
+++ b/test_file.txt
@@ -1,0 +1,1 @@
+added test text

--- a/test_file.txt
+++ b/test_file.txt
@@ -1,1 +1,0 @@
-added test text


### PR DESCRIPTION
**Description of proposed changes**

Add missing commands in pygmt.Figure.rose

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses Issue #1445 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
