### PR TITLE
Refactor x2sys_cross to remove verbose info and return output statements

### DIFF
--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -44,14 +44,12 @@ def test_x2sys_cross_input_file_output_file(mock_x2sys_home):
         x2sys_init(tag=tag, fmtfile="xyz", force=True)
         outfile = os.path.join(tmpdir, "tmp_coe.txt")
         output = x2sys_cross(
-            tracks=["@tut_ship.xyz"], tag=tag, coe="i", outfile=outfile, verbose="i"
+            tracks=["@tut_ship.xyz"], tag=tag, coe="i", outfile=outfile
         )
 
         assert output is None  # check that output is None since outfile is set
         assert os.path.exists(path=outfile)  # check that outfile exists at path
         _ = pd.read_csv(outfile, sep="\t", header=2)  # ensure ASCII text file loads ok
-
-    return output
 
 
 def test_x2sys_cross_input_file_output_dataframe(mock_x2sys_home):
@@ -62,15 +60,13 @@ def test_x2sys_cross_input_file_output_dataframe(mock_x2sys_home):
     with TemporaryDirectory(prefix="X2SYS", dir=os.getcwd()) as tmpdir:
         tag = os.path.basename(tmpdir)
         x2sys_init(tag=tag, fmtfile="xyz", force=True)
-        output = x2sys_cross(tracks=["@tut_ship.xyz"], tag=tag, coe="i", verbose="i")
+        output = x2sys_cross(tracks=["@tut_ship.xyz"], tag=tag, coe="i")
 
         assert isinstance(output, pd.DataFrame)
         assert output.shape == (14294, 12)
         columns = list(output.columns)
         assert columns[:6] == ["x", "y", "i_1", "i_2", "dist_1", "dist_2"]
         assert columns[6:] == ["head_1", "head_2", "vel_1", "vel_2", "z_X", "z_M"]
-
-    return output
 
 
 def test_x2sys_cross_input_dataframe_output_dataframe(mock_x2sys_home, tracks):
@@ -82,7 +78,7 @@ def test_x2sys_cross_input_dataframe_output_dataframe(mock_x2sys_home, tracks):
         tag = os.path.basename(tmpdir)
         x2sys_init(tag=tag, fmtfile="xyz", force=True)
 
-        output = x2sys_cross(tracks=tracks, tag=tag, coe="i", verbose="i")
+        output = x2sys_cross(tracks=tracks, tag=tag, coe="i")
 
         assert isinstance(output, pd.DataFrame)
         assert output.shape == (14, 12)
@@ -91,8 +87,6 @@ def test_x2sys_cross_input_dataframe_output_dataframe(mock_x2sys_home, tracks):
         assert columns[6:] == ["head_1", "head_2", "vel_1", "vel_2", "z_X", "z_M"]
         assert output.dtypes["i_1"].type == np.object_
         assert output.dtypes["i_2"].type == np.object_
-
-    return output
 
 
 def test_x2sys_cross_input_two_dataframes(mock_x2sys_home):
@@ -120,7 +114,7 @@ def test_x2sys_cross_input_two_dataframes(mock_x2sys_home):
             track["time"] = pd.date_range(start=f"2020-{i}1-01", periods=10, freq="ms")
             tracks.append(track)
 
-        output = x2sys_cross(tracks=tracks, tag=tag, coe="e", verbose="i")
+        output = x2sys_cross(tracks=tracks, tag=tag, coe="e")
 
         assert isinstance(output, pd.DataFrame)
         assert output.shape == (30, 12)
@@ -171,9 +165,7 @@ def test_x2sys_cross_input_two_filenames(mock_x2sys_home):
             ) as fname:
                 np.savetxt(fname=fname, X=np.random.rand(10, 3))
 
-        output = x2sys_cross(
-            tracks=["track_0.xyz", "track_1.xyz"], tag=tag, coe="e", verbose="i"
-        )
+        output = x2sys_cross(tracks=["track_0.xyz", "track_1.xyz"], tag=tag, coe="e")
 
         assert isinstance(output, pd.DataFrame)
         assert output.shape == (24, 12)
@@ -181,8 +173,6 @@ def test_x2sys_cross_input_two_filenames(mock_x2sys_home):
         assert columns[:6] == ["x", "y", "i_1", "i_2", "dist_1", "dist_2"]
         assert columns[6:] == ["head_1", "head_2", "vel_1", "vel_2", "z_X", "z_M"]
         _ = [os.remove(f"track_{i}.xyz") for i in range(2)]  # cleanup track files
