### PR TITLE
Set timeout limit for CI tests

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -36,6 +36,7 @@ jobs:
             isDraft: true
           - os: windows-latest
             isDraft: true
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -53,6 +53,7 @@ jobs:
           - python-version: 3.9
             numpy-version: '1.21'
             optional-packages: 'geopandas ipython'
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -53,7 +53,7 @@ jobs:
           - python-version: 3.9
             numpy-version: '1.21'
             optional-packages: 'geopandas ipython'
-    timeout-minutes: 60
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -32,7 +32,7 @@ jobs:
         python-version: [3.9]
         os: [ubuntu-latest, macOS-11.0, windows-2022]
         gmt_git_ref: [master]
-    timeout-minutes: 60
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -32,6 +32,7 @@ jobs:
         python-version: [3.9]
         os: [ubuntu-latest, macOS-11.0, windows-2022]
         gmt_git_ref: [master]
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
**Description of proposed changes**

Occasionally, the CI tests get caught and timeout after 6 hours. Given that the tests should complete within 30 minutes, this PR proposes to set [timeout-minutes](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) to end after 60 minutes rather than the default of 360.

To-do:
- [x] Set limit for dev tests

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
