### PR TITLE
Remove disclaimer from install.rst

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -3,17 +3,6 @@
 Installing
 ==========
 
-.. note::
-
-   🚨 **This package is in the early stages of design and implementation.** 🚨
-
-    We welcome any feedback and ideas!
-    Let us know by submitting
-    `issues on GitHub <https://github.com/GenericMappingTools/pygmt/issues>`__
-    or by posting on our `Discourse forum
-    <https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a>`__.
-
-
 Quickstart
 ----------
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -29,6 +29,13 @@ The development of PyGMT has been supported by NSF grants
 `OCE-1558403 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1558403>`__ and
 `EAR-1948603 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1948602>`__.
 
+    We welcome any feedback and ideas!
+    Let us know by submitting
+    `issues on GitHub <https://github.com/GenericMappingTools/pygmt/issues>`__
+    or by posting on our `Discourse forum
+    <https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a>`__.
+
+
 Presentations
 -------------
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -29,11 +29,10 @@ The development of PyGMT has been supported by NSF grants
 `OCE-1558403 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1558403>`__ and
 `EAR-1948603 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1948602>`__.
 
-    We welcome any feedback and ideas!
-    Let us know by submitting
-    `issues on GitHub <https://github.com/GenericMappingTools/pygmt/issues>`__
-    or by posting on our `Discourse forum
-    <https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a>`__.
+We welcome any feedback and ideas! Let us know by submitting
+`issues on GitHub <https://github.com/GenericMappingTools/pygmt/issues>`__
+or by posting on our `Discourse forum
+<https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a>`__.
 
 
 Presentations


### PR DESCRIPTION
As a follow up to #1590, @meghanrjones suggested that we tone down "This package is in the early stages of design and implementation." in the installation guide. This pull request removes that disclaimer, and moves the mention of the Discourse and GitHub Issues to the overview page.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
