### PR TITLE
Update test_legend_specfile baseline for GMT 6.3

### DIFF
--- a/pygmt/tests/baseline/test_legend_specfile.png.dvc
+++ b/pygmt/tests/baseline/test_legend_specfile.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 331f8fcdf2a864fb840ec48b865327bc
-  size: 52216
+- md5: 3f8466fcf78fc398e6764414505baf79
+  size: 52245
   path: test_legend_specfile.png


### PR DESCRIPTION
**Description of proposed changes**

This PR updates the baseline image for test_legend_specfile to reflect differences between GMT 6.2 and 6.3.

Part of #1644

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
