### PR TITLE
Add missing aliases to pygmt.surface

### DIFF
--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -25,8 +25,14 @@ from pygmt.io import load_dataarray
     G="outgrid",
     V="verbose",
     a="aspatial",
+    b="binary",
+    d="nodata",
+    e="find",
     f="coltypes",
+    h="header",
+    i="incols",
     r="registration",
+    s="skiprows",   
 )
 @kwargs_to_strings(R="sequence")
 def surface(x=None, y=None, z=None, data=None, **kwargs):
@@ -68,9 +74,15 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
 
     {V}
     {a}
+    {b}
+    {d}
+    {e}
     {f}
+    {h}
+    {i}
     {r}
-
+    {s}
+    
     Returns
     -------
     ret: xarray.DataArray or None

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -33,6 +33,7 @@ from pygmt.io import load_dataarray
     i="incols",
     r="registration",
     s="skiprows",
+    w="wrap",
 )
 @kwargs_to_strings(R="sequence")
 def surface(x=None, y=None, z=None, data=None, **kwargs):
@@ -82,6 +83,7 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
     {i}
     {r}
     {s}
+    {w}
 
     Returns
     -------

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -32,7 +32,7 @@ from pygmt.io import load_dataarray
     h="header",
     i="incols",
     r="registration",
-    s="skiprows",   
+    s="skiprows",
 )
 @kwargs_to_strings(R="sequence")
 def surface(x=None, y=None, z=None, data=None, **kwargs):
@@ -82,7 +82,7 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
     {i}
     {r}
     {s}
-    
+
     Returns
     -------
     ret: xarray.DataArray or None


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the common options binary, nodata, find, header, incols and skiprows to the pygmt.surface method.

Addresses #1445

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
