### PR TITLE
Expand table-like input options for sphdistance

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  # pull_request:
+  pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  pull_request:
+  # pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -81,6 +81,7 @@ Operations on tabular data:
 
     blockmean
     blockmedian
+    sphdistance
     surface
 
 Operations on grids:
@@ -97,7 +98,6 @@ Operations on grids:
     grdproject
     grdsample
     grdtrack
-    sphdistance
     xyz2grd
 
 Crossover analysis with x2sys:

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -24,7 +24,8 @@ from pygmt.io import load_dataarray
 @kwargs_to_strings(I="sequence", R="sequence")
 def sphdistance(data=None, x=None, y=None, **kwargs):
     r"""
-    Create Voronoi polygons from lat/lon coordinates.
+    Create Voronoi distance, node, or natural nearest-neighbor grid on a
+    sphere.
 
     Reads a table containing *lon, lat* columns and performs
     the construction of Voronoi polygons. These polygons are

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -50,7 +50,7 @@ def sphdistance(data, **kwargs):
     -------
     ret: xarray.DataArray or None
         Return type depends on whether the ``outgrid`` parameter is set:
-        
+
         - :class:`xarray.DataArray` if ``outgrid`` is not set
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -22,7 +22,7 @@ from pygmt.io import load_dataarray
     V="verbose",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def sphdistance(data, **kwargs):
+def sphdistance(x=None, y=None, z=None, data=None, **kwargs):
     r"""
     Create Voroni polygons from lat/lon coordinates.
 
@@ -35,6 +35,8 @@ def sphdistance(data, **kwargs):
 
     Parameters
     ----------
+    x/y/z : 1d arrays
+        Arrays of x and y coordinates and values z of the data points.
     data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2D
@@ -59,7 +61,9 @@ def sphdistance(data, **kwargs):
         raise GMTInvalidInput("Both 'region' and 'spacing' must be specified.")
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_from_data(check_kind="vector", data=data)
+            file_context = lib.virtualfile_from_data(
+                check_kind="vector", data=data, x=x, y=y, z=z
+            )
             with file_context as infile:
                 if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -35,7 +35,7 @@ def sphdistance(table, **kwargs):
 
     Parameters
     ----------
-    table : str or {table-like}
+    data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2D
         {table-classes}.

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -26,10 +26,10 @@ def sphdistance(data=None, x=None, y=None, **kwargs):
     r"""
     Create Voroni polygons from lat/lon coordinates.
 
-    Reads one or more ASCII [or binary] files (or standard
-    input) containing lon, lat and performs the construction of Voronoi
-    polygons. These polygons are then processed to calculate the nearest
-    distance to each node of the lattice and written to the specified grid.
+    Reads a table containing *lon, lat* columns and performs
+    the construction of Voronoi polygons. These polygons are
+    then processed to calculate the nearest distance to each
+    node of the lattice and written to the specified grid.
 
     Full option list at :gmt-docs:`sphdistance.html
 

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -22,7 +22,7 @@ from pygmt.io import load_dataarray
     V="verbose",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def sphdistance(table, **kwargs):
+def sphdistance(data, **kwargs):
     r"""
     Create Voroni polygons from lat/lon coordinates.
 
@@ -58,7 +58,7 @@ def sphdistance(table, **kwargs):
         raise GMTInvalidInput("Both 'region' and 'spacing' must be specified.")
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_from_data(check_kind="vector", data=table)
+            file_context = lib.virtualfile_from_data(check_kind="vector", data=data)
             with file_context as infile:
                 if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -50,6 +50,7 @@ def sphdistance(data, **kwargs):
     -------
     ret: xarray.DataArray or None
         Return type depends on whether the ``outgrid`` parameter is set:
+        
         - :class:`xarray.DataArray` if ``outgrid`` is not set
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -24,7 +24,7 @@ from pygmt.io import load_dataarray
 @kwargs_to_strings(I="sequence", R="sequence")
 def sphdistance(data=None, x=None, y=None, **kwargs):
     r"""
-    Create Voroni polygons from lat/lon coordinates.
+    Create Voronoi polygons from lat/lon coordinates.
 
     Reads a table containing *lon, lat* columns and performs
     the construction of Voronoi polygons. These polygons are

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -31,6 +31,8 @@ def sphdistance(data=None, x=None, y=None, **kwargs):
     polygons. These polygons are then processed to calculate the nearest
     distance to each node of the lattice and written to the specified grid.
 
+    Full option list at :gmt-docs:`sphdistance.html
+
     {aliases}
 
     Parameters

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -22,7 +22,7 @@ from pygmt.io import load_dataarray
     V="verbose",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def sphdistance(data=None, x=None, y=None, z=None, **kwargs):
+def sphdistance(data=None, x=None, y=None, **kwargs):
     r"""
     Create Voroni polygons from lat/lon coordinates.
 
@@ -36,7 +36,7 @@ def sphdistance(data=None, x=None, y=None, z=None, **kwargs):
     Parameters
     ----------
     data : str or {table-like}
