### PR TITLE
Add missing aliases to pygmt.Figure.velo

### DIFF
--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -30,6 +30,10 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     Y="yshift",
     Z="zvalue",
     c="panel",
+    d="nodata",
+    e="find",
+    h="header",
+    i="incols",
     p="perspective",
     t="transparency",
 )
@@ -225,6 +229,10 @@ def velo(self, data=None, **kwargs):
         (i.e., vector or rotation uncertainty) to lookup the color and paint
         the error ellipse or wedge instead, append **+e**.
     {c}
+    {d}
+    {e}
+    {h}
+    {i}
     {p}
     {t}
     """


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the common options nodata, find, header and incols to the pygmt.Figure.velo method.

Addresses #1445


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
