### PR TITLE
Remove Boolean from frame docstring

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -32,7 +32,7 @@ COMMON_OPTIONS = {
             *max_level* will not be plotted [Default is 0/0/4 (all
             features)].""",
     "B": r"""
-        frame : bool or str or list
+        frame : str or list
             Set map boundary
             :doc:`frame and axes attributes </tutorials/basics/frames>`. """,
     "U": """\


### PR DESCRIPTION
As GMT 6.3 no longer accepts a plain `-B` when setting the frame, this pull request removes the Boolean option for `frame`.



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