-        Pass in (x, y, z) or (longitude, latitude, elevation) values by
+        Pass in (x, y) or (longitude, latitude) values by
         providing a file name to an ASCII data table, a 2D
         {table-classes}.
     x/y/z : 1d arrays
@@ -62,7 +62,7 @@ def sphdistance(data=None, x=None, y=None, z=None, **kwargs):
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
             file_context = lib.virtualfile_from_data(
-                check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
+                check_kind="vector", data=data, x=x, y=y
             )
             with file_context as infile:
                 if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -35,6 +35,10 @@ def sphdistance(table, **kwargs):
 
     Parameters
     ----------
+    table : str or {table-like}
+        Pass in (x, y, z) or (longitude, latitude, elevation) values by
+        providing a file name to an ASCII data table, a 2D
+        {table-classes}.
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid
         in.

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -39,8 +39,8 @@ def sphdistance(data=None, x=None, y=None, **kwargs):
         Pass in (x, y) or (longitude, latitude) values by
         providing a file name to an ASCII data table, a 2D
         {table-classes}.
-    x/y/z : 1d arrays
-        Arrays of x and y coordinates and values z of the data points.
+    x/y : 1d arrays
+        Arrays of x and y coordinates.
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid
         in.

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -22,7 +22,7 @@ from pygmt.io import load_dataarray
     V="verbose",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def sphdistance(x=None, y=None, z=None, data=None, **kwargs):
+def sphdistance(data=None, x=None, y=None, z=None, **kwargs):
     r"""
     Create Voroni polygons from lat/lon coordinates.
 
@@ -35,12 +35,12 @@ def sphdistance(x=None, y=None, z=None, data=None, **kwargs):
 
     Parameters
     ----------
-    x/y/z : 1d arrays
-        Arrays of x and y coordinates and values z of the data points.
     data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2D
         {table-classes}.
+    x/y/z : 1d arrays
+        Arrays of x and y coordinates and values z of the data points.
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid
         in.
@@ -62,7 +62,7 @@ def sphdistance(x=None, y=None, z=None, data=None, **kwargs):
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
             file_context = lib.virtualfile_from_data(
-                check_kind="vector", data=data, x=x, y=y, z=z
+                check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
             )
             with file_context as infile:
                 if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile

--- a/pygmt/tests/test_sphdistance.py
+++ b/pygmt/tests/test_sphdistance.py
@@ -26,7 +26,7 @@ def test_sphdistance_outgrid(array):
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         result = sphdistance(
-            table=array, outgrid=tmpfile.name, spacing=1, region=[82, 87, 22, 24]
+            data=array, outgrid=tmpfile.name, spacing=1, region=[82, 87, 22, 24]
         )
         assert result is None  # return value is None
         assert os.path.exists(path=tmpfile.name)  # check that outgrid exists
@@ -36,7 +36,7 @@ def test_sphdistance_no_outgrid(array):
     """
     Test sphdistance with no set outgrid.
     """
-    temp_grid = sphdistance(table=array, spacing=[1, 2], region=[82, 87, 22, 24])
+    temp_grid = sphdistance(data=array, spacing=[1, 2], region=[82, 87, 22, 24])
     assert temp_grid.dims == ("lat", "lon")
     assert temp_grid.gmt.gtype == 1  # Geographic grid
     assert temp_grid.gmt.registration == 0  # Gridline registration
@@ -52,4 +52,4 @@ def test_sphdistance_fails(array):
     given.
     """
     with pytest.raises(GMTInvalidInput):
-        sphdistance(table=array)
+        sphdistance(data=array)

--- a/pygmt/tests/test_sphdistance.py
+++ b/pygmt/tests/test_sphdistance.py
@@ -20,6 +20,22 @@ def fixture_table():
     return np.array(coords_list)
 
 
+def test_sphdistance_xy_inputs():
+    """
+    Test inputs using separate xy arguments.
+    """
+    y = [22.3, 22.6, 22.4, 23.3]
+    x = [85.5, 82.3, 85.8, 86.5]
+    temp_grid = sphdistance(x=x, y=y, spacing=[1, 2], region=[82, 87, 22, 24])
+    assert temp_grid.dims == ("lat", "lon")
+    assert temp_grid.gmt.gtype == 1  # Geographic grid
+    assert temp_grid.gmt.registration == 0  # Gridline registration
+    npt.assert_allclose(temp_grid.max(), 232977.546875)
+    npt.assert_allclose(temp_grid.min(), 0)
+    npt.assert_allclose(temp_grid.median(), 0)
+    npt.assert_allclose(temp_grid.mean(), 62469.17)
+
+
 def test_sphdistance_outgrid(array):
     """
     Test sphdistance with a set outgrid.


### PR DESCRIPTION
This pull request adds `data` to the parameter list in the docstring and moves the `sphdistance` function to the tabular data section in the index.



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
