### PR TITLE
Add missing aliases to pygmt.grdtrack

### DIFF
--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -26,10 +26,18 @@ from pygmt.helpers import (
     T="radius",
     V="verbose",
     Z="z_only",
+    b="binary",
+    d="nodata",
+    e="find",
     f="coltypes",
+    g="gap",
+    h="header",
     i="incols",
     j="distcalc",
     n="interpolation",
+    o="outcols",
+    s="skiprows",
+    w="wrap",    
 )
 @kwargs_to_strings(R="sequence", S="sequence", i="sequence_comma")
 def grdtrack(points, grid, newcolname=None, outfile=None, **kwargs):
@@ -232,10 +240,18 @@ def grdtrack(points, grid, newcolname=None, outfile=None, **kwargs):
     {V}
     z_only : bool
         Only write out the sampled z-values [Default writes all columns].
+    {b}
+    {d}
+    {e}
     {f}
+    {g}
+    {h}
     {i}
     {j}
     {n}
+    {o}
+    {s}
+    {w}
 
     Returns
     -------

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -37,7 +37,7 @@ from pygmt.helpers import (
     n="interpolation",
     o="outcols",
     s="skiprows",
-    w="wrap",    
+    w="wrap",
 )
 @kwargs_to_strings(R="sequence", S="sequence", i="sequence_comma")
 def grdtrack(points, grid, newcolname=None, outfile=None, **kwargs):


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the following common options to the pygmt.grdtrack method:

- [x]  binary
- [x] nodata 
- [x] find
- [x] gap
- [x]  header
- [x] outcols
- [x] skiprows
- [x] wrap 

Addresses #1445

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
