### PR TITLE
Add tests for load_dataarray to increase code coverage

### DIFF
--- a/pygmt/tests/test_io.py
+++ b/pygmt/tests/test_io.py
@@ -1,0 +1,34 @@
+"""
+Tests for input/output (I/O) utilities.
+"""
+import numpy as np
+import pytest
+import xarray as xr
+from pygmt.helpers import GMTTempFile
+from pygmt.io import load_dataarray
+
+
+def test_io_load_dataarray():
+    """
+    Check that load_dataarray works to read a NetCDF grid with
+    GMTDataArrayAccessor information loaded.
+    """
+    with GMTTempFile(suffix=".nc") as tmpfile:
+        grid = xr.DataArray(
+            data=np.random.rand(2, 2), coords=[[0.1, 0.2], [0.3, 0.4]], dims=("x", "y")
+        )
+        grid.to_netcdf(tmpfile.name)
+        dataarray = load_dataarray(tmpfile.name)
+        assert dataarray.gmt.gtype == 0  # Cartesian grid
+        assert dataarray.gmt.registration == 1  # Pixel registration
+        # this would fail if we used xr.open_dataarray instead of
+        # load_dataarray
+        dataarray.to_netcdf(tmpfile.name)
+
+
+def test_io_load_dataarray_cache():
+    """
+    Check that load_dataarray fails when the cache argument is used.
+    """
+    with pytest.raises(TypeError):
+        _ = load_dataarray("somefile.nc", cache=True)


### PR DESCRIPTION
**Description of proposed changes**

Patches missing code coverage of `pygmt.load_dataarray` function wrapped in #1439. This commit was cherry-picked from test_io_load_dataarray in #1494.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
