### PR TITLE
Figure.wiggle: Deprecate parameter "columns" to "incols" (remove in v0.7.0)

### DIFF
--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -2,11 +2,17 @@
 wiggle - Plot z=f(x,y) anomalies along tracks.
 """
 from pygmt.clib import Session
-from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias, deprecate_parameter
+from pygmt.helpers import (
+    build_arg_string,
+    deprecate_parameter,
+    fmt_docstring,
+    kwargs_to_strings,
+    use_alias,
+)
 
 
 @fmt_docstring
-@deprecate_parameter("columns", "incols", "v0.4.1", remove_version="v0.6.0")
+@deprecate_parameter("columns", "incols", "v0.5.0", remove_version="v0.7.0")
 @use_alias(
     B="frame",
     D="position",

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -2,10 +2,11 @@
 wiggle - Plot z=f(x,y) anomalies along tracks.
 """
 from pygmt.clib import Session
-from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias, deprecate_parameter
 
 
 @fmt_docstring
+@deprecate_parameter("columns", "incols", "v0.4.1", remove_version="v0.6.0")
 @use_alias(
     B="frame",
     D="position",
@@ -25,7 +26,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     e="find",
     g="gap",
     h="header",
-    i="columns",
+    i="incols",
     p="perspective",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
@@ -49,7 +50,7 @@ def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
     data : str or {table-like}
         Pass in either a file name to an ASCII data table, a 2D
         {table-classes}.
-        Use parameter ``columns`` to choose which columns are x, y, z,
+        Use parameter ``incols`` to choose which columns are x, y, z,
         respectively.
     {J}
     {R}
@@ -86,11 +87,7 @@ def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
     {e}
     {g}
     {h}
-    columns : str or 1d array
-        Choose which columns are x, y, and z, respectively if input is provided
-        via *data*. E.g. ``columns = [0, 1, 2]`` or ``columns = "0,1,2"`` if
-        the *x* values are stored in the first column, *y* values in the second
-        one and *z* values in the third one. Note: zero-based indexing is used.
+    {i}
     {p}
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access

--- a/pygmt/tests/test_wiggle.py
+++ b/pygmt/tests/test_wiggle.py
@@ -45,7 +45,7 @@ def test_wiggle_deprecate_columns_to_incols():
     x = np.arange(-2, 2, 0.02)
     y = np.zeros(x.size)
     z = np.cos(2 * np.pi * x)
-    data = np.array([y, x, z])
+    data = np.array([y, x, z]).T
 
     fig = Figure()
     with pytest.warns(expected_warning=FutureWarning) as record:

--- a/pygmt/tests/test_wiggle.py
+++ b/pygmt/tests/test_wiggle.py
@@ -29,3 +29,36 @@ def test_wiggle():
         position="jRM+w2+lnT",
     )
     return fig
+
+
+@pytest.mark.mpl_image_compare(filename="test_wiggle.png")
+def test_wiggle_deprecate_columns_to_incols():
+    """
+    Make sure that the old parameter "columns" is supported and it reports a
+    warning.
+
+    Modified from the test_wiggle() test.
+    """
+
+    # put data into numpy array and swap x and y columns
+    # as the use of the 'columns' parameter will reverse this action
+    x = np.arange(-2, 2, 0.02)
+    y = np.zeros(x.size)
+    z = np.cos(2 * np.pi * x)
+    data = np.array([y, x, z])
+
+    fig = Figure()
+    with pytest.warns(expected_warning=FutureWarning) as record:
+        fig.wiggle(
+            region=[-4, 4, -1, 1],
+            projection="X8c",
+            data=data,
+            columns=[1, 0, 2],
+            scale="0.5c",
+            color=["red+p", "gray+n"],
+            pen="1.0p",
+            track="0.5p",
+            position="jRM+w2+lnT",
+        )
+        assert len(record) == 1  # check that only one warning was raised
+    return fig


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the deprecate_parameter decorator for backward-compatibility to Figure.wiggle().

- [x] Updates tests and examples to use the new parameter name
- [x] Use the deprecate_parameter decorator for backward-compatibility
- [x] Add a test for checking 'columns' backward compatibility


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
