### PR TITLE
Increase minimum thumbnail height in style.css to fit text

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -209,6 +209,11 @@ a.copybtn {
     text-align: center!important;
 }
 
+.sphx-glr-thumbcontainer {
+    min-height: 240px !important;
+}
+
+
 .sphx-glr-single-img {
     max-width: 80%!important;
 }
@@ -230,13 +235,13 @@ a.copybtn {
 .team-img {
     border-radius: 0.5rem;
     width: 100%;
-    height: 15vh!important;
+    height: 20vh!important;
     object-fit: cover;
 }
 
 .team-card-body {
     padding: 1.25rem;
-    height: 100px;
+    height: 135px;
 }
 
 .team-card-text {


### PR DESCRIPTION
**Description of proposed changes**

Sphinx-gallery updated the [default thumbnail size in v0.9.0](https://sphinx-gallery.github.io/dev/configuration.html#setting-gallery-thumbnail-size), such that the text does not fit in our boxes in the [devdocs gallery](https://www.pygmt.org/dev/gallery/index.html). This PR increases the height slightly for the gallery and the team page so the text fits.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
