### PR TITLE
Change test_grdsample.py to use static_earth_relief

### DIFF
--- a/pygmt/tests/test_grdsample.py
+++ b/pygmt/tests/test_grdsample.py
@@ -4,7 +4,8 @@ Tests for grdsample.
 import os
 
 import pytest
-from pygmt import grdinfo, grdsample
+import xarray as xr
+from pygmt import grdinfo, grdsample, load_dataarray
 from pygmt.datasets import load_earth_relief
 from pygmt.helpers import GMTTempFile
 
@@ -15,24 +16,67 @@ def fixture_grid():
     Load the grid data from the sample earth_relief file.
     """
     return load_earth_relief(
-        resolution="01d", region=[-5, 5, -5, 5], registration="pixel"
+        resolution="01d", registration="pixel", region=[124, 130, -25, -20]
     )
 
 
-def test_grdsample_file_out(grid):
+@pytest.fixture(scope="module", name="expected_grid")
+def fixture_grid_result():
     """
-    grdsample with an outgrid set and the spacing is changed.
+    Load the expected grdsample grid result.
+    """
+    return xr.DataArray(
+        data=[
+            [433.65625, 447.96875, 540.0625],
+            [397.28125, 386.15625, 484.125],
+            [334.96875, 417.25, 385.1875],
+            [303.40625, 373.625, 395.0],
+            [311.15625, 321.15625, 389.875],
+        ],
+        coords=dict(
+            lon=[
+                125.0,
+                127.0,
+                129.0,
+            ],
+            lat=[
+                -24.5,
+                -23.5,
+                -22.5,
+                -21.5,
+                -20.5,
+            ],
+        ),
+        dims=["lat", "lon"],
+    )
+
+
+def test_grdsample_file_out(grid, expected_grid):
+    """
+    Test grdsample with an outgrid set and the spacing is changed.
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
-        result = grdsample(grid=grid, outgrid=tmpfile.name, spacing=[1, 0.5])
+        result = grdsample(grid=grid, outgrid=tmpfile.name, spacing=[2, 1])
         assert result is None  # return value is None
         assert os.path.exists(path=tmpfile.name)  # check that outgrid exists
-        result = grdinfo(tmpfile.name, per_column=True).strip().split()
-        assert float(result[6]) == 1  # x-increment
-        assert float(result[7]) == 0.5  # y-increment
+        temp_grid = load_dataarray(tmpfile.name)
+        xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
-def test_grdsample_no_outgrid(grid):
+def test_grdsample_dataarray_out(grid, expected_grid):
+    """
+    Test grdsample with no outgrid set and the spacing is changed.
+    """
+    result = grdsample(grid=grid, spacing=[2, 1])
+    # check information of the output grid
+    assert isinstance(result, xr.DataArray)
+    assert result.gmt.gtype == 1  # Geographic grid
+    assert result.gmt.registration == 1  # Pixel registration
+    # check information of the output grid
+    xr.testing.assert_allclose(a=result, b=expected_grid)
+
+
+def test_grdsample_registration_changes(grid):
     """
     Test grdsample with no set outgrid and applying registration changes.
     """

--- a/pygmt/tests/test_grdsample.py
+++ b/pygmt/tests/test_grdsample.py
@@ -6,18 +6,16 @@ import os
 import pytest
 import xarray as xr
 from pygmt import grdsample, load_dataarray
-from pygmt.datasets import load_earth_relief
 from pygmt.helpers import GMTTempFile
+from pygmt.helpers.testing import load_static_earth_relief
 
 
 @pytest.fixture(scope="module", name="grid")
 def fixture_grid():
     """
-    Load the grid data from the sample earth_relief file.
+    Load the grid data from the static_earth_relief file.
     """
-    return load_earth_relief(
-        resolution="01d", registration="pixel", region=[124, 130, -25, -20]
-    )
+    return load_static_earth_relief()
 
 
 @pytest.fixture(scope="module", name="expected_grid")
