### PR TITLE
Add missing aliases to pygmt.blockmean and pygmt.blockmedian

### DIFF
--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -78,7 +78,7 @@ def _blockm(block_method, table, outfile, x, y, z, **kwargs):
     o="outcols",
     r="registration",
     s="skiprows",
-    w="wrap",    
+    w="wrap",
 )
 @kwargs_to_strings(R="sequence", i="sequence_comma")
 def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
@@ -155,7 +155,7 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     o="outcols",
     r="registration",
     s="skiprows",
-    w="wrap",    
+    w="wrap",
 )
 @kwargs_to_strings(R="sequence", i="sequence_comma")
 def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -70,12 +70,15 @@ def _blockm(block_method, table, outfile, x, y, z, **kwargs):
     R="region",
     V="verbose",
     a="aspatial",
+    d="data",
+    e="find",
     f="coltypes",
+    h="header",
     i="incols",
     o="outcols",
     r="registration",
     s="skiprows",
-    w="wrap",
+    w="wrap",    
 )
 @kwargs_to_strings(R="sequence", i="sequence_comma")
 def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
@@ -113,8 +116,11 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
 
     {V}
     {a}
+    {d}
+    {e}
     {i}
     {f}
+    {h}
     {o}
     {r}
     {s}
@@ -141,12 +147,15 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     R="region",
     V="verbose",
     a="aspatial",
+    d="nodata",
+    e="find",
     f="coltypes",
+    h="header",
     i="incols",
     o="outcols",
     r="registration",
     s="skiprows",
-    w="wrap",
+    w="wrap",    
 )
 @kwargs_to_strings(R="sequence", i="sequence_comma")
 def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
@@ -184,7 +193,10 @@ def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
 
     {V}
     {a}
+    {d}
+    {e}
     {f}
+    {h}
     {i}
     {o}
     {r}

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -70,6 +70,7 @@ def _blockm(block_method, table, outfile, x, y, z, **kwargs):
     R="region",
     V="verbose",
     a="aspatial",
+    b="binary",
     d="data",
     e="find",
     f="coltypes",
@@ -116,6 +117,7 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
 
     {V}
     {a}
+    {b}
     {d}
     {e}
     {i}
@@ -147,6 +149,7 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     R="region",
     V="verbose",
     a="aspatial",
+    b="binary",
     d="nodata",
     e="find",
     f="coltypes",
@@ -193,6 +196,7 @@ def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
 
     {V}
     {a}
+    {b}
     {d}
     {e}
     {f}


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the common options nodata, find and header to the pygmt.blockmean and pygmt.blockmedian methods.

Addresses #1445

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
