### PR TITLE
Unpin GMT dev version from conda-forge/label/dev on Windows

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -6,7 +6,7 @@ on:
   # push:
   #   branches: [ main ]
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [ready_for_review]
     paths-ignore:
       - 'doc/**'
       - 'examples/**'

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9]
-        os: [ubuntu-latest, macOS-11.0, windows-latest]
+        os: [ubuntu-latest, macOS-11.0, windows-2022]
         gmt_git_ref: [master]
     defaults:
       run:

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -102,7 +102,7 @@ jobs:
         if: runner.os != 'Windows'
 
       - name: Install GMT dev version from conda-forge (Windows)
-        run: mamba install -c conda-forge/label/dev gmt=6.3
+        run: mamba install -c conda-forge/label/dev gmt
         if: runner.os == 'Windows'
 
       # Download cached remote files (artifacts) from GitHub

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -6,7 +6,7 @@ on:
   # push:
   #   branches: [ main ]
   pull_request:
-    types: [ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths-ignore:
       - 'doc/**'
       - 'examples/**'


### PR DESCRIPTION
**Description of proposed changes**

Remove the pin to GMT 6.3 in the ci_tests_dev.yaml file so that GMT 6.4 and above will be installed instead. A recent version bump was made in https://github.com/conda-forge/gmt-feedstock/pull/190.Also run tests on Windows Server 2022.

For context, the pin was originally made deeafadad8fc69637eaa8de252e558574c22292b to fix a problem with the conda/mamba resolver (see https://github.com/GenericMappingTools/pygmt/pull/841#discussion_r711413201). Let's see if unpinning works. For even more context on why we install GMT dev from conda-forge on Windows instead of [building GMT from source](https://github.com/GenericMappingTools/gmt/blob/6.3.0/BUILDING.md#building-gmt-source-codes), see #755.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This should hopefully fix a recent installation error on GMT Dev Tests for Windows caused by a missing compatible version of GDAL, e.g. at https://github.com/GenericMappingTools/pygmt/runs/4419658321?check_suite_focus=true#step:9:41:

```
 Looking for: ['gmt=6.3']


Pinned packages:
  - python 3.9.*


Encountered problems while solving:
  - nothing provides gdal >=2.2.4,<2.3.0a0 needed by fiona-1.8a2-py37h01e27f7_1
```

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
