### PR TITLE
Add a gallery example showing the usage of text symbols

### DIFF
--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -11,10 +11,12 @@ fig = pygmt.Figure()
 fig.basemap(region=[0, 8, 0, 3], projection="X12c/4c", frame=True)
 
 pen = "1.5p"
-fig.plot(x = 1, y = 1.5, style = "l3.5c+tA", color = "dodgerblue3", pen = pen)
-fig.plot(x = 2.5, y = 1, style = "l3.5c+t*", color = "red3", pen = pen)
-fig.plot(x = 4, y = 1.5, style = "l3.5c+tZ+f12p,Courier-Bold,black", color = "seagreen3", pen = pen)
-fig.plot(x = 5.5, y = 1.5, style = "l3.5c+ts+f12p,Times-Italic,black", color = "gold", pen = pen)
-fig.plot(x = 7, y = 1.5, style = 'l3.5c+t\160+fSymbol', color = "magenta4", pen = pen)
+fig.plot(x=1, y=1.5, style="l3.5c+tA", color="dodgerblue3", pen=pen)
+fig.plot(x=2.5, y=1, style="l3.5c+t*", color="red3", pen=pen)
+fig.plot(
+    x=4, y=1.5, style="l3.5c+tZ+f12p,Courier-Bold,black", color="seagreen3", pen=pen
+)
+fig.plot(x=5.5, y=1.5, style="l3.5c+ts+f12p,Times-Italic,black", color="gold", pen=pen)
+fig.plot(x=7, y=1.5, style="l3.5c+t\160+fSymbol", color="magenta4", pen=pen)
 
 fig.show()

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -6,11 +6,11 @@ A text symbol can be drawn by passing **l**\ *size*\ **+t**\ *string* to
 the ``style`` parameter where *size* defines the size of the text symbol
 (note: the size is only approximate; no individual scaling is done for
 different characters) and *string* can be a letter or a text string
-(less than 256 characters). Optionally, you can append **+f**\ *font* select
-a particular font [Default is FONT_ANNOT_PRIMARY] as well as **+j**\ *justify*
-to change the justification [Default is CM]. Outline and fill color of the
-text symbols can be customized via the ``pen`` and ``color`` parameters,
-respectively.
+(less than 256 characters). Optionally, you can append **+f**\ *font* to
+select a particular font [Default is FONT_ANNOT_PRIMARY] as well as
+**+j**\ *justify* to change the justification [Default is CM]. Outline
+* and fill color of the text symbols can be customized via the ``pen``
+* and ``color`` parameters, respectively.
 """
 
 import pygmt

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -11,6 +11,10 @@ select a particular font [Default is FONT_ANNOT_PRIMARY] as well as
 **+j**\ *justify* to change the justification [Default is CM]. Outline
 * and fill color of the text symbols can be customized via the ``pen``
 * and ``color`` parameters, respectively.
+
+For all supported octal codes and fonts see the GMT cookbook
+https://docs.generic-mapping-tools.org/latest/cookbook/octal-codes.html and
+https://docs.generic-mapping-tools.org/latest/cookbook/postscript-fonts.html
 """
 
 import pygmt

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -2,6 +2,14 @@
 Text symbols
 ------------
 The :meth:`pygmt.Figure.plot` method allows to plot text symbols.
