### PR TITLE
Fix lint warnings for pylint 2.10

### DIFF
--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -84,7 +84,7 @@ class GMTTempFile:
         content : str
             Content of the temporary file as a Unicode string.
         """
-        with open(self.name) as tmpfile:
+        with open(self.name, mode="r", encoding="utf8") as tmpfile:
             content = tmpfile.read()
             if not keep_tabs:
                 content = content.replace("\t", " ")

--- a/pygmt/sphinx_gallery.py
+++ b/pygmt/sphinx_gallery.py
@@ -24,7 +24,7 @@ class PyGMTScraper:  # pylint: disable=too-few-public-methods
         Called by sphinx-gallery to save the figures generated after running
         code.
         """
-        image_names = list()
+        image_names = []
         image_path_iterator = block_vars["image_path_iterator"]
         figures = SHOWED_FIGURES
         while figures:

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -93,7 +93,7 @@ def test_gmttempfile_read():
     Make sure GMTTempFile.read() works.
     """
     with GMTTempFile() as tmpfile:
-        with open(tmpfile.name, "w") as ftmp:
+        with open(tmpfile.name, "w", encoding="utf8") as ftmp:
             ftmp.write("in.dat: N = 2\t<1/3>\t<2/4>\n")
         assert tmpfile.read() == "in.dat: N = 2 <1/3> <2/4>\n"
         assert tmpfile.read(keep_tabs=True) == "in.dat: N = 2\t<1/3>\t<2/4>\n"

--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -93,7 +93,7 @@ T so we may have to adjust the box height to get the right size box.
 """
 
     with GMTTempFile() as specfile:
-        with open(specfile.name, "w") as file:
+        with open(specfile.name, "w", encoding="utf8") as file:
             file.write(specfile_contents)
         fig = Figure()
         fig.basemap(projection="x6i", region=[0, 1, 0, 1], frame=True)

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -169,7 +169,7 @@ def test_meca_spec_file():
     focal_mechanism = [-127.43, 40.81, 12, -3.19, 1.16, 3.93, -1.02, -3.93, -1.02, 23]
     # writes temp file to pass to gmt
     with GMTTempFile() as temp:
-        with open(temp.name, mode="w") as temp_file:
+        with open(temp.name, mode="w", encoding="utf8") as temp_file:
             temp_file.write(" ".join([str(x) for x in focal_mechanism]))
         # supply focal mechanisms to meca as a file
         fig.meca(

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -289,7 +289,7 @@ def test_text_angle_font_justify_from_textfile():
     """
     fig = Figure()
     with GMTTempFile(suffix=".txt") as tempfile:
-        with open(tempfile.name, "w") as tmpfile:
+        with open(tempfile.name, "w", encoding="utf8") as tmpfile:
             tmpfile.write("114 0.5 30 22p,Helvetica-Bold,black LM BORNEO")
         fig.text(
             region=[113, 117.5, -0.5, 3],

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -107,7 +107,9 @@ def test_x2sys_cross_input_two_dataframes(mock_x2sys_home):
         )
 
         # Add a time row to the x2sys fmtfile
-        with open(file=os.path.join(tmpdir, "xyz.fmt"), mode="a") as fmtfile:
+        with open(
+            file=os.path.join(tmpdir, "xyz.fmt"), mode="a", encoding="utf8"
+        ) as fmtfile:
             fmtfile.write("time\ta\tN\t0\t1\t0\t%g\n")
 
         # Create pandas.DataFrame track tables
@@ -164,7 +166,9 @@ def test_x2sys_cross_input_two_filenames(mock_x2sys_home):
         # Create temporary xyz files
         for i in range(2):
             np.random.seed(seed=i)
-            with open(os.path.join(os.getcwd(), f"track_{i}.xyz"), mode="w") as fname:
+            with open(
+                os.path.join(os.getcwd(), f"track_{i}.xyz"), mode="w", encoding="utf8"
+            ) as fname:
                 np.savetxt(fname=fname, X=np.random.rand(10, 3))
 
         output = x2sys_cross(

--- a/pygmt/tests/test_x2sys_init.py
+++ b/pygmt/tests/test_x2sys_init.py
@@ -29,7 +29,7 @@ def test_x2sys_init_region_spacing(mock_x2sys_home):
             tag=tag, fmtfile="xyz", force=True, region=[0, 10, 20, 30], spacing=[5, 5]
         )
 
-        with open(os.path.join(tmpdir, f"{tag}.tag"), "r") as tagpath:
+        with open(os.path.join(tmpdir, f"{tag}.tag"), "r", encoding="utf8") as tagpath:
             tail_line = tagpath.readlines()[-1]
             assert "-R0/10/20/30" in tail_line
             assert "-I5/5" in tail_line
@@ -50,7 +50,7 @@ def test_x2sys_init_units_gap(mock_x2sys_home):
             gap=["tseconds", "de"],
         )
 
-        with open(os.path.join(tmpdir, f"{tag}.tag"), "r") as tagpath:
+        with open(os.path.join(tmpdir, f"{tag}.tag"), "r", encoding="utf8") as tagpath:
             tail_line = tagpath.readlines()[-1]
             assert "-Nse -Nde" in tail_line
             assert "-Wtseconds -Wde" in tail_line

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ LICENSE = "BSD License"
 URL = "https://github.com/GenericMappingTools/pygmt"
 DESCRIPTION = "A Python interface for the Generic Mapping Tools"
 KEYWORDS = ""
-with open("README.rst") as f:
+with open("README.rst", "r", encoding="utf8") as f:
     LONG_DESCRIPTION = "".join(f.readlines())
 
 PACKAGES = find_packages(exclude=["doc"])


### PR DESCRIPTION
**Description of proposed changes**

The Style Check workflow fails with the following warnings:
```
************* Module pygmt.sphinx_gallery
pygmt/sphinx_gallery.py:27:22: R1734: Consider using [] instead of list() (use-list-literal)
************* Module pygmt.helpers.tempfile
pygmt/helpers/tempfile.py:87:13: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
************* Module pygmt.tests.test_x2sys_init
pygmt/tests/test_x2sys_init.py:32:13: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
pygmt/tests/test_x2sys_init.py:53:13: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
************* Module pygmt.tests.test_text
pygmt/tests/test_text.py:292:13: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
************* Module pygmt.tests.test_x2sys_cross
pygmt/tests/test_x2sys_cross.py:110:13: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
pygmt/tests/test_x2sys_cross.py:167:17: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
************* Module pygmt.tests.test_legend
pygmt/tests/test_legend.py:96:13: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
************* Module pygmt.tests.test_meca
pygmt/tests/test_meca.py:172:13: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
************* Module pygmt.tests.test_helpers
pygmt/tests/test_helpers.py:96:13: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
************* Module setup
setup.py:16:5: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
```

These new warnings are introduced in the recent [pylint v2.10.0 release](https://github.com/PyCQA/pylint/releases/tag/v2.10.0).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
