### PR TITLE
Fix pylint 2.11 consider-using-f-string checker errors

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -127,11 +127,9 @@ else:
 release = __version__
 
 # These enable substitutions using |variable| in the rst files
-rst_epilog = """
+rst_epilog = f"""
 .. |year| replace:: {year}
-""".format(
-    year=year
-)
+"""
 
 html_last_updated_fmt = "%b %d, %Y"
 html_title = "PyGMT"

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -77,7 +77,7 @@ def print_clib_info():
     lines = ["GMT library information:"]
     with Session() as ses:
         for key in sorted(ses.info):
-            lines.append("  {}: {}".format(key, ses.info[key]))
+            lines.append(f"  {key}: {ses.info[key]}")
     print("\n".join(lines))
 
 
@@ -212,7 +212,7 @@ def test(doctest=True, verbose=True, coverage=False, figures=True):
     if verbose:
         args.append("-vv")
     if coverage:
-        args.append("--cov={}".format(package))
+        args.append(f"--cov={package}")
         args.append("--cov-report=term-missing")
     if doctest:
         args.append("--doctest-modules")

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -113,9 +113,7 @@ class Session:
     ...         with GMTTempFile() as fout:
     ...             # Call the grdinfo module with the virtual file as input
     ...             # and the temp file as output.
-    ...             ses.call_module(
-    ...                 "grdinfo", f"{fin} -C ->{fout.name}"
-    ...             )
+    ...             ses.call_module("grdinfo", f"{fin} -C ->{fout.name}")
     ...             # Read the contents of the temp file before it's deleted.
     ...             print(fout.read().strip())
     ...
@@ -1120,9 +1118,7 @@ class Session:
         ...     with ses.virtualfile_from_vectors(x, y, z) as fin:
         ...         # Send the output to a file so that we can read it
         ...         with GMTTempFile() as fout:
-        ...             ses.call_module(
-        ...                 "info", f"{fin} ->{fout.name}"
-        ...             )
+        ...             ses.call_module("info", f"{fin} ->{fout.name}")
         ...             print(fout.read().strip())
         ...
         <vector memory>: N = 3 <1/3> <4/6> <7/9>
@@ -1233,9 +1229,7 @@ class Session:
         ...     with ses.virtualfile_from_matrix(data) as fin:
         ...         # Send the output to a file so that we can read it
         ...         with GMTTempFile() as fout:
-        ...             ses.call_module(
-        ...                 "info", f"{fin} ->{fout.name}"
-        ...             )
+        ...             ses.call_module("info", f"{fin} ->{fout.name}")
         ...             print(fout.read().strip())
         ...
         <matrix memory>: N = 4 <0/9> <1/10> <2/11>

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -114,7 +114,7 @@ class Session:
     ...             # Call the grdinfo module with the virtual file as input
     ...             # and the temp file as output.
     ...             ses.call_module(
-    ...                 "grdinfo", "{} -C ->{}".format(fin, fout.name)
+    ...                 "grdinfo", f"{fin} -C ->{fout.name}"
     ...             )
     ...             # Read the contents of the temp file before it's deleted.
     ...             print(fout.read().strip())
@@ -189,9 +189,8 @@ class Session:
         if Version(version) < Version(self.required_version):
             self.destroy()
             raise GMTVersionError(
-                "Using an incompatible GMT version {}. Must be equal or newer than {}.".format(
-                    version, self.required_version
-                )
+                f"Using an incompatible GMT version {version}. "
+                f"Must be equal or newer than {self.required_version}."
             )
         return self
 
@@ -366,7 +365,7 @@ class Session:
 
         if session is None:
             raise GMTCLibError(
-                "Failed to create a GMT API session:\n{}".format(self._error_message)
+                f"Failed to create a GMT API session:\n{self._error_message}"
             )
 
         self.session_pointer = session
@@ -412,7 +411,7 @@ class Session:
         status = c_destroy_session(self.session_pointer)
         if status:
             raise GMTCLibError(
-                "Failed to destroy GMT API session:\n{}".format(self._error_message)
+                f"Failed to destroy GMT API session:\n{self._error_message}"
             )
 
         self.session_pointer = None
