### PR TITLE
Add missing aliases to pygmt.Figure.plot

### DIFF
--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -50,7 +50,7 @@ from pygmt.src.which import which
     l="label",
     p="perspective",
     t="transparency",
-    w="wrap",   
+    w="wrap",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
@@ -211,7 +211,7 @@ def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
     {t}
         *transparency* can also be a 1d array to set varying transparency
         for symbols, but this option is only valid if using x/y.
-    {w}   
+    {w}
     """
     # pylint: disable=too-many-locals
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -39,12 +39,18 @@ from pygmt.src.which import which
     Y="yshift",
     Z="zvalue",
     a="aspatial",
+    b="binary",
+    c="panel",
+    d="nodata",
+    e="find",
+    f="coltypes",
+    g="gap",
+    h="header",
     i="incols",
     l="label",
-    c="panel",
-    f="coltypes",
     p="perspective",
     t="transparency",
+    w="wrap",   
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
@@ -192,14 +198,20 @@ def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
         ``color='+z'``. To apply it to the pen color, append **+z** to
         ``pen``.
     {a}
+    {b}
     {c}
+    {d}
+    {e}
     {f}
+    {g}
+    {h}
     {i}
     {l}
     {p}
     {t}
         *transparency* can also be a 1d array to set varying transparency
         for symbols, but this option is only valid if using x/y.
+    {w}   
     """
     # pylint: disable=too-many-locals
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the common options binary, nodata, find, gap, header, and wrap to the pygmt.Figure.plot method.

Addresses #1445


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
