### PR TITLE
Make IPython partially optional on CI to increase test coverage of figure.py

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -52,7 +52,7 @@ jobs:
             optional-packages: ''
           - python-version: 3.9
             numpy-version: '1.21'
-            optional-packages: 'geopandas'
+            optional-packages: 'geopandas ipython'
     defaults:
       run:
         shell: bash -l {0}
@@ -92,7 +92,7 @@ jobs:
           conda install gmt=6.2.0 numpy=${{ matrix.numpy-version }} \
                         pandas xarray netCDF4 packaging \
                         ${{ matrix.optional-packages }} \
-                        codecov coverage[toml] dvc ipython make \
+                        codecov coverage[toml] dvc make \
                         pytest-cov pytest-mpl pytest>=6.0 \
                         sphinx-gallery
 

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -119,7 +119,7 @@ def inset(self, **kwargs):
     ...
     >>> # Map elements outside the "with" block are plotted in the main figure
     >>> fig.logo(position="jBR+o0.2c+w3c")
-    >>> fig.show()
+    >>> fig.show()  # doctest: +SKIP
     <IPython.core.display.Image object>
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -5,11 +5,17 @@ Doesn't include the plotting commands which have their own test files.
 """
 import os
 
+try:
+    import IPython
+except ModuleNotFoundError:
+    IPython = None  # pylint: disable=invalid-name
+
+
 import numpy as np
 import numpy.testing as npt
 import pytest
 from pygmt import Figure, set_display
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTError, GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 
 
@@ -198,6 +204,18 @@ def test_figure_show_invalid_method():
     fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
     with pytest.raises(GMTInvalidInput):
         fig.show(method="test")
+
+
+@pytest.mark.skipif(IPython is not None, reason="run without IPython installed")
+def test_figure_show_notebook_error_without_ipython():
+    """
+    Test to check if an error is raised when display method is 'notebook', but
+    IPython is not installed.
+    """
+    fig = Figure()
+    fig.basemap(region=[0, 1, 2, 3], frame=True)
+    with pytest.raises(GMTError):
+        fig.show(method="notebook")
 
 
 def test_figure_set_display_invalid():

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -182,11 +182,11 @@ def test_figure_savefig():
     )
 
 
+@pytest.mark.skipif(IPython is None, reason="run when IPython is installed")
 def test_figure_show():
     """
     Test that show creates the correct file name and deletes the temp dir.
     """
-    pytest.importorskip("IPython")
     fig = Figure()
     fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
     fig.show()

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -58,6 +58,23 @@ def test_figure_region_country_codes():
     npt.assert_allclose(fig.region, np.array([0.0, 360.0, -90.0, 90.0]))
 
 
+def test_figure_repr():
+    """
+    Make sure that figure output's PNG and HTML printable representations look
+    ok.
+    """
+    fig = Figure()
+    fig.basemap(region=[0, 1, 2, 3], frame=True)
+    # Check that correct PNG 8-byte file header is produced
+    # https://en.wikipedia.org/wiki/Portable_Network_Graphics#File_header
+    repr_png = fig._repr_png_()
+    assert repr_png.hex().startswith("89504e470d0a1a0a")
+    # Check that correct HTML image tags are produced
+    repr_html = fig._repr_html_()
+    assert repr_html.startswith('<img src="data:image/png;base64,')
+    assert repr_html.endswith('" width="500px">')
+
+
 def test_figure_savefig_exists():
     """
     Make sure the saved figure has the right name.

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -67,10 +67,10 @@ def test_figure_repr():
     fig.basemap(region=[0, 1, 2, 3], frame=True)
     # Check that correct PNG 8-byte file header is produced
     # https://en.wikipedia.org/wiki/Portable_Network_Graphics#File_header
-    repr_png = fig._repr_png_()
+    repr_png = fig._repr_png_()  # pylint: disable=protected-access
     assert repr_png.hex().startswith("89504e470d0a1a0a")
     # Check that correct HTML image tags are produced
-    repr_html = fig._repr_html_()
+    repr_html = fig._repr_html_()  # pylint: disable=protected-access
     assert repr_html.startswith('<img src="data:image/png;base64,')
     assert repr_html.endswith('" width="500px">')
 

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -237,7 +237,7 @@ def test_figure_show_notebook_error_without_ipython():
 
 def test_figure_display_external():
     """
-    Test to check that a figure can displayed in an external window.
+    Test to check that a figure can be displayed in an external window.
     """
     fig = Figure()
     fig.basemap(region=[0, 3, 6, 9], projection="X1c", frame=True)

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -163,6 +163,7 @@ def test_figure_show():
     """
     Test that show creates the correct file name and deletes the temp dir.
     """