@@ -462,9 +461,7 @@ class Session:
 
         if status != 0:
             raise GMTCLibError(
-                "Error getting default value for '{}' (error code {}).".format(
-                    name, status
-                )
+                f"Error getting default value for '{name}' (error code {status})."
             )
 
         return value.value.decode()
@@ -503,9 +500,7 @@ class Session:
         )
         if status != 0:
             raise GMTCLibError(
-                "Module '{}' failed with status code {}:\n{}".format(
-                    module, status, self._error_message
-                )
+                f"Module '{module}' failed with status code {status}:\n{self._error_message}"
             )
 
     def create_data(self, family, geometry, mode, **kwargs):
@@ -650,20 +645,16 @@ class Session:
         nmodifiers = len(parts) - 1
         if nmodifiers > 1:
             raise GMTInvalidInput(
-                "Only one modifier is allowed in constants, {} given: '{}'".format(
-                    nmodifiers, constant
-                )
+                f"Only one modifier is allowed in constants, {nmodifiers} given: '{constant}'"
             )
         if nmodifiers > 0 and valid_modifiers is None:
             raise GMTInvalidInput(
                 "Constant modifiers not allowed since valid values were not "
-                + "given: '{}'".format(constant)
+                + f"given: '{constant}'"
             )
         if name not in valid:
             raise GMTInvalidInput(
-                "Invalid constant argument '{}'. Must be one of {}.".format(
-                    name, str(valid)
-                )
+                f"Invalid constant argument '{name}'. Must be one of {str(valid)}."
             )
         if (
             nmodifiers > 0
@@ -671,9 +662,7 @@ class Session:
             and parts[1] not in valid_modifiers
         ):
             raise GMTInvalidInput(
-                "Invalid constant modifier '{}'. Must be one of {}.".format(
-                    parts[1], str(valid_modifiers)
-                )
+                f"Invalid constant modifier '{parts[1]}'. Must be one of {str(valid_modifiers)}."
             )
         integer_value = sum(self[part] for part in parts)
         return integer_value
@@ -905,7 +894,7 @@ class Session:
             self.session_pointer, dataset, gmt_type, pad, matrix_pointer
         )
         if status != 0:
