### PR TITLE
Use frame="a" in colorbars_multiple.py

### DIFF
--- a/examples/gallery/embellishments/colorbars_multiple.py
+++ b/examples/gallery/embellishments/colorbars_multiple.py
@@ -36,9 +36,7 @@ with fig.subplot(
         pygmt.makecpt(cmap="globe", series=[-6000, 3000])
         # "M?" means Mercator projection with map width also automatically
         # determined from the subplot width.
-        fig.grdimage(
-            grid=grid_subset, projection="M?", region=subset_region, frame="a"
-        )
+        fig.grdimage(grid=grid_subset, projection="M?", region=subset_region, frame="a")
         fig.colorbar(frame=["a2000f1000", "x+lElevation", "y+lm"])
 
 fig.show()

--- a/examples/gallery/embellishments/colorbars_multiple.py
+++ b/examples/gallery/embellishments/colorbars_multiple.py
@@ -28,7 +28,7 @@ with fig.subplot(
         pygmt.makecpt(cmap="geo", series=[-8000, 8000])
         # "R?" means Winkel Tripel projection with map width automatically
         # determined from the subplot width.
-        fig.grdimage(grid=grid_globe, projection="R?", region="g", frame=True)
+        fig.grdimage(grid=grid_globe, projection="R?", region="g", frame="a")
         fig.colorbar(frame=["a4000f2000", "x+lElevation", "y+lm"])
     # Activate the second panel so that the colormap created by the makecpt
     # method is a panel-level CPT
@@ -37,7 +37,7 @@ with fig.subplot(
         # "M?" means Mercator projection with map width also automatically
         # determined from the subplot width.
         fig.grdimage(
-            grid=grid_subset, projection="M?", region=subset_region, frame=True
+            grid=grid_subset, projection="M?", region=subset_region, frame="a"
         )
         fig.colorbar(frame=["a2000f1000", "x+lElevation", "y+lm"])
 


### PR DESCRIPTION
**Description of proposed changes**

This PR changes `frame=True` to `frame="a"` in the colorbars_multiple.py gallery example, as a workaround to https://github.com/GenericMappingTools/gmt/issues/6100 in order to allow updating the GMT version to 6.3.0 (https://github.com/GenericMappingTools/pygmt/pull/1649).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
