### PR TITLE
Fix common options in blockm, surface, histogram, rose, and grdtrack

### DIFF
--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -241,7 +241,7 @@ def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     r="registration",
     w="wrap",
 )
-@kwargs_to_strings(R="sequence", i="sequence_comma")
+@kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
 def blockmode(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     r"""
     Block average (x,y,z) data tables by mode estimation.

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -81,7 +81,7 @@ def _blockm(block_method, table, outfile, x, y, z, **kwargs):
     r="registration",
     w="wrap",
 )
-@kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
+@kwargs_to_strings(R="sequence", i="sequence_comma")
 def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     r"""
     Block average (x,y,z) data tables by mean estimation.
@@ -158,7 +158,7 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     r="registration",
     w="wrap",
 )
-@kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
+@kwargs_to_strings(R="sequence", i="sequence_comma")
 def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     r"""
     Block average (x,y,z) data tables by median estimation.
@@ -241,7 +241,7 @@ def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     r="registration",
     w="wrap",
 )
-@kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
+@kwargs_to_strings(R="sequence", i="sequence_comma")
 def blockmode(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     r"""
     Block average (x,y,z) data tables by mode estimation.

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -79,7 +79,6 @@ def _blockm(block_method, table, outfile, x, y, z, **kwargs):
     i="incols",
     o="outcols",
     r="registration",
-    s="skiprows",
     w="wrap",
 )
 @kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
@@ -126,7 +125,6 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     {h}
     {o}
     {r}
-    {s}
     {w}
 
     Returns
@@ -158,7 +156,6 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     i="incols",
     o="outcols",
     r="registration",
-    s="skiprows",
     w="wrap",
 )
 @kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
@@ -205,7 +202,6 @@ def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     {i}
     {o}
     {r}
-    {s}
     {w}
 
     Returns
@@ -243,7 +239,6 @@ def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     i="incols",
     o="outcols",
     r="registration",
-    s="skiprows",
     w="wrap",
 )
 @kwargs_to_strings(R="sequence", i="sequence_comma")
@@ -290,7 +285,6 @@ def blockmode(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     {i}
     {o}
     {r}
-    {s}
     {w}
 
     Returns

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -81,7 +81,7 @@ def _blockm(block_method, table, outfile, x, y, z, **kwargs):
     s="skiprows",
     w="wrap",
 )
-@kwargs_to_strings(R="sequence", i="sequence_comma")
+@kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
 def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     r"""
     Block average (x,y,z) data tables by mean estimation.
@@ -160,7 +160,7 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     s="skiprows",
     w="wrap",
 )
-@kwargs_to_strings(R="sequence", i="sequence_comma")
+@kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
 def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     r"""
     Block average (x,y,z) data tables by median estimation.

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -26,6 +26,7 @@ from pygmt.helpers import (
     T="radius",
     V="verbose",
     Z="z_only",
+    a="aspatial",
     b="binary",
     d="nodata",
     e="find",
@@ -240,6 +241,7 @@ def grdtrack(points, grid, newcolname=None, outfile=None, **kwargs):
     {V}
     z_only : bool
         Only write out the sampled z-values [Default writes all columns].
+    {a}
     {b}
     {d}
     {e}

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -40,7 +40,7 @@ from pygmt.helpers import (
     s="skiprows",
     w="wrap",
 )
-@kwargs_to_strings(R="sequence", S="sequence", i="sequence_comma", o="sequence_comma")
+@kwargs_to_strings(R="sequence", S="sequence", i="sequence_comma")
 def grdtrack(points, grid, newcolname=None, outfile=None, **kwargs):
     r"""
     Sample grids at specified (x,y) locations.

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -39,7 +39,7 @@ from pygmt.helpers import (
     s="skiprows",
     w="wrap",
 )
-@kwargs_to_strings(R="sequence", S="sequence", i="sequence_comma")
+@kwargs_to_strings(R="sequence", S="sequence", i="sequence_comma", o="sequence_comma")
 def grdtrack(points, grid, newcolname=None, outfile=None, **kwargs):
     r"""
     Sample grids at specified (x,y) locations.

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -31,7 +31,6 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     c="panel",
     d="nodata",
     e="find",
-    g="gap",
     h="header",
     l="label",
     p="perspective",
@@ -128,7 +127,6 @@ def histogram(self, table, **kwargs):
     {b}
     {d}
     {e}
-    {g}
     {h}
     {l}
     {p}

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -38,7 +38,9 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     t="transparency",
     w="wrap",
 )
-@kwargs_to_strings(R="sequence", T="sequence", c="sequence_comma", p="sequence")
+@kwargs_to_strings(
+    R="sequence", T="sequence", c="sequence_comma", i="sequence_comma", p="sequence"
+)
 def histogram(self, table, **kwargs):
     r"""
     Plots a histogram, and can read data from a file or

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -32,6 +32,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     d="nodata",
     e="find",
     h="header",
+    i="incols",
     l="label",
     p="perspective",
     t="transparency",
@@ -128,6 +129,7 @@ def histogram(self, table, **kwargs):
     {d}
     {e}
     {h}
+    {i}
     {l}
     {p}
     {t}

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -39,7 +39,6 @@ from pygmt.helpers import (
     b="binary",
     d="nodata",
     e="find",
-    g="gap",
     h="header",
     i="incols",
     c="panel",
@@ -196,7 +195,6 @@ def rose(self, length=None, azimuth=None, data=None, **kwargs):
     {c}
     {d}
     {e}
-    {g}
     {h}
     {i}
     {p}

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -32,7 +32,6 @@ from pygmt.io import load_dataarray
     h="header",
     i="incols",
     r="registration",
-    s="skiprows",
     w="wrap",
 )
 @kwargs_to_strings(R="sequence")
@@ -82,7 +81,6 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
     {h}
     {i}
     {r}
-    {s}
     {w}
 
     Returns


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes some erroneous additions from https://github.com/GenericMappingTools/pygmt/issues/1445 and prior PRs based on fixes made to GMT in https://github.com/GenericMappingTools/gmt/pull/5759. Here is the detailed list:
    - ``skiprows`` no longer in blockmean, blockmedian, blockmode, surface (not supported)
    - ``gap`` no longer in histogram, rose (not supported)
    - ``aspatial`` now documented in grdtrack
    - ``incols`` now documented in histogram
  

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Closes #1445


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
