### PR TITLE
Add missing aliases to pygmt.Figure.wiggle

### DIFF
--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -95,9 +95,9 @@ def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
         via *data*. E.g. ``columns = [0, 1, 2]`` or ``columns = "0,1,2"`` if
         the *x* values are stored in the first column, *y* values in the second
         one and *z* values in the third one. Note: zero-based indexing is used.
-    {p}  
-    {t} 
-    {w} 
+    {p}
+    {t}
+    {w}
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
 

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -87,6 +87,7 @@ def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
     {c}
     {d}
     {e}
+    {f}
     {g}
     {h}
     columns : str or 1d array
@@ -95,7 +96,6 @@ def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
         the *x* values are stored in the first column, *y* values in the second
         one and *z* values in the third one. Note: zero-based indexing is used.
     {p}  
-    {f} 
     {t} 
     {w} 
     """

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -29,7 +29,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     i="columns",
     p="perspective",
     t="transparency",
-    w="wrap",    
+    w="wrap",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -23,10 +23,13 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     c="panel",
     d="nodata",
     e="find",
+    f="coltypes",
     g="gap",
     h="header",
     i="columns",
     p="perspective",
+    t="transparency",
+    w="wrap",    
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
@@ -91,7 +94,10 @@ def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
         via *data*. E.g. ``columns = [0, 1, 2]`` or ``columns = "0,1,2"`` if
         the *x* values are stored in the first column, *y* values in the second
         one and *z* values in the third one. Note: zero-based indexing is used.
-    {p}
+    {p}  
+    {f} 
+    {t} 
+    {w} 
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
 


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the common options coltypes, transparency and wrap to the pygmt.Figure.wiggle method.

Addresses #1445

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