+
+A text symbol can be drawn by passing **l**\ *size*\ **+t**\ *string* to
+the ``style`` parameter where *size* defines the size of the text symbol
+(note: the size is only approximate; no individual scaling is done for
+different characters) and *string* can be a letter or a text string
+(less than 256 characters). Optionally, you can append **+f**\ *font* select
+a particular font [Default is FONT_ANNOT_PRIMARY] as well as **+j**\ *justify*
+to change the justification [Default is CM].
 """
 
 import pygmt

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -31,8 +31,8 @@ fig.plot(x=1, y=1.5, style="l3.5c+tA", color="dodgerblue3", pen=pen)
 # plot an "asterisk" of size 3.5c, color fill is set to "red3"
 fig.plot(x=2.5, y=1, style="l3.5c+t*", color="red3", pen=pen)
 # plot an uppercase "Z" of size 3.5c and use the "Courier-Bold" font,
-# color fill is set to "seagreen3"
-fig.plot(x=4, y=1.5, style="l3.5c+tZ+fCourier-Bold", color="seagreen3", pen=pen)
+# color fill is set to "seagreen"
+fig.plot(x=4, y=1.5, style="l3.5c+tZ+fCourier-Bold", color="seagreen", pen=pen)
 # plot a lowercase "s" of size 3.5c and use the "Times-Italic" font,
 # color fill is set to "gold"
 fig.plot(x=5.5, y=1.5, style="l3.5c+ts+fTimes-Italic", color="gold", pen=pen)

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -1,7 +1,9 @@
 r"""
 Text symbols
 ------------
