### PR TITLE
Fix sphinx reference in pygmt/src/sphdistance.py

### DIFF
--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -38,7 +38,7 @@ def sphdistance(data=None, x=None, y=None, **kwargs):
     then processed to calculate the nearest distance to each
     node of the lattice and written to the specified grid.
 
-    Full option list at :gmt-docs:`sphdistance.html
+    Full option list at :gmt-docs:`sphdistance.html`
 
     {aliases}
 


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes a minor typo in the sphinx :gmt-docs: reference.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
