### PR TITLE
Pin dvc to 2.3.0 as a workaround to fix the recent dvc pulling issue

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -96,7 +96,7 @@ jobs:
           mamba install gmt=6.2.0 numpy=${{ matrix.numpy-version }} \
                         pandas xarray netCDF4 packaging \
                         ${{ matrix.optional-packages }} \
-                        coverage[toml] dvc make pytest>=6.0 \
+                        coverage[toml] dvc=2.3.0 make pytest>=6.0 \
                         pytest-cov pytest-mpl sphinx-gallery
 
       # Show installed pkg information for postmortem diagnostic

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: Install dependencies
         run: |
           mamba install ninja cmake libblas libcblas liblapack fftw gdal geopandas \
-                        ghostscript libnetcdf hdf5 zlib curl pcre make dvc
+                        ghostscript libnetcdf hdf5 zlib curl pcre make dvc=2.3.0
           pip install --pre numpy pandas xarray netCDF4 packaging \
                             ipython pytest-cov pytest-mpl pytest>=6.0 sphinx-gallery \
                             tomli

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
     - blackdoc
     - coverage[toml]
     - docformatter
-    - dvc
+    - dvc=2.3.0
     - flake8
     - ipython
     - isort>=5


### PR DESCRIPTION
**Description of proposed changes**


Address https://github.com/GenericMappingTools/pygmt/issues/1543.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
