### PR TITLE
Support 1d array for outcols in grdtrack and blockm functions

### DIFF
--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -82,7 +82,7 @@ def _blockm(block_method, table, outfile, x, y, z, **kwargs):
     s="skiprows",
     w="wrap",
 )
-@kwargs_to_strings(R="sequence", i="sequence_comma")
+@kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
 def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     r"""
     Block average (x,y,z) data tables by mean estimation.
@@ -161,7 +161,7 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     s="skiprows",
     w="wrap",
 )
-@kwargs_to_strings(R="sequence", i="sequence_comma")
+@kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
 def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     r"""
     Block average (x,y,z) data tables by median estimation.
@@ -246,7 +246,7 @@ def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     s="skiprows",
     w="wrap",
 )
-@kwargs_to_strings(R="sequence", i="sequence_comma")
+@kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
 def blockmode(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     r"""
     Block average (x,y,z) data tables by mode estimation.

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -39,7 +39,7 @@ from pygmt.helpers import (
     s="skiprows",
     w="wrap",
 )
-@kwargs_to_strings(R="sequence", S="sequence", i="sequence_comma")
+@kwargs_to_strings(R="sequence", S="sequence", i="sequence_comma", o="sequence_comma")
 def grdtrack(points, grid, newcolname=None, outfile=None, **kwargs):
     r"""
     Sample grids at specified (x,y) locations.


### PR DESCRIPTION
**Description of proposed changes**

This PR adds support for 1d array for `outcols` in grdtrack and blockm* functions by updating kwargs_to_strings arguments.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #1445.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
