### PR TITLE
Raise an error for zero increment grid

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -82,7 +82,7 @@ def dataarray_to_matrix(grid):
     """
     if len(grid.dims) != 2:
         raise GMTInvalidInput(
-            "Invalid number of grid dimensions '{}'. Must be 2.".format(len(grid.dims))
+            f"Invalid number of grid dimensions '{len(grid.dims)}'. Must be 2."
         )
     # Extract region and inc from the grid
     region = []
@@ -96,9 +96,7 @@ def dataarray_to_matrix(grid):
         coord_inc = coord_incs[0]
         if not np.allclose(coord_incs, coord_inc):
             raise GMTInvalidInput(
-                "Grid appears to have irregular spacing in the '{}' dimension.".format(
-                    dim
-                )
+                f"Grid appears to have irregular spacing in the '{dim}' dimension."
             )
         if coord_inc == 0:
             raise GMTInvalidInput(

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -102,9 +102,7 @@ def dataarray_to_matrix(grid):
             )
         if coord_inc == 0:
             raise GMTInvalidInput(
-                "Grid has zero increment in the '{}' dimension.".format(
-                    dim
-                )
+                "Grid has zero increment in the '{}' dimension.".format(dim)
             )
         region.extend(
             [

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -100,7 +100,7 @@ def dataarray_to_matrix(grid):
                     dim
                 )
             )
-        elif coord_inc <= 0:
+        if coord_inc <= 0:
             raise GMTInvalidInput(
                 "Grid needs to be monotonically increasing in the '{}' dimension.".format(
                     dim

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -102,7 +102,7 @@ def dataarray_to_matrix(grid):
             )
         if coord_inc == 0:
             raise GMTInvalidInput(
-                "Grid has zero increment in the '{}' dimension.".format(dim)
+                f"Grid has a zero increment in the '{dim}' dimension."
             )
         region.extend(
             [

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -102,7 +102,7 @@ def dataarray_to_matrix(grid):
             )
         if coord_inc == 0:
             raise GMTInvalidInput(
-                "Grid needs to be monotonically increasing or decreasing in the '{}' dimension.".format(
+                "Grid has zero increment in the '{}' dimension.".format(
                     dim
                 )
             )

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -100,9 +100,9 @@ def dataarray_to_matrix(grid):
                     dim
                 )
             )
-        if coord_inc <= 0:
+        if coord_inc == 0:
             raise GMTInvalidInput(
-                "Grid needs to be monotonically increasing in the '{}' dimension.".format(
+                "Grid needs to be monotonically increasing or decreasing in the '{}' dimension.".format(
                     dim
                 )
             )

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -100,6 +100,12 @@ def dataarray_to_matrix(grid):
                     dim
                 )
             )
+        elif coord_inc <= 0:
+            raise GMTInvalidInput(
+                "Grid needs to be monotonically increasing in the '{}' dimension.".format(
+                    dim
+                )
+            )
         region.extend(
             [
                 coord.min() - coord_inc / 2 * grid.gmt.registration,

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -742,6 +742,22 @@ def test_dataarray_to_matrix_inc_fails():
     with pytest.raises(GMTInvalidInput):
         dataarray_to_matrix(grid)
 
+def test_dataarray_to_matrix_zero_inc_fails():
+    """
+    Check that dataarray_to_matrix fails for zero increments grid.
+    """
+    data = np.ones((5, 5), dtype="float64")
+    x = np.linspace(0, 1, 5)
+    y = np.zeros_like(x)
+    grid = xr.DataArray(data, coords=[("y", y), ("x", x)])
+    with pytest.raises(GMTInvalidInput):
+        dataarray_to_matrix(grid)
+    y = np.linspace(0, 1, 5)
+    x = np.zeros_like(x)
+    grid = xr.DataArray(data, coords=[("y", y), ("x", x)])
+    with pytest.raises(GMTInvalidInput):
+        dataarray_to_matrix(grid)
+
 
 def test_get_default():
     """

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -747,7 +747,7 @@ def test_dataarray_to_matrix_zero_inc_fails():
     """
     Check that dataarray_to_matrix fails for zero increments grid.
     """
-    data = np.ones((5, 5), dtype="float64")
+    data = np.ones((5, 5), dtype="float32")
     x = np.linspace(0, 1, 5)
     y = np.zeros_like(x)
     grid = xr.DataArray(data, coords=[("y", y), ("x", x)])

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -742,6 +742,7 @@ def test_dataarray_to_matrix_inc_fails():
     with pytest.raises(GMTInvalidInput):
         dataarray_to_matrix(grid)
 
+
 def test_dataarray_to_matrix_zero_inc_fails():
     """
     Check that dataarray_to_matrix fails for zero increments grid.

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -753,6 +753,7 @@ def test_dataarray_to_matrix_zero_inc_fails():
     grid = xr.DataArray(data, coords=[("y", y), ("x", x)])
     with pytest.raises(GMTInvalidInput):
         dataarray_to_matrix(grid)
+
     y = np.linspace(0, 1, 5)
     x = np.zeros_like(x)
     grid = xr.DataArray(data, coords=[("y", y), ("x", x)])


### PR DESCRIPTION
Raise an error when `DataArray` has zero increment grid.

Fixes #1483 


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
