### PR TITLE
Add MaunaLoa_CO2.txt to cached files

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  # pull_request:
+  pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  pull_request:
+  # pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -167,7 +167,7 @@ def download_test_data():
         "@N00W090.earth_relief_03m_p.nc",
         # Earth seafloor age grids
         "@earth_age_01d_g",
-        "S90W180.earth_age_05m_g.nc"  # Specific grid for 05m test
+        "@S90W180.earth_age_05m_g.nc"  # Specific grid for 05m test
         # Other cache files
         "@EGM96_to_36.txt",
         "@MaunaLoa_CO2.txt",

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -167,7 +167,7 @@ def download_test_data():
         "@N00W090.earth_relief_03m_p.nc",
         # Earth seafloor age grids
         "@earth_age_01d_g",
-        "@S90W180.earth_age_05m_g.nc"  # Specific grid for 05m test
+        "@S90W180.earth_age_05m_g.nc",  # Specific grid for 05m test
         # Other cache files
         "@EGM96_to_36.txt",
         "@MaunaLoa_CO2.txt",

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -174,6 +174,7 @@ def download_test_data():
         "@hotspots.txt",
         "@ridge.txt",
         "@mars370d.txt",
+        "@MaunaLoa_CO2.txt",
         "@srtm_tiles.nc",  # needed for 03s and 01s relief data
         "@Table_5_11.txt",
         "@test.dat.nc",

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -170,11 +170,11 @@ def download_test_data():
         "S90W180.earth_age_05m_g.nc"  # Specific grid for 05m test
         # Other cache files
         "@EGM96_to_36.txt",
+        "@MaunaLoa_CO2.txt",
         "@fractures_06.txt",
         "@hotspots.txt",
         "@ridge.txt",
         "@mars370d.txt",
-        "@MaunaLoa_CO2.txt",
         "@srtm_tiles.nc",  # needed for 03s and 01s relief data
         "@Table_5_11.txt",
         "@test.dat.nc",

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -171,12 +171,12 @@ def download_test_data():
         # Other cache files
         "@EGM96_to_36.txt",
         "@MaunaLoa_CO2.txt",
+        "@Table_5_11.txt",
         "@fractures_06.txt",
         "@hotspots.txt",
         "@ridge.txt",
         "@mars370d.txt",
         "@srtm_tiles.nc",  # needed for 03s and 01s relief data
-        "@Table_5_11.txt",
         "@test.dat.nc",
         "@tut_bathy.nc",
         "@tut_quakes.ngdc",


### PR DESCRIPTION
As discussed by @weiji14 at [this comment](https://github.com/GenericMappingTools/pygmt/pull/1512#discussion_r744173378), this pull request adds the MaunaLoa_CO2.txt remote file to the cached files for testing.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
