### PR TITLE
Add html-noplot target to doc/Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,11 +13,12 @@ ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees  $(SPHINXOPTS) .
 
 help:
 	@echo "Please use 'make <target>' where <target> is one of"
-	@echo "  all        build the HTML files from the existing rst sources"
-	@echo "  api        generate rst source files of API documentation"
-	@echo "  html       build the HTML files from the existing rst sources"
-	@echo "  server     make a local HTTP server for previewing the built documentation"
-	@echo "  clean      clean up built and generated files"
+	@echo "  all          build the HTML files from the existing rst sources"
+	@echo "  api          generate rst source files of API documentation"
+	@echo "  html         build the HTML files from the existing rst sources"
+	@echo "  html-noplot  build the HTML files without running any examples"
+	@echo "  server       make a local HTTP server for previewing the built documentation"
+	@echo "  clean        clean up built and generated files"
 
 all: html
 
@@ -33,6 +34,15 @@ html: api
 	@echo
 	# Set PYGMT_USE_EXTERNAL_DISPLAY to "false" to disable external display
 	PYGMT_USE_EXTERNAL_DISPLAY="false" $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+html-noplot: api
+	@echo
+	@echo "Building HTML files."
+	@echo
+	# Set PYGMT_USE_EXTERNAL_DISPLAY to "false" to disable external display
+	PYGMT_USE_EXTERNAL_DISPLAY="false" $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -39,7 +39,7 @@ html: api
 
 html-noplot: api
 	@echo
-	@echo "Building HTML files."
+	@echo "Building HTML files without example plots."
 	@echo
 	# Set PYGMT_USE_EXTERNAL_DISPLAY to "false" to disable external display
 	PYGMT_USE_EXTERNAL_DISPLAY="false" $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -41,8 +41,7 @@ html-noplot: api
 	@echo
 	@echo "Building HTML files without example plots."
 	@echo
-	# Set PYGMT_USE_EXTERNAL_DISPLAY to "false" to disable external display
-	PYGMT_USE_EXTERNAL_DISPLAY="false" $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
**Description of proposed changes**

We have many gallery examples and tutorials :tada:, such that it takes a long time to generate the html documentation. I find this frustrating when locally editing/reviewing documentation unrelated to the gallery (e.g., when wrapping a new module). This PR adds an `html-noplot` target to `doc/Makefile` to generate the html documentation without running the examples.

Note: there will be a `WARNING: The config value 'plot_gallery' has type 'str', defaults to 'bool'.` when using this target - from looking at the sphinx_gallery issues I do not think there's a way around this.

Ref: https://sphinx-gallery.github.io/stable/advanced.html#build-the-gallery-without-running-any-examples

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