@@ -27,25 +25,15 @@ def fixture_grid_result():
     """
     return xr.DataArray(
         data=[
-            [433.65625, 447.96875, 540.0625],
-            [397.28125, 386.15625, 484.125],
-            [334.96875, 417.25, 385.1875],
-            [303.40625, 373.625, 395.0],
-            [311.15625, 321.15625, 389.875],
+            [460.84375, 482.78125, 891.09375],
+            [680.46875, 519.09375, 764.9375],
+            [867.75, 579.03125, 852.53125],
+            [551.75, 666.6875, 958.21875],
+            [411.3125, 518.4375, 931.28125],
         ],
         coords=dict(
-            lon=[
-                125.0,
-                127.0,
-                129.0,
-            ],
-            lat=[
-                -24.5,
-                -23.5,
-                -22.5,
-                -21.5,
-                -20.5,
-            ],
+            lon=[-52, -50, -48],
+            lat=[-19.5, -18.5, -17.5, -16.5, -15.5],
         ),
         dims=["lat", "lon"],
     )
@@ -56,7 +44,9 @@ def test_grdsample_file_out(grid, expected_grid):
     Test grdsample with an outgrid set and the spacing is changed.
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
-        result = grdsample(grid=grid, outgrid=tmpfile.name, spacing=[2, 1])
+        result = grdsample(
+            grid=grid, outgrid=tmpfile.name, spacing=[2, 1], region=[-53, -47, -20, -15]
+        )
         assert result is None  # return value is None
         assert os.path.exists(path=tmpfile.name)  # check that outgrid exists
         temp_grid = load_dataarray(tmpfile.name)
@@ -67,7 +57,7 @@ def test_grdsample_dataarray_out(grid, expected_grid):
     """
     Test grdsample with no outgrid set and the spacing is changed.
     """
-    result = grdsample(grid=grid, spacing=[2, 1])
+    result = grdsample(grid=grid, spacing=[2, 1], region=[-53, -47, -20, -15])
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
     assert result.gmt.gtype == 1  # Geographic grid
@@ -81,7 +71,7 @@ def test_grdsample_registration_changes(grid):
     Test grdsample with no set outgrid and applying registration changes.
     """
     assert grid.gmt.registration == 1  # Pixel registration
-    translated_grid = grdsample(grid=grid, translate=True)
+    translated_grid = grdsample(grid=grid, translate=True, region=[-53, -47, -20, -15])
     assert translated_grid.gmt.registration == 0  # Gridline registration
     registration_grid = grdsample(grid=translated_grid, registration="p")
     assert registration_grid.gmt.registration == 1  # Pixel registration

--- a/pygmt/tests/test_grdsample.py
+++ b/pygmt/tests/test_grdsample.py
@@ -18,6 +18,22 @@ def fixture_grid():
     return load_static_earth_relief()
 
 
+@pytest.fixture(scope="module", name="region")
+def fixture_region():
+    """
+    Return the region settings for the grdsample tests.
+    """
+    return [-53, -47, -20, -15]
+
+
+@pytest.fixture(scope="module", name="spacing")
+def fixture_spacing():
+    """
+    Return the spacing settings for the grdsample tests.
+    """
+    return [2, 1]
+
+
 @pytest.fixture(scope="module", name="expected_grid")
 def fixture_grid_result():
     """
@@ -39,13 +55,13 @@ def fixture_grid_result():
     )
 
 
-def test_grdsample_file_out(grid, expected_grid):
+def test_grdsample_file_out(grid, expected_grid, region, spacing):
     """
     Test grdsample with an outgrid set and the spacing is changed.
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         result = grdsample(
-            grid=grid, outgrid=tmpfile.name, spacing=[2, 1], region=[-53, -47, -20, -15]
+            grid=grid, outgrid=tmpfile.name, spacing=spacing, region=region
         )
         assert result is None  # return value is None
         assert os.path.exists(path=tmpfile.name)  # check that outgrid exists
@@ -53,11 +69,11 @@ def test_grdsample_file_out(grid, expected_grid):
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
-def test_grdsample_dataarray_out(grid, expected_grid):
+def test_grdsample_dataarray_out(grid, expected_grid, region, spacing):
     """
     Test grdsample with no outgrid set and the spacing is changed.
     """
-    result = grdsample(grid=grid, spacing=[2, 1], region=[-53, -47, -20, -15])
+    result = grdsample(grid=grid, spacing=spacing, region=region)
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
     assert result.gmt.gtype == 1  # Geographic grid

--- a/pygmt/tests/test_grdsample.py
+++ b/pygmt/tests/test_grdsample.py
@@ -5,7 +5,7 @@ import os
 
 import pytest
 import xarray as xr
-from pygmt import grdinfo, grdsample, load_dataarray
+from pygmt import grdsample, load_dataarray
 from pygmt.datasets import load_earth_relief
 from pygmt.helpers import GMTTempFile
 

--- a/pygmt/tests/test_grdsample.py
+++ b/pygmt/tests/test_grdsample.py
@@ -71,7 +71,7 @@ def test_grdsample_registration_changes(grid):
     Test grdsample with no set outgrid and applying registration changes.
     """
     assert grid.gmt.registration == 1  # Pixel registration
-    translated_grid = grdsample(grid=grid, translate=True, region=[-53, -47, -20, -15])
+    translated_grid = grdsample(grid=grid, translate=True)
     assert translated_grid.gmt.registration == 0  # Gridline registration
     registration_grid = grdsample(grid=translated_grid, registration="p")
     assert registration_grid.gmt.registration == 1  # Pixel registration


### PR DESCRIPTION
**Description of proposed changes**

This PR refactors the pygmt.grdsample tests to use xarray.testing.assert_allclose() rather than pygmt.grdinfo() in preparation for the deprecation associated with better return values for grdinfo (https://github.com/GenericMappingTools/pygmt/issues/593).



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
