### PR TITLE
Add issue template with checklist for bumping the minimum required GMT version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bump_gmt_checklist.md
+++ b/.github/ISSUE_TEMPLATE/bump_gmt_checklist.md
@@ -26,4 +26,4 @@ assignees: ''
   - [ ] Update compatibility table in `README.rst`
 - [ ] Fix failing tests (1 or more PRs)
 - [ ] Remove [xfail](https://docs.pytest.org/en/stable/skipping.html#xfail-mark-test-functions-as-expected-to-fail) pytest markers on tests that are now xpass
-- [ ] Update deprecated syntax based on the [GMT Changelog](https://docs.generic-mapping-tools.org/latest/changes.html)
+- [ ] Update deprecated syntax in code examples based on the [GMT Changelog](https://docs.generic-mapping-tools.org/latest/changes.html)

--- a/.github/ISSUE_TEMPLATE/bump_gmt_checklist.md
+++ b/.github/ISSUE_TEMPLATE/bump_gmt_checklist.md
@@ -1,0 +1,29 @@
+---
+name: Bump GMT version checklist.
+about: Checklist for bumping the minimum required GMT version.
+title: Bump to GMT X.Y.Z
+labels: maintenance
+assignees: ''
+
+---
+
+:tada: [GMT X.Y.Z](https://github.com/GenericMappingTools/gmt/releases/tag/X.Y.Z) has been released! It is installable from the
+[conda-forge channel](https://anaconda.org/conda-forge/gmt/files) using the following command:
+
+`conda install -c conda-forge gmt=X.Y.Z`
+
+<!-- Please add specific checklist items for the tests, xfail pytest markers, and deprecated syntax that need to be updated. -->
+
+**To-Do**:
+- [ ] Bump the minimum required GMT version (1 PR)
+  - [ ] Update `.github/workflows/cache_data.yaml`
+  - [ ] Update `.github/workflows/ci_docs.yml`
+  - [ ] Update `.github/workflows/ci_tests.yaml`
+  - [ ] Update `doc/install.rst`
+  - [ ] Update `environment.yml`
+  - [ ] Update `required_version` in `pygmt/clib/session.py`
+  - [ ] Update `test_get_default` in `pygmt/tests/test_clib.py`
+  - [ ] Update compatibility table in `README.rst`
+- [ ] Fix failing tests (1 or more PRs)
+- [ ] Remove [xfail](https://docs.pytest.org/en/stable/skipping.html#xfail-mark-test-functions-as-expected-to-fail) pytest markers on tests that are now xpass
+- [ ] Update deprecated syntax based on the [GMT Changelog](https://docs.generic-mapping-tools.org/latest/changes.html)

--- a/.github/ISSUE_TEMPLATE/bump_gmt_checklist.md
+++ b/.github/ISSUE_TEMPLATE/bump_gmt_checklist.md
@@ -26,4 +26,4 @@ assignees: ''
   - [ ] Update compatibility table in `README.rst`
 - [ ] Fix failing tests (1 or more PRs)
 - [ ] Remove [xfail](https://docs.pytest.org/en/stable/skipping.html#xfail-mark-test-functions-as-expected-to-fail) pytest markers on tests that are now xpass
-- [ ] Update deprecated syntax in code examples based on the [GMT Changelog](https://docs.generic-mapping-tools.org/latest/changes.html)
+- [ ] Update deprecated syntax in source code and examples based on the [GMT Changelog](https://docs.generic-mapping-tools.org/latest/changes.html)

--- a/.github/ISSUE_TEMPLATE/bump_gmt_checklist.md
+++ b/.github/ISSUE_TEMPLATE/bump_gmt_checklist.md
@@ -1,5 +1,5 @@
 ---
-name: Bump GMT version checklist.
+name: Bump GMT version checklist
 about: Checklist for bumping the minimum required GMT version.
 title: Bump to GMT X.Y.Z
 labels: maintenance


### PR DESCRIPTION
**Description of proposed changes**

Bumping the required GMT version is often an involved process with multiple PRs, but infrequent enough (~2/year) that it's easy to forget all the changes needed. This PR proposed an issue template with a checklist for common steps needed for bumping the required GMT version after a GMT release.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
