### PR TITLE
Update deprecated -g common option syntax

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -175,9 +175,7 @@ COMMON_OPTIONS = {
             Examine the spacing between consecutive data points in order to
             impose breaks in the line. To specify multiple criteria, provide
             a list with each item containing a string describing one set of
-            criteria. Prepend **a** to specify that all the criteria must be
-            met [Default is to impose breaks if any criteria are met]. The
-            following modifiers are supported:
+            criteria.
 
                 - **x**\|\ **X** - define a gap when there is a large enough
                   change in the x coordinates (upper case to use projected
@@ -188,9 +186,9 @@ COMMON_OPTIONS = {
                 - **d**\|\ **D** - define a gap when there is a large enough
                   distance between coordinates (upper case to use projected
                   coordinates).
-                - [*col*]\ **z** - define a gap when there is a large enough
-                  change in the data in column *col* [default *col* is 2 (i.e.,
-                  3rd column)].
+                - **z** - define a gap when there is a large enough change in
+                   the z data. Use **+c**\ *col* to change the z data column
+                   [Default *col* is 2 (i.e., 3rd column)].
 
             A unit **u** may be appended to the specified *gap*:
 
@@ -202,9 +200,10 @@ COMMON_OPTIONS = {
                 - For projected data (**X**\|\ **Y**\|\ **D**), the unit may be
                   **i**\ (nch), **c**\ (entimeter), or **p**\ (oint).
 
-            One of the following modifiers can be appended to *gap* [Default
-            imposes breaks based on the absolute value of the difference
-            between the current and previous value]:
+            Append modifier **+a** to specify that *all* the criteria must be
+            met [default imposes breaks if any one criterion is met].
+
+            One of the following modifiers can be appended:
 
                 - **+n** - specify that the previous value minus the current
                   column value must exceed *gap* for a break to be imposed.

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -170,7 +170,7 @@ COMMON_OPTIONS = {
             :gmt-docs:`gmt.html#f-full`.""",
     "g": r"""
         gap : str or list
-            **x**\|\ **y**\|\ **z**\|\ **d**\|\ **X**\|\ **Y**\|\ 
+            **x**\|\ **y**\|\ **z**\|\ **d**\|\ **X**\|\ **Y**\|\
             **D**\ *gap*\ [**u**][**+a**][**+c**\ *col*][**+n**\|\ **p**].
             Examine the spacing between consecutive data points in order to
             impose breaks in the line. To specify multiple criteria, provide

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -170,8 +170,8 @@ COMMON_OPTIONS = {
             :gmt-docs:`gmt.html#f-full`.""",
     "g": r"""
         gap : str or list
-            [**a**]\ **x**\|\ **y**\|\ **d**\|\ **X**\|\ **Y**\|\
-            **D**\|[*col*]\ **z**\ *gap*\ [**+n**\|\ **p**].
+            **x**\|\ **y**\|\ **z**\|\ **d**\|\ **X**\|\ **Y**\|\ 
+            **D**\ *gap*\ [**u**][**+a**][**+c**\ *col*][**+n**\|\ **p**].
             Examine the spacing between consecutive data points in order to
             impose breaks in the line. To specify multiple criteria, provide
             a list with each item containing a string describing one set of

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -187,8 +187,8 @@ COMMON_OPTIONS = {
                   distance between coordinates (upper case to use projected
                   coordinates).
                 - **z** - define a gap when there is a large enough change in
-                   the z data. Use **+c**\ *col* to change the z data column
-                   [Default *col* is 2 (i.e., 3rd column)].
+                  the z data. Use **+c**\ *col* to change the z data column
+                  [Default *col* is 2 (i.e., 3rd column)].
 
             A unit **u** may be appended to the specified *gap*:
 


### PR DESCRIPTION
**Description of proposed changes**

This PR updates the deprecated -g common option syntax to account for GMT 6.3 change made at GenericMappingTools/gmt#5617.

Part of #1644

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
