### PR TITLE
Add R-noplot to COMMON_OPTIONS

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -20,6 +20,10 @@ COMMON_OPTIONS = {
             *Required if this is the first plot command*.
             *xmin/xmax/ymin/ymax*\ [**+r**][**+u**\ *unit*].
             Specify the :doc:`region </tutorials/regions>` of interest.""",
+    "R-noplot": r"""
+        region : str or list
+            *xmin/xmax/ymin/ymax*\ [**+r**][**+u**\ *unit*].
+            Specify the :doc:`region </tutorials/regions>` of interest.""",
     "J": r"""
         projection : str
             *Required if this is the first plot command*.

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -158,6 +158,7 @@ def grd2cpt(grid, **kwargs):
         Produce a wrapped (cyclic) color table that endlessly repeats its
         range. Note that ``cyclic=True`` cannot be set together with
         ``categorical=True``.
+    {R-noplot}
     {V}
     """
     if "W" in kwargs and "Ww" in kwargs:

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -53,7 +53,7 @@ def grdclip(grid, **kwargs):
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid
         in.
-    {R}
+    {R-noplot}
     above : str or list or tuple
         [*high*, *above*].
         Set all data[i] > *high* to *above*.

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -50,7 +50,7 @@ def grdcut(grid, **kwargs):
         The name of the output netCDF file with extension .nc to store the grid
         in.
     {J}
-    {R}
+    {R-noplot}
     extend : bool or int or float
         Allow grid to be extended if new ``region`` exceeds existing
         boundaries. Give a value to initialize nodes outside current region.

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -51,7 +51,7 @@ def grdfill(grid, **kwargs):
         **s** for bicubic spline (optionally append a *tension*
         parameter [Default is no tension]).
 
-    {R}
+    {R-noplot}
     {V}
 
     Returns

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -101,7 +101,7 @@ def grdfilter(grid, **kwargs):
     nans : str or float
         **i**\|\ **p**\|\ **r**.
         Determine how NaN-values in the input grid affects the filtered output.
-    {R}
+    {R-noplot}
     toggle : bool
         Toggle the node registration for the output grid so as to become the
         opposite of the input grid. [Default gives the same registration as the

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -89,7 +89,7 @@ def grdgradient(grid, **kwargs):
         algorithm; in this case the *azim* and *elev* are hardwired to 315
         and 45 degrees. This means that even if you provide other values
         they will be ignored.)
-    {R}
+    {R-noplot}
     {V}
     {n}
 

--- a/pygmt/src/grdinfo.py
+++ b/pygmt/src/grdinfo.py
@@ -40,7 +40,7 @@ def grdinfo(grid, **kwargs):
     grid : str or xarray.DataArray
         The file name of the input grid or the grid loaded as a DataArray.
         This is the only required parameter.
-    {R}
+    {R-noplot}
     per_column : str or bool
         **n**\|\ **t**.
         Formats the report using tab-separated fields on a single line. The

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -48,7 +48,7 @@ def grdlandmask(**kwargs):
         The name of the output netCDF file with extension .nc to store the grid
         in.
     {I}
-    {R}
+    {R-noplot}
     {A}
     resolution : str
         *res*\[\ **+f**\]. Selects the resolution of the data set to use

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -57,7 +57,7 @@ def grdproject(grid, **kwargs):
         When set to ``True`` transforms grid from rectangular to
         geographical [Default is False].
     {J}
-    {R}
+    {R-noplot}
     {V}
     {n}
     {r}

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -54,7 +54,7 @@ def grdsample(grid, **kwargs):
         The name of the output netCDF file with extension .nc to store the grid
         in.
     {I}
-    {R}
+    {R-noplot}
     translate : bool
         Translate between grid and pixel registration; if the input is
         grid-registered, the output will be pixel-registered and vice-versa.

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -171,7 +171,7 @@ def grdtrack(points, grid, newcolname=None, outfile=None, **kwargs):
         nearest distance nodes along the cross-profiles. We write 13 output
         columns per track: *dist, lonc, latc, distc, azimuthc, zc, lonl, latl,
         distl, lonr, latr, distr, width*.
-    {R}
+    {R-noplot}
     no_skip : bool
         Do *not* skip points that fall outside the domain of the grid(s)
         [Default only output points within grid domain].

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -39,7 +39,7 @@ def sphdistance(table, **kwargs):
         The name of the output netCDF file with extension .nc to store the grid
         in.
     {I}
-    {R}
+    {R-noplot}
     {V}
 
     Returns

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -58,9 +58,7 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
 
     {I}
 
-    region : str or list
-        *xmin/xmax/ymin/ymax*\[**+r**][**+u**\ *unit*].
-        Specify the region of interest.
+    {R-noplot}
 
     outgrid : str
         Optional. The file name for the output netcdf file with extension .nc

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -41,7 +41,7 @@ def xyz2grd(table, **kwargs):
         Optional. The name of the output netCDF file with extension .nc to
         store the grid in.
     {I}
-    {R}
+    {R-noplot}
     {V}
 
     Returns


### PR DESCRIPTION
This adds a non-plotting module docstring for region to the COMMON_OPTIONS in `decorators.py`.



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1493 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
