### PR TITLE
Expand table-like input options for xyz2grd

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -87,6 +87,7 @@ Operations on tabular data:
     sphdistance
     sphinterpolate
     surface
+    xyz2grd
 
 Operations on grids:
 
@@ -103,7 +104,6 @@ Operations on grids:
     grdproject
     grdsample
     grdtrack
-    xyz2grd
 
 Crossover analysis with x2sys:
 

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -63,8 +63,7 @@ def xyz2grd(data=None, x=None, y=None, z=None, **kwargs):
                 if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})
                 outgrid = kwargs["G"]
-                arg_str = build_arg_string(kwargs)
-                arg_str = " ".join([infile, arg_str])
+                arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("xyz2grd", arg_str)
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -20,7 +20,7 @@ from pygmt.io import load_dataarray
     V="verbose",
 )
 @kwargs_to_strings(R="sequence")
-def xyz2grd(data, **kwargs):
+def xyz2grd(data=None, x=None, y=None, z=None, **kwargs):
     """
     Create a grid file from table data.
 
@@ -34,9 +34,10 @@ def xyz2grd(data, **kwargs):
     Parameters
     ----------
     data : str or {table-like}
-        Pass in either a file name to an ASCII data table, a 1D/2D
-        {table-classes}.
-
+        Pass in (x, y, z) or (longitude, latitude, elevation) values by
+        providing a file name to an ASCII data table, a 2D {table-classes}.
+    x/y/z : 1d arrays
+        The arrays of x and y coordinates and z data points.
     outgrid : str or None
         Optional. The name of the output netCDF file with extension .nc to
         store the grid in.
@@ -51,11 +52,13 @@ def xyz2grd(data, **kwargs):
 
         - :class:`xarray.DataArray`: if ``outgrid`` is not set
         - None if ``outgrid`` is set (grid output will be stored in file set by
-          ``outgrid``)```
+          ``outgrid``)
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_from_data(check_kind="vector", data=data)
+            file_context = lib.virtualfile_from_data(
+                check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
+            )
             with file_context as infile:
                 if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})


### PR DESCRIPTION
**Description of proposed changes**

Support syntax like `xyz2grd(x=x, y=y, z=z)`

Continuation of #635 and #636.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
