### PR TITLE
Use a single function for loading any sample dataset

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -210,6 +210,7 @@ and store them in the GMT cache folder.
 .. autosummary::
     :toctree: generated
 
+    datasets.list_sample_dataframes
     datasets.load_earth_age
     datasets.load_earth_relief
     datasets.load_fractures_compilation
@@ -218,6 +219,7 @@ and store them in the GMT cache folder.
     datasets.load_mars_shape
     datasets.load_ocean_ridge_points
     datasets.load_sample_bathymetry
+    datasets.load_sample_dataframe
     datasets.load_usgs_quakes
 
 .. automodule:: pygmt.exceptions

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -213,13 +213,13 @@ and store them in the GMT cache folder.
     datasets.list_sample_data
     datasets.load_earth_age
     datasets.load_earth_relief
+    datasets.load_sample_data
     datasets.load_fractures_compilation
     datasets.load_hotspots
     datasets.load_japan_quakes
     datasets.load_mars_shape
     datasets.load_ocean_ridge_points
     datasets.load_sample_bathymetry
-    datasets.load_sample_data
     datasets.load_usgs_quakes
 
 .. automodule:: pygmt.exceptions

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -210,7 +210,7 @@ and store them in the GMT cache folder.
 .. autosummary::
     :toctree: generated
 
-    datasets.list_sample_dataframes
+    datasets.list_sample_data
     datasets.load_earth_age
     datasets.load_earth_relief
     datasets.load_fractures_compilation
@@ -219,7 +219,7 @@ and store them in the GMT cache folder.
     datasets.load_mars_shape
     datasets.load_ocean_ridge_points
     datasets.load_sample_bathymetry
-    datasets.load_sample_dataframe
+    datasets.load_sample_data
     datasets.load_usgs_quakes
 
 .. automodule:: pygmt.exceptions

--- a/pygmt/datasets/__init__.py
+++ b/pygmt/datasets/__init__.py
@@ -5,11 +5,13 @@
 from pygmt.datasets.earth_age import load_earth_age
 from pygmt.datasets.earth_relief import load_earth_relief
 from pygmt.datasets.samples import (
+    list_sample_dataframes,
     load_fractures_compilation,
     load_hotspots,
     load_japan_quakes,
     load_mars_shape,
     load_ocean_ridge_points,
     load_sample_bathymetry,
+    load_sample_dataframe,
     load_usgs_quakes,
 )

--- a/pygmt/datasets/__init__.py
+++ b/pygmt/datasets/__init__.py
@@ -5,13 +5,13 @@
 from pygmt.datasets.earth_age import load_earth_age
 from pygmt.datasets.earth_relief import load_earth_relief
 from pygmt.datasets.samples import (
-    list_sample_dataframes,
+    list_sample_data,
     load_fractures_compilation,
     load_hotspots,
     load_japan_quakes,
     load_mars_shape,
     load_ocean_ridge_points,
     load_sample_bathymetry,
-    load_sample_dataframe,
+    load_sample_data,
     load_usgs_quakes,
 )

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -61,7 +61,7 @@ def load_japan_quakes(**kwargs):
     pandas.DataFrame.
 
     .. warning:: Deprecated since v0.6.0. This function has been replaced with
-       ``load_sample_data(name="tut_quakes.ngdc")`` and will be removed in
+       ``load_sample_data(name="japan_quakes")`` and will be removed in
        v0.9.0.
 
     Data is from the NOAA NGDC database. This is the ``@tut_quakes.ngdc``
@@ -82,7 +82,7 @@ def load_japan_quakes(**kwargs):
         warnings.warn(
             "This function has been deprecated since v0.6.0 and will be "
             "removed in v0.9.0.. Please use "
-            "load_sample_data(name='tut_quakes.ngdc') instead.",
+            "load_sample_data(name='japan_quakes') instead.",
             category=FutureWarning,
             stacklevel=2,
         )
@@ -108,7 +108,7 @@ def load_ocean_ridge_points(**kwargs):
     pandas.DataFrame (Deprecated).
 
     .. warning:: Deprecated since v0.6.0. This function has been replaced with
-       ``load_sample_data(name="ridge.txt")`` and will be removed in
+       ``load_sample_data(name="ocean_ridge_points")`` and will be removed in
        v0.9.0.
 
     This is the ``@ridge.txt`` dataset used in the GMT tutorials.
