### PR TITLE
Document gmtwhich -Ga option to download to appropriate cache folder

### DIFF
--- a/pygmt/src/which.py
+++ b/pygmt/src/which.py
@@ -15,7 +15,7 @@ from pygmt.helpers import (
 @use_alias(G="download", V="verbose")
 @kwargs_to_strings(fname="sequence_space")
 def which(fname, **kwargs):
-    """
+    r"""
     Find the full path to specified files.
 
     Reports the full paths to the files given through *fname*. We look for
@@ -37,10 +37,16 @@ def which(fname, **kwargs):
     fname : str or list
         One or more file names of any data type (grids, tables, etc.).
     download : bool or str
-        If the file is downloadable and not found, we will try to download the
-        it. Use True or 'l' (default) to download to the current directory. Use
-        'c' to place in the user cache directory or 'u' user data directory
-        instead.
+        [**a**\|\ **c**\|\ **l**\|\ **u**].
+        If the fname argument is a downloadable file (either a complete URL, an
+        @file for downloading from the GMT data server, or @earth_relief_xxy)
+        we will try to download the file if it is not found in your local data
+        or cache dirs. By default [``download=True`` or ``download="l"``] we
+        download to the current directory. Use **a** to place files in the
+        appropriate folder under the user directory (this is where GMT normally
+        places downloaded files), **c** to place it in the user cache
+        directory, or **u** for the user data directory instead (i.e., ignoring
+        any subdirectory structure).
     {V}
 
     Returns


### PR DESCRIPTION
**Description of proposed changes**

The `gmtwhich -Ga` option was added in GMT 6.1 at https://github.com/GenericMappingTools/gmt/pull/3370/commits/d390ea4287fb4f5b6430716b93921548d2da77c3, but hasn't been documented in PyGMT since. See https://docs.generic-mapping-tools.org/6.2/gmtwhich#g.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
