### PR TITLE
Use pytest.importorskip for sphinx_gallery test

### DIFF
--- a/pygmt/sphinx_gallery.py
+++ b/pygmt/sphinx_gallery.py
@@ -2,8 +2,8 @@
 Utilities for using pygmt with sphinx-gallery.
 """
 
+import sphinx_gallery.scrapers
 from pygmt.figure import SHOWED_FIGURES
-from sphinx_gallery.scrapers import figure_rst
 
 
 class PyGMTScraper:  # pylint: disable=too-few-public-methods
@@ -29,4 +29,4 @@ class PyGMTScraper:  # pylint: disable=too-few-public-methods
             fig = figures.pop(0)
             fig.savefig(fname, transparent=True, dpi=200)
             image_names.append(fname)
-        return figure_rst(image_names, gallery_conf["src_dir"])
+        return sphinx_gallery.scrapers.figure_rst(image_names, gallery_conf["src_dir"])

--- a/pygmt/sphinx_gallery.py
+++ b/pygmt/sphinx_gallery.py
@@ -1,12 +1,9 @@
 """
 Utilities for using pygmt with sphinx-gallery.
 """
-try:
-    from sphinx_gallery.scrapers import figure_rst
-except ImportError:
-    figure_rst = None
 
 from pygmt.figure import SHOWED_FIGURES
+from sphinx_gallery.scrapers import figure_rst
 
 
 class PyGMTScraper:  # pylint: disable=too-few-public-methods

--- a/pygmt/tests/test_sphinx_gallery.py
+++ b/pygmt/tests/test_sphinx_gallery.py
@@ -6,16 +6,12 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
-try:
-    import sphinx_gallery
-except ImportError:
-    sphinx_gallery = None
+sphinx_gallery = pytest.importorskip("sphinx_gallery", reason="requires sphinx-gallery")
 
 from pygmt.figure import SHOWED_FIGURES, Figure
 from pygmt.sphinx_gallery import PyGMTScraper
 
 
-@pytest.mark.skipif(sphinx_gallery is None, reason="requires sphinx-gallery")
 def test_pygmtscraper():
     """
     Make sure the scraper finds the figures and removes them from the pool.

--- a/pygmt/tests/test_sphinx_gallery.py
+++ b/pygmt/tests/test_sphinx_gallery.py
@@ -5,14 +5,11 @@ import os
 from tempfile import TemporaryDirectory
 
 import pytest
+from pygmt.figure import SHOWED_FIGURES, Figure
 
-sphinx_gallery = pytest.importorskip("sphinx_gallery", reason="requires sphinx-gallery")
-
-# pylint: disable=wrong-import-position
-from pygmt.figure import SHOWED_FIGURES, Figure  # noqa: E402
-from pygmt.sphinx_gallery import PyGMTScraper  # noqa: E402
-
-# pylint: enable=wrong-import-position
+pygmt_sphinx_gallery = pytest.importorskip(
+    "pygmt.sphinx_gallery", reason="requires sphinx-gallery to be installed"
+)
 
 
 def test_pygmtscraper():
@@ -29,7 +26,7 @@ def test_pygmtscraper():
         fig.show()
         assert len(SHOWED_FIGURES) == 1
         assert SHOWED_FIGURES[0] is fig
-        scraper = PyGMTScraper()
+        scraper = pygmt_sphinx_gallery.PyGMTScraper()
         with TemporaryDirectory(dir=os.getcwd()) as tmpdir:
             conf = {"src_dir": "meh"}
             fname = os.path.join(tmpdir, "meh.png")

--- a/pygmt/tests/test_sphinx_gallery.py
+++ b/pygmt/tests/test_sphinx_gallery.py
@@ -8,8 +8,8 @@ import pytest
 
 sphinx_gallery = pytest.importorskip("sphinx_gallery", reason="requires sphinx-gallery")
 
-from pygmt.figure import SHOWED_FIGURES, Figure
-from pygmt.sphinx_gallery import PyGMTScraper
+from pygmt.figure import SHOWED_FIGURES, Figure  # noqa: E402
+from pygmt.sphinx_gallery import PyGMTScraper  # noqa: E402
 
 
 def test_pygmtscraper():

--- a/pygmt/tests/test_sphinx_gallery.py
+++ b/pygmt/tests/test_sphinx_gallery.py
@@ -8,8 +8,11 @@ import pytest
 
 sphinx_gallery = pytest.importorskip("sphinx_gallery", reason="requires sphinx-gallery")
 
+# pylint: disable=wrong-import-position
 from pygmt.figure import SHOWED_FIGURES, Figure  # noqa: E402
 from pygmt.sphinx_gallery import PyGMTScraper  # noqa: E402
+
+# pylint: enable=wrong-import-position
 
 
 def test_pygmtscraper():


### PR DESCRIPTION
**Description of proposed changes**

Scratching my recent code coverage itch :smile: This PR completes code coverage on the `sphinx_gallery.py` file which had the `except ImportError: figure_rst = None` lines not covered by Continuous Integration tests. Fun fact: `git blame` shows that these two lines go way back to 2019 (e9929a81361c80dd6944752478182466f393e6b7/#268).

![image](https://user-images.githubusercontent.com/23487320/133912211-5accc866-22b8-4e1a-8a32-c7ecfdd0f396.png)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Specifically, it removes the try-except block in both `pygmt/sphinx_gallery.py` and `pygmt/tests/test_sphinx_gallery.py`, and uses [`pytest.importorskip`](https://docs.pytest.org/en/6.2.x/reference.html#pytest-importorskip-ref) instead (if someone does want to run the test but doesn't have sphinx-gallery installed). To be honest, most users probably won't be doing `from pygmt.sphinx_gallery import PyGMTScraper` anyway, so this is just a backend maintenance refactor.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
