### PR TITLE
Use xarray.testing rather than pygmt.grdinfo in grdcut tests

### DIFF
--- a/pygmt/tests/test_grdcut.py
+++ b/pygmt/tests/test_grdcut.py
@@ -6,7 +6,7 @@ import os
 import numpy as np
 import pytest
 import xarray as xr
-from pygmt import grdcut, grdinfo
+from pygmt import grdcut, load_dataarray
 from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
@@ -20,67 +20,64 @@ def fixture_grid():
     return load_earth_relief(registration="pixel")
 
 
-def test_grdcut_file_in_file_out():
+@pytest.fixture(scope="module", name="expected_grid")
+def fixture_grid_result():
+    """
+    Load the expected grdhisteq grid result.
+    """
+    return xr.DataArray(
+        data=[
+            [-5069.5, -5105.0, -4937.0, -4708.0],
+            [-4115.5, -4996.0, -4762.0, -4599.0],
+            [-656.0, -160.0, -3484.5, -3897.5],
+        ],
+        coords=dict(lon=[-2.5, -1.5, -0.5, 0.5], lat=[2.5, 3.5, 4.5]),
+        dims=["lat", "lon"],
+    )
+
+
+def test_grdcut_file_in_file_out(expected_grid):
     """
     grdcut an input grid file, and output to a grid file.
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
-        result = grdcut("@earth_relief_01d", outgrid=tmpfile.name, region="0/180/0/90")
+        result = grdcut("@earth_relief_01d", outgrid=tmpfile.name, region="-3/1/2/5")
         assert result is None  # return value is None
         assert os.path.exists(path=tmpfile.name)  # check that outgrid exists
-        result = grdinfo(tmpfile.name, per_column=True)
-        assert result == "0 180 0 90 -8182 5651.5 1 1 180 90 1 1\n"
+        temp_grid = load_dataarray(tmpfile.name)
+        xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
-def test_grdcut_file_in_dataarray_out():
+def test_grdcut_file_in_dataarray_out(expected_grid):
     """
     grdcut an input grid file, and output as DataArray.
     """
-    outgrid = grdcut("@earth_relief_01d", region="0/180/0/90")
+    outgrid = grdcut("@earth_relief_01d", region="-3/1/2/5")
     assert isinstance(outgrid, xr.DataArray)
     assert outgrid.gmt.registration == 1  # Pixel registration
     assert outgrid.gmt.gtype == 1  # Geographic type
     # check information of the output grid
-    # the '@earth_relief_01d' is in pixel registration, so the grid range is
-    # not exactly 0/180/0/90
-    assert outgrid.coords["lat"].data.min() == 0.5
-    assert outgrid.coords["lat"].data.max() == 89.5
-    assert outgrid.coords["lon"].data.min() == 0.5
-    assert outgrid.coords["lon"].data.max() == 179.5
-    assert outgrid.data.min() == -8182.0
-    assert outgrid.data.max() == 5651.5
-    assert outgrid.sizes["lat"] == 90
-    assert outgrid.sizes["lon"] == 180
+    xr.testing.assert_allclose(a=outgrid, b=expected_grid)
 
 
-def test_grdcut_dataarray_in_file_out(grid):
+def test_grdcut_dataarray_in_file_out(grid, expected_grid):
     """
     grdcut an input DataArray, and output to a grid file.
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
-        result = grdcut(grid, outgrid=tmpfile.name, region="0/180/0/90")
+        result = grdcut(grid, outgrid=tmpfile.name, region="-3/1/2/5")
         assert result is None  # grdcut returns None if output to a file
-        result = grdinfo(tmpfile.name, per_column=True)
-        assert result == "0 180 0 90 -8182 5651.5 1 1 180 90 1 1\n"
+        temp_grid = load_dataarray(tmpfile.name)
+        xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
-def test_grdcut_dataarray_in_dataarray_out(grid):
+def test_grdcut_dataarray_in_dataarray_out(grid, expected_grid):
     """
     grdcut an input DataArray, and output as DataArray.
     """
-    outgrid = grdcut(grid, region="0/180/0/90")
+    outgrid = grdcut(grid, region="-3/1/2/5")
     assert isinstance(outgrid, xr.DataArray)
-    # check information of the output grid
-    # the '@earth_relief_01d' is in pixel registration, so the grid range is
-    # not exactly 0/180/0/90
-    assert outgrid.coords["lat"].data.min() == 0.5
-    assert outgrid.coords["lat"].data.max() == 89.5
-    assert outgrid.coords["lon"].data.min() == 0.5
-    assert outgrid.coords["lon"].data.max() == 179.5
-    assert outgrid.data.min() == -8182.0
-    assert outgrid.data.max() == 5651.5
-    assert outgrid.sizes["lat"] == 90
-    assert outgrid.sizes["lon"] == 180
+    xr.testing.assert_allclose(a=outgrid, b=expected_grid)
 
 
 def test_grdcut_fails():


### PR DESCRIPTION
**Description of proposed changes**

This PR refactors the pygmt.grdcut tests to use xarray.testing.assert_allclose() rather than pygmt.grdinfo() in preparation for the deprecation associated with better return values for grdinfo (#593).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
