### PR TITLE
Update test_rose_bools.png.dvc for GMT 6.3

### DIFF
--- a/pygmt/tests/baseline/test_rose_bools.png.dvc
+++ b/pygmt/tests/baseline/test_rose_bools.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 3a2af68ba35cb59b0adfc0ce26d8b0c2
-  size: 59435
+- md5: 8757835301c781f1309113b21d4f94b3
+  size: 59516
   path: test_rose_bools.png


### PR DESCRIPTION
**Description of proposed changes**

This PR updates the baseline image used for `pygmt/tests/test_rose.py::test_rose_bools` and `pygmt/tests/test_rose.py::test_rose_deprecate_columns_to_incols` to pass with GMT 6.3.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Part of #1644


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
