### PR TITLE
Fix pylint 2.12 consider-iterating-dictionary checker errors

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -506,7 +506,7 @@ def _insert_alias(module_func, default_value=None):
     kwargs_param = wrapped_params.pop(-1)
     # Add new parameters from aliases
     for alias in module_func.aliases.values():
-        if alias not in sig.parameters.keys():
+        if alias not in sig.parameters:
             new_param = Parameter(
                 alias, kind=Parameter.KEYWORD_ONLY, default=default_value
             )

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -165,7 +165,7 @@ def grd2cpt(grid, **kwargs):
     with Session() as lib:
         file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
         with file_context as infile:
-            if "H" not in kwargs.keys():  # if no output is set
+            if "H" not in kwargs:  # if no output is set
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
             if "H" in kwargs:  # if output is set
                 outfile = kwargs.pop("H")

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -82,7 +82,7 @@ def grdclip(grid, **kwargs):
         with Session() as lib:
             file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
             with file_context as infile:
-                if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
+                if "G" not in kwargs:  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})
                 outgrid = kwargs["G"]
                 arg_str = " ".join([infile, build_arg_string(kwargs)])

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -92,7 +92,7 @@ def grdcut(grid, **kwargs):
         with Session() as lib:
             file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
             with file_context as infile:
-                if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
+                if "G" not in kwargs:  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})
                 outgrid = kwargs["G"]
                 arg_str = " ".join([infile, build_arg_string(kwargs)])

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -63,13 +63,13 @@ def grdfill(grid, **kwargs):
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)
     """
-    if "A" not in kwargs.keys() and "L" not in kwargs.keys():
+    if "A" not in kwargs and "L" not in kwargs:
         raise GMTInvalidInput("At least parameter 'mode' or 'L' must be specified.")
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
             file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
             with file_context as infile:
-                if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
+                if "G" not in kwargs:  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})
                 outgrid = kwargs["G"]
                 arg_str = " ".join([infile, build_arg_string(kwargs)])

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -145,7 +145,7 @@ def grdfilter(grid, **kwargs):
         with Session() as lib:
             file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
             with file_context as infile:
-                if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
+                if "G" not in kwargs:  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})
                 outgrid = kwargs["G"]
                 arg_str = " ".join([infile, build_arg_string(kwargs)])

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -160,7 +160,7 @@ def grdgradient(grid, **kwargs):
         with Session() as lib:
             file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
             with file_context as infile:
-                if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
+                if "G" not in kwargs:  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})
                 outgrid = kwargs["G"]
                 arg_str = " ".join([infile, build_arg_string(kwargs)])

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -93,12 +93,12 @@ def grdlandmask(**kwargs):
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)
     """
-    if "I" not in kwargs.keys() or "R" not in kwargs.keys():
+    if "I" not in kwargs or "R" not in kwargs:
         raise GMTInvalidInput("Both 'region' and 'spacing' must be specified.")
 
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
+            if "G" not in kwargs:  # if outgrid is unset, output to tempfile
                 kwargs.update({"G": tmpfile.name})
             outgrid = kwargs["G"]
             arg_str = build_arg_string(kwargs)

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -96,13 +96,13 @@ def grdproject(grid, **kwargs):
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)
     """
-    if "J" not in kwargs.keys():
+    if "J" not in kwargs:
         raise GMTInvalidInput("The projection must be specified.")
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
             file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
             with file_context as infile:
-                if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
+                if "G" not in kwargs:  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})
                 outgrid = kwargs["G"]
                 arg_str = " ".join([infile, build_arg_string(kwargs)])

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -79,7 +79,7 @@ def grdsample(grid, **kwargs):
         with Session() as lib:
             file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
             with file_context as infile:
-                if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
+                if "G" not in kwargs:  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})
                 outgrid = kwargs["G"]
                 arg_str = " ".join([infile, build_arg_string(kwargs)])

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -219,7 +219,7 @@ def meca(
         Set optional parameter pointers based on DataFrame or dict, if those
         parameters are present in the DataFrame or dict.
         """
-        for param in list(data_pointers.keys()):
+        for param in list(data_pointers):
             if param in spec:
                 # set pointer based on param name
                 data_pointers[param] = spec[param]
@@ -302,7 +302,7 @@ def meca(
 
         # set convention and focal parameters based on spec convention
         for conv in list(param_conventions):
-            if set(spec_conv.keys()) == set(param_conventions[conv]):
+            if set(spec_conv) == set(param_conventions[conv]):
                 convention = conv.lower()
                 foc_params = param_conventions[conv]
                 break

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -139,7 +139,7 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
             )
             with table_context as infile:
-                if "G" not in kwargs.keys():  # if outgrid is unset, output to tmpfile
+                if "G" not in kwargs:  # if outgrid is unset, output to tmpfile
                     kwargs.update({"G": tmpfile.name})
                 outgrid = kwargs["G"]
                 arg_str = " ".join([infile, build_arg_string(kwargs)])

