### PR TITLE
pygmt.xyz2grd: Rename the parameter 'table' to 'data'

### DIFF
--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -20,7 +20,7 @@ from pygmt.io import load_dataarray
     V="verbose",
 )
 @kwargs_to_strings(R="sequence")
-def xyz2grd(table, **kwargs):
+def xyz2grd(data, **kwargs):
     """
     Create a grid file from table data.
 
@@ -33,7 +33,7 @@ def xyz2grd(table, **kwargs):
 
     Parameters
     ----------
-    table : str or {table-like}
+    data : str or {table-like}
         Pass in either a file name to an ASCII data table, a 1D/2D
         {table-classes}.
 
@@ -55,7 +55,7 @@ def xyz2grd(table, **kwargs):
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_from_data(check_kind="vector", data=table)
+            file_context = lib.virtualfile_from_data(check_kind="vector", data=data)
             with file_context as infile:
                 if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})

--- a/pygmt/tests/test_xyz2grd.py
+++ b/pygmt/tests/test_xyz2grd.py
@@ -23,7 +23,7 @@ def test_xyz2grd_input_file():
     """
     Run xyz2grd by passing in a filename.
     """
-    output = xyz2grd(table="@tut_ship.xyz", spacing=5, region=[245, 255, 20, 30])
+    output = xyz2grd(data="@tut_ship.xyz", spacing=5, region=[245, 255, 20, 30])
     assert isinstance(output, xr.DataArray)
     assert output.gmt.registration == 0  # Gridline registration
     assert output.gmt.gtype == 0  # Cartesian type
@@ -34,7 +34,7 @@ def test_xyz2grd_input_array(ship_data):
     """
     Run xyz2grd by passing in a numpy array.
     """
-    output = xyz2grd(table=np.array(ship_data), spacing=5, region=[245, 255, 20, 30])
+    output = xyz2grd(data=np.array(ship_data), spacing=5, region=[245, 255, 20, 30])
     assert isinstance(output, xr.DataArray)
     assert output.gmt.registration == 0  # Gridline registration
     assert output.gmt.gtype == 0  # Cartesian type
@@ -45,7 +45,7 @@ def test_xyz2grd_input_df(ship_data):
     """
     Run xyz2grd by passing in a data frame.
     """
-    output = xyz2grd(table=ship_data, spacing=5, region=[245, 255, 20, 30])
+    output = xyz2grd(data=ship_data, spacing=5, region=[245, 255, 20, 30])
     assert isinstance(output, xr.DataArray)
     assert output.gmt.registration == 0  # Gridline registration
     assert output.gmt.gtype == 0  # Cartesian type
@@ -58,7 +58,7 @@ def test_xyz2grd_input_array_file_out(ship_data):
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         result = xyz2grd(
-            table=np.array(ship_data),
+            data=np.array(ship_data),
             spacing=5,
             region=[245, 255, 20, 30],
             outgrid=tmpfile.name,


### PR DESCRIPTION
**Description of proposed changes**

Rename the parameter 'table' to 'data' **without a deprecation cycle**,
because the xyz2grd function was added after v0.4.1.

Address #1479.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