-            raise GMTCLibError("Failed to put matrix of type {}.".format(matrix.dtype))
+            raise GMTCLibError(f"Failed to put matrix of type {matrix.dtype}.")
 
     def write_data(self, family, geometry, mode, wesn, output, data):
         """
@@ -974,7 +963,7 @@ class Session:
             data,
         )
         if status != 0:
-            raise GMTCLibError("Failed to write dataset to '{}'".format(output))
+            raise GMTCLibError(f"Failed to write dataset to '{output}'")
 
     @contextmanager
     def open_virtual_file(self, family, geometry, direction, data):
@@ -1036,7 +1025,7 @@ class Session:
         ...     with lib.open_virtual_file(*vfargs) as vfile:
         ...         # Send the output to a temp file so that we can read it
         ...         with GMTTempFile() as ofile:
-        ...             args = "{} ->{}".format(vfile, ofile.name)
+        ...             args = f"{vfile} ->{ofile.name}"
         ...             lib.call_module("info", args)
         ...             print(ofile.read().strip())
         ...
@@ -1083,7 +1072,7 @@ class Session:
         finally:
             status = c_close_virtualfile(self.session_pointer, vfname.encode())
             if status != 0:
-                raise GMTCLibError("Failed to close virtual file '{}'.".format(vfname))
+                raise GMTCLibError(f"Failed to close virtual file '{vfname}'.")
 
     @contextmanager
     def virtualfile_from_vectors(self, *vectors):
@@ -1132,7 +1121,7 @@ class Session:
         ...         # Send the output to a file so that we can read it
         ...         with GMTTempFile() as fout:
         ...             ses.call_module(
-        ...                 "info", "{} ->{}".format(fin, fout.name)
+        ...                 "info", f"{fin} ->{fout.name}"
         ...             )
         ...             print(fout.read().strip())
         ...
@@ -1245,7 +1234,7 @@ class Session:
         ...         # Send the output to a file so that we can read it
         ...         with GMTTempFile() as fout:
         ...             ses.call_module(
-        ...                 "info", "{} ->{}".format(fin, fout.name)
+        ...                 "info", f"{fin} ->{fout.name}"
         ...             )
         ...             print(fout.read().strip())
         ...
@@ -1327,7 +1316,7 @@ class Session:
         ...     with ses.virtualfile_from_grid(data) as fin:
         ...         # Send the output to a file so that we can read it
         ...         with GMTTempFile() as fout:
-        ...             args = "{} -L0 -Cn ->{}".format(fin, fout.name)
+        ...             args = f"{fin} -L0 -Cn ->{fout.name}"
         ...             ses.call_module("grdinfo", args)
         ...             print(fout.read().strip())
         ...
@@ -1508,7 +1497,7 @@ class Session:
         >>> with Session() as lib:
         ...     wesn = lib.extract_region()
         ...
-        >>> print(", ".join(["{:.2f}".format(x) for x in wesn]))
+        >>> print(", ".join([f"{x:.2f}" for x in wesn]))
         0.00, 10.00, -20.00, -10.00
 
         Using ISO country codes for the regions (for example ``'US.HI'`` for
@@ -1521,7 +1510,7 @@ class Session:
         >>> with Session() as lib:
         ...     wesn = lib.extract_region()
         ...
-        >>> print(", ".join(["{:.2f}".format(x) for x in wesn]))
+        >>> print(", ".join([f"{x:.2f}" for x in wesn]))
         -164.71, -154.81, 18.91, 23.58
 
         The country codes can have an extra argument that rounds the region a
@@ -1535,7 +1524,7 @@ class Session:
         >>> with Session() as lib:
         ...     wesn = lib.extract_region()
         ...
-        >>> print(", ".join(["{:.2f}".format(x) for x in wesn]))
+        >>> print(", ".join([f"{x:.2f}" for x in wesn]))
         -165.00, -150.00, 15.00, 25.00
         """
         c_extract_region = self.get_libgmt_func(

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -73,7 +73,7 @@ class Figure:
     >>> fig = Figure()
     >>> fig.basemap(region="JP", projection="M3i", frame=True)
     >>> # The fig.region attribute shows the WESN bounding box for the figure
-    >>> print(", ".join("{:.2f}".format(i) for i in fig.region))
+    >>> print(", ".join(f"{i:.2f}" for i in fig.region))
     122.94, 145.82, 20.53, 45.52
     """
 
@@ -103,7 +103,7 @@ class Figure:
         # Passing format '-' tells pygmt.end to not produce any files.
         fmt = "-"
         with Session() as lib:
-            lib.call_module("figure", "{} {}".format(self._name, fmt))
+            lib.call_module("figure", f"{self._name} {fmt}")
 
     def _preprocess(self, **kwargs):
         """
@@ -358,9 +358,9 @@ class Figure:
         self._preprocess()
         args = ["-T"]
         if xshift:
-            args.append("-X{}".format(xshift))
+            args.append(f"-X{xshift}")
         if yshift:
-            args.append("-Y{}".format(yshift))
+            args.append(f"-Y{yshift}")
 
         with Session() as lib:
             lib.call_module("plot", " ".join(args))

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -634,10 +634,7 @@ def kwargs_to_strings(**conversions):
     ...     "A module that prints the arguments it received"
     ...     print("{", end="")
     ...     print(
-    ...         ", ".join(
-    ...             f"'{k}': {repr(kwargs)[k]}"
-    ...             for k in sorted(kwargs)
-    ...         ),
+    ...         ", ".join(f"'{k}': {repr(kwargs)[k]}" for k in sorted(kwargs)),
     ...         end="",
     ...     )
     ...     print("}")

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -468,7 +468,7 @@ def fmt_docstring(module_func):
         aliases = ["**Aliases:**\n"]
         for arg in sorted(module_func.aliases):
             alias = module_func.aliases[arg]
-            aliases.append("- {} = {}".format(arg, alias))
+            aliases.append(f"- {arg} = {alias}")
         filler_text["aliases"] = "\n".join(aliases)
 
     filler_text["table-like"] = " or ".join(
@@ -635,14 +635,14 @@ def kwargs_to_strings(**conversions):
     ...     print("{", end="")
     ...     print(
     ...         ", ".join(
-    ...             "'{}': {}".format(k, repr(kwargs[k]))
+    ...             f"'{k}': {repr(kwargs)[k]}"
     ...             for k in sorted(kwargs)
     ...         ),
     ...         end="",
     ...     )
     ...     print("}")
     ...     if args:
-    ...         print("args:", " ".join("{}".format(x) for x in args))
+    ...         print("args:", " ".join(f"{x}" for x in args))
     >>> module(R=[1, 2, 3, 4])
     {'R': '1/2/3/4'}
     >>> # It's already a string, do nothing
@@ -690,7 +690,7 @@ def kwargs_to_strings(**conversions):
     for arg, fmt in conversions.items():
         if fmt not in valid_conversions:
             raise GMTInvalidInput(
-                "Invalid conversion type '{}' for argument '{}'.".format(fmt, arg)
+                f"Invalid conversion type '{fmt}' for argument '{arg}'."
             )
 
     separators = {

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -634,7 +634,7 @@ def kwargs_to_strings(**conversions):
     ...     "A module that prints the arguments it received"
     ...     print("{", end="")
     ...     print(
-    ...         ", ".join(f"'{k}': {repr(kwargs)[k]}" for k in sorted(kwargs)),
+    ...         ", ".join(f"'{k}': {repr(kwargs[k])}" for k in sorted(kwargs)),
     ...         end="",
     ...     )
     ...     print("}")

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -113,9 +113,9 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
                     for key in ["actual", "expected", "diff"]:
                         err[key] = os.path.relpath(err[key])
                     raise GMTImageComparisonFailure(
-                        "images not close (RMS %(rms).3f):\n\t%(actual)s\n\t%(expected)s ".format(
-                            **err
-                        )
+                        f"images not close (RMS {err['rms']:.3f}):\n"
+                        f"\t{err['actual']}\n"
+                        f"\t{err['expected']}"
                     )
             finally:
                 del fig_ref

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -113,8 +113,9 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
                     for key in ["actual", "expected", "diff"]:
                         err[key] = os.path.relpath(err[key])
                     raise GMTImageComparisonFailure(
-                        "images not close (RMS %(rms).3f):\n\t%(actual)s\n\t%(expected)s "
-                        % err
+                        "images not close (RMS %(rms).3f):\n\t%(actual)s\n\t%(expected)s ".format(
+                            **err
+                        )
                     )
             finally:
                 del fig_ref

--- a/pygmt/src/config.py
+++ b/pygmt/src/config.py
@@ -56,7 +56,7 @@ class config:  # pylint: disable=invalid-name
 
         # call gmt set to change GMT defaults
         arg_str = " ".join(
-            ["{}={}".format(key, value) for key, value in kwargs.items()]
+            [f"{key}={value}" for key, value in kwargs.items()]
         )
         with Session() as lib:
             lib.call_module("set", arg_str)
@@ -67,7 +67,7 @@ class config:  # pylint: disable=invalid-name
     def __exit__(self, exc_type, exc_value, traceback):
         # revert to initial values
         arg_str = " ".join(
-            ["{}={}".format(key, value) for key, value in self.old_defaults.items()]
+            [f"{key}={value}" for key, value in self.old_defaults.items()]
         )
         with Session() as lib:
             lib.call_module("set", arg_str)

--- a/pygmt/src/config.py
+++ b/pygmt/src/config.py
@@ -55,9 +55,7 @@ class config:  # pylint: disable=invalid-name
                     self.old_defaults[key] = lib.get_default(key)
 
         # call gmt set to change GMT defaults
-        arg_str = " ".join(
-            [f"{key}={value}" for key, value in kwargs.items()]
-        )
+        arg_str = " ".join([f"{key}={value}" for key, value in kwargs.items()])
         with Session() as lib:
             lib.call_module("set", arg_str)
 

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -167,7 +167,7 @@ def grd2cpt(grid, **kwargs):
         with file_context as infile:
             if "H" not in kwargs.keys():  # if no output is set
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
-            elif "H" in kwargs.keys():  # if output is set
+            if "H" in kwargs:  # if output is set
                 outfile = kwargs.pop("H")
                 if not outfile or not isinstance(outfile, str):
                     raise GMTInvalidInput("'output' should be a proper file name.")

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -86,6 +86,6 @@ def legend(self, spec=None, position="JTR+jTR+o0.2c", box="+gwhite+p1p", **kwarg
         elif data_kind(spec) == "file":
             specfile = spec
         else:
-            raise GMTInvalidInput("Unrecognized data type: {}".format(type(spec)))
+            raise GMTInvalidInput(f"Unrecognized data type: {type(spec)}")
         arg_str = " ".join([specfile, build_arg_string(kwargs)])
         lib.call_module("legend", arg_str)

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -149,9 +149,9 @@ def makecpt(**kwargs):
     with Session() as lib:
         if "W" in kwargs and "Ww" in kwargs:
             raise GMTInvalidInput("Set only categorical or cyclic to True, not both.")
-        if "H" not in kwargs.keys():  # if no output is set
+        if "H" not in kwargs:  # if no output is set
             arg_str = build_arg_string(kwargs)
-        elif "H" in kwargs.keys():  # if output is set
+        elif "H" in kwargs:  # if output is set
             outfile = kwargs.pop("H")
             if not outfile or not isinstance(outfile, str):
                 raise GMTInvalidInput("'output' should be a proper file name.")

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -455,7 +455,7 @@ def meca(
         elif kind == "file":
             file_context = dummy_context(spec)
         else:
-            raise GMTInvalidInput("Unrecognized data type: {}".format(type(spec)))
+            raise GMTInvalidInput(f"Unrecognized data type: {type(spec)}")
         with file_context as fname:
             arg_str = " ".join([fname, build_arg_string(kwargs)])
             lib.call_module("meca", arg_str)

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -105,7 +105,7 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
             elif kind == "vectors":
                 file_context = lib.virtualfile_from_vectors(x, y, z)
             else:
-                raise GMTInvalidInput("Unrecognized data type: {}".format(type(data)))
+                raise GMTInvalidInput(f"Unrecognized data type: {type(data)}")
             with file_context as infile:
                 if "G" not in kwargs.keys():  # if outgrid is unset, output to tmpfile
                     kwargs.update({"G": tmpfile.name})

--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -202,7 +202,7 @@ def x2sys_cross(tracks=None, outfile=None, **kwargs):
                 # $X2SYS_HOME/TAGNAME/TAGNAME.tag file
                 lastline = (
                     Path(os.environ["X2SYS_HOME"], kwargs["T"], f"{kwargs['T']}.tag")
-                    .read_text()
+                    .read_text(encoding="utf8")
                     .strip()
                     .split("\n")[-1]
                 )  # e.g. "-Dxyz -Etsv -I1/1"

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -153,7 +153,7 @@ def test_call_module():
     out_fname = "test_call_module.txt"
     with clib.Session() as lib:
         with GMTTempFile() as out_fname:
-            lib.call_module("info", "{} -C ->{}".format(data_fname, out_fname.name))
+            lib.call_module("info", f"{data_fname} -C ->{out_fname.name}")
             assert os.path.exists(out_fname.name)
             output = out_fname.read().strip()
             assert output == "11.5309 61.7074 -2.9289 7.8648 0.1412 0.9338"
@@ -364,12 +364,12 @@ def test_virtual_file():
             vfargs = (family, geometry, "GMT_IN|GMT_IS_REFERENCE", dataset)
             with lib.open_virtual_file(*vfargs) as vfile:
                 with GMTTempFile() as outfile:
-                    lib.call_module("info", "{} ->{}".format(vfile, outfile.name))
+                    lib.call_module("info", f"{vfile} ->{outfile.name}")
                     output = outfile.read(keep_tabs=True)
             bounds = "\t".join(
-                ["<{:.0f}/{:.0f}>".format(col.min(), col.max()) for col in data.T]
+                [f"<{col.min():.0f}/{col.max():.0f}>" for col in data.T]
             )
-            expected = "<matrix memory>: N = {}\t{}\n".format(shape[0], bounds)
+            expected = f"<matrix memory>: N = {shape[0]}\t{bounds}\n"
             assert output == expected
 
 
@@ -486,12 +486,12 @@ def test_virtualfile_from_vectors():
         with clib.Session() as lib:
             with lib.virtualfile_from_vectors(x, y, z) as vfile:
                 with GMTTempFile() as outfile:
-                    lib.call_module("info", "{} ->{}".format(vfile, outfile.name))
+                    lib.call_module("info", f"{vfile} ->{outfile.name}")
                     output = outfile.read(keep_tabs=True)
             bounds = "\t".join(
-                ["<{:.0f}/{:.0f}>".format(i.min(), i.max()) for i in (x, y, z)]
+                [f"<{i.min():.0f}/{i.max():.0f}>" for i in (x, y, z)]
             )
-            expected = "<vector memory>: N = {}\t{}\n".format(size, bounds)
+            expected = f"<vector memory>: N = {size}\t{bounds}\n"
             assert output == expected
 
 
@@ -547,12 +547,12 @@ def test_virtualfile_from_vectors_transpose():
         with clib.Session() as lib:
             with lib.virtualfile_from_vectors(*data.T) as vfile:
                 with GMTTempFile() as outfile:
-                    lib.call_module("info", "{} -C ->{}".format(vfile, outfile.name))
+                    lib.call_module("info", f"{vfile} -C ->{outfile.name}")
                     output = outfile.read(keep_tabs=True)
             bounds = "\t".join(
-                ["{:.0f}\t{:.0f}".format(col.min(), col.max()) for col in data.T]
+                [f"{col.min():.0f}\t{col.max():.0f}" for col in data.T]
             )
-            expected = "{}\n".format(bounds)
+            expected = f"{bounds}\n"
             assert output == expected
 
 
@@ -579,12 +579,12 @@ def test_virtualfile_from_matrix():
         with clib.Session() as lib:
             with lib.virtualfile_from_matrix(data) as vfile:
                 with GMTTempFile() as outfile:
-                    lib.call_module("info", "{} ->{}".format(vfile, outfile.name))
+                    lib.call_module("info", f"{vfile} ->{outfile.name}")
                     output = outfile.read(keep_tabs=True)
             bounds = "\t".join(
-                ["<{:.0f}/{:.0f}>".format(col.min(), col.max()) for col in data.T]
+                [f"<{col.min():.0f}/{col.max():.0f}>" for col in data.T]
             )
-            expected = "<matrix memory>: N = {}\t{}\n".format(shape[0], bounds)
+            expected = f"<matrix memory>: N = {shape[0]}\t{bounds}\n"
             assert output == expected
 
 
@@ -602,12 +602,12 @@ def test_virtualfile_from_matrix_slice():
         with clib.Session() as lib:
             with lib.virtualfile_from_matrix(data) as vfile:
                 with GMTTempFile() as outfile:
-                    lib.call_module("info", "{} ->{}".format(vfile, outfile.name))
+                    lib.call_module("info", f"{vfile} ->{outfile.name}")
                     output = outfile.read(keep_tabs=True)
             bounds = "\t".join(
-                ["<{:.0f}/{:.0f}>".format(col.min(), col.max()) for col in data.T]
+                [f"<{col.min():.0f}/{col.max():.0f}>" for col in data.T]
             )
-            expected = "<matrix memory>: N = {}\t{}\n".format(rows, bounds)
+            expected = f"<matrix memory>: N = {rows}\t{bounds}\n"
             assert output == expected
 
 
@@ -628,15 +628,15 @@ def test_virtualfile_from_vectors_pandas():
         with clib.Session() as lib:
             with lib.virtualfile_from_vectors(data.x, data.y, data.z) as vfile:
                 with GMTTempFile() as outfile:
-                    lib.call_module("info", "{} ->{}".format(vfile, outfile.name))
+                    lib.call_module("info", f"{vfile} ->{outfile.name}")
                     output = outfile.read(keep_tabs=True)
             bounds = "\t".join(
                 [
-                    "<{:.0f}/{:.0f}>".format(i.min(), i.max())
+                    f"<{i.min():.0f}/{i.max():.0f}>"
                     for i in (data.x, data.y, data.z)
                 ]
             )
-            expected = "<vector memory>: N = {}\t{}\n".format(size, bounds)
+            expected = f"<vector memory>: N = {size}\t{bounds}\n"
             assert output == expected
 
 
@@ -651,12 +651,12 @@ def test_virtualfile_from_vectors_arraylike():
     with clib.Session() as lib:
         with lib.virtualfile_from_vectors(x, y, z) as vfile:
             with GMTTempFile() as outfile:
-                lib.call_module("info", "{} ->{}".format(vfile, outfile.name))
+                lib.call_module("info", f"{vfile} ->{outfile.name}")
                 output = outfile.read(keep_tabs=True)
         bounds = "\t".join(
-            ["<{:.0f}/{:.0f}>".format(min(i), max(i)) for i in (x, y, z)]
+            [f"<{min(i):.0f}/{max(i):.0f}>" for i in (x, y, z)]
         )
-        expected = "<vector memory>: N = {}\t{}\n".format(size, bounds)
+        expected = f"<vector memory>: N = {size}\t{bounds}\n"
         assert output == expected
 
 
@@ -686,14 +686,14 @@ def test_extract_region_two_figures():
     # Activate the first figure and extract the region from it
     # Use in a different session to avoid any memory problems.
     with clib.Session() as lib:
-        lib.call_module("figure", "{} -".format(fig1._name))
+        lib.call_module("figure", f"{fig1._name} -")
     with clib.Session() as lib:
         wesn1 = lib.extract_region()
         npt.assert_allclose(wesn1, region1)
 
     # Now try it with the second one
     with clib.Session() as lib:
-        lib.call_module("figure", "{} -".format(fig2._name))
+        lib.call_module("figure", f"{fig2._name} -")
     with clib.Session() as lib:
         wesn2 = lib.extract_region()
         npt.assert_allclose(wesn2, np.array([-165.0, -150.0, 15.0, 25.0]))

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -366,9 +366,7 @@ def test_virtual_file():
                 with GMTTempFile() as outfile:
                     lib.call_module("info", f"{vfile} ->{outfile.name}")
                     output = outfile.read(keep_tabs=True)
-            bounds = "\t".join(
-                [f"<{col.min():.0f}/{col.max():.0f}>" for col in data.T]
-            )
+            bounds = "\t".join([f"<{col.min():.0f}/{col.max():.0f}>" for col in data.T])
             expected = f"<matrix memory>: N = {shape[0]}\t{bounds}\n"
             assert output == expected
 
@@ -488,9 +486,7 @@ def test_virtualfile_from_vectors():
                 with GMTTempFile() as outfile:
                     lib.call_module("info", f"{vfile} ->{outfile.name}")
                     output = outfile.read(keep_tabs=True)
-            bounds = "\t".join(
-                [f"<{i.min():.0f}/{i.max():.0f}>" for i in (x, y, z)]
-            )
+            bounds = "\t".join([f"<{i.min():.0f}/{i.max():.0f}>" for i in (x, y, z)])
             expected = f"<vector memory>: N = {size}\t{bounds}\n"
             assert output == expected
 
@@ -549,9 +545,7 @@ def test_virtualfile_from_vectors_transpose():
                 with GMTTempFile() as outfile:
                     lib.call_module("info", f"{vfile} -C ->{outfile.name}")
                     output = outfile.read(keep_tabs=True)
-            bounds = "\t".join(
-                [f"{col.min():.0f}\t{col.max():.0f}" for col in data.T]
-            )
+            bounds = "\t".join([f"{col.min():.0f}\t{col.max():.0f}" for col in data.T])
             expected = f"{bounds}\n"
             assert output == expected
 
@@ -581,9 +575,7 @@ def test_virtualfile_from_matrix():
                 with GMTTempFile() as outfile:
                     lib.call_module("info", f"{vfile} ->{outfile.name}")
                     output = outfile.read(keep_tabs=True)
-            bounds = "\t".join(
-                [f"<{col.min():.0f}/{col.max():.0f}>" for col in data.T]
-            )
+            bounds = "\t".join([f"<{col.min():.0f}/{col.max():.0f}>" for col in data.T])
             expected = f"<matrix memory>: N = {shape[0]}\t{bounds}\n"
             assert output == expected
 
@@ -604,9 +596,7 @@ def test_virtualfile_from_matrix_slice():
                 with GMTTempFile() as outfile:
                     lib.call_module("info", f"{vfile} ->{outfile.name}")
                     output = outfile.read(keep_tabs=True)
-            bounds = "\t".join(
-                [f"<{col.min():.0f}/{col.max():.0f}>" for col in data.T]
-            )
+            bounds = "\t".join([f"<{col.min():.0f}/{col.max():.0f}>" for col in data.T])
             expected = f"<matrix memory>: N = {rows}\t{bounds}\n"
             assert output == expected
 
@@ -631,10 +621,7 @@ def test_virtualfile_from_vectors_pandas():
                     lib.call_module("info", f"{vfile} ->{outfile.name}")
                     output = outfile.read(keep_tabs=True)
             bounds = "\t".join(
-                [
-                    f"<{i.min():.0f}/{i.max():.0f}>"
-                    for i in (data.x, data.y, data.z)
-                ]
+                [f"<{i.min():.0f}/{i.max():.0f}>" for i in (data.x, data.y, data.z)]
             )
             expected = f"<vector memory>: N = {size}\t{bounds}\n"
             assert output == expected
@@ -653,9 +640,7 @@ def test_virtualfile_from_vectors_arraylike():
             with GMTTempFile() as outfile:
                 lib.call_module("info", f"{vfile} ->{outfile.name}")
                 output = outfile.read(keep_tabs=True)
-        bounds = "\t".join(
-            [f"<{min(i):.0f}/{max(i):.0f}>" for i in (x, y, z)]
-        )
+        bounds = "\t".join([f"<{min(i):.0f}/{max(i):.0f}>" for i in (x, y, z)])
         expected = f"<vector memory>: N = {size}\t{bounds}\n"
         assert output == expected
 


### PR DESCRIPTION
**Description of proposed changes**

[Pylint v2.11.1](https://github.com/PyCQA/pylint/releases/tag/v2.11.1) released on 17 Sep 2021 added a few more checks, most notably, a recommendation to use f-strings (C0209), and a couple of other ones.

```bash
pylint pygmt setup.py doc/conf.py
************* Module pygmt.figure
pygmt/figure.py:106:38: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/figure.py:361:24: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/figure.py:363:24: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module pygmt.src.grd2cpt
pygmt/src/grd2cpt.py:170:24: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.legend
pygmt/src/legend.py:89:34: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module pygmt.src.makecpt
pygmt/src/makecpt.py:154:20: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.surface
pygmt/src/surface.py:108:38: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module pygmt.src.x2sys_cross
pygmt/src/x2sys_cross.py:204:20: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
************* Module pygmt.src.config
pygmt/src/config.py:59:13: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/src/config.py:70:13: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module pygmt
pygmt/__init__.py:80:25: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/__init__.py:215:20: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module pygmt.src.meca
pygmt/src/meca.py:458:34: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module pygmt.clib.session
pygmt/clib/session.py:192:16: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/clib/session.py:369:16: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/clib/session.py:415:16: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/clib/session.py:465:16: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/clib/session.py:506:16: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/clib/session.py:653:16: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/clib/session.py:660:18: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/clib/session.py:664:16: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/clib/session.py:674:16: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/clib/session.py:908:31: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/clib/session.py:977:31: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/clib/session.py:1086:35: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module pygmt.tests.test_clib
pygmt/tests/test_clib.py:156:36: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:367:44: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:370:17: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:372:23: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:489:44: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:492:17: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:494:23: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:550:44: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:553:17: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:555:23: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:582:44: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:585:17: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:587:23: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:605:44: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:608:17: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:610:23: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:631:44: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:635:20: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:639:23: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:654:40: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:657:13: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:659:19: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:689:34: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/tests/test_clib.py:696:34: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module conf
doc/conf.py:130:13: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module pygmt.helpers.testing
pygmt/helpers/testing.py:116:24: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module pygmt.helpers.decorators
pygmt/helpers/decorators.py:471:27: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
pygmt/helpers/decorators.py:693:16: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)

-----------------------------------
Your code has been rated at 9.90/10
```

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Luckily there was a tool called [`flynt`](https://github.com/ikamensh/flynt) that semi-automatically did the f-string conversion, so I only had to manually change some that weren't caught. Let me know if you find any more!

Also made some edits where `dict.keys()` was not required anymore, and a missing encoding from `pathlib.Path.read_text()`

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
