### PR TITLE
Expand table-like input options for pygmt.surface

### DIFF
--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -3,11 +3,9 @@ surface - Grids table data using adjustable tension continuous curvature
 splines.
 """
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     GMTTempFile,
     build_arg_string,
-    data_kind,
     deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -86,7 +86,7 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
         with Session() as lib:
             # Choose how data will be passed into the module
             file_context = lib.virtualfile_from_data(
-                    check_kind="vector", data=data, x=x, y=y, z=z
+                check_kind="vector", data=data, x=x, y=y, z=z
             )
             with file_context as infile:
                 if "G" not in kwargs.keys():  # if outfile is unset, output to tmpfile

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -9,7 +9,6 @@ from pygmt.helpers import (
     build_arg_string,
     data_kind,
     deprecate_parameter,
-    dummy_context,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
@@ -92,8 +91,6 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)
     """
-    kind = data_kind(data, x, y, z, required_z=True)
-
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
             # Choose how data will be passed into the module

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -86,7 +86,7 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
         with Session() as lib:
             # Choose how data will be passed into the module
             file_context = lib.virtualfile_from_data(
-                    kind = "vector", data=data, x=x, y=y, z=z
+                    check_kind="vector", data=data, x=x, y=y, z=z
             )
             with file_context as infile:
                 if "G" not in kwargs.keys():  # if outfile is unset, output to tmpfile

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -84,14 +84,10 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
 
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            if kind == "file":
-                file_context = dummy_context(data)
-            elif kind == "matrix":
-                file_context = lib.virtualfile_from_matrix(data)
-            elif kind == "vectors":
-                file_context = lib.virtualfile_from_vectors(x, y, z)
-            else:
-                raise GMTInvalidInput("Unrecognized data type: {}".format(type(data)))
+            # Choose how data will be passed into the module
+            file_context = lib.virtualfile_from_data(
+                    kind = "vector", data=data, x=x, y=y, z=z
+            )
             with file_context as infile:
                 if "G" not in kwargs.keys():  # if outfile is unset, output to tmpfile
                     kwargs.update({"G": tmpfile.name})

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -58,14 +58,14 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
     ----------
     x/y/z : 1d arrays
         Arrays of x and y coordinates and values z of the data points.
-    data : str or 2d array
-        Either a data file name or a 2d numpy array with the tabular data.
+    data : str or {table-like}
+        Pass in (x, y, z) or (longitude, latitude, elevation) values by
+        providing a file name to an ASCII data table, a 2D
+        {table-classes}.
 
     {I}
 
-    region : str or list
-        *xmin/xmax/ymin/ymax*\[**+r**][**+u**\ *unit*].
-        Specify the region of interest.
+    {R}
 
     outgrid : str
         Optional. The file name for the output netcdf file with extension .nc


### PR DESCRIPTION
**Description of proposed changes**

This PR expands the table-like input options for pygmt.surface

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Closes #1443 


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
