### PR TITLE
Document interpolation restriction for grdtrack xarray input

### DIFF
--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -251,7 +251,7 @@ def grdtrack(points, grid, newcolname=None, outfile=None, **kwargs):
     {i}
     {j}
     {n}
-        
+
         Note: Only bilinear or nearest-neighbor interpolation are currently
         available when ``grid`` is an :class:`xarray.DataArray`.
     {o}


### PR DESCRIPTION
**Description of proposed changes**

This PR documents the workaround to https://github.com/GenericMappingTools/pygmt/issues/1309 implemented in https://github.com/GenericMappingTools/gmt/pull/5283. 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
