### PR TITLE
Update region and projection standard docstrings

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -17,12 +17,10 @@ from pygmt.helpers.utils import is_nonstr_iter
 COMMON_OPTIONS = {
     "R": r"""
         region : str or list
-            *Required if this is the first plot command*.
             *xmin/xmax/ymin/ymax*\ [**+r**][**+u**\ *unit*].
             Specify the :doc:`region </tutorials/regions>` of interest.""",
     "J": r"""
         projection : str
-            *Required if this is the first plot command*.
             *projcode*\[*projparams*/]\ *width*.
             Select map :doc:`projection </projections/index>`.""",
     "A": r"""

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -52,9 +52,11 @@ def basemap(self, **kwargs):
     Parameters
     ----------
     {J}
+        *Required if this is the first plot command.*
     zscale/zsize : float or str
         Set z-axis scaling or z-axis size.
     {R}
+        *Required if this is the first plot command.*
     {B}
     map_scale : str
         [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -64,7 +64,9 @@ def coast(self, **kwargs):
     Parameters
     ----------
     {J}
+        *Required if this is the first plot command.*
     {R}
+        *Required if this is the first plot command.*
     {A}
     {B}
     lakes : str or list

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -54,7 +54,9 @@ def histogram(self, table, **kwargs):
         Pass in either a file name to an ASCII data table, a Python list, a 2D
         {table-classes}.
     {J}
+        *Required if this is the first plot command.*
     {R}
+        *Required if this is the first plot command.*
     {B}
     {CPT}
     {G}

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -50,7 +50,9 @@ def solar(self, terminator="d", terminator_datetime=None, **kwargs):
         passed as a string or Python datetime object.
         [Default is the current UTC date and time]
     {R}
+        *Required if this is the first plot command.*
     {J}
+        *Required if this is the first plot command.*
     {B}
     fill : str
         Color or pattern for filling of terminators.

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -116,7 +116,9 @@ def text_(
         left. If no justification is explicitly given (i.e. ``justify=True``),
         then the input to ``textfiles`` must have this as a column.
     {J}
+        *Required if this is the first plot command.*
     {R}
+        *Required if this is the first plot command.*
     clearance : str
         [*dx/dy*][**+to**\|\ **O**\|\ **c**\|\ **C**].
         Adjust the clearance between the text and the surrounding box


### PR DESCRIPTION
This pull request modifies the COMMON_OPTIONS text for `region` and `projection`. It also adds that it is requirement for certain plotting commands to individual modules. This partially addresses #1493.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
