### PR TITLE
WIP: Separate grdhisteq into equalize_grid and compute_bins

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -96,8 +96,8 @@ jobs:
           mamba install gmt=6.2.0 numpy=${{ matrix.numpy-version }} \
                         pandas xarray netCDF4 packaging \
                         ${{ matrix.optional-packages }} \
-                        coverage[toml] dvc=2.3.0 make pytest>=6.0 \
-                        pytest-cov pytest-mpl sphinx-gallery
+                        dvc=2.3.0 make pytest>=6.0 \
+                        pytest-cov pytest-mpl sphinx-gallery tomli
 
       # Show installed pkg information for postmortem diagnostic
       - name: List installed packages

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -99,9 +99,8 @@ Operations on grids:
     grdfill
     grdfilter
     grdgradient
-    grdhisteq
-    grdhisteq.equalize_grid
     grdhisteq.compute_bins
+    grdhisteq.equalize_grid
     grdlandmask
     grdproject
     grdsample

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,6 @@ dependencies:
     # Development dependencies
     - black
     - blackdoc
-    - coverage[toml]
     - docformatter
     - dvc=2.3.0
     - flake8

--- a/examples/gallery/symbols/datetime_inputs.py
+++ b/examples/gallery/symbols/datetime_inputs.py
@@ -41,26 +41,26 @@ fig.basemap(
 # numpy.datetime64 types
 x = np.array(["2010-06-01", "2011-06-01T12", "2012-01-01T12:34:56"], dtype="datetime64")
 y = [1, 2, 3]
-fig.plot(x, y, style="c0.4c", pen="1p", color="red3")
+fig.plot(x=x, y=y, style="c0.4c", pen="1p", color="red3")
 
 # pandas.DatetimeIndex
 x = pd.date_range("2013", periods=3, freq="YS")
 y = [4, 5, 6]
-fig.plot(x, y, style="t0.4c", pen="1p", color="gold")
+fig.plot(x=x, y=y, style="t0.4c", pen="1p", color="gold")
 
 # xarray.DataArray
 x = xr.DataArray(data=pd.date_range(start="2015-03", periods=3, freq="QS"))
 y = [7.5, 6, 4.5]
-fig.plot(x, y, style="s0.4c", pen="1p")
+fig.plot(x=x, y=y, style="s0.4c", pen="1p")
 
 # raw datetime strings
 x = ["2016-02-01", "2016-06-04T14", "2016-10-04T00:00:15"]
 y = [7, 8, 9]
-fig.plot(x, y, style="a0.4c", pen="1p", color="dodgerblue")
+fig.plot(x=x, y=y, style="a0.4c", pen="1p", color="dodgerblue")
 
 # the Python built-in datetime and date
 x = [datetime.date(2018, 1, 1), datetime.datetime(2019, 6, 1, 20, 5, 45)]
 y = [6.5, 4.5]
-fig.plot(x, y, style="i0.4c", pen="1p", color="seagreen")
+fig.plot(x=x, y=y, style="i0.4c", pen="1p", color="seagreen")
 
 fig.show()

--- a/examples/gallery/symbols/points.py
+++ b/examples/gallery/symbols/points.py
@@ -19,5 +19,5 @@ fig = pygmt.Figure()
 # data region
 fig.basemap(region=region, projection="X15c", frame=True)
 # Plot using inverted triangles (i) of 0.5 cm size
-fig.plot(x, y, style="i0.5c", color="black")
+fig.plot(x=x, y=y, style="i0.5c", color="black")
 fig.show()

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -1,6 +1,8 @@
 """
 Functions to convert data types into ctypes friendly formats.
 """
+import warnings
+
 import numpy as np
 import pandas as pd
 from pygmt.exceptions import GMTInvalidInput
@@ -95,9 +97,14 @@ def dataarray_to_matrix(grid):
         coord_incs = coord[1:] - coord[0:-1]
         coord_inc = coord_incs[0]
         if not np.allclose(coord_incs, coord_inc):
-            raise GMTInvalidInput(
-                f"Grid appears to have irregular spacing in the '{dim}' dimension."
+            # calculate the increment if irregular spacing is found
+            coord_inc = (coord[-1] - coord[0]) / (coord.size - 1)
+            msg = (
+                f"Grid may have irregular spacing in the '{dim}' dimension, "
+                "but GMT only supports regular spacing. Calculated regular spacing "
+                f"{coord_inc} is assumed in the '{dim}' dimension."
             )
+            warnings.warn(msg, category=RuntimeWarning)
         if coord_inc == 0:
             raise GMTInvalidInput(
                 f"Grid has a zero increment in the '{dim}' dimension."

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -857,7 +857,15 @@ def check_data_input_order(deprecate_version, remove_version):
             New module instance that raises a warning if positional arguments
             are passed.
             """
-            if len(args) > 0:  # positional arguments are used
+            # Plotting functions always have a "self" parameter
+            # which is a pygmt.Figure instance that has a "savefig" method
+            if len(args) > 1 and hasattr(args[0], "savefig"):
+                plotting_func = 1
+            else:
+                plotting_func = 0
+
+            if len(args) > 1 + plotting_func:
+                # more than one positional arguments are used
                 msg = (
                     "The function parameters has been re-ordered as 'data, x, y, [z]' "
                     f"since {deprecate_version} but you're passing positional arguments. "

--- a/pygmt/src/__init__.py
+++ b/pygmt/src/__init__.py
@@ -17,7 +17,6 @@ from pygmt.src.grdcut import grdcut
 from pygmt.src.grdfill import grdfill
 from pygmt.src.grdfilter import grdfilter
 from pygmt.src.grdgradient import grdgradient
-from pygmt.src.grdhisteq import grdhisteq
 from pygmt.src.grdimage import grdimage
 from pygmt.src.grdinfo import grdinfo
 from pygmt.src.grdlandmask import grdlandmask

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -6,13 +6,14 @@ from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,
     build_arg_string,
+    check_data_input_order,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
 )
 
 
-def _blockm(block_method, table, outfile, x, y, z, **kwargs):
+def _blockm(block_method, data, x, y, z, outfile, **kwargs):
     r"""
     Block average (x,y,z) data tables by mean, median, or mode estimation.
 
@@ -38,12 +39,11 @@ def _blockm(block_method, table, outfile, x, y, z, **kwargs):
         - None if ``outfile`` is set (filtered output will be stored in file
           set by ``outfile``)
     """
-
     with GMTTempFile(suffix=".csv") as tmpfile:
         with Session() as lib:
             # Choose how data will be passed into the module
             table_context = lib.virtualfile_from_data(
-                check_kind="vector", data=table, x=x, y=y, z=z, required_z=True
+                check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
             )
             # Run blockm* on data table
             with table_context as infile:
@@ -55,7 +55,7 @@ def _blockm(block_method, table, outfile, x, y, z, **kwargs):
         # Read temporary csv output to a pandas table
         if outfile == tmpfile.name:  # if user did not set outfile, return pd.DataFrame
             try:
-                column_names = table.columns.to_list()
+                column_names = data.columns.to_list()
                 result = pd.read_csv(tmpfile.name, sep="\t", names=column_names)
             except AttributeError:  # 'str' object has no attribute 'columns'
                 result = pd.read_csv(tmpfile.name, sep="\t", header=None, comment=">")
@@ -66,83 +66,7 @@ def _blockm(block_method, table, outfile, x, y, z, **kwargs):
 
 
 @fmt_docstring
-@use_alias(
-    I="spacing",
-    R="region",
-    V="verbose",
-    a="aspatial",
-    b="binary",
-    d="data",
-    e="find",
-    f="coltypes",
-    h="header",
-    i="incols",
-    o="outcols",
-    r="registration",
-    w="wrap",
-)
-@kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
-def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
-    r"""
-    Block average (x,y,z) data tables by mean estimation.
-
-    Reads arbitrarily located (x,y,z) triples [or optionally weighted
-    quadruples (x,y,z,w)] and writes to the output a mean position and value
-    for every non-empty block in a grid region defined by the ``region`` and
-    ``spacing`` parameters.
-
-    Takes a matrix, xyz triplets, or a file name as input.
-
-    Must provide either ``table`` or ``x``, ``y``, and ``z``.
-
-    Full option list at :gmt-docs:`blockmean.html`
-
-    {aliases}
-
-    Parameters
-    ----------
-    table : str or {table-like}
-        Pass in (x, y, z) or (longitude, latitude, elevation) values by
-        providing a file name to an ASCII data table, a 2D
-        {table-classes}.
-    x/y/z : 1d arrays
-        Arrays of x and y coordinates and values z of the data points.
-
-    {I}
-
-    {R}
-
-    outfile : str
-        The file name for the output ASCII file.
-
-    {V}
-    {a}
-    {b}
-    {d}
-    {e}
-    {i}
-    {f}
-    {h}
-    {o}
-    {r}
-    {w}
-
-    Returns
-    -------
-    output : pandas.DataFrame or None
-        Return type depends on whether the ``outfile`` parameter is set:
-
-        - :class:`pandas.DataFrame` table with (x, y, z) columns if ``outfile``
-          is not set.
-        - None if ``outfile`` is set (filtered output will be stored in file
-          set by ``outfile``).
-    """
-    return _blockm(
-        block_method="blockmean", table=table, outfile=outfile, x=x, y=y, z=z, **kwargs
-    )
-
-
-@fmt_docstring
+@check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(
     I="spacing",
     R="region",
@@ -159,7 +83,85 @@ def blockmean(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     w="wrap",
 )
 @kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
-def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
+def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
+    r"""
+    Block average (x,y,z) data tables by mean estimation.
+
+    Reads arbitrarily located (x,y,z) triples [or optionally weighted
+    quadruples (x,y,z,w)] and writes to the output a mean position and value
+    for every non-empty block in a grid region defined by the ``region`` and
+    ``spacing`` parameters.
+
+    Takes a matrix, xyz triplets, or a file name as input.
+
+    Must provide either ``data`` or ``x``, ``y``, and ``z``.
+
+    Full option list at :gmt-docs:`blockmean.html`
+
+    {aliases}
+
+    Parameters
+    ----------
+    data : str or {table-like}
+        Pass in (x, y, z) or (longitude, latitude, elevation) values by
+        providing a file name to an ASCII data table, a 2D
+        {table-classes}.
+    x/y/z : 1d arrays
+        Arrays of x and y coordinates and values z of the data points.
+
+    {I}
+
+    {R}
+
+    outfile : str
+        The file name for the output ASCII file.
+
+    {V}
+    {a}
+    {b}
+    {d}
+    {e}
+    {i}
+    {f}
+    {h}
+    {o}
+    {r}
+    {w}
+
+    Returns
+    -------
+    output : pandas.DataFrame or None
+        Return type depends on whether the ``outfile`` parameter is set:
+
+        - :class:`pandas.DataFrame` table with (x, y, z) columns if ``outfile``
+          is not set.
+        - None if ``outfile`` is set (filtered output will be stored in file
+          set by ``outfile``).
+    """
+    return _blockm(
+        block_method="blockmean", data=data, x=x, y=y, z=z, outfile=outfile, **kwargs
+    )
+
+
+@fmt_docstring
+@check_data_input_order("v0.5.0", remove_version="v0.7.0")
+@use_alias(
+    I="spacing",
+    R="region",
+    V="verbose",
+    a="aspatial",
+    b="binary",
+    d="nodata",
+    e="find",
+    f="coltypes",
+    h="header",
+    i="incols",
+    o="outcols",
+    r="registration",
+    w="wrap",
+)
+@kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
+def blockmedian(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     r"""
     Block average (x,y,z) data tables by median estimation.
 
@@ -170,7 +172,7 @@ def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
 
     Takes a matrix, xyz triplets, or a file name as input.
 
-    Must provide either ``table`` or ``x``, ``y``, and ``z``.
+    Must provide either ``data`` or ``x``, ``y``, and ``z``.
 
     Full option list at :gmt-docs:`blockmedian.html`
 
@@ -178,7 +180,7 @@ def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
 
     Parameters
     ----------
-    table : str or {table-like}
+    data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2D
         {table-classes}.
@@ -215,24 +217,19 @@ def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
           set by ``outfile``).
     """
     return _blockm(
-        block_method="blockmedian",
-        table=table,
-        outfile=outfile,
-        x=x,
-        y=y,
-        z=z,
-        **kwargs
+        block_method="blockmedian", data=data, x=x, y=y, z=z, outfile=outfile, **kwargs
     )
 
 
 @fmt_docstring
+@check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(
     I="spacing",
     R="region",
     V="verbose",
     a="aspatial",
     b="binary",
-    d="data",
+    d="nodata",
     e="find",
     f="coltypes",
     h="header",
@@ -242,7 +239,7 @@ def blockmedian(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
     w="wrap",
 )
 @kwargs_to_strings(R="sequence", i="sequence_comma", o="sequence_comma")
-def blockmode(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
+def blockmode(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     r"""
     Block average (x,y,z) data tables by mode estimation.
 
@@ -253,7 +250,7 @@ def blockmode(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
 
     Takes a matrix, xyz triplets, or a file name as input.
 
-    Must provide either ``table`` or ``x``, ``y``, and ``z``.
+    Must provide either ``data`` or ``x``, ``y``, and ``z``.
 
     Full option list at :gmt-docs:`blockmode.html`
 
@@ -261,7 +258,7 @@ def blockmode(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
 
     Parameters
     ----------
-    table : str or {table-like}
+    data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2D
         {table-classes}.
@@ -298,5 +295,5 @@ def blockmode(table=None, outfile=None, *, x=None, y=None, z=None, **kwargs):
           set by ``outfile``).
     """
     return _blockm(
-        block_method="blockmode", table=table, outfile=outfile, x=x, y=y, z=z, **kwargs
+        block_method="blockmode", data=data, x=x, y=y, z=z, outfile=outfile, **kwargs
     )

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -5,6 +5,7 @@ contour - Plot contour table data.
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_string,
+    check_data_input_order,
     deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
@@ -14,6 +15,7 @@ from pygmt.helpers import (
 
 @fmt_docstring
 @deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
+@check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(
     A="annotation",
     B="frame",
@@ -41,7 +43,7 @@ from pygmt.helpers import (
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
-def contour(self, x=None, y=None, z=None, data=None, **kwargs):
+def contour(self, data=None, x=None, y=None, z=None, **kwargs):
     r"""
     Contour table data by direct triangulation.
 
@@ -56,12 +58,12 @@ def contour(self, x=None, y=None, z=None, data=None, **kwargs):
 
     Parameters
     ----------
-    x/y/z : 1d arrays
-        Arrays of x and y coordinates and values z of the data points.
     data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2D
         {table-classes}
+    x/y/z : 1d arrays
+        Arrays of x and y coordinates and values z of the data points.
     {J}
     {R}
     annotation : str or int

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -1,13 +1,13 @@
 """
 grdhisteq - Perform histogram equalization for a grid.
 """
+import warnings
 
 import pandas as pd
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     GMTTempFile,
-    args_in_kwargs,
     build_arg_string,
     fmt_docstring,
     kwargs_to_strings,
@@ -16,250 +16,223 @@ from pygmt.helpers import (
 from pygmt.io import load_dataarray
 
 
-class grdhisteq:
+def _grdhisteq(grid, outgrid=None, outfile=None, output_type=None, **kwargs):
     r"""
     Perform histogram equalization for a grid.
 
     Two common use cases of :meth:`pygmt.grdhisteq` are to find data values
-    that divide a grid into patches of equal area using
-    :meth:`pygmt.grdhisteq.equalize_grid` or to write a grid with
-    statistics based on some kind of cumulative distribution function using
-    :meth:`pygmt.grdhisteq.compute_bins`.
+    that divide a grid into patches of equal area or to write a grid with
+    statistics based on some kind of cumulative distribution function.
 
     Histogram equalization provides a way to highlight data that has most
     values clustered in a small portion of the dynamic range, such as a
     grid of flat topography with a mountain in the middle. Ordinary gray
     shading of this grid (using :meth:`pygmt.Figure.grdimage` or
     :meth:`pygmt.Figure.grdview`) with a linear mapping from topography to
-    graytone will result in most of the image being very dark gray, with the
-    mountain being almost white. :meth:`pygmt.grdhisteq.compute_bins` can
-    provide a list of data values that divide the data range into divisions
-    which have an equal area in the image [Default is 16 if ``divisions`` is
-    not set]. The :class:`pandas.DataFrame` or ASCII file output can be used to
+    graytone will result in most of the image being very dark gray, with
+    the mountain being almost white. :meth:`pygmt.grdhisteq` can provide a
+    list of data values that divide the data range into divisions which
+    have an equal area in the image [Default is 16 if ``divisions`` is not
+    set]. The :class:`pandas.DataFrame` or ASCII file output can be used to
     make a colormap with :meth:`pygmt.makecpt` and an image with
     :meth:`pygmt.Figure.grdimage` that has all levels of gray occuring
     equally.
 
-    :meth:`pygmt.grdhisteq.equalize_grid` provides a way to write a grid with
+    :meth:`pygmt.grdhisteq` also provides a way to write a grid with
     statistics based on a cumulative distribution function. In this
     application, the ``outgrid`` has relative highs and lows in the same
     (x,y) locations as the ``grid``, but the values are changed to reflect
     their place in the cumulative distribution.
+
+    Must provide ``outfile`` or ``outgrid``.
+
+    Full option list at :gmt-docs:`grdhisteq.html`
+
+    Parameters
+    ----------
+    grid : str or xarray.DataArray
+        The file name of the input grid or the grid loaded as a DataArray.
+    outgrid : str or bool or None
+        The name of the output netCDF file with extension .nc to store the
+        grid in.
+    outfile : str or bool or None
+        The name of the output ASCII file to store the results of the
+        histogram equalization in. Not allowed if ``outgrid`` is used.
+
+    Returns
+    -------
+    ret: pandas.DataFrame or xarray.DataArray or None
+        Return type depends on whether the ``outgrid`` parameter is set:
+
+        - pandas.DataFrame if ``outfile`` is True
+        - xarray.DataArray if ``outgrid`` is True
+        - None if ``outgrid`` is a str (grid output is stored in
+          ``outgrid``)
+        - None if ``outfile`` is a str (file output is stored in
+          ``outfile``)
+
+     See Also
+    -------
+    :meth:`pygmt.grd2cpt`
     """
 
-    @staticmethod
-    def _grdhisteq(grid, **kwargs):
-        r"""
-        Perform histogram equalization for a grid.
+    with GMTTempFile(suffix=".nc") as tmpfile:
+        with Session() as lib:
+            file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
+            with file_context as infile:
+                if outgrid is None:
+                    if output_type != "file":
+                        outfile = tmpfile.name
+                    # Temporary workaround to GMT bug (Issue #5785)
+                    kwargs.update({"D": True})
+                    kwargs.update({">": outfile})
+                else:
+                    if output_type != "file":
+                        kwargs.update({"G": tmpfile.name})
+                    else:
+                        kwargs.update({"G": outgrid})
+                arg_str = " ".join([infile, build_arg_string(kwargs)])
+                lib.call_module("grdhisteq", arg_str)
 
-        Two common use cases of :meth:`pygmt.grdhisteq` are to find data values
-        that divide a grid into patches of equal area or to write a grid with
-        statistics based on some kind of cumulative distribution function.
+        if output_type == "file":
+            return None
+        if output_type == "xarray":
+            return load_dataarray(tmpfile.name)
 
-        Histogram equalization provides a way to highlight data that has most
-        values clustered in a small portion of the dynamic range, such as a
-        grid of flat topography with a mountain in the middle. Ordinary gray
-        shading of this grid (using :meth:`pygmt.Figure.grdimage` or
-        :meth:`pygmt.Figure.grdview`) with a linear mapping from topography to
-        graytone will result in most of the image being very dark gray, with
-        the mountain being almost white. :meth:`pygmt.grdhisteq` can provide a
-        list of data values that divide the data range into divisions which
-        have an equal area in the image [Default is 16 if ``divisions`` is not
-        set]. The :class:`pandas.DataFrame` or ASCII file output can be used to
-        make a colormap with :meth:`pygmt.makecpt` and an image with
-        :meth:`pygmt.Figure.grdimage` that has all levels of gray occuring
-        equally.
-
-        :meth:`pygmt.grdhisteq` also provides a way to write a grid with
-        statistics based on a cumulative distribution function. In this
-        application, the ``outgrid`` has relative highs and lows in the same
-        (x,y) locations as the ``grid``, but the values are changed to reflect
-        their place in the cumulative distribution.
-
-        Must provide ``outfile`` or ``outgrid``.
-
-        Full option list at :gmt-docs:`grdhisteq.html`
-
-        {aliases}
-
-        Parameters
-        ----------
-        grid : str or xarray.DataArray
-            The file name of the input grid or the grid loaded as a DataArray.
-        outgrid : str or bool or None
-            The name of the output netCDF file with extension .nc to store the
-            grid in.
-        outfile : str or bool or None
-            The name of the output ASCII file to store the results of the
-            histogram equalization in. Not allowed if ``outgrid`` is used.
-        divisions : int
-            Set the number of divisions of the data range.
-
-        {R}
-        {V}
-
-        Returns
-        -------
-        ret: pandas.DataFrame or xarray.DataArray or None
-            Return type depends on whether the ``outgrid`` parameter is set:
-
-            - pandas.DataFrame if ``outfile`` is True
-            - xarray.DataArray if ``outgrid`` is True
-            - None if ``outgrid`` is a str (grid output is stored in
-              ``outgrid``)
-            - None if ``outfile`` is a str (file output is stored in
-              ``outfile``)
-
-        See Also
-        -------
-        :meth:`pygmt.grd2cpt`
-        """
-        if "D" in kwargs and "G" in kwargs:
-            raise GMTInvalidInput("Cannot use both ``outfile`` and ``outgrid``.")
-        if not args_in_kwargs(["D", "G"], kwargs):
-            raise GMTInvalidInput("Must set ``outgrid`` or ``outfile``.")
-        with GMTTempFile(suffix=".nc") as tmpfile:
-            with Session() as lib:
-                file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
-                with file_context as infile:
-                    # Return table data if outgrid is not set
-                    if "G" not in kwargs or kwargs["G"] is None:
-                        # Return pd.Dataframe if filename not provided
-                        if "D" not in kwargs or kwargs["D"] is True:
-                            outfile = tmpfile.name
-                        else:  # Return set output to file Name
-                            outfile = kwargs["D"]
-                        # Temporary workaround to GMT bug (Issue #5785)
-                        kwargs.update({"D": True})
-                        kwargs.update({">": outfile})
-                    else:  # NetCDF or xarray.DataArray output if outgrid is set
-                        if kwargs["G"] is True:
-                            kwargs.update({"G": tmpfile.name})
-                        outgrid = kwargs["G"]
-                    arg_str = " ".join([infile, build_arg_string(kwargs)])
-                    lib.call_module("grdhisteq", arg_str)
-
-            try:  # Try returning a xr.DataArray
-                result = load_dataarray(outgrid) if outgrid == tmpfile.name else None
-            except UnboundLocalError:  # if outgrid unset, return pd.DataFrame or text file
-                result = (
-                    pd.read_csv(outfile, sep="\t", header=None)
-                    if outfile == tmpfile.name
-                    else None
-                )
+        result = pd.read_csv(outfile, sep="\t", header=None)
+        if output_type == "numpy":
+            result = result.to_numpy()
         return result
 
-    @staticmethod
-    @fmt_docstring
-    @use_alias(
-        C="divisions",
-        G="outgrid",
-        R="region",
-        N="gaussian",
-        Q="quadratic",
-        V="verbose",
-    )
-    @kwargs_to_strings(R="sequence")
-    def equalize_grid(grid, **kwargs):
-        r"""
-        Perform histogram equalization for a grid.
+
+@fmt_docstring
+@use_alias(
+    C="divisions",
+    R="region",
+    N="gaussian",
+    Q="quadratic",
+    V="verbose",
+)
+@kwargs_to_strings(R="sequence")
+def equalize_grid(grid, outgrid=True, **kwargs):
+    r"""
+    Perform histogram equalization for a grid.
 
 
-        :meth:`pygmt.grdhisteq.equalize_grid` provides a way to write a grid
-        with statistics based on a cumulative distribution function. The
-        ``outgrid`` has relative highs and lows in the same (x,y) locations as
-        the ``grid``, but the values are changed to reflect their place in the
-        cumulative distribution.
+    :meth:`pygmt.grdhisteq.equalize_grid` provides a way to write a grid
+    with statistics based on a cumulative distribution function. The
+    ``outgrid`` has relative highs and lows in the same (x,y) locations as
+    the ``grid``, but the values are changed to reflect their place in the
+    cumulative distribution.
 
-        Full option list at :gmt-docs:`grdhisteq.html`
+    Full option list at :gmt-docs:`grdhisteq.html`
 
-        {aliases}
+    {aliases}
 
-        Parameters
-        ----------
-        grid : str or xarray.DataArray
-            The file name of the input grid or the grid loaded as a DataArray.
-        outgrid : str or bool or None
-            The name of the output netCDF file with extension .nc to store the
-            grid in.
-        divisions : int
-            Set the number of divisions of the data range.
+    Parameters
+    ----------
+    grid : str or xarray.DataArray
+        The file name of the input grid or the grid loaded as a DataArray.
+    outgrid : str or bool or None
+        The name of the output netCDF file with extension .nc to store the
+        grid in.
+    divisions : int
+        Set the number of divisions of the data range.
 
-        {R}
-        {V}
+    {R}
+    {V}
 
-        Returns
-        -------
-        ret: xarray.DataArray or None
-            Return type depends on the ``outgrid`` parameter:
+    Returns
+    -------
+    ret: xarray.DataArray or None
+        Return type depends on the ``outgrid`` parameter:
 
-            - xarray.DataArray if ``outgrid`` is True or None
-            - None if ``outgrid`` is a str (grid output is stored in
-              ``outgrid``)
+        - xarray.DataArray if ``outgrid`` is True or None
+        - None if ``outgrid`` is a str (grid output is stored in ``outgrid``)
 
-        See Also
-        -------
-        :meth:`pygmt.grd2cpt`
-        """
-        return grdhisteq._grdhisteq(grid, **kwargs)
+    """
+    if isinstance(outgrid, str):
+        output_type = "file"
+    else:
+        output_type = "xarray"
+    return _grdhisteq(grid=grid, outgrid=outgrid, output_type=output_type, **kwargs)
 
-    @staticmethod
-    @fmt_docstring
-    @use_alias(
-        C="divisions",
-        D="outfile",
-        R="region",
-        N="gaussian",
-        Q="quadratic",
-        V="verbose",
-    )
-    @kwargs_to_strings(R="sequence")
-    def compute_bins(grid, **kwargs):
-        r"""
-        Perform histogram equalization for a grid.
 
-        Histogram equalization provides a way to highlight data that has most
-        values clustered in a small portion of the dynamic range, such as a
-        grid of flat topography with a mountain in the middle. Ordinary gray
-        shading of this grid (using :meth:`pygmt.Figure.grdimage` or
-        :meth:`pygmt.Figure.grdview`) with a linear mapping from topography to
-        graytone will result in most of the image being very dark gray, with
-        the mountain being almost white. :meth:`pygmt.grdhisteq.compute_bins`
-        can provide a list of data values that divide the data range into
-        divisions which have an equal area in the image [Default is 16 if
-        ``divisions`` is not set]. The :class:`pandas.DataFrame` or ASCII file
-        output can be used to make a colormap with :meth:`pygmt.makecpt` and an
-        image with :meth:`pygmt.Figure.grdimage` that has all levels of gray
-        occuring equally.
+@fmt_docstring
+@use_alias(
+    C="divisions",
+    R="region",
+    N="gaussian",
+    Q="quadratic",
+    V="verbose",
+)
+@kwargs_to_strings(R="sequence")
+def compute_bins(grid, output_type="pandas", outfile=None, **kwargs):
+    r"""
+    Perform histogram equalization for a grid.
 
-        Full option list at :gmt-docs:`grdhisteq.html`
+    Histogram equalization provides a way to highlight data that has most
+    values clustered in a small portion of the dynamic range, such as a
+    grid of flat topography with a mountain in the middle. Ordinary gray
+    shading of this grid (using :meth:`pygmt.Figure.grdimage` or
+    :meth:`pygmt.Figure.grdview`) with a linear mapping from topography to
+    graytone will result in most of the image being very dark gray, with
+    the mountain being almost white. :meth:`pygmt.grdhisteq.compute_bins`
+    can provide a list of data values that divide the data range into
+    divisions which have an equal area in the image [Default is 16 if
+    ``divisions`` is not set]. The :class:`pandas.DataFrame` or ASCII file
+    output can be used to make a colormap with :meth:`pygmt.makecpt` and an
+    image with :meth:`pygmt.Figure.grdimage` that has all levels of gray
+    occuring equally.
 
-        {aliases}
+    Full option list at :gmt-docs:`grdhisteq.html`
 
-        Parameters
-        ----------
-        grid : str or xarray.DataArray
-            The file name of the input grid or the grid loaded as a DataArray.
-        outfile : str or bool or None
-            The name of the output ASCII file to store the results of the
-            histogram equalization in.
-        divisions : int
-            Set the number of divisions of the data range.
+    {aliases}
 
-        {R}
-        {V}
+    Parameters
+    ----------
+    grid : str or xarray.DataArray
+        The file name of the input grid or the grid loaded as a DataArray.
+    output_type : str
+        Determine the format the xyz data will be returned in [Default is
+        ``pandas``]:
 
-        Returns
-        -------
-        ret: pandas.DataFrame None
-            Return type depends on the ``outfile`` parameter:
+            - ``numpy`` - :class:`numpy.ndarray`
+            - ``pandas``- :class:`pandas.DataFrame`
+            - ``file`` - ASCII file (requires ``outfile``)
+    outfile : str
+        The file name for the output ASCII file.
+    divisions : int
+        Set the number of divisions of the data range.
 
-            - pandas.DataFrame if ``outfile`` is True or None
-            - None if ``outfile`` is a str (file output is stored in
-              ``outfile``)
+    {R}
+    {V}
 
-        See Also
-        -------
-        :meth:`pygmt.grd2cpt`
-        """
-        return grdhisteq._grdhisteq(grid, **kwargs)
+    Returns
+    -------
+    ret : pandas.DataFrame or numpy.ndarray or None
+        Return type depends on ``outfile`` and ``output_type``:
+
+        - None if ``outfile`` is set (output will be stored in file set by
+          ``outfile``)
+        - :class:`pandas.DataFrame` or :class:`numpy.ndarray` if ``outfile`` is
+          not set (depends on ``output_type``)
+
+    See Also
+    -------
+    :meth:`pygmt.grd2cpt`
+    """
+    if output_type not in ["numpy", "pandas", "file"]:
+        raise GMTInvalidInput(
+            "Must specify 'output_type' either as 'numpy', 'pandas' or 'file'."
+        )
+
+    if outfile is not None and output_type != "file":
+        msg = (
+            f"Changing 'output_type' of grd2xyz from '{output_type}' to 'file' "
+            "since 'outfile' parameter is set. Please use output_type='file' "
+            "to silence this warning."
+        )
+        warnings.warn(message=msg, category=RuntimeWarning, stacklevel=2)
+        output_type = "file"
+    return _grdhisteq(grid, outfile=outfile, output_type=output_type, **kwargs)

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -5,6 +5,7 @@ from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     build_arg_string,
+    check_data_input_order,
     data_kind,
     deprecate_parameter,
     fmt_docstring,
@@ -18,6 +19,7 @@ from pygmt.src.which import which
 @fmt_docstring
 @deprecate_parameter("sizes", "size", "v0.4.0", remove_version="v0.6.0")
 @deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
+@check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(
     A="straight_line",
     B="frame",
@@ -53,7 +55,7 @@ from pygmt.src.which import which
     w="wrap",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
-def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
+def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
     r"""
     Plot lines, polygons, and symbols in 2-D.
 
@@ -81,14 +83,14 @@ def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
 
     Parameters
     ----------
-    x/y : float or 1d arrays
-        The x and y coordinates, or arrays of x and y coordinates of the
-        data points
     data : str or {table-like}
         Pass in either a file name to an ASCII data table, a 2D
         {table-classes}.
         Use parameter ``incols`` to choose which columns are x, y, color, and
         size, respectively.
+    x/y : float or 1d arrays
+        The x and y coordinates, or arrays of x and y coordinates of the
+        data points
     size : 1d array
         The size of the data points in units specified using ``style``.
         Only valid if using ``x``/``y``.

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -5,6 +5,7 @@ from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     build_arg_string,
+    check_data_input_order,
     data_kind,
     deprecate_parameter,
     fmt_docstring,
@@ -18,6 +19,7 @@ from pygmt.src.which import which
 @fmt_docstring
 @deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
 @deprecate_parameter("sizes", "size", "v0.4.0", remove_version="v0.6.0")
+@check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(
     A="straight_line",
     B="frame",
@@ -54,7 +56,7 @@ from pygmt.src.which import which
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 def plot3d(
-    self, x=None, y=None, z=None, data=None, size=None, direction=None, **kwargs
+    self, data=None, x=None, y=None, z=None, size=None, direction=None, **kwargs
 ):
     r"""
     Plot lines, polygons, and symbols in 3-D.
@@ -83,13 +85,13 @@ def plot3d(
 
     Parameters
     ----------
-    x/y/z : float or 1d arrays
-        The x, y, and z coordinates, or arrays of x, y and z coordinates of
-        the data points
     data : str or {table-like}
         Either a data file name, a 2d {table-classes}.
         Optionally, use parameter ``incols`` to specify which columns are x, y,
         z, color, and size, respectively.
+    x/y/z : float or 1d arrays
+        The x, y, and z coordinates, or arrays of x, y and z coordinates of
+        the data points
     size : 1d array
         The size of the data points in units specified in ``style``.
         Only valid if using ``x``/``y``/``z``.

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -5,6 +5,7 @@ rose - Plot windrose diagrams or polar histograms.
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_string,
+    check_data_input_order,
     deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
@@ -14,6 +15,7 @@ from pygmt.helpers import (
 
 @fmt_docstring
 @deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
+@check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(
     A="sector",
     B="frame",
@@ -47,7 +49,7 @@ from pygmt.helpers import (
     w="wrap",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
-def rose(self, length=None, azimuth=None, data=None, **kwargs):
+def rose(self, data=None, length=None, azimuth=None, **kwargs):
     """
     Plot windrose diagrams or polar histograms.
 
@@ -67,10 +69,6 @@ def rose(self, length=None, azimuth=None, data=None, **kwargs):
 
     Parameters
     ----------
-    length/azimuth : float or 1d arrays
-        Length and azimuth values, or arrays of length and azimuth
-        values
-
     data : str or {table-like}
         Pass in either a file name to an ASCII data table, a 2D
         {table-classes}.
@@ -78,6 +76,10 @@ def rose(self, length=None, azimuth=None, data=None, **kwargs):
         respectively. If a file with only azimuths is given, use ``columns`` to
         indicate the single column with azimuths; then all lengths are set to
         unity (see ``scale = 'u'`` to set actual lengths to unity as well).
+
+    length/azimuth : float or 1d arrays
+        Length and azimuth values, or arrays of length and azimuth
+        values
 
     orientation : bool
         Specifies that the input data are orientation data (i.e., have a

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -6,6 +6,7 @@ from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,
     build_arg_string,
+    check_data_input_order,
     deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
@@ -16,6 +17,7 @@ from pygmt.io import load_dataarray
 
 @fmt_docstring
 @deprecate_parameter("outfile", "outgrid", "v0.5.0", remove_version="v0.7.0")
+@check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(
     I="spacing",
     R="region",
@@ -32,7 +34,7 @@ from pygmt.io import load_dataarray
     w="wrap",
 )
 @kwargs_to_strings(R="sequence")
-def surface(x=None, y=None, z=None, data=None, **kwargs):
+def surface(data=None, x=None, y=None, z=None, **kwargs):
     r"""
     Grids table data using adjustable tension continuous curvature splines.
 
@@ -54,12 +56,12 @@ def surface(x=None, y=None, z=None, data=None, **kwargs):
 
     Parameters
     ----------
-    x/y/z : 1d arrays
-        Arrays of x and y coordinates and values z of the data points.
     data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2D
         {table-classes}.
+    x/y/z : 1d arrays
+        Arrays of x and y coordinates and values z of the data points.
 
     {I}
 

--- a/pygmt/src/which.py
+++ b/pygmt/src/which.py
@@ -15,7 +15,7 @@ from pygmt.helpers import (
 @use_alias(G="download", V="verbose")
 @kwargs_to_strings(fname="sequence_space")
 def which(fname, **kwargs):
-    """
+    r"""
     Find the full path to specified files.
 
     Reports the full paths to the files given through *fname*. We look for
@@ -37,10 +37,16 @@ def which(fname, **kwargs):
     fname : str or list
         One or more file names of any data type (grids, tables, etc.).
     download : bool or str
-        If the file is downloadable and not found, we will try to download the
-        it. Use True or 'l' (default) to download to the current directory. Use
-        'c' to place in the user cache directory or 'u' user data directory
-        instead.
+        [**a**\|\ **c**\|\ **l**\|\ **u**].
+        If the fname argument is a downloadable file (either a complete URL, an
+        @file for downloading from the GMT data server, or @earth_relief_xxy)
+        we will try to download the file if it is not found in your local data
+        or cache dirs. By default [``download=True`` or ``download="l"``] we
+        download to the current directory. Use **a** to place files in the
+        appropriate folder under the user directory (this is where GMT normally
+        places downloaded files), **c** to place it in the user cache
+        directory, or **u** for the user data directory instead (i.e., ignoring
+        any subdirectory structure).
     {V}
 
     Returns

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -4,6 +4,7 @@ wiggle - Plot z=f(x,y) anomalies along tracks.
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_string,
+    check_data_input_order,
     deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
@@ -13,6 +14,7 @@ from pygmt.helpers import (
 
 @fmt_docstring
 @deprecate_parameter("columns", "incols", "v0.5.0", remove_version="v0.7.0")
+@check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(
     B="frame",
     D="position",
@@ -39,7 +41,7 @@ from pygmt.helpers import (
     w="wrap",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
-def wiggle(self, x=None, y=None, z=None, data=None, **kwargs):
+def wiggle(self, data=None, x=None, y=None, z=None, **kwargs):
     r"""
     Plot z=f(x,y) anomalies along tracks.
 

--- a/pygmt/tests/test_blockm.py
+++ b/pygmt/tests/test_blockm.py
@@ -26,7 +26,7 @@ def test_blockmean_input_dataframe(dataframe):
     """
     Run blockmean by passing in a pandas.DataFrame as input.
     """
-    output = blockmean(table=dataframe, spacing="5m", region=[245, 255, 20, 30])
+    output = blockmean(data=dataframe, spacing="5m", region=[245, 255, 20, 30])
     assert isinstance(output, pd.DataFrame)
     assert all(dataframe.columns == output.columns)
     assert output.shape == (5849, 3)
@@ -40,7 +40,7 @@ def test_blockmean_input_table_matrix(array_func, dataframe):
     matrix.
     """
     table = array_func(dataframe)
-    output = blockmean(table=table, spacing="5m", region=[245, 255, 20, 30])
+    output = blockmean(data=table, spacing="5m", region=[245, 255, 20, 30])
     assert isinstance(output, pd.DataFrame)
     assert output.shape == (5849, 3)
     npt.assert_allclose(output.iloc[0], [245.888877, 29.978707, -384.0])
@@ -70,7 +70,7 @@ def test_blockmean_wrong_kind_of_input_table_grid(dataframe):
     invalid_table = dataframe.bathymetry.to_xarray()
     assert data_kind(invalid_table) == "grid"
     with pytest.raises(GMTInvalidInput):
-        blockmean(table=invalid_table, spacing="5m", region=[245, 255, 20, 30])
+        blockmean(data=invalid_table, spacing="5m", region=[245, 255, 20, 30])
 
 
 def test_blockmean_input_filename():
@@ -79,7 +79,7 @@ def test_blockmean_input_filename():
     """
     with GMTTempFile() as tmpfile:
         output = blockmean(
-            table="@tut_ship.xyz",
+            data="@tut_ship.xyz",
             spacing="5m",
             region=[245, 255, 20, 30],
             outfile=tmpfile.name,
@@ -95,7 +95,7 @@ def test_blockmean_without_outfile_setting():
     """
     Run blockmean by not passing in outfile parameter setting.
     """
-    output = blockmean(table="@tut_ship.xyz", spacing="5m", region=[245, 255, 20, 30])
+    output = blockmean(data="@tut_ship.xyz", spacing="5m", region=[245, 255, 20, 30])
     assert isinstance(output, pd.DataFrame)
     assert output.shape == (5849, 3)
     npt.assert_allclose(output.iloc[0], [245.888877, 29.978707, -384.0])
@@ -105,7 +105,7 @@ def test_blockmode_input_dataframe(dataframe):
     """
     Run blockmode by passing in a pandas.DataFrame as input.
     """
-    output = blockmode(table=dataframe, spacing="5m", region=[245, 255, 20, 30])
+    output = blockmode(data=dataframe, spacing="5m", region=[245, 255, 20, 30])
     assert isinstance(output, pd.DataFrame)
     assert all(dataframe.columns == output.columns)
     assert output.shape == (5849, 3)

--- a/pygmt/tests/test_blockmedian.py
+++ b/pygmt/tests/test_blockmedian.py
@@ -24,7 +24,7 @@ def test_blockmedian_input_dataframe(dataframe):
     """
     Run blockmedian by passing in a pandas.DataFrame as input.
     """
-    output = blockmedian(table=dataframe, spacing="5m", region=[245, 255, 20, 30])
+    output = blockmedian(data=dataframe, spacing="5m", region=[245, 255, 20, 30])
     assert isinstance(output, pd.DataFrame)
     assert all(dataframe.columns == output.columns)
     assert output.shape == (5849, 3)
@@ -37,7 +37,7 @@ def test_blockmedian_input_table_matrix(dataframe):
     a matrix.
     """
     table = dataframe.values
-    output = blockmedian(table=table, spacing="5m", region=[245, 255, 20, 30])
+    output = blockmedian(data=table, spacing="5m", region=[245, 255, 20, 30])
     assert isinstance(output, pd.DataFrame)
     assert output.shape == (5849, 3)
     npt.assert_allclose(output.iloc[0], [245.88819, 29.97895, -385.0])
@@ -67,7 +67,7 @@ def test_blockmedian_wrong_kind_of_input_table_grid(dataframe):
     invalid_table = dataframe.bathymetry.to_xarray()
     assert data_kind(invalid_table) == "grid"
     with pytest.raises(GMTInvalidInput):
-        blockmedian(table=invalid_table, spacing="5m", region=[245, 255, 20, 30])
+        blockmedian(data=invalid_table, spacing="5m", region=[245, 255, 20, 30])
 
 
 def test_blockmedian_input_filename():
@@ -76,7 +76,7 @@ def test_blockmedian_input_filename():
     """
     with GMTTempFile() as tmpfile:
         output = blockmedian(
-            table="@tut_ship.xyz",
+            data="@tut_ship.xyz",
             spacing="5m",
             region=[245, 255, 20, 30],
             outfile=tmpfile.name,
@@ -92,7 +92,7 @@ def test_blockmedian_without_outfile_setting():
     """
     Run blockmedian by not passing in outfile parameter setting.
     """
-    output = blockmedian(table="@tut_ship.xyz", spacing="5m", region=[245, 255, 20, 30])
+    output = blockmedian(data="@tut_ship.xyz", spacing="5m", region=[245, 255, 20, 30])
     assert isinstance(output, pd.DataFrame)
     assert output.shape == (5849, 3)
     npt.assert_allclose(output.iloc[0], [245.88819, 29.97895, -385.0])

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -805,16 +805,18 @@ def test_dataarray_to_matrix_dims_fails():
         dataarray_to_matrix(grid)
 
 
-def test_dataarray_to_matrix_inc_fails():
+def test_dataarray_to_matrix_irregular_inc_warning():
     """
-    Check that it fails for variable increments.
+    Check that it warns for variable increments, see also
+    https://github.com/GenericMappingTools/pygmt/issues/1468.
     """
     data = np.ones((4, 5), dtype="float64")
     x = np.linspace(0, 1, 5)
     y = np.logspace(2, 3, 4)
     grid = xr.DataArray(data, coords=[("y", y), ("x", x)])
-    with pytest.raises(GMTInvalidInput):
+    with pytest.warns(expected_warning=RuntimeWarning) as record:
         dataarray_to_matrix(grid)
+        assert len(record) == 1
 
 
 def test_dataarray_to_matrix_zero_inc_fails():

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -98,7 +98,7 @@ def test_contour_deprecate_columns_to_incols(region):
 
     with pytest.warns(expected_warning=FutureWarning) as record:
         fig.contour(
-            data=data,
+            data,
             projection="X10c",
             region=region,
             frame="a",

--- a/pygmt/tests/test_grdhisteq.py
+++ b/pygmt/tests/test_grdhisteq.py
@@ -61,7 +61,7 @@ def fixture_df_result():
     ).astype({0: np.float64, 1: np.float64, 2: np.int64})
 
 
-def test_grdhisteq_outgrid_file(grid, expected_grid):
+def test_equalize_grid_file_output(grid, expected_grid):
     """
     Test the gaussian parameter of grdhisteq with a set outgrid.
     """
@@ -75,7 +75,7 @@ def test_grdhisteq_outgrid_file(grid, expected_grid):
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
-def test_grdhisteq_outgrid(grid, expected_grid):
+def test_equalize_grid_xarray_output(grid, expected_grid):
     """
     Test the quadratic and region parameters for grdhisteq with
     ``outgrid=True``.
@@ -88,24 +88,30 @@ def test_grdhisteq_outgrid(grid, expected_grid):
     xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
-def test_grdhisteq_no_outgrid(grid, expected_df):
+def test_compute_bins_pandas_output(grid, expected_df):
     """
-    Test the quadratic and region parameters for grdhisteq with no ``outgrid``.
+    Test the quadratic and region parameters for grdhisteq with
+    ``output_type``="pandas".
     """
     temp_df = grdhisteq.compute_bins(
-        grid=grid, quadratic=True, region=[-3, 1, 2, 5], outfile=True
+        grid=grid, quadratic=True, region=[-3, 1, 2, 5], output_type="pandas"
     )
     assert isinstance(temp_df, pd.DataFrame)
     pd.testing.assert_frame_equal(left=temp_df, right=expected_df)
 
 
-def test_grdhisteq_outfile(grid, expected_df):
+def test_compute_bins_file_output(grid, expected_df):
     """
-    Test the quadratic and region parameters for grdhisteq with no ``outgrid``.
+    Test the quadratic and region parameters for grdhisteq with
+    ``output_type``="file".
     """
     with GMTTempFile(suffix=".txt") as tmpfile:
         result = grdhisteq.compute_bins(
-            grid=grid, quadratic=True, region=[-3, 1, 2, 5], outfile=tmpfile.name
+            grid=grid,
+            quadratic=True,
+            region=[-3, 1, 2, 5],
+            output_type="file",
+            outfile=tmpfile.name,
         )
         assert result is None  # return value is None
         assert os.path.exists(path=tmpfile.name)

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -435,27 +435,27 @@ def test_plot_datetime():
         ["2010-06-01", "2011-06-01T12", "2012-01-01T12:34:56"], dtype="datetime64"
     )
     y = [1.0, 2.0, 3.0]
-    fig.plot(x, y, style="c0.2c", pen="1p")
+    fig.plot(x=x, y=y, style="c0.2c", pen="1p")
 
     # pandas.DatetimeIndex
     x = pd.date_range("2013", freq="YS", periods=3)
     y = [4, 5, 6]
-    fig.plot(x, y, style="t0.2c", pen="1p")
+    fig.plot(x=x, y=y, style="t0.2c", pen="1p")
 
     # xarray.DataArray
     x = xr.DataArray(data=pd.date_range(start="2015-03", freq="QS", periods=3))
     y = [7.5, 6, 4.5]
-    fig.plot(x, y, style="s0.2c", pen="1p")
+    fig.plot(x=x, y=y, style="s0.2c", pen="1p")
 
     # raw datetime strings
     x = ["2016-02-01", "2017-03-04T00:00"]
     y = [7, 8]
-    fig.plot(x, y, style="a0.2c", pen="1p")
+    fig.plot(x=x, y=y, style="a0.2c", pen="1p")
 
     # the Python built-in datetime and date
     x = [datetime.date(2018, 1, 1), datetime.datetime(2019, 1, 1)]
     y = [8.5, 9.5]
-    fig.plot(x, y, style="i0.2c", pen="1p")
+    fig.plot(x=x, y=y, style="i0.2c", pen="1p")
     return fig
 
 

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -319,7 +319,7 @@ def test_plot3d_matrix(data, region):
     """
     fig = Figure()
     fig.plot3d(
-        data=data,
+        data,
         zscale=5,
         perspective=[225, 30],
         region=region,
@@ -343,7 +343,7 @@ def test_plot3d_matrix_color(data, region):
     """
     fig = Figure()
     fig.plot3d(
-        data=data,
+        data,
         zscale=5,
         perspective=[225, 30],
         region=region,
@@ -464,7 +464,7 @@ def test_plot3d_deprecate_columns_to_incols(data, region):
     fig = Figure()
     with pytest.warns(expected_warning=FutureWarning) as record:
         fig.plot3d(
-            data=data,
+            data,
             zscale=5,
             perspective=[225, 30],
             region=region,

--- a/pygmt/tests/test_rose.py
+++ b/pygmt/tests/test_rose.py
@@ -202,7 +202,7 @@ def test_rose_deprecate_columns_to_incols(data_fractures_compilation):
     fig = Figure()
     with pytest.warns(expected_warning=FutureWarning) as record:
         fig.rose(
-            data=data,
+            data,
             region=[0, 1, 0, 360],
             sector=10,
             columns=[1, 0],

--- a/pygmt/tests/test_wiggle.py
+++ b/pygmt/tests/test_wiggle.py
@@ -50,9 +50,9 @@ def test_wiggle_deprecate_columns_to_incols():
     fig = Figure()
     with pytest.warns(expected_warning=FutureWarning) as record:
         fig.wiggle(
+            data,
             region=[-4, 4, -1, 1],
             projection="X8c",
-            data=data,
             columns=[1, 0, 2],
             scale="0.5c",
             color=["red+p", "gray+n"],


### PR DESCRIPTION
**Description of proposed changes**

This PR modifies #1433 by splitting the grdhisteq module into two functions, compute_bins and equalize_grid which output tabular or gridded data respectively. 

Note that the target branch for the PR is grdhisteq, not main. I opened this as a separate PR from #1433 to facilitate discussion about the API for modules that can output grids or tables.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Relates to #1536


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