+    pytest.importorskip("IPython")
     fig = Figure()
     fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
     fig.show()

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -235,6 +235,15 @@ def test_figure_show_notebook_error_without_ipython():
         fig.show(method="notebook")
 
 
+def test_figure_display_external():
+    """
+    Test to check that a figure can displayed in an external window.
+    """
+    fig = Figure()
+    fig.basemap(region=[0, 3, 6, 9], projection="X1c", frame=True)
+    fig.show(method="external")
+
+
 def test_figure_set_display_invalid():
     """
     Test to check if an error is raised when an invalid method is passed to

--- a/pygmt/tests/test_sphinx_gallery.py
+++ b/pygmt/tests/test_sphinx_gallery.py
@@ -13,8 +13,10 @@ def test_pygmtscraper():
     """
     Make sure the scraper finds the figures and removes them from the pool.
     """
-    pytest.importorskip("sphinx_gallery")
-    pytest.importorskip("IPython")
+    pytest.importorskip(
+        "sphinx_gallery", reason="Requires sphinx-gallery to be installed"
+    )
+    pytest.importorskip("IPython", reason="Requires IPython to be installed")
 
     showed = SHOWED_FIGURES.copy()
     for _ in range(len(SHOWED_FIGURES)):

--- a/pygmt/tests/test_sphinx_gallery.py
+++ b/pygmt/tests/test_sphinx_gallery.py
@@ -8,19 +8,15 @@ import pytest
 from pygmt.figure import SHOWED_FIGURES, Figure
 
 pygmt_sphinx_gallery = pytest.importorskip(
-    "pygmt.sphinx_gallery", reason="requires sphinx-gallery to be installed"
+    "pygmt.sphinx_gallery", reason="Requires sphinx-gallery to be installed"
 )
+pytest.importorskip("IPython", reason="Requires IPython to be installed")
 
 
 def test_pygmtscraper():
     """
     Make sure the scraper finds the figures and removes them from the pool.
     """
-    pytest.importorskip(
-        "sphinx_gallery", reason="Requires sphinx-gallery to be installed"
-    )
-    pytest.importorskip("IPython", reason="Requires IPython to be installed")
-
     showed = SHOWED_FIGURES.copy()
     for _ in range(len(SHOWED_FIGURES)):
         SHOWED_FIGURES.pop()

--- a/pygmt/tests/test_sphinx_gallery.py
+++ b/pygmt/tests/test_sphinx_gallery.py
@@ -5,21 +5,16 @@ import os
 from tempfile import TemporaryDirectory
 
 import pytest
-
-try:
-    import sphinx_gallery
-except ImportError:
-    sphinx_gallery = None
-
 from pygmt.figure import SHOWED_FIGURES, Figure
 from pygmt.sphinx_gallery import PyGMTScraper
 
 
-@pytest.mark.skipif(sphinx_gallery is None, reason="requires sphinx-gallery")
 def test_pygmtscraper():
     """
     Make sure the scraper finds the figures and removes them from the pool.
     """
+    pytest.importorskip("sphinx_gallery")
+    pytest.importorskip("IPython")
 
     showed = SHOWED_FIGURES.copy()
     for _ in range(len(SHOWED_FIGURES)):


### PR DESCRIPTION
**Description of proposed changes**

The [`pygmt/figure.py`](https://github.com/GenericMappingTools/pygmt/blob/v0.4.1/pygmt/figure.py) file has the smallest code coverage in the PyGMT project, with 15 lines uncovered. This is mostly due to if-branches that only get triggered when [`IPython`](https://ipython.org) isn't installed.

![image](https://user-images.githubusercontent.com/23487320/132987114-6048b2d6-23bc-448b-a82e-bf9f8bd5868e.png)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This PR makes `IPython` an optional dependency in Continuous Integration for the minimum dependency stream (Python 3.7/NumPy 1.18), so that those uncovered if-branches are covered. Tests which require `IPython` will have a [`pytest.importorskip`](https://docs.pytest.org/en/stable/skipping.html#skipping-on-a-missing-import-dependency) line added so that the test suite doesn't break.

See coverage diff at https://app.codecov.io/gh/GenericMappingTools/pygmt/compare/1496/changes. Project test coverage increased by 0.96% to 98.25%!

References:
- https://docs.pytest.org/en/stable/skipping.html#skipping-on-a-missing-import-dependency
- https://sphinx-hxl.readthedocs.io/en/stable/usage/extensions/doctest.html#skipping-tests-conditionally
- https://stackoverflow.com/questions/42708809/python-doctest-skip-a-test-conditionally

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses https://github.com/GenericMappingTools/pygmt/pull/1247#issuecomment-827991167 and patches #529 with more code coverage.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