-The :meth:`pygmt.Figure.plot` method allows to plot text symbols.
+The :meth:`pygmt.Figure.plot` method allows to plot text symbols. Text is
+normally placed with the :meth:`pygmt.Figure.text` method but there are times
+we wish to treat a character of even a string as plottable symbol.
 A text symbol can be drawn by passing **l**\ *size*\ **+t**\ *string* to
 the ``style`` parameter where *size* defines the size of the text symbol
 (note: the size is only approximate; no individual scaling is done for

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -3,20 +3,20 @@ Text symbols
 ------------
 The :meth:`pygmt.Figure.plot` method allows to plot text symbols. Text is
 normally placed with the :meth:`pygmt.Figure.text` method but there are times
-we wish to treat a character of even a string as plottable symbol.
+we wish to treat a character or even a string as a plottable symbol.
 A text symbol can be drawn by passing **l**\ *size*\ **+t**\ *string* to
 the ``style`` parameter where *size* defines the size of the text symbol
 (note: the size is only approximate; no individual scaling is done for
 different characters) and *string* can be a letter or a text string
 (less than 256 characters). Optionally, you can append **+f**\ *font* to
-select a particular font [Default is FONT_ANNOT_PRIMARY] as well as
+select a particular font [Default is :gmt-term:`FONT_ANNOT_PRIMARY`] as well as
 **+j**\ *justify* to change the justification [Default is CM]. Outline
 and fill color of the text symbols can be customized via the ``pen``
 and ``color`` parameters, respectively.
 
 For all supported octal codes and fonts see the GMT cookbook
-https://docs.generic-mapping-tools.org/latest/cookbook/octal-codes.html and
-https://docs.generic-mapping-tools.org/latest/cookbook/postscript-fonts.html.
+:gmt-docs:`cookbook/octal-codes.html` and
+:gmt-docs:`cookbook/postscript-fonts.html`.
 """
 
 import pygmt

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -9,8 +9,8 @@ different characters) and *string* can be a letter or a text string
 (less than 256 characters). Optionally, you can append **+f**\ *font* to
 select a particular font [Default is FONT_ANNOT_PRIMARY] as well as
 **+j**\ *justify* to change the justification [Default is CM]. Outline
-* and fill color of the text symbols can be customized via the ``pen``
-* and ``color`` parameters, respectively.
+and fill color of the text symbols can be customized via the ``pen``
+and ``color`` parameters, respectively.
 
 For all supported octal codes and fonts see the GMT cookbook
 https://docs.generic-mapping-tools.org/latest/cookbook/octal-codes.html and

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -14,7 +14,7 @@ and ``color`` parameters, respectively.
 
 For all supported octal codes and fonts see the GMT cookbook
 https://docs.generic-mapping-tools.org/latest/cookbook/octal-codes.html and
-https://docs.generic-mapping-tools.org/latest/cookbook/postscript-fonts.html
+https://docs.generic-mapping-tools.org/latest/cookbook/postscript-fonts.html.
 """
 
 import pygmt

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -20,12 +20,18 @@ fig = pygmt.Figure()
 fig.basemap(region=[0, 8, 0, 3], projection="X12c/4c", frame=True)
 
 pen = "1.5p"
+# plot an uppercase "A" of size 3.5c, color fill is set to "dodgerblue3"
 fig.plot(x=1, y=1.5, style="l3.5c+tA", color="dodgerblue3", pen=pen)
+# plot an "asterisk" of size 3.5c, color fill is set to "red3"
 fig.plot(x=2.5, y=1, style="l3.5c+t*", color="red3", pen=pen)
-fig.plot(
-    x=4, y=1.5, style="l3.5c+tZ+f12p,Courier-Bold,black", color="seagreen3", pen=pen
-)
-fig.plot(x=5.5, y=1.5, style="l3.5c+ts+f12p,Times-Italic,black", color="gold", pen=pen)
+# plot an uppercase "Z" of size 3.5c and use the "Courier-Bold" font,
+# color fill is set to "seagreen3"
+fig.plot(x=4, y=1.5, style="l3.5c+tZ+fCourier-Bold", color="seagreen3", pen=pen)
+# plot a lowercase "s" of size 3.5c and use the "Times-Italic" font,
+# color fill is set to "gold"
+fig.plot(x=5.5, y=1.5, style="l3.5c+ts+fTimes-Italic", color="gold", pen=pen)
+# plot the pi symbol (\160 is octal code for pi) of size 3.5c, for this use
+# the "Symbol" font, color fill is set to "magenta4"
 fig.plot(x=7, y=1.5, style="l3.5c+t\160+fSymbol", color="magenta4", pen=pen)
 
 fig.show()

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -1,0 +1,20 @@
+"""
+Text symbols
+------------
+The :meth:`pygmt.Figure.plot` method allows to plot text symbols.
+"""
+
+import pygmt
+
+fig = pygmt.Figure()
+
+fig.basemap(region=[0, 8, 0, 3], projection="X12c/4c", frame=True)
+
+pen = "1.5p"
+fig.plot(x = 1, y = 1.5, style = "l3.5c+tA", color = "dodgerblue3", pen = pen)
+fig.plot(x = 2.5, y = 1, style = "l3.5c+t*", color = "red3", pen = pen)
+fig.plot(x = 4, y = 1.5, style = "l3.5c+tZ+f12p,Courier-Bold,black", color = "seagreen3", pen = pen)
+fig.plot(x = 5.5, y = 1.5, style = "l3.5c+ts+f12p,Times-Italic,black", color = "gold", pen = pen)
+fig.plot(x = 7, y = 1.5, style = 'l3.5c+t\160+fSymbol', color = "magenta4", pen = pen)
+
+fig.show()

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -1,15 +1,16 @@
-"""
+r"""
 Text symbols
 ------------
 The :meth:`pygmt.Figure.plot` method allows to plot text symbols.
-
 A text symbol can be drawn by passing **l**\ *size*\ **+t**\ *string* to
 the ``style`` parameter where *size* defines the size of the text symbol
 (note: the size is only approximate; no individual scaling is done for
 different characters) and *string* can be a letter or a text string
 (less than 256 characters). Optionally, you can append **+f**\ *font* select
 a particular font [Default is FONT_ANNOT_PRIMARY] as well as **+j**\ *justify*
-to change the justification [Default is CM].
+to change the justification [Default is CM]. Outline and fill color of the
+text symbols can be customized via the ``pen`` and ``color`` parameters,
+respectively.
 """
 
 import pygmt


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a gallery example that shows the usage of text symbols via ``Figure.plot()``.

![Text symbols gallery example](https://pygmt-git-gallery-text-symbols-gmt.vercel.app/_images/sphx_glr_text_symbols_001.png)

**Preview** at https://pygmt-git-gallery-text-symbols-gmt.vercel.app/gallery/symbols/text_symbols.html

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
