### PR TITLE
Add missing alias to pygmt.Figure.legend

### DIFF
--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -19,6 +19,7 @@ from pygmt.helpers import (
     J="projection",
     D="position",
     F="box",
+    U="timestamp",
     V="verbose",
     X="xshift",
     Y="yshift",
@@ -64,6 +65,7 @@ def legend(self, spec=None, position="JTR+jTR+o0.2c", box="+gwhite+p1p", **kwarg
         using :gmt-term:`MAP_FRAME_PEN`. By default, uses
         **+g**\ white\ **+p**\ 1p which draws a box around the legend using a
         1p black pen and adds a white background.
+    {U}
     {V}
     {XY}
     {c}


### PR DESCRIPTION
**Description of proposed changes**
Add in missing alias info for U - timestamp to the pygmt.Figure.legend


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #1445

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
