### PR TITLE
Update xfail velo tests for GMT 6.3

### DIFF
--- a/pygmt/tests/baseline/test_velo_numpy_array_numeric_only.png.dvc
+++ b/pygmt/tests/baseline/test_velo_numpy_array_numeric_only.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 64e45d586112fc131090cfac2c104b63
-  size: 45483
+- md5: 852dba2075122641e3785603207f9b88
+  size: 44362
   path: test_velo_numpy_array_numeric_only.png

--- a/pygmt/tests/baseline/test_velo_pandas_dataframe.png.dvc
+++ b/pygmt/tests/baseline/test_velo_pandas_dataframe.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 60dff1a72e6d984f095fb4973cecaec7
-  size: 42430
+- md5: 136a1b34e8ad58de070a83ed3941276e
+  size: 42906
   path: test_velo_pandas_dataframe.png

--- a/pygmt/tests/test_velo.py
+++ b/pygmt/tests/test_velo.py
@@ -54,7 +54,7 @@ def test_velo_numpy_array_text_column(dataframe):
         fig.velo(
             data=dataframe.to_numpy(),
             spec="e0.2/0.39/18",
-            vector="0.3c+p1p+e+g1p,red",
+            vector="0.3c+p1p+e+gred",
         )
 
 

--- a/pygmt/tests/test_velo.py
+++ b/pygmt/tests/test_velo.py
@@ -30,10 +30,6 @@ def fixture_dataframe():
     )
 
 
-@pytest.mark.xfail(
-    condition=gmt_version > Version("6.2.0"),
-    reason="Upstream bug fixed by https://github.com/GenericMappingTools/gmt/pull/5360.",
-)
 @pytest.mark.mpl_image_compare
 def test_velo_numpy_array_numeric_only(dataframe):
     """
@@ -58,7 +54,7 @@ def test_velo_numpy_array_text_column(dataframe):
         fig.velo(
             data=dataframe.to_numpy(),
             spec="e0.2/0.39/18",
-            vector="0.3c+p1p+e+gred",
+            vector="0.3c+p1p+e+g1p,red",
         )
 
 
@@ -71,10 +67,6 @@ def test_velo_without_spec(dataframe):
         fig.velo(data=dataframe)
 
 
-@pytest.mark.xfail(
-    condition=gmt_version > Version("6.2.0"),
-    reason="Upstream bug fixed by https://github.com/GenericMappingTools/gmt/pull/5360.",
-)
 @pytest.mark.mpl_image_compare
 def test_velo_pandas_dataframe(dataframe):
     """


### PR DESCRIPTION
**Description of proposed changes**

This PR updates the baseline images for the velo tests that now pass with 6.3 and removes the xfail marks.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Part of #1644 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