--- a/pygmt/src/sph2grd.py
+++ b/pygmt/src/sph2grd.py
@@ -68,7 +68,7 @@ def sph2grd(data, **kwargs):
         with Session() as lib:
             file_context = lib.virtualfile_from_data(check_kind="vector", data=data)
             with file_context as infile:
-                if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
+                if "G" not in kwargs:  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})
                 outgrid = kwargs["G"]
                 arg_str = " ".join([infile, build_arg_string(kwargs)])

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -100,7 +100,7 @@ def sphdistance(data=None, x=None, y=None, **kwargs):
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)
     """
-    if "I" not in kwargs.keys() or "R" not in kwargs.keys():
+    if "I" not in kwargs or "R" not in kwargs:
         raise GMTInvalidInput("Both 'region' and 'spacing' must be specified.")
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
@@ -108,7 +108,7 @@ def sphdistance(data=None, x=None, y=None, **kwargs):
                 check_kind="vector", data=data, x=x, y=y
             )
             with file_context as infile:
-                if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
+                if "G" not in kwargs:  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})
                 outgrid = kwargs["G"]
                 arg_str = build_arg_string(kwargs)

--- a/pygmt/src/sphinterpolate.py
+++ b/pygmt/src/sphinterpolate.py
@@ -60,7 +60,7 @@ def sphinterpolate(data, **kwargs):
         with Session() as lib:
             file_context = lib.virtualfile_from_data(check_kind="vector", data=data)
             with file_context as infile:
-                if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
+                if "G" not in kwargs:  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})
                 outgrid = kwargs["G"]
                 arg_str = " ".join([infile, build_arg_string(kwargs)])

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -98,7 +98,7 @@ def surface(data=None, x=None, y=None, z=None, **kwargs):
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
             )
             with file_context as infile:
-                if "G" not in kwargs.keys():  # if outgrid is unset, output to tmpfile
+                if "G" not in kwargs:  # if outgrid is unset, output to tmpfile
                     kwargs.update({"G": tmpfile.name})
                 outgrid = kwargs["G"]
                 arg_str = " ".join([infile, build_arg_string(kwargs)])

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -184,7 +184,7 @@ def text_(
         raise GMTInvalidInput("Must provide text with x/y pairs or position")
 
     # Build the -F option in gmt text.
-    if "F" not in kwargs.keys() and (
+    if "F" not in kwargs and (
         (
             position is not None
             or angle is not None

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -138,7 +138,7 @@ def xyz2grd(data=None, x=None, y=None, z=None, **kwargs):
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
             )
             with file_context as infile:
-                if "G" not in kwargs.keys():  # if outgrid is unset, output to tempfile
+                if "G" not in kwargs:  # if outgrid is unset, output to tempfile
                     kwargs.update({"G": tmpfile.name})
                 outgrid = kwargs["G"]
                 arg_str = " ".join([infile, build_arg_string(kwargs)])


### PR DESCRIPTION
**Description of proposed changes**

[Pylint v2.12.2](https://github.com/PyCQA/pylint/releases/tag/v2.12.2) released on 4 Dec 2021 fixed a false negative for `consider-iterating-dictionary` (CO201) so a few checker errors popped up that needs to be fixed.

```
pylint pygmt setup.py doc/conf.py
************* Module pygmt.src.sphdistance
pygmt/src/sphdistance.py:103:18: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
pygmt/src/sphdistance.py:103:46: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
pygmt/src/sphdistance.py:111:30: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.surface
pygmt/src/surface.py:101:30: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.grdsample
pygmt/src/grdsample.py:82:30: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.sph2grd
pygmt/src/sph2grd.py:71:30: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.grdclip
pygmt/src/grdclip.py:85:30: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.grd2cpt
pygmt/src/grd2cpt.py:168:26: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.xyz2grd
pygmt/src/xyz2grd.py:141:30: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.grdfill
pygmt/src/grdfill.py:66:18: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
pygmt/src/grdfill.py:66:47: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
pygmt/src/grdfill.py:72:30: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.sphinterpolate
pygmt/src/sphinterpolate.py:63:30: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.grdproject
pygmt/src/grdproject.py:99:18: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
pygmt/src/grdproject.py:105:30: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.grdgradient
pygmt/src/grdgradient.py:163:30: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.grdlandmask
pygmt/src/grdlandmask.py:96:18: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
pygmt/src/grdlandmask.py:96:46: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
pygmt/src/grdlandmask.py:101:26: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.grdcut
pygmt/src/grdcut.py:95:30: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.grdfilter
pygmt/src/grdfilter.py:148:30: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
************* Module pygmt.src.nearneighbor
pygmt/src/nearneighbor.py:142:30: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)

-----------------------------------
Your code has been rated at 9.96/10
```

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
