### PR TITLE
Update text symbol gallery example

### DIFF
--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -10,10 +10,10 @@ the ``style`` parameter where *size* defines the size of the text symbol
 different characters) and *string* can be a letter or a text string
 (less than 256 characters). Optionally, you can append **+f**\ *font* to
 select a particular font [Default is :gmt-term:`FONT_ANNOT_PRIMARY`] as well as
-**+j**\ *justify* to change the justification [Default is CM]. Outline
-and fill color of the text symbols can be customized via the ``pen``
-and ``color`` parameters, respectively.
-
+**+j**\ *justify* to change the justification [Default is CM]. Outline color of 
+the text symbols can also be defined via the ``style`` parameter [Default is 
+black] while the fill color and the outline width can be customized via the 
+``color`` and ``pen`` parameters, respectively.
 For all supported octal codes and fonts see the GMT cookbook
 :gmt-docs:`cookbook/octal-codes.html` and
 :gmt-docs:`cookbook/postscript-fonts.html`.
@@ -37,7 +37,8 @@ fig.plot(x=4, y=1.5, style="l3.5c+tZ+fCourier-Bold", color="seagreen", pen=pen)
 # color fill is set to "gold"
 fig.plot(x=5.5, y=1.5, style="l3.5c+ts+fTimes-Italic", color="gold", pen=pen)
 # plot the pi symbol (\160 is octal code for pi) of size 3.5c, for this use
-# the "Symbol" font, color fill is set to "magenta4"
-fig.plot(x=7, y=1.5, style="l3.5c+t\160+fSymbol", color="magenta4", pen=pen)
+# the "Symbol" font, outline color of the symbol is set to "darkorange", 
+# color fill is set to "magenta4"
+fig.plot(x=7, y=1.5, style="l3.5c+t\160+fSymbol,darkorange", color="magenta4", pen=pen)
 
 fig.show()

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -8,11 +8,11 @@ A text symbol can be drawn by passing **l**\ *size*\ **+t**\ *string* to
 the ``style`` parameter where *size* defines the size of the text symbol
 (note: the size is only approximate; no individual scaling is done for
 different characters) and *string* can be a letter or a text string
-(less than 256 characters). Optionally, you can append **+f**\ *font* to
-select a particular font [Default is :gmt-term:`FONT_ANNOT_PRIMARY`] as well as
-**+j**\ *justify* to change the justification [Default is CM]. The outline
-color of the text symbols can be defined via the ``style`` parameter [Default
-is black], the fill color can be set with the ``color`` parameter, and the
+(less than 256 characters). Optionally, you can append
+**+f**\ *font*,*outlinecolor* to select a particular font [Default is
+:gmt-term:`FONT_ANNOT_PRIMARY`] and outline color [Default is black] as well
+as **+j**\ *justify* to change the justification [Default is CM]. The fill
+color of the text symbols can be set with the ``color`` parameter, and the
 outline width can be customized with the ``pen`` parameter.
 For all supported octal codes and fonts see the GMT cookbook
 :gmt-docs:`cookbook/octal-codes.html` and

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -10,9 +10,9 @@ the ``style`` parameter where *size* defines the size of the text symbol
 different characters) and *string* can be a letter or a text string
 (less than 256 characters). Optionally, you can append **+f**\ *font* to
 select a particular font [Default is :gmt-term:`FONT_ANNOT_PRIMARY`] as well as
-**+j**\ *justify* to change the justification [Default is CM]. Outline color of 
-the text symbols can also be defined via the ``style`` parameter [Default is 
-black] while the fill color and the outline width can be customized via the 
+**+j**\ *justify* to change the justification [Default is CM]. Outline color of
+the text symbols can also be defined via the ``style`` parameter [Default is
+black] while the fill color and the outline width can be customized via the
 ``color`` and ``pen`` parameters, respectively.
 For all supported octal codes and fonts see the GMT cookbook
 :gmt-docs:`cookbook/octal-codes.html` and

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -37,7 +37,7 @@ fig.plot(x=4, y=1.5, style="l3.5c+tZ+fCourier-Bold", color="seagreen", pen=pen)
 # color fill is set to "gold"
 fig.plot(x=5.5, y=1.5, style="l3.5c+ts+fTimes-Italic", color="gold", pen=pen)
 # plot the pi symbol (\160 is octal code for pi) of size 3.5c, for this use
