### PR TITLE
Remove unused global variable 'gmt_version' from tests

### DIFF
--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -2,12 +2,8 @@
 Tests Figure.basemap.
 """
 import pytest
-from packaging.version import Version
-from pygmt import Figure, clib
+from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput
-
-with clib.Session() as _lib:
-    gmt_version = Version(_lib.info["version"])
 
 
 def test_basemap_required_args():

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -27,9 +27,6 @@ from pygmt.helpers import GMTTempFile
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 POINTS_DATA = os.path.join(TEST_DATA_DIR, "points.txt")
 
-with clib.Session() as _lib:
-    gmt_version = Version(_lib.info["version"])
-
 
 @pytest.fixture(scope="module")
 def data():

--- a/pygmt/tests/test_clib_put_strings.py
+++ b/pygmt/tests/test_clib_put_strings.py
@@ -4,13 +4,9 @@ Test the functions that put string data into GMT.
 import numpy as np
 import numpy.testing as npt
 import pytest
-from packaging.version import Version
 from pygmt import clib
 from pygmt.exceptions import GMTCLibError
 from pygmt.helpers import GMTTempFile
-
-with clib.Session() as _lib:
-    gmt_version = Version(_lib.info["version"])
 
 
 def test_put_strings():


### PR DESCRIPTION
**Description of proposed changes**

The variable `gmt_version` was used when we need to write tests that fail or pass with specific GMT versions. Now the variable is no longer needed and can be removed.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