@@ -126,7 +126,7 @@ def load_ocean_ridge_points(**kwargs):
     if "suppress_warning" not in kwargs:
         warnings.warn(
             "This function has been deprecated since v0.6.0 and will be removed "
-            "in v0.9.0. Please use load_sample_data(name='ridge.txt') "
+            "in v0.9.0. Please use load_sample_data(name='ocean_ridge_points') "
             "instead.",
             category=FutureWarning,
             stacklevel=2,

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -10,16 +10,27 @@ from pygmt.src import which
 
 def list_sample_data():
     """
-    Report tabular datasets available for tests and documentation examples.
+    Report datasets available for tests and documentation examples.
 
     Returns
     -------
     output : dict
-        Names and short descriptions of available sample dataframes.
+        Names and short descriptions of available sample datasets.
+
+    See Also
+    --------
+    load_sample_data : Load an example dataset from the GMT server.
     """
     names = {
         "japan_quakes": "Table of earthquakes around Japan from NOAA NGDC database",
         "ocean_ridge_points": "Table of ocean ridge points for the entire world",
+        "bathymetry": "Table of ship bathymetric observations off Baja California",
+        "usgs_quakes": "Table of global earthquakes from the USGS",
+        "fractures": "Table of hypothetical fracture lengths and azimuths",
+        "hotspots": "Table of locations, names, and symbol sizes of hotpots from "
+        " Mueller et al., 1993",
+        "mars_shape": "Table of topographic signature of the hemispheric dichotomy of "
+        " Mars from Smith and Zuber (1996)",
     }
     return names
 
@@ -39,8 +50,14 @@ def load_sample_data(name):
 
     Returns
     -------
-    output : pandas.DataFrame
-        Tabular dataset.
+    output : pandas.DataFrame or xarray.DataArray
+        Sample dataset loaded as a pandas.DataFrame for tabular data or
+        xarray.DataArray for raster data
+
+    See Also
+    --------
+    list_sample_data : Report datasets available for tests and documentation
+        examples.
     """
     names = list_sample_data()
     if name not in names:
@@ -51,6 +68,21 @@ def load_sample_data(name):
 
     if name == "ocean_ridge_points":
         data = load_ocean_ridge_points(suppress_warning=True)
+
+    if name == "bathymetry":
+        data = load_sample_bathymetry(suppress_warning=True)
+
+    if name == "usgs_quakes":
+        data = load_usgs_quakes(suppress_warning=True)
+
+    if name == "fractures":
+        data = load_fractures_compilation(suppress_warning=True)
+
+    if name == "hotspots":
+        data = load_hotspots(suppress_warning=True)
+
+    if name == "mars_shape":
+        data = load_mars_shape(suppress_warning=True)
 
     return data
 
@@ -81,7 +113,7 @@ def load_japan_quakes(**kwargs):
     if "suppress_warning" not in kwargs:
         warnings.warn(
             "This function has been deprecated since v0.6.0 and will be "
-            "removed in v0.9.0.. Please use "
+            "removed in v0.9.0. Please use "
             "load_sample_data(name='japan_quakes') instead.",
             category=FutureWarning,
             stacklevel=2,
@@ -104,8 +136,8 @@ def load_japan_quakes(**kwargs):
 
 def load_ocean_ridge_points(**kwargs):
     """
-    Load a table of ocean ridge points for the entire world as a
-    pandas.DataFrame (Deprecated).
+    (Deprecated) Load a table of ocean ridge points for the entire world as a
+    pandas.DataFrame.
 
     .. warning:: Deprecated since v0.6.0. This function has been replaced with
        ``load_sample_data(name="ocean_ridge_points")`` and will be removed in
@@ -139,10 +171,14 @@ def load_ocean_ridge_points(**kwargs):
     return data
 
 
-def load_sample_bathymetry():
+def load_sample_bathymetry(**kwargs):
     """
-    Load a table of ship observations of bathymetry off Baja California as a
-    pandas.DataFrame.
+    (Deprecated) Load a table of ship observations of bathymetry off Baja
+    California as a pandas.DataFrame.
+
+    .. warning:: Deprecated since v0.6.0. This function has been replaced with
+       ``load_sample_data(name="bathymetry")`` and will be removed in
+       v0.9.0.
 
     This is the ``@tut_ship.xyz`` dataset used in the GMT tutorials.
 
@@ -155,6 +191,15 @@ def load_sample_bathymetry():
     data : pandas.DataFrame
         The data table. Columns are longitude, latitude, and bathymetry.
     """
+
+    if "suppress_warning" not in kwargs:
+        warnings.warn(
+            "This function has been deprecated since v0.6.0 and will be "
+            "removed in v0.9.0. Please use "
+            "load_sample_data(name='bathymetry') instead.",
+            category=FutureWarning,
+            stacklevel=2,
+        )
     fname = which("@tut_ship.xyz", download="c")
     data = pd.read_csv(
         fname, sep="\t", header=None, names=["longitude", "latitude", "bathymetry"]
@@ -162,9 +207,14 @@ def load_sample_bathymetry():
     return data
 
 
-def load_usgs_quakes():
+def load_usgs_quakes(**kwargs):
     """
-    Load a table of global earthquakes form the USGS as a pandas.DataFrame.
+    (Deprecated) Load a table of global earthquakes from the USGS as a
+    pandas.DataFrame.
+
+    .. warning:: Deprecated since v0.6.0. This function has been replaced with
+       ``load_sample_data(name="usgs_quakes")`` and will be removed in
+       v0.9.0.
 
     This is the ``@usgs_quakes_22.txt`` dataset used in the GMT tutorials.
 
@@ -178,15 +228,28 @@ def load_usgs_quakes():
         The data table. Use ``print(data.describe())`` to see the available
         columns.
     """
+
+    if "suppress_warning" not in kwargs:
+        warnings.warn(
+            "This function has been deprecated since v0.6.0 and will be "
+            "removed in v0.9.0. Please use "
+            "load_sample_data(name='usgs_quakes') instead.",
+            category=FutureWarning,
+            stacklevel=2,
+        )
     fname = which("@usgs_quakes_22.txt", download="c")
     data = pd.read_csv(fname)
     return data
 
 
-def load_fractures_compilation():
+def load_fractures_compilation(**kwargs):
     """
-    Load a table of fracture lengths and azimuths as hypothetically digitized
-    from geological maps as a pandas.DataFrame.
+    (Deprecated) Load a table of fracture lengths and azimuths as
+    hypothetically digitized from geological maps as a pandas.DataFrame.
+
+    .. warning:: Deprecated since v0.6.0. This function has been replaced with
+       ``load_sample_data(name="fractures")`` and will be removed in
+       v0.9.0.
 
     This is the ``@fractures_06.txt`` dataset used in the GMT tutorials.
 
@@ -200,15 +263,28 @@ def load_fractures_compilation():
         The data table. Use ``print(data.describe())`` to see the available
         columns.
     """
+
+    if "suppress_warning" not in kwargs:
+        warnings.warn(
+            "This function has been deprecated since v0.6.0 and will be "
+            "removed in v0.9.0. Please use "
+            "load_sample_data(name='fractures') instead.",
+            category=FutureWarning,
+            stacklevel=2,
+        )
     fname = which("@fractures_06.txt", download="c")
     data = pd.read_csv(fname, header=None, sep=r"\s+", names=["azimuth", "length"])
     return data[["length", "azimuth"]]
 
 
-def load_hotspots():
+def load_hotspots(**kwargs):
     """
-    Load a table with the locations, names, and suggested symbol sizes of
-    hotspots.
+    (Deprecated) Load a table with the locations, names, and suggested symbol
+    sizes of hotspots.
+
+    .. warning:: Deprecated since v0.6.0. This function has been replaced with
+       ``load_sample_data(name="hotspots")`` and will be removed in
+       v0.9.0.
 
     This is the ``@hotspots.txt`` dataset used in the GMT tutorials, with data
     from Mueller, Royer, and Lawver, 1993, Geology, vol. 21, pp. 275-278. The
@@ -225,15 +301,28 @@ def load_hotspots():
         The data table with columns "longitude", "latitude", "symbol_size", and
         "placename".
     """
+
+    if "suppress_warning" not in kwargs:
+        warnings.warn(
+            "This function has been deprecated since v0.6.0 and will be "
+            "removed in v0.9.0. Please use "
+            "load_sample_data(name='hotspots') instead.",
+            category=FutureWarning,
+            stacklevel=2,
+        )
     fname = which("@hotspots.txt", download="c")
     columns = ["longitude", "latitude", "symbol_size", "place_name"]
     data = pd.read_table(filepath_or_buffer=fname, sep="\t", skiprows=3, names=columns)
     return data
 
 
-def load_mars_shape():
+def load_mars_shape(**kwargs):
     """
-    Load a table of data for the shape of Mars.
+    (Deprecated) Load a table of data for the shape of Mars.
+
+    .. warning:: Deprecated since v0.6.0. This function has been replaced with
+       ``load_sample_data(name="mars_shape")`` and will be removed in
+       v0.9.0.
 
     This is the ``@mars370d.txt`` dataset used in GMT examples, with data and
     information from Smith, D. E., and M. T. Zuber (1996), The shape of Mars
@@ -249,6 +338,15 @@ def load_mars_shape():
     data : pandas.DataFrame
         The data table with columns "longitude", "latitude", and "radius(m)".
     """
+
+    if "suppress_warning" not in kwargs:
+        warnings.warn(
+            "This function has been deprecated since v0.6.0 and will be "
+            "removed in v0.9.0. Please use "
+            "load_sample_data(name='mars_shape') instead.",
+            category=FutureWarning,
+            stacklevel=2,
+        )
     fname = which("@mars370d.txt", download="c")
     data = pd.read_csv(
         fname, sep="\t", header=None, names=["longitude", "latitude", "radius(m)"]

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -52,7 +52,7 @@ def load_sample_data(name):
     -------
     :class:`pandas.DataFrame` or :class:`xarray.DataArray`
         Sample dataset loaded as a pandas.DataFrame for tabular data or
-        xarray.DataArray for raster data
+        xarray.DataArray for raster data.
 
     See Also
     --------

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -1,13 +1,79 @@
 """
 Functions to load sample data.
 """
+import warnings
+
 import pandas as pd
+from pygmt.exceptions import GMTInvalidInput
 from pygmt.src import which
+
+
+def list_sample_dataframes():
+    """
+    Report tabular datasets available for tests and documentation examples.
+
+    Returns
+    -------
+    output : dict
+        Names and short descriptions of available sample dataframes.
+    """
+    names = {
+        "tut_quakes.ngdc": "Table of earthquakes around Japan from NOAA NGDC database",
+        "ridge.txt": "Table of ocean ridge points for the entire world",
+    }
+    return names
+
+
+def load_sample_dataframe(name):
+    """
+    Load an example dataset from the GMT server.
+
+    The data are downloaded to a cache directory (usually ``~/.gmt/cache``) the
+    first time you invoke this function. Afterwards, it will load the data from
+    the cache. So you'll need an internet connection the first time around.
+
+    Parameters
+    ----------
+    name : str
+        Name of the dataset to load.
+
+    Returns
+    -------
+    output : pandas.DataFrame
+        Tabular dataset.
+    """
+    names = list_sample_dataframes()
+    if name not in names:
+        raise GMTInvalidInput(f"Invalid dataset name '{name}'")
+
+    fname = which("@" + name, download="c")
+
+    if name == "tut_quakes.ngdc":
+        data = pd.read_csv(fname, header=1, sep=r"\s+")
+        data.columns = [
+            "year",
+            "month",
+            "day",
+            "latitude",
+            "longitude",
+            "depth_km",
+            "magnitude",
+        ]
+
+    if name == "ridge.txt":
+        data = pd.read_csv(
+            fname, sep=r"\s+", names=["longitude", "latitude"], skiprows=1, comment=">"
+        )
+    return data
 
 
 def load_japan_quakes():
     """
-    Load a table of earthquakes around Japan as a pandas.DataFrame.
+    Load a table of earthquakes around Japan as a pandas.DataFrame (Deprecated)
+
+    .. warning:: Deprecated since v0.6.0. This function has been replaced with
+       ``load_sample_dataframe(name="tut_quakes.ngdc")`` and will be removed in
+       v0.9.0.
 
     Data is from the NOAA NGDC database. This is the ``@tut_quakes.ngdc``
     dataset used in the GMT tutorials.
@@ -15,31 +81,27 @@ def load_japan_quakes():
     The data are downloaded to a cache directory (usually ``~/.gmt/cache``) the
     first time you invoke this function. Afterwards, it will load the data from
     the cache. So you'll need an internet connection the first time around.
-
-    Returns
-    -------
-    data : pandas.DataFrame
-        The data table. Columns are year, month, day, latitude, longitude,
-        depth (in km), and magnitude of the earthquakes.
     """
-    fname = which("@tut_quakes.ngdc", download="c")
-    data = pd.read_csv(fname, header=1, sep=r"\s+")
-    data.columns = [
-        "year",
-        "month",
-        "day",
-        "latitude",
-        "longitude",
-        "depth_km",
-        "magnitude",
-    ]
-    return data
+
+    warnings.warn(
+        "This function has been deprecated since v0.6.0 and will be removed "
+        "in v0.9.0. Please use load_sample_dataframe(name='tut_quakes.ngdc') "
+        "instead.",
+        category=FutureWarning,
+        stacklevel=2,
+    )
+
+    return load_sample_dataframe("tut_quakes.ngdc")
 
 
 def load_ocean_ridge_points():
     """
     Load a table of ocean ridge points for the entire world as a
-    pandas.DataFrame.
+    pandas.DataFrame (Deprecated).
+
+    .. warning:: Deprecated since v0.6.0. This function has been replaced with
+       ``load_sample_dataframe(name="ridge.txt")`` and will be removed in
+       v0.9.0.
 
     This is the ``@ridge.txt`` dataset used in the GMT tutorials.
 
@@ -52,11 +114,15 @@ def load_ocean_ridge_points():
     data : pandas.DataFrame
         The data table. Columns are longitude and latitude.
     """
-    fname = which("@ridge.txt", download="c")
-    data = pd.read_csv(
-        fname, sep=r"\s+", names=["longitude", "latitude"], skiprows=1, comment=">"
+    warnings.warn(
+        "This function has been deprecated since v0.6.0 and will be removed "
+        "in v0.9.0. Please use load_sample_dataframe(name='ridge.txt') "
+        "instead.",
+        category=FutureWarning,
+        stacklevel=2,
     )
-    return data
+
+    return load_sample_dataframe("ridge.txt")
 
 
 def load_sample_bathymetry():

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -22,15 +22,15 @@ def list_sample_data():
     load_sample_data : Load an example dataset from the GMT server.
     """
     names = {
-        "japan_quakes": "Table of earthquakes around Japan from NOAA NGDC database",
-        "ocean_ridge_points": "Table of ocean ridge points for the entire world",
         "bathymetry": "Table of ship bathymetric observations off Baja California",
-        "usgs_quakes": "Table of global earthquakes from the USGS",
         "fractures": "Table of hypothetical fracture lengths and azimuths",
         "hotspots": "Table of locations, names, and symbol sizes of hotpots from "
         " Mueller et al., 1993",
+        "japan_quakes": "Table of earthquakes around Japan from NOAA NGDC database",
         "mars_shape": "Table of topographic signature of the hemispheric dichotomy of "
         " Mars from Smith and Zuber (1996)",
+        "ocean_ridge_points": "Table of ocean ridge points for the entire world",
+        "usgs_quakes": "Table of global earthquakes from the USGS",
     }
     return names
 
@@ -64,13 +64,13 @@ def load_sample_data(name):
         raise GMTInvalidInput(f"Invalid dataset name '{name}'.")
 
     load_func = {
-        "japan_quakes": load_japan_quakes,
-        "ocean_ridge_points": load_ocean_ridge_points,
         "bathymetry": load_sample_bathymetry,
-        "usgs_quakes": load_usgs_quakes,
         "fractures": load_fractures_compilation,
         "hotspots": load_hotspots,
+        "japan_quakes": load_japan_quakes,
         "mars_shape": load_mars_shape,
+        "ocean_ridge_points": load_ocean_ridge_points,
+        "usgs_quakes": load_usgs_quakes,
     }
 
     data = load_func[name](suppress_warning=True)

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -14,7 +14,7 @@ def list_sample_data():
 
     Returns
     -------
-    output : dict
+    dict
         Names and short descriptions of available sample datasets.
 
     See Also
@@ -50,7 +50,7 @@ def load_sample_data(name):
 
     Returns
     -------
-    output : pandas.DataFrame or xarray.DataArray
+    :class:`pandas.DataFrame` or :class:`xarray.DataArray`
         Sample dataset loaded as a pandas.DataFrame for tabular data or
         xarray.DataArray for raster data
 
@@ -61,7 +61,7 @@ def load_sample_data(name):
     """
     names = list_sample_data()
     if name not in names:
-        raise GMTInvalidInput(f"Invalid dataset name '{name}'")
+        raise GMTInvalidInput(f"Invalid dataset name '{name}'.")
 
     if name == "japan_quakes":
         data = load_japan_quakes(suppress_warning=True)

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -18,8 +18,8 @@ def list_sample_dataframes():
         Names and short descriptions of available sample dataframes.
     """
     names = {
-        "tut_quakes.ngdc": "Table of earthquakes around Japan from NOAA NGDC database",
-        "ridge.txt": "Table of ocean ridge points for the entire world",
+        "japan_quakes": "Table of earthquakes around Japan from NOAA NGDC database",
+        "ocean_ridge_points": "Table of ocean ridge points for the entire world",
     }
     return names
 
@@ -46,24 +46,12 @@ def load_sample_dataframe(name):
     if name not in names:
         raise GMTInvalidInput(f"Invalid dataset name '{name}'")
 
-    fname = which("@" + name, download="c")
+    if name == "japan_quakes":
+        data = load_tut_quakes()
 
-    if name == "tut_quakes.ngdc":
-        data = pd.read_csv(fname, header=1, sep=r"\s+")
-        data.columns = [
-            "year",
-            "month",
-            "day",
-            "latitude",
-            "longitude",
-            "depth_km",
-            "magnitude",
-        ]
+    if name == "ocean_ridge_points":
+        data = load_ridge()
 
-    if name == "ridge.txt":
-        data = pd.read_csv(
-            fname, sep=r"\s+", names=["longitude", "latitude"], skiprows=1, comment=">"
-        )
     return data
 
 
@@ -81,6 +69,12 @@ def load_japan_quakes():
     The data are downloaded to a cache directory (usually ``~/.gmt/cache``) the
     first time you invoke this function. Afterwards, it will load the data from
     the cache. So you'll need an internet connection the first time around.
+
+    Returns
+    -------
+    data : pandas.DataFrame
+        The data table. Columns are year, month, day, latitude, longitude,
+        depth (in km), and magnitude of the earthquakes.
     """
 
     warnings.warn(
@@ -91,7 +85,36 @@ def load_japan_quakes():
         stacklevel=2,
     )
 
-    return load_sample_dataframe("tut_quakes.ngdc")
+    return load_sample_dataframe("japan_quakes")
+
+
+def load_tut_quakes():
+    """
+    Load the remote file @tut_quakes.ngdc as a pandas.DataFrame.
+
+    Data is from the NOAA NGDC database. This is the ``@tut_quakes.ngdc``
+    dataset used in the GMT tutorials.
+
+    Returns
+    -------
+    data : pandas.DataFrame
+        The data table. Columns are year, month, day, latitude, longitude,
+        depth (in km), and magnitude of the earthquakes.
+    """
+
+    fname = which("@tut_quakes.ngdc", download="c")
+    data = pd.read_csv(fname, header=1, sep=r"\s+")
+    data.columns = [
+        "year",
+        "month",
+        "day",
+        "latitude",
+        "longitude",
+        "depth_km",
+        "magnitude",
+    ]
+
+    return data
 
 
 def load_ocean_ridge_points():
@@ -122,7 +145,24 @@ def load_ocean_ridge_points():
         stacklevel=2,
     )
 
-    return load_sample_dataframe("ridge.txt")
+    return load_sample_dataframe("ocean_ridge_points")
+
+
+def load_ridge():
+    """
+    Load a table of ocean ridge points for the entire world as a
+    pandas.DataFrame.
+
+    Returns
+    -------
+    data : pandas.DataFrame
+        The data table. Columns are longitude and latitude.
+    """
+    fname = which("@ridge.txt", download="c")
+    data = pd.read_csv(
+        fname, sep=r"\s+", names=["longitude", "latitude"], skiprows=1, comment=">"
+    )
+    return data
 
 
 def load_sample_bathymetry():

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -63,26 +63,17 @@ def load_sample_data(name):
     if name not in names:
         raise GMTInvalidInput(f"Invalid dataset name '{name}'.")
 
-    if name == "japan_quakes":
-        data = load_japan_quakes(suppress_warning=True)
+    load_func = {
+        "japan_quakes": load_japan_quakes,
+        "ocean_ridge_points": load_ocean_ridge_points,
+        "bathymetry": load_sample_bathymetry,
+        "usgs_quakes": load_usgs_quakes,
+        "fractures": load_fractures_compilation,
+        "hotspots": load_hotspots,
+        "mars_shape": load_mars_shape,
+    }
 
-    if name == "ocean_ridge_points":
-        data = load_ocean_ridge_points(suppress_warning=True)
-
-    if name == "bathymetry":
-        data = load_sample_bathymetry(suppress_warning=True)
-
-    if name == "usgs_quakes":
-        data = load_usgs_quakes(suppress_warning=True)
-
-    if name == "fractures":
-        data = load_fractures_compilation(suppress_warning=True)
-
-    if name == "hotspots":
-        data = load_hotspots(suppress_warning=True)
-
-    if name == "mars_shape":
-        data = load_mars_shape(suppress_warning=True)
+    data = load_func[name](suppress_warning=True)
 
     return data
 

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -8,7 +8,7 @@ from pygmt.exceptions import GMTInvalidInput
 from pygmt.src import which
 
 
-def list_sample_dataframes():
+def list_sample_data():
     """
     Report tabular datasets available for tests and documentation examples.
 
@@ -24,7 +24,7 @@ def list_sample_dataframes():
     return names
 
 
-def load_sample_dataframe(name):
+def load_sample_data(name):
     """
     Load an example dataset from the GMT server.
 
@@ -42,7 +42,7 @@ def load_sample_dataframe(name):
     output : pandas.DataFrame
         Tabular dataset.
     """
-    names = list_sample_dataframes()
+    names = list_sample_data()
     if name not in names:
         raise GMTInvalidInput(f"Invalid dataset name '{name}'")
 
@@ -61,7 +61,7 @@ def load_japan_quakes(**kwargs):
     pandas.DataFrame.
 
     .. warning:: Deprecated since v0.6.0. This function has been replaced with
-       ``load_sample_dataframe(name="tut_quakes.ngdc")`` and will be removed in
+       ``load_sample_data(name="tut_quakes.ngdc")`` and will be removed in
        v0.9.0.
 
     Data is from the NOAA NGDC database. This is the ``@tut_quakes.ngdc``
@@ -82,7 +82,7 @@ def load_japan_quakes(**kwargs):
         warnings.warn(
             "This function has been deprecated since v0.6.0 and will be "
             "removed in v0.9.0.. Please use "
-            "load_sample_dataframe(name='tut_quakes.ngdc') instead.",
+            "load_sample_data(name='tut_quakes.ngdc') instead.",
             category=FutureWarning,
             stacklevel=2,
         )
@@ -108,7 +108,7 @@ def load_ocean_ridge_points(**kwargs):
     pandas.DataFrame (Deprecated).
 
     .. warning:: Deprecated since v0.6.0. This function has been replaced with
-       ``load_sample_dataframe(name="ridge.txt")`` and will be removed in
+       ``load_sample_data(name="ridge.txt")`` and will be removed in
        v0.9.0.
 
     This is the ``@ridge.txt`` dataset used in the GMT tutorials.
@@ -126,7 +126,7 @@ def load_ocean_ridge_points(**kwargs):
     if "suppress_warning" not in kwargs:
         warnings.warn(
             "This function has been deprecated since v0.6.0 and will be removed "
-            "in v0.9.0. Please use load_sample_dataframe(name='ridge.txt') "
+            "in v0.9.0. Please use load_sample_data(name='ridge.txt') "
             "instead.",
             category=FutureWarning,
             stacklevel=2,

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -57,7 +57,7 @@ def load_sample_dataframe(name):
 
 def load_japan_quakes():
     """
-    Load a table of earthquakes around Japan as a pandas.DataFrame (Deprecated)
+    (Deprecated) Load a table of earthquakes around Japan as a pandas.DataFrame.
 
     .. warning:: Deprecated since v0.6.0. This function has been replaced with
        ``load_sample_dataframe(name="tut_quakes.ngdc")`` and will be removed in
@@ -88,7 +88,7 @@ def load_japan_quakes():
     return load_sample_dataframe("japan_quakes")
 
 
-def load_tut_quakes():
+def _load_tut_quakes():
     """
     Load the remote file @tut_quakes.ngdc as a pandas.DataFrame.
 

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -47,17 +47,18 @@ def load_sample_dataframe(name):
         raise GMTInvalidInput(f"Invalid dataset name '{name}'")
 
     if name == "japan_quakes":
-        data = load_tut_quakes()
+        data = load_japan_quakes(suppress_warning=True)
 
     if name == "ocean_ridge_points":
-        data = load_ridge()
+        data = load_ocean_ridge_points(suppress_warning=True)
 
     return data
 
 
-def load_japan_quakes():
+def load_japan_quakes(**kwargs):
     """
-    (Deprecated) Load a table of earthquakes around Japan as a pandas.DataFrame.
+    (Deprecated) Load a table of earthquakes around Japan as a
+    pandas.DataFrame.
 
     .. warning:: Deprecated since v0.6.0. This function has been replaced with
        ``load_sample_dataframe(name="tut_quakes.ngdc")`` and will be removed in
@@ -77,30 +78,14 @@ def load_japan_quakes():
         depth (in km), and magnitude of the earthquakes.
     """
 
-    warnings.warn(
-        "This function has been deprecated since v0.6.0 and will be removed "
-        "in v0.9.0. Please use load_sample_dataframe(name='tut_quakes.ngdc') "
-        "instead.",
-        category=FutureWarning,
-        stacklevel=2,
-    )
-
-    return load_sample_dataframe("japan_quakes")
-
-
-def _load_tut_quakes():
-    """
-    Load the remote file @tut_quakes.ngdc as a pandas.DataFrame.
-
-    Data is from the NOAA NGDC database. This is the ``@tut_quakes.ngdc``
-    dataset used in the GMT tutorials.
-
-    Returns
-    -------
-    data : pandas.DataFrame
-        The data table. Columns are year, month, day, latitude, longitude,
-        depth (in km), and magnitude of the earthquakes.
-    """
+    if "suppress_warning" not in kwargs:
+        warnings.warn(
+            "This function has been deprecated since v0.6.0 and will be "
+            "removed in v0.9.0.. Please use "
+            "load_sample_dataframe(name='tut_quakes.ngdc') instead.",
+            category=FutureWarning,
+            stacklevel=2,
+        )
 
     fname = which("@tut_quakes.ngdc", download="c")
     data = pd.read_csv(fname, header=1, sep=r"\s+")
@@ -117,7 +102,7 @@ def _load_tut_quakes():
     return data
 
 
-def load_ocean_ridge_points():
+def load_ocean_ridge_points(**kwargs):
     """
     Load a table of ocean ridge points for the entire world as a
     pandas.DataFrame (Deprecated).
@@ -137,27 +122,16 @@ def load_ocean_ridge_points():
     data : pandas.DataFrame
         The data table. Columns are longitude and latitude.
     """
-    warnings.warn(
-        "This function has been deprecated since v0.6.0 and will be removed "
-        "in v0.9.0. Please use load_sample_dataframe(name='ridge.txt') "
-        "instead.",
-        category=FutureWarning,
-        stacklevel=2,
-    )
 
-    return load_sample_dataframe("ocean_ridge_points")
+    if "suppress_warning" not in kwargs:
+        warnings.warn(
+            "This function has been deprecated since v0.6.0 and will be removed "
+            "in v0.9.0. Please use load_sample_dataframe(name='ridge.txt') "
+            "instead.",
+            category=FutureWarning,
+            stacklevel=2,
+        )
 
-
-def load_ridge():
-    """
-    Load a table of ocean ridge points for the entire world as a
-    pandas.DataFrame.
-
-    Returns
-    -------
-    data : pandas.DataFrame
-        The data table. Columns are longitude and latitude.
-    """
     fname = which("@ridge.txt", download="c")
     data = pd.read_csv(
         fname, sep=r"\s+", names=["longitude", "latitude"], skiprows=1, comment=">"

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -2,6 +2,7 @@
 Test basic functionality for loading sample datasets.
 """
 import pandas as pd
+import pytest
 from pygmt.datasets import (
     load_fractures_compilation,
     load_hotspots,
@@ -9,15 +10,42 @@ from pygmt.datasets import (
     load_mars_shape,
     load_ocean_ridge_points,
     load_sample_bathymetry,
+    load_sample_dataframe,
     load_usgs_quakes,
 )
+from pygmt.exceptions import GMTInvalidInput
+
+
+def test_load_sample_invalid():
+    """
+    Check that the function raises error for unsupported filenames.
+    """
+    with pytest.raises(GMTInvalidInput):
+        load_sample_dataframe(name="bad.filename")
 
 
 def test_japan_quakes():
     """
     Check that the dataset loads without errors.
     """
-    data = load_japan_quakes()
+    with pytest.warns(expected_warning=FutureWarning) as record:
+        data = load_japan_quakes()
+        assert len(record) == 1
+    assert data.shape == (115, 7)
+    summary = data.describe()
+    assert summary.loc["min", "year"] == 1987
+    assert summary.loc["max", "year"] == 1988
+    assert summary.loc["min", "month"] == 1
+    assert summary.loc["max", "month"] == 12
+    assert summary.loc["min", "day"] == 1
+    assert summary.loc["max", "day"] == 31
+
+
+def test_load_sample_dataframe():
+    """
+    Check that the dataset loads without errors.
+    """
+    data = load_sample_dataframe(name="tut_quakes.ngdc")
     assert data.shape == (115, 7)
     summary = data.describe()
     assert summary.loc["min", "year"] == 1987
@@ -32,7 +60,9 @@ def test_ocean_ridge_points():
     """
     Check that the @ridge.txt dataset loads without errors.
     """
-    data = load_ocean_ridge_points()
+    with pytest.warns(expected_warning=FutureWarning) as record:
+        data = load_ocean_ridge_points()
+        assert len(record) == 1
     assert data.shape == (4146, 2)
     summary = data.describe()
     assert summary.loc["min", "longitude"] == -179.9401

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -45,7 +45,7 @@ def test_load_sample_dataframe():
     """
     Check that the dataset loads without errors.
     """
-    data = load_sample_dataframe(name="tut_quakes.ngdc")
+    data = load_sample_dataframe(name="japan_quakes")
     assert data.shape == (115, 7)
     summary = data.describe()
     assert summary.loc["min", "year"] == 1987

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -75,7 +75,9 @@ def test_sample_bathymetry():
     """
     Check that the @tut_ship.xyz dataset loads without errors.
     """
-    data = load_sample_bathymetry()
+    with pytest.warns(expected_warning=FutureWarning) as record:
+        data = load_sample_bathymetry()
+        assert len(record) == 1
     assert data.shape == (82970, 3)
     summary = data.describe()
     assert summary.loc["min", "longitude"] == 245.0
@@ -90,7 +92,9 @@ def test_usgs_quakes():
     """
     Check that the dataset loads without errors.
     """
-    data = load_usgs_quakes()
+    with pytest.warns(expected_warning=FutureWarning) as record:
+        data = load_usgs_quakes()
+        assert len(record) == 1
     assert data.shape == (1197, 22)
 
 
@@ -98,7 +102,9 @@ def test_fractures_compilation():
     """
     Check that the @fractures_06.txt dataset loads without errors.
     """
-    data = load_fractures_compilation()
+    with pytest.warns(expected_warning=FutureWarning) as record:
+        data = load_fractures_compilation()
+        assert len(record) == 1
     assert data.shape == (361, 2)
     summary = data.describe()
     assert summary.loc["min", "length"] == 98.6561
@@ -111,7 +117,9 @@ def test_mars_shape():
     """
     Check that the @mars370d.txt dataset loads without errors.
     """
-    data = load_mars_shape()
+    with pytest.warns(expected_warning=FutureWarning) as record:
+        data = load_mars_shape()
+        assert len(record) == 1
     assert data.shape == (370, 3)
     summary = data.describe()
     assert summary.loc["min", "longitude"] == 0.008
@@ -126,7 +134,9 @@ def test_hotspots():
     """
     Check that the @hotspots.txt dataset loads without errors.
     """
-    data = load_hotspots()
+    with pytest.warns(expected_warning=FutureWarning) as record:
+        data = load_hotspots()
+        assert len(record) == 1
     assert data.shape == (55, 4)
     assert data.columns.values.tolist() == [
         "longitude",

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -10,7 +10,7 @@ from pygmt.datasets import (
     load_mars_shape,
     load_ocean_ridge_points,
     load_sample_bathymetry,
-    load_sample_dataframe,
+    load_sample_data,
     load_usgs_quakes,
 )
 from pygmt.exceptions import GMTInvalidInput
@@ -21,7 +21,7 @@ def test_load_sample_invalid():
     Check that the function raises error for unsupported filenames.
     """
     with pytest.raises(GMTInvalidInput):
-        load_sample_dataframe(name="bad.filename")
+        load_sample_data(name="bad.filename")
 
 
 def test_japan_quakes():
@@ -41,11 +41,11 @@ def test_japan_quakes():
     assert summary.loc["max", "day"] == 31
 
 
-def test_load_sample_dataframe():
+def test_load_sample_data():
     """
     Check that the dataset loads without errors.
     """
-    data = load_sample_dataframe(name="japan_quakes")
+    data = load_sample_data(name="japan_quakes")
     assert data.shape == (115, 7)
     summary = data.describe()
     assert summary.loc["min", "year"] == 1987


### PR DESCRIPTION
**Description of proposed changes**

This PR partially implements the suggestions in #1436, in deprecating individual functions in favor of a single function for loading sample datasets.

It also adds a `list_sample_dataframes` function that lists the available dataset names to provide to `load_sample_dataframe`.

A couple questions:
1. Should we have one function that returns either an xarray.DataArray or pandas.DataFrame depending on the specific file requested or one function for tabular data samples and another for raster data samples?
2. Currently, the user would pass exact name of the file on the GMT server. Should we continue with this implementation or provide different names that are more similar to the existing functions (e.g., `name="japan_quakes"` vs `name="tut_quakes.ngdc"`)?

To do:
- [ ] Deprecate other functions for loading a sample pandas.DataFrame
- [ ] Deprecate functions for loading a sample xarray.DataArray
- [ ] Update syntax in gallery examples and tutorials.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
