### PR TITLE
Add alias for blockmean's -S parameter

### DIFF
--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -113,6 +113,7 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     {I}
 
     restype: str
+        [**m**\|\ **n**\|\ **s**\|\ **w**].
         Result type calculated by blockmean. Use **n** to report the number of
         input points inside each block, **s** to report the sum of all z-values
         inside a block, **w** to report the sum of weights [Default or **m**

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -114,7 +114,7 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
 
     summary: str
         [**m**\|\ **n**\|\ **s**\|\ **w**].
-        Type of summary values calculated by blockmean. 
+        Type of summary values calculated by blockmean.
         - **n**: report the number of input points inside each block
         - **s**: report the sum of all z-values inside a block
         - **w**: report the sum of weights

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -111,11 +111,11 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
         Arrays of x and y coordinates and values z of the data points.
 
     {I}
-    
+
     restype: str
-        Result type calculated by blockmean. Use **n** to report the number of 
-        input points inside each block, **s** to report the sum of all z-values 
-        inside a block, **w** to report the sum of weights [Default or **m** 
+        Result type calculated by blockmean. Use **n** to report the number of
+        input points inside each block, **s** to report the sum of all z-values
+        inside a block, **w** to report the sum of weights [Default or **m**
         reports mean value].
 
     {R}

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -70,7 +70,7 @@ def _blockm(block_method, data, x, y, z, outfile, **kwargs):
 @use_alias(
     I="spacing",
     R="region",
-    S="summarize",
+    S="summary",
     V="verbose",
     a="aspatial",
     b="binary",
@@ -112,12 +112,14 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
 
     {I}
 
-    summarize: str
+    summary: str
         [**m**\|\ **n**\|\ **s**\|\ **w**].
-        Type of summary values calculated by blockmean. Use **n** to report the
-        number of input points inside each block, **s** to report the sum of
-        all z-values inside a block, **w** to report the sum of weights
-        [Default or **m** reports mean value].
+        Type of summary values calculated by blockmean. 
+        
+        - **n**: report the number of input points inside each block
+        - **s**: report the sum of all z-values inside a block
+        - **w**: report the sum of weights
+        - **m**: report mean value [Default]
 
     {R}
 

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -70,6 +70,7 @@ def _blockm(block_method, data, x, y, z, outfile, **kwargs):
 @use_alias(
     I="spacing",
     R="region",
+    S="restype",
     V="verbose",
     a="aspatial",
     b="binary",
@@ -110,6 +111,12 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
         Arrays of x and y coordinates and values z of the data points.
 
     {I}
+    
+    restype: str
+        Result type calculated by blockmean. Use **n** to report the number of 
+        input points inside each block, **s** to report the sum of all z-values 
+        inside a block, **w** to report the sum of weights [Default or **m** 
+        reports mean value].
 
     {R}
 

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -115,6 +115,7 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     summary: str
         [**m**\|\ **n**\|\ **s**\|\ **w**].
         Type of summary values calculated by blockmean.
+
         - **n**: report the number of input points inside each block
         - **s**: report the sum of all z-values inside a block
         - **w**: report the sum of weights

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -112,14 +112,14 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
 
     {I}
 
-    summary: str
+    summary : str
         [**m**\|\ **n**\|\ **s**\|\ **w**].
         Type of summary values calculated by blockmean.
 
-        - **n**: report the number of input points inside each block
-        - **s**: report the sum of all z-values inside a block
-        - **w**: report the sum of weights
-        - **m**: report mean value [Default]
+        - **m** - reports mean value [Default]
+        - **n** - report the number of input points inside each block
+        - **s** - report the sum of all z-values inside a block
+        - **w** - report the sum of weights
 
     {R}
 

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -115,7 +115,6 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     summary: str
         [**m**\|\ **n**\|\ **s**\|\ **w**].
         Type of summary values calculated by blockmean. 
-        
         - **n**: report the number of input points inside each block
         - **s**: report the sum of all z-values inside a block
         - **w**: report the sum of weights

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -70,7 +70,7 @@ def _blockm(block_method, data, x, y, z, outfile, **kwargs):
 @use_alias(
     I="spacing",
     R="region",
-    S="restype",
+    S="summarize",
     V="verbose",
     a="aspatial",
     b="binary",
@@ -112,12 +112,12 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
 
     {I}
 
-    restype: str
+    summarize: str
         [**m**\|\ **n**\|\ **s**\|\ **w**].
-        Result type calculated by blockmean. Use **n** to report the number of
-        input points inside each block, **s** to report the sum of all z-values
-        inside a block, **w** to report the sum of weights [Default or **m**
-        reports mean value].
+        Type of summary values calculated by blockmean. Use **n** to report the
+        number of input points inside each block, **s** to report the sum of
+        all z-values inside a block, **w** to report the sum of weights
+        [Default or **m** reports mean value].
 
     {R}
 


### PR DESCRIPTION
**Description of proposed changes**

According to #1598 this PR add an alias for the -S parameter of blockmean.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
