### PR TITLE
Figure.histogram: Deprecate parameter "table" to "data" (remove in v0.7.0)

### DIFF
--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -58,7 +58,7 @@ def histogram(self, data, **kwargs):
     {aliases}
 
     Parameters
-    ---------
+    ----------
     data : str or list or {table-like}
         Pass in either a file name to an ASCII data table, a Python list, a 2D
         {table-classes}.

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -2,10 +2,17 @@
 Histogram - Create a histogram
 """
 from pygmt.clib import Session
-from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
+from pygmt.helpers import (
+    build_arg_string,
+    deprecate_parameter,
+    fmt_docstring,
+    kwargs_to_strings,
+    use_alias,
+)
 
 
 @fmt_docstring
+@deprecate_parameter("table", "data", "v0.5.0", remove_version="v0.7.0")
 @use_alias(
     A="horizontal",
     B="frame",
@@ -41,7 +48,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
 @kwargs_to_strings(
     R="sequence", T="sequence", c="sequence_comma", i="sequence_comma", p="sequence"
 )
-def histogram(self, table, **kwargs):
+def histogram(self, data, **kwargs):
     r"""
     Plots a histogram, and can read data from a file or
     list, array, or dataframe.
@@ -51,8 +58,8 @@ def histogram(self, table, **kwargs):
     {aliases}
 
     Parameters
-    ----------
-    table : str or list or {table-like}
+    ---------
+    data : str or list or {table-like}
         Pass in either a file name to an ASCII data table, a Python list, a 2D
         {table-classes}.
     {J}
@@ -139,7 +146,7 @@ def histogram(self, table, **kwargs):
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
     with Session() as lib:
-        file_context = lib.virtualfile_from_data(check_kind="vector", data=table)
+        file_context = lib.virtualfile_from_data(check_kind="vector", data=data)
         with file_context as infile:
             arg_str = " ".join([infile, build_arg_string(kwargs)])
             lib.call_module("histogram", arg_str)

--- a/pygmt/tests/test_histogram.py
+++ b/pygmt/tests/test_histogram.py
@@ -7,7 +7,7 @@ import pytest
 from pygmt import Figure
 
 
-@pytest.fixture(scope="module", name="table", params=[list, pd.Series])
+@pytest.fixture(scope="module", name="data", params=[list, pd.Series])
 def fixture_table(request):
     """
     Returns a list of integers to be used in the histogram.
@@ -17,13 +17,13 @@ def fixture_table(request):
 
 
 @pytest.mark.mpl_image_compare(filename="test_histogram.png")
-def test_histogram(table):
+def test_histogram(data):
     """
     Tests plotting a histogram using a sequence of integers from a table.
     """
     fig = Figure()
     fig.histogram(
-        table=table,
+        data=data,
         projection="X10c/10c",
         region=[0, 9, 0, 6],
         series=1,


### PR DESCRIPTION
**Description of proposed changes**

I don't add a test for this deprecation, because we already have a similar test for `pygmt.info` in PR https://github.com/GenericMappingTools/pygmt/pull/1538.

Address #1479 

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
