### PR TITLE
Update fig.basemap baseline images for GMT 6.3.0

### DIFF
--- a/pygmt/tests/baseline/test_basemap_compass.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_compass.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 77dc6e9b11b2fa1cf79c7de525704fca
-  size: 76593
+- md5: 5212622b9bc57723ee11de53b817b8dc
+  size: 76589
   path: test_basemap_compass.png

--- a/pygmt/tests/baseline/test_basemap_rose.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_rose.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 50267f9329529a279a1846185b78f0ef
-  size: 32476
+- md5: f14e2aaafe4667b2dc06ad1684f7a7ee
+  size: 32442
   path: test_basemap_rose.png


### PR DESCRIPTION
**Description of proposed changes**

Fix two broken tests on GMT 6.3.0 for fig.basemap. Changes mainly due to small differences in axis labels.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Part of #1644


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
