### PR TITLE
Fix missing gcmt convention keys in pygmt.meca

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -249,7 +249,16 @@ def meca(
 
         param_conventions = {
             "AKI": ["strike", "dip", "rake", "magnitude"],
-            "GCMT": ["strike1", "dip1", "dip2", "rake2", "mantissa", "exponent"],
+            "GCMT": [
+                "strike1",
+                "dip1",
+                "rake1",
+                "strike2",
+                "dip2",
+                "rake2",
+                "mantissa",
+                "exponent",
+            ],
             "MT": ["mrr", "mtt", "mff", "mrt", "mrf", "mtf", "exponent"],
             "PARTIAL": ["strike1", "dip1", "strike2", "fault_type", "magnitude"],
             "PRINCIPAL_AXIS": [

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -110,7 +110,7 @@ def data_format_code(convention, component="full"):
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def meca(
-    self,  # pylint: disable=unused-argument
+    self,
     spec,
     scale,
     longitude=None,
@@ -284,23 +284,21 @@ def meca(
             "plot_latitude": plot_latitude,
         }
 
-        # make a DataFrame copy to check convention if it contains
-        # other parameters
-        if isinstance(spec, (dict, pd.DataFrame)):
-            # check if a copy is necessary
-            copy = False
-            drop_list = []
-            for pointer in data_pointers:
-                if pointer in spec:
-                    copy = True
-                    drop_list.append(pointer)
-            if copy:
-                spec_conv = spec.copy()
-                # delete optional parameters from copy for convention check
-                for item in drop_list:
-                    del spec_conv[item]
-            else:
-                spec_conv = spec
+        # make a DataFrame copy to check convention if it contains other params
+        # check if a copy is necessary
+        copy = False
+        drop_list = []
+        for pointer in data_pointers:
+            if pointer in spec:
+                copy = True
+                drop_list.append(pointer)
+        if copy:
+            spec_conv = spec.copy()
+            # delete optional parameters from copy for convention check
+            for item in drop_list:
+                del spec_conv[item]
+        else:
+            spec_conv = spec
 
         # set convention and focal parameters based on spec convention
         for conv in list(param_conventions):

--- a/pygmt/tests/baseline/test_meca_gcmt_convention.png.dvc
+++ b/pygmt/tests/baseline/test_meca_gcmt_convention.png.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: a44dc0f1af50958aeff2d359ea8b03a7
+  size: 8732
+  path: test_meca_gcmt_convention.png

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -209,7 +209,7 @@ def test_meca_loc_array():
 
 
 @pytest.mark.mpl_image_compare
-def test_meca_spec_gcmt_convention():
+def test_meca_gcmt_convention():
     """
     Test plotting beachballs using the global CMT convention.
     """

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -9,8 +9,6 @@ import pytest
 from pygmt import Figure
 from pygmt.helpers import GMTTempFile
 
-TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
-
 
 @pytest.mark.mpl_image_compare
 def test_meca_spec_dictionary():
@@ -208,5 +206,36 @@ def test_meca_loc_array():
         depth,
         region=[-125, -122, 47, 49],
         projection="M14c",
+    )
+    return fig
+
+
+@pytest.mark.mpl_image_compare
+def test_meca_spec_gcmt_convention():
+    """
+    Test plotting beachballs using the global CMT convention.
+    """
+    fig = Figure()
+    # specify focal mechanisms
+    focal_mechanisms = dict(
+        strike1=180,
+        dip1=18,
+        rake1=-88,
+        strike2=0,
+        dip2=72,
+        rake2=-90,
+        mantissa=5.5,
+        exponent=0,
+    )
+    fig.meca(
+        spec=focal_mechanisms,
+        scale="1c",
+        longitude=239.384,
+        latitude=34.556,
+        depth=12,
+        convention="gcmt",
+        region=[239, 240, 34, 35.2],
+        projection="m2.5c",
+        frame=True,
     )
     return fig

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -1,8 +1,6 @@
 """
 Tests for meca.
 """
-import os
-
 import numpy as np
 import pandas as pd
 import pytest


### PR DESCRIPTION
**Description of proposed changes**

Adds the 'rake1' and 'strike2' keys to the global CMT (gcmt) convention, and add a unit test adapted from https://docs.generic-mapping-tools.org/6.2/supplements/seis/meca.html#examples.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1580, Patches #516.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
