### PR TITLE
Bump the minimum required GMT version to 6.3.0

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -38,7 +38,7 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          mamba install gmt=6.2.0 \
+          mamba install gmt=6.3.0 \
                         numpy pandas xarray netCDF4 packaging matplotlib
 
       # Install the package that we want to test

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -70,7 +70,7 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          mamba install gmt=6.2.0 numpy pandas xarray netCDF4 packaging \
+          mamba install gmt=6.3.0 numpy pandas xarray netCDF4 packaging \
                         ipython make myst-parser geopandas \
                         sphinx sphinx-copybutton sphinx-gallery sphinx_rtd_theme
 

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -93,7 +93,7 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          mamba install gmt=6.2.0 numpy=${{ matrix.numpy-version }} \
+          mamba install gmt=6.3.0 numpy=${{ matrix.numpy-version }} \
                         pandas xarray netCDF4 packaging \
                         ${{ matrix.optional-packages }} \
                         dvc make pytest>=6.0 \

--- a/README.rst
+++ b/README.rst
@@ -214,7 +214,7 @@ Compatibility with GMT/Python/NumPy versions
       - Numpy
     * - `Dev <https://github.com/GenericMappingTools/pygmt/milestone/9>`_ (upcoming release)
       - `Dev Documentation <https://www.pygmt.org/dev>`_ (reflects `main branch <https://github.com/GenericMappingTools/pygmt>`_)
-      - >=6.2.0
+      - >=6.3.0
       - >=3.7
       - >=1.18
     * - `v0.5.0 <https://github.com/GenericMappingTools/pygmt/releases/tag/v0.5.0>`_ (latest release)

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -51,7 +51,7 @@ Which GMT?
 PyGMT requires Generic Mapping Tools (GMT) version 6 as a minimum, which is the
 latest released version that can be found at
 the `GMT official site <https://www.generic-mapping-tools.org>`__.
-We need the latest GMT (>=6.2.0) since there are many changes being made to GMT
+We need the latest GMT (>=6.3.0) since there are many changes being made to GMT
 itself in response to the development of PyGMT, mainly the new
 `modern execution mode <https://docs.generic-mapping-tools.org/latest/cookbook/introduction.html#modern-and-classic-mode>`__.
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
     # Required dependencies
     - pip
-    - gmt=6.2.0
+    - gmt=6.3.0
     - numpy>=1.18
     - pandas
     - xarray

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -121,7 +121,7 @@ class Session:
     """
 
     # The minimum version of GMT required
-    required_version = "6.2.0"
+    required_version = "6.3.0"
 
     @property
     def session_pointer(self):

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -844,7 +844,7 @@ def test_get_default():
     with clib.Session() as lib:
         assert lib.get_default("API_GRID_LAYOUT") in ["rows", "columns"]
         assert int(lib.get_default("API_CORES")) >= 1
-        assert Version(lib.get_default("API_VERSION")) >= Version("6.2.0")
+        assert Version(lib.get_default("API_VERSION")) >= Version("6.3.0")
 
 
 def test_get_default_fails():


### PR DESCRIPTION
**Description of proposed changes**

Bump the minimum required GMT version from 6.2.0 to 6.3.0. Also update GitHub Actions CI workflows to use GMT 6.3.0.

Relates to #1644. Supersedes #1321.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
