### PR TITLE
Remove projection alias from grdsample

### DIFF
--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -16,7 +16,6 @@ from pygmt.io import load_dataarray
 @fmt_docstring
 @use_alias(
     G="outgrid",
-    J="projection",
     I="spacing",
     R="region",
     T="translate",


### PR DESCRIPTION
**Description of proposed changes**

This PR removes the unavailable projection common option from the grdsample module.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
