### PR TITLE
Mark two grdtrack tests as xfail due to upstream GMT 6.3 fixes

### DIFF
--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -6,6 +6,7 @@ import os
 import numpy.testing as npt
 import pandas as pd
 import pytest
+from packaging.version import Version
 from pygmt import clib, grdtrack, which
 from pygmt.datasets import load_earth_relief, load_ocean_ridge_points
 from pygmt.exceptions import GMTInvalidInput

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -6,7 +6,7 @@ import os
 import numpy.testing as npt
 import pandas as pd
 import pytest
-from pygmt import grdtrack, which
+from pygmt import clib, grdtrack, which
 from pygmt.datasets import load_earth_relief, load_ocean_ridge_points
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import data_kind

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -14,6 +14,9 @@ from pygmt.helpers import data_kind
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 TEMP_TRACK = os.path.join(TEST_DATA_DIR, "tmp_track.txt")
 
+with clib.Session() as _lib:
+    gmt_version = Version(_lib.info["version"])
+
 
 @pytest.fixture(scope="module", name="dataarray")
 def fixture_dataarray():
@@ -49,6 +52,10 @@ def fixture_ncfile():
     return which("@earth_relief_01d", download="a")
 
 
+@pytest.mark.xfail(
+    condition=gmt_version <= Version("6.2.0"),
+    reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/5893.",
+)
 def test_grdtrack_input_dataframe_and_dataarray(dataarray, dataframe):
     """
     Run grdtrack by passing in a pandas.DataFrame and xarray.DataArray as
@@ -57,11 +64,15 @@ def test_grdtrack_input_dataframe_and_dataarray(dataarray, dataframe):
     output = grdtrack(points=dataframe, grid=dataarray, newcolname="bathymetry")
     assert isinstance(output, pd.DataFrame)
     assert output.columns.to_list() == ["longitude", "latitude", "bathymetry"]
-    npt.assert_allclose(output.iloc[0], [-110.9536, -42.2489, -2790.488422])
+    npt.assert_allclose(output.iloc[0], [-110.9536, -42.2489, -2797.394987])
 
     return output
 
 
+@pytest.mark.xfail(
+    condition=gmt_version <= Version("6.2.0"),
+    reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/5893.",
+)
 def test_grdtrack_input_csvfile_and_dataarray(dataarray, csvfile):
     """
     Run grdtrack by passing in a csvfile and xarray.DataArray as inputs.
@@ -72,7 +83,7 @@ def test_grdtrack_input_csvfile_and_dataarray(dataarray, csvfile):
         assert os.path.exists(path=TEMP_TRACK)  # check that outfile exists at path
 
         track = pd.read_csv(TEMP_TRACK, sep="\t", header=None, comment=">")
-        npt.assert_allclose(track.iloc[0], [-110.9536, -42.2489, -2790.488422])
+        npt.assert_allclose(track.iloc[0], [-110.9536, -42.2489, -2797.394987])
     finally:
         os.remove(path=TEMP_TRACK)
 


### PR DESCRIPTION
**Description of proposed changes**

Using correct output values for `grdtrack` with bicubic interpolation on `xarray.DataArray` grids on GMT 6.3.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes https://github.com/GenericMappingTools/pygmt/issues/1309#issuecomment-953452875, Supersedes #1587.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
