### PR TITLE
Expand table-like input options for Figure.contour

### DIFF
--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -5,9 +5,7 @@ contour - Plot contour table data.
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_string,
-    data_kind,
     deprecate_parameter,
-    dummy_context,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
@@ -60,8 +58,10 @@ def contour(self, x=None, y=None, z=None, data=None, **kwargs):
     ----------
     x/y/z : 1d arrays
         Arrays of x and y coordinates and values z of the data points.
-    data : str or 2d array
-        Either a data file name or a 2d numpy array with the tabular data.
+    data : str or {table-like}
+        Pass in (x, y, z) or (longitude, latitude, elevation) values by
+        providing a file name to an ASCII data table, a 2D
+        {table-classes}
     {J}
     {R}
     annotation : str or int
@@ -126,17 +126,11 @@ def contour(self, x=None, y=None, z=None, data=None, **kwargs):
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
 
-    kind = data_kind(data, x, y, z, required_z=True)
-
     with Session() as lib:
-        # Choose how data will be passed in to the module
-        if kind == "file":
-            file_context = dummy_context(data)
-        elif kind == "matrix":
-            file_context = lib.virtualfile_from_matrix(data)
-        elif kind == "vectors":
-            file_context = lib.virtualfile_from_vectors(x, y, z)
-
+        # Choose how data will be passed into the module
+        file_context = lib.virtualfile_from_data(
+            check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
+        )
         with file_context as fname:
             arg_str = " ".join([fname, build_arg_string(kwargs)])
             lib.call_module("contour", arg_str)

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -5,7 +5,9 @@ Tests contour.
 import os
 
 import numpy as np
+import pandas as pd
 import pytest
+import xarray as xr
 from pygmt import Figure
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
@@ -17,7 +19,7 @@ def data():
     """
     Load the point data from the test file.
     """
-    return np.loadtxt(POINTS_DATA)
+    return pd.read_table(POINTS_DATA, header=None, sep=r"\s+")
 
 
 @pytest.fixture(scope="module")
@@ -45,13 +47,19 @@ def test_contour_vec(region):
     return fig
 
 
-@pytest.mark.mpl_image_compare
-def test_contour_matrix(data, region):
+@pytest.mark.mpl_image_compare(filename="test_contour_matrix.png")
+@pytest.mark.parametrize(
+    "array_func",
+    [np.array, pd.DataFrame, xr.Dataset],
+)
+def test_contour_matrix(array_func, data, region):
     """
     Plot data.
     """
     fig = Figure()
-    fig.contour(data=data, projection="X10c", region=region, frame="ag", pen=True)
+    fig.contour(
+        data=array_func(data), projection="X10c", region=region, frame="ag", pen=True
+    )
     return fig
 
 


### PR DESCRIPTION
**Description of proposed changes**

This PR expands table-like input options for Figure.contour while refactoring to use virtualfile_from_data.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #949 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
