### PR TITLE
Remove unnecessary returns from surface tests

### DIFF
--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -31,7 +31,6 @@ def test_surface_input_file():
     assert isinstance(output, xr.DataArray)
     assert output.gmt.registration == 0  # Gridline registration
     assert output.gmt.gtype == 0  # Cartesian type
-    return output
 
 
 def test_surface_input_data_array(ship_data):
@@ -41,7 +40,6 @@ def test_surface_input_data_array(ship_data):
     data = ship_data.values  # convert pandas.DataFrame to numpy.ndarray
     output = surface(data=data, spacing="5m", region=[245, 255, 20, 30])
     assert isinstance(output, xr.DataArray)
-    return output
 
 
 def test_surface_input_xyz(ship_data):
@@ -56,7 +54,6 @@ def test_surface_input_xyz(ship_data):
         region=[245, 255, 20, 30],
     )
     assert isinstance(output, xr.DataArray)
-    return output
 
 
 def test_surface_wrong_kind_of_input(ship_data):
@@ -84,7 +81,6 @@ def test_surface_with_outgrid_param(ship_data):
             assert isinstance(grid, xr.DataArray)  # ensure netcdf grid loads ok
     finally:
         os.remove(path=TEMP_GRID)
-    return output
 
 
 def test_surface_deprecate_outfile_to_outgrid(ship_data):
@@ -122,4 +118,3 @@ def test_surface_short_aliases(ship_data):
             assert isinstance(grid, xr.DataArray)  # ensure netcdf grid loads ok
     finally:
         os.remove(path=TEMP_GRID)
-    return output


### PR DESCRIPTION
**Description of proposed changes**

This PR removes unnecessary return statements from the surface tests. I think removing the return statements in the surface tests could reduce maintainer effort for future PRs that use these tests as examples, based on my experience with writing and reviewing blockm* PRs.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
