### PR TITLE
Use alias long-form for grdimage, text, and psconvert tests

### DIFF
--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -159,7 +159,7 @@ def test_grdimage_over_dateline(xrgrid):
     fig = Figure()
     assert xrgrid.gmt.registration == 0  # gridline registration
     xrgrid.gmt.gtype = 1  # geographic coordinate system
-    fig.grdimage(grid=xrgrid, region="g", projection="A0/0/1c", V="i")
+    fig.grdimage(grid=xrgrid, region="g", projection="A0/0/1c", verbose="i")
     return fig
 
 

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -159,7 +159,7 @@ def test_grdimage_over_dateline(xrgrid):
     fig = Figure()
     assert xrgrid.gmt.registration == 0  # gridline registration
     xrgrid.gmt.gtype = 1  # geographic coordinate system
-    fig.grdimage(grid=xrgrid, region="g", projection="A0/0/1c", verbose="i")
+    fig.grdimage(grid=xrgrid, region="g", projection="A0/0/1c")
     return fig
 
 

--- a/pygmt/tests/test_psconvert.py
+++ b/pygmt/tests/test_psconvert.py
@@ -11,9 +11,9 @@ def test_psconvert():
     psconvert creates a figure in the current directory.
     """
     fig = Figure()
-    fig.basemap(R="10/70/-3/8", J="X4i/3i", B="a")
+    fig.basemap(region="10/70/-3/8", projection="X4i/3i", frame="a")
     prefix = "test_psconvert"
-    fig.psconvert(F=prefix, T="f", A=True)
+    fig.psconvert(prefix=prefix, fmt="f", crop=True)
     fname = prefix + ".pdf"
     assert os.path.exists(fname)
     os.remove(fname)
@@ -24,15 +24,15 @@ def test_psconvert_twice():
     Call psconvert twice to get two figures.
     """
     fig = Figure()
-    fig.basemap(R="10/70/-3/8", J="X4i/3i", B="a")
+    fig.basemap(region="10/70/-3/8", projection="X4i/3i", frame="a")
     prefix = "test_psconvert_twice"
     # Make a PDF
-    fig.psconvert(F=prefix, T="f")
+    fig.psconvert(prefix=prefix, fmt="f")
     fname = prefix + ".pdf"
     assert os.path.exists(fname)
     os.remove(fname)
     # Make a PNG
-    fig.psconvert(F=prefix, T="g")
+    fig.psconvert(prefix=prefix, fmt="g")
     fname = prefix + ".png"
     assert os.path.exists(fname)
     os.remove(fname)
@@ -43,7 +43,7 @@ def test_psconvert_aliases():
     Use the aliases to make sure they work.
     """
     fig = Figure()
-    fig.basemap(R="10/70/-3/8", J="X4i/3i", B="a")
+    fig.basemap(region="10/70/-3/8", projection="X4i/3i", frame="a")
     prefix = "test_psconvert_aliases"
     fig.psconvert(prefix=prefix, fmt="g", crop=True, dpi=100)
     fname = prefix + ".png"

--- a/pygmt/tests/test_psconvert.py
+++ b/pygmt/tests/test_psconvert.py
@@ -36,16 +36,3 @@ def test_psconvert_twice():
     fname = prefix + ".png"
     assert os.path.exists(fname)
     os.remove(fname)
-
-
-def test_psconvert_aliases():
-    """
-    Use the aliases to make sure they work.
-    """
-    fig = Figure()
-    fig.basemap(region="10/70/-3/8", projection="X4i/3i", frame="a")
-    prefix = "test_psconvert_aliases"
-    fig.psconvert(prefix=prefix, fmt="g", crop=True, dpi=100)
-    fname = prefix + ".png"
-    assert os.path.exists(fname)
-    os.remove(fname)

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -276,7 +276,7 @@ def test_text_justify_parsed_from_textfile():
         projection="H90/9i",
         justify=True,
         textfiles=CITIES_DATA,
-        D="j0.45/0+vred",  # draw red-line from xy point to text label (city name)
+        offset="j0.45/0+vred",  # draw red-line from xy point to text label (city name)
     )
     return fig
 


### PR DESCRIPTION
**Description of proposed changes**

This PR modifies the tests for grdimage, text, and psconvert to use the long-form of aliases so that pytest results are not diluted by the resultant syntax warnings.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