-# the "Symbol" font, the outline color of the symbol is set to 
+# the "Symbol" font, the outline color of the symbol is set to
 # "darkorange", the color fill is set to "magenta4"
 fig.plot(x=7, y=1.5, style="l3.5c+t\160+fSymbol,darkorange", color="magenta4", pen=pen)
 

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -10,9 +10,9 @@ the ``style`` parameter where *size* defines the size of the text symbol
 different characters) and *string* can be a letter or a text string
 (less than 256 characters). Optionally, you can append **+f**\ *font* to
 select a particular font [Default is :gmt-term:`FONT_ANNOT_PRIMARY`] as well as
-**+j**\ *justify* to change the justification [Default is CM]. The outline color of
-the text symbols can be defined via the ``style`` parameter [Default is
-black], the fill color can be set with the ``color`` parameter, and the 
+**+j**\ *justify* to change the justification [Default is CM]. The outline
+color of the text symbols can be defined via the ``style`` parameter [Default
+is black], the fill color can be set with the ``color`` parameter, and the
 outline width can be customized with the ``pen`` parameter.
 For all supported octal codes and fonts see the GMT cookbook
 :gmt-docs:`cookbook/octal-codes.html` and

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -37,7 +37,7 @@ fig.plot(x=4, y=1.5, style="l3.5c+tZ+fCourier-Bold", color="seagreen", pen=pen)
 # color fill is set to "gold"
 fig.plot(x=5.5, y=1.5, style="l3.5c+ts+fTimes-Italic", color="gold", pen=pen)
 # plot the pi symbol (\160 is octal code for pi) of size 3.5c, for this use
-# the "Symbol" font, outline color of the symbol is set to "darkorange", 
+# the "Symbol" font, outline color of the symbol is set to "darkorange",
 # color fill is set to "magenta4"
 fig.plot(x=7, y=1.5, style="l3.5c+t\160+fSymbol,darkorange", color="magenta4", pen=pen)
 

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -10,10 +10,10 @@ the ``style`` parameter where *size* defines the size of the text symbol
 different characters) and *string* can be a letter or a text string
 (less than 256 characters). Optionally, you can append **+f**\ *font* to
 select a particular font [Default is :gmt-term:`FONT_ANNOT_PRIMARY`] as well as
-**+j**\ *justify* to change the justification [Default is CM]. Outline color of
-the text symbols can also be defined via the ``style`` parameter [Default is
-black] while the fill color and the outline width can be customized via the
-``color`` and ``pen`` parameters, respectively.
+**+j**\ *justify* to change the justification [Default is CM]. The outline color of
+the text symbols can be defined via the ``style`` parameter [Default is
+black], the fill color can be set with the ``color`` parameter, and the 
+outline width can be customized with the ``pen`` parameter.
 For all supported octal codes and fonts see the GMT cookbook
 :gmt-docs:`cookbook/octal-codes.html` and
 :gmt-docs:`cookbook/postscript-fonts.html`.
@@ -37,8 +37,8 @@ fig.plot(x=4, y=1.5, style="l3.5c+tZ+fCourier-Bold", color="seagreen", pen=pen)
 # color fill is set to "gold"
 fig.plot(x=5.5, y=1.5, style="l3.5c+ts+fTimes-Italic", color="gold", pen=pen)
 # plot the pi symbol (\160 is octal code for pi) of size 3.5c, for this use
-# the "Symbol" font, outline color of the symbol is set to "darkorange",
-# color fill is set to "magenta4"
+# the "Symbol" font, the outline color of the symbol is set to 
+# "darkorange", the color fill is set to "magenta4"
 fig.plot(x=7, y=1.5, style="l3.5c+t\160+fSymbol,darkorange", color="magenta4", pen=pen)
 
 fig.show()

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -9,7 +9,7 @@ the ``style`` parameter where *size* defines the size of the text symbol
 (note: the size is only approximate; no individual scaling is done for
 different characters) and *string* can be a letter or a text string
 (less than 256 characters). Optionally, you can append
-**+f**\ *font*,*outlinecolor* to select a particular font [Default is
+**+f**\ *font,outlinecolor* to select a particular font [Default is
 :gmt-term:`FONT_ANNOT_PRIMARY`] and outline color [Default is black] as well
 as **+j**\ *justify* to change the justification [Default is CM]. The fill
 color of the text symbols can be set with the ``color`` parameter, and the


### PR DESCRIPTION
**Description of proposed changes**

According to a recent [forum post](https://forum.generic-mapping-tools.org/t/changing-symbol-outline-color-using-plot/2410), here's an update for the text symbol gallery example. Since it is not fully clear from the current example how to change the outline color of the symbols, for the last symbol now the outline color is changed and the docstring is slightly adjusted.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