-
-    return output
 
 
 def test_x2sys_cross_invalid_tracks_input_type(tracks):


### PR DESCRIPTION
**Description of proposed changes**

Silences captured stderr messages in the log. Patches #546.

```python-traceback
___________________ test_x2sys_cross_input_file_output_file ____________________
----------------------------- Captured stderr call -----------------------------
x2sys_cross [INFORMATION]: Files found: 1
x2sys_cross [INFORMATION]: Checking for duplicates :
x2sys_cross [INFORMATION]: 0 found
Warning: ss [WARNING]: No time column, use dummy times
Not a valid unit: c [meter assumed]
Not a valid unit: c [meter assumed]
x2sys_cross [INFORMATION]: Writing Data Table to file /home/runner/work/pygmt/pygmt/tmp-test-dir-with-unique-name/X2SYSr58ly6wo/tmp_coe.txt
x2sys_cross [INFORMATION]: Processing @tut_ship - @tut_ship : 14294
_________________ test_x2sys_cross_input_file_output_dataframe _________________
----------------------------- Captured stderr call -----------------------------
x2sys_cross [INFORMATION]: Files found: 1
x2sys_cross [INFORMATION]: Checking for duplicates :
x2sys_cross [INFORMATION]: 0 found
Warning: ss [WARNING]: No time column, use dummy times
Not a valid unit: c [meter assumed]
Not a valid unit: c [meter assumed]
x2sys_cross [INFORMATION]: Writing Data Table to file /tmp/pygmt-hmkwjhzz.txt
x2sys_cross [INFORMATION]: Processing @tut_ship - @tut_ship : 14294
______________ test_x2sys_cross_input_dataframe_output_dataframe _______________
----------------------------- Captured stderr call -----------------------------
x2sys_cross [INFORMATION]: Files found: 1
x2sys_cross [INFORMATION]: Checking for duplicates :
x2sys_cross [INFORMATION]: 0 found
Warning: ss [WARNING]: No time column, use dummy times
Not a valid unit: c [meter assumed]
Not a valid unit: c [meter assumed]
x2sys_cross [INFORMATION]: Writing Data Table to file /tmp/pygmt-1o71k5fm.txt
x2sys_cross [INFORMATION]: Processing track-c48ce7c - track-c48ce7c : 14
____________________ test_x2sys_cross_input_two_dataframes _____________________
----------------------------- Captured stderr call -----------------------------
x2sys_cross [INFORMATION]: Files found: 2
x2sys_cross [INFORMATION]: Checking for duplicates :
x2sys_cross [INFORMATION]: 0 found
x2sys_cross [INFORMATION]: Writing Data Table to file /tmp/pygmt-twq1zmqn.txt
x2sys_cross [INFORMATION]: Processing track-ab8038e - track-ce196c4 : 30
__________________ test_x2sys_cross_input_dataframe_with_nan ___________________
----------------------------- Captured stderr call -----------------------------
Warning: ss [WARNING]: No time column, use dummy times
_____________________ test_x2sys_cross_input_two_filenames _____________________
----------------------------- Captured stderr call -----------------------------
x2sys_cross [INFORMATION]: Files found: 2
x2sys_cross [INFORMATION]: Checking for duplicates :
x2sys_cross [INFORMATION]: 0 found
Warning: ss [WARNING]: No time column, use dummy times
Not a valid unit: c [meter assumed]
Not a valid unit: c [meter assumed]
x2sys_cross [INFORMATION]: Writing Data Table to file /tmp/pygmt-qlquqjz8.txt
x2sys_cross [INFORMATION]: Processing track_0 - track_1 : 24
_______________ test_x2sys_cross_region_interpolation_numpoints ________________
----------------------------- Captured stderr call -----------------------------
Warning: ss [WARNING]: No time column, use dummy times
Not a valid unit: c [meter assumed]
Not a valid unit: c [meter assumed]
_________________________ test_x2sys_cross_trackvalues _________________________
----------------------------- Captured stderr call -----------------------------
Warning: ss [WARNING]: No time column, use dummy times
Not a valid unit: c [meter assumed]
Not a valid unit: c [meter assumed]
```


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
