### PR TITLE
Update the release checklist to remove deprecations and related tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -16,6 +16,7 @@ assignees: ''
 - [ ] Wrap Y ()
 
 **Before release**:
+- [ ] Remove deprecations and related tests that should be removed in this version
 - [ ] Reserve a DOI on [Zenodo](https://zenodo.org) by clicking on "New Version"
 - [ ] Finish up 'Changelog entry for v0.x.x' Pull Request:
   - [ ] Add a new entry in `doc/_static/version_switch.js` for documentation switcher

--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -16,7 +16,7 @@ assignees: ''
 - [ ] Wrap Y ()
 
 **Before release**:
-- [ ] Remove deprecations and related tests that should be removed in this version
+- [ ] Run `grep 'remove_version="vX.Y.Z"' **/*.py` to check if any deprecations and related tests should be removed in this version
 - [ ] Reserve a DOI on [Zenodo](https://zenodo.org) by clicking on "New Version"
 - [ ] Finish up 'Changelog entry for v0.x.x' Pull Request:
   - [ ] Add a new entry in `doc/_static/version_switch.js` for documentation switcher

--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -16,7 +16,7 @@ assignees: ''
 - [ ] Wrap Y ()
 
 **Before release**:
-- [ ] Run `grep 'remove_version="vX.Y.Z"' **/*.py` to check if any deprecations and related tests should be removed in this version
+- [ ] Run `grep --include="*.py" -r 'remove_version="vX.Y.Z"' pygmt` from the base of the repository to check if any deprecations and related tests should be removed in this version
 - [ ] Reserve a DOI on [Zenodo](https://zenodo.org) by clicking on "New Version"
 - [ ] Finish up 'Changelog entry for v0.x.x' Pull Request:
   - [ ] Add a new entry in `doc/_static/version_switch.js` for documentation switcher


### PR DESCRIPTION
**Description of proposed changes**

We should run commands like `grep 'remove_version="v0.5.0"' **/*.py` to see if any deprecations should be fully removed in a new release. This PR add it to the release checklist so that we won't forget to remove the deprecations.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
