### PR TITLE
Let required_z check work on xarray.Dataset inputs

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1375,6 +1375,8 @@ class Session:
         extra_arrays : list of 1d arrays
             Optional. A list of numpy arrays in addition to x, y and z. All
             of these arrays must be of the same size as the x/y/z arrays.
+        required_z : bool
+            State whether the 'z' column is required. [Default is False].
 
         Returns
         -------

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1376,7 +1376,7 @@ class Session:
             Optional. A list of numpy arrays in addition to x, y and z. All
             of these arrays must be of the same size as the x/y/z arrays.
         required_z : bool
-            State whether the 'z' column is required. [Default is False].
+            State whether the 'z' column is required.
 
         Returns
         -------

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -39,8 +39,9 @@ def data_kind(data, x=None, y=None, z=None, required_z=False):
     x/y : 1d arrays or None
         x and y columns as numpy arrays.
     z : 1d array or None
-        z column as numpy array. To be used optionally when x and y
-        are given.
+        z column as numpy array. To be used optionally when x and y are given.
+    required_z : bool
+        State whether the 'z' column is required. [Default is False].
 
     Returns
     -------

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -80,7 +80,10 @@ def data_kind(data, x=None, y=None, z=None, required_z=False):
     elif hasattr(data, "__geo_interface__"):
         kind = "geojson"
     elif data is not None:
-        if required_z and data.shape[1] < 3:
+        if required_z and (
+            getattr(data, "shape", (3, 3))[1] < 3  # np.array, pd.DataFrame
+            or len(getattr(data, "data_vars", (0, 1, 2))) < 3  # xr.Dataset
+        ):
             raise GMTInvalidInput("data must provide x, y, and z columns.")
         kind = "matrix"
     else:

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -41,7 +41,7 @@ def data_kind(data, x=None, y=None, z=None, required_z=False):
     z : 1d array or None
         z column as numpy array. To be used optionally when x and y are given.
     required_z : bool
-        State whether the 'z' column is required. [Default is False].
+        State whether the 'z' column is required.
 
     Returns
     -------

--- a/pygmt/tests/test_blockm.py
+++ b/pygmt/tests/test_blockm.py
@@ -3,9 +3,11 @@ Tests for blockmean and blockmode.
 """
 import os
 
+import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
+import xarray as xr
 from pygmt import blockmean, blockmode
 from pygmt.datasets import load_sample_bathymetry
 from pygmt.exceptions import GMTInvalidInput
@@ -31,12 +33,13 @@ def test_blockmean_input_dataframe(dataframe):
     npt.assert_allclose(output.iloc[0], [245.888877, 29.978707, -384.0])
 
 
-def test_blockmean_input_table_matrix(dataframe):
+@pytest.mark.parametrize("array_func", [np.array, xr.Dataset])
+def test_blockmean_input_table_matrix(array_func, dataframe):
     """
     Run blockmean using table input that is not a pandas.DataFrame but still a
     matrix.
     """
-    table = dataframe.values
+    table = array_func(dataframe)
     output = blockmean(table=table, spacing="5m", region=[245, 255, 20, 30])
     assert isinstance(output, pd.DataFrame)
     assert output.shape == (5849, 3)


### PR DESCRIPTION
**Description of proposed changes**

This PR modifies the if-statement check in `data_kind` helper function to use `len(data.data_vars)` to check the shape of [`xarray.Dataset`](https://xarray.pydata.org/en/stable/generated/xarray.Dataset.html#xarray.Dataset) inputs. Added two regression tests in test_clib and test_blockm to ensure this works on both the low-level clib and high-level module APIs.

_Originally posted by @weiji14 in https://github.com/GenericMappingTools/pygmt/pull/1478#discussion_r711649040_

> Checking for `data.shape[1]` fails for [xarray.Dataset](https://xarray.pydata.org/en/v0.18.1/generated/xarray.Dataset.html) inputs with `AttributeError: 'Dataset' object has no attribute 'shape'. The `shape` attribute is valid only for `numpy.ndarray`, `pandas.DataFrame`, and maybe a few other PyData objects. Will need to create a bugfix and add some extra tests for `xarray.Dataset` inputs.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

For a list of data formats supported by PyGMT, see #1268.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Patches #1478, addressing https://github.com/GenericMappingTools/pygmt/pull/1478#discussion_r711649040.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
