### PR TITLE
Update the baseline image for pygmt/test/test_plot.py:test_plot_matrix

### DIFF
--- a/pygmt/tests/baseline/test_plot_matrix.png.dvc
+++ b/pygmt/tests/baseline/test_plot_matrix.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 41e2e88122f0a2036943ec8017ac0f4f
-  size: 17139
+- md5: 868f554737ce7b116b50e68ea32b6331
+  size: 13639
   path: test_plot_matrix.png

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -9,12 +9,16 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from pygmt import Figure
+from packaging.version import Version
+from pygmt import Figure, clib
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 POINTS_DATA = os.path.join(TEST_DATA_DIR, "points.txt")
+
+with clib.Session() as _lib:
+    gmt_version = Version(_lib.info["version"])
 
 
 @pytest.fixture(scope="module")
@@ -299,6 +303,10 @@ def test_plot_sizes_colors_transparencies():
 
 
 @pytest.mark.mpl_image_compare
+@pytest.mark.xfail(
+    condition=gmt_version <= Version("6.2.0"),
+    reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/5799.",
+)
 def test_plot_matrix(data):
     """
     Plot the data passing in a matrix and specifying columns.
@@ -311,7 +319,7 @@ def test_plot_matrix(data):
         style="cc",
         color="#aaaaaa",
         frame="a",
-        incols="0,1,2+s0.005",
+        incols="0,1,2+s0.5",
     )
     return fig
 


### PR DESCRIPTION
**Description of proposed changes**

See #1539 for the bug report and https://github.com/GenericMappingTools/pygmt/issues/1539 for the upstream fix.

Changes in this PR:

- Changing `incols="0,1,2+s0.005"` to `incols="0,1,2+s0.5"` so that circils are large enough to be visible
- Update the baseline image with the GMT master branch
- Mark the test as `xfail` for GMT <= 6.2.0

Fixes #1539.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
