### PR TITLE
Add an "add a title" to starter tutorial

### DIFF
--- a/examples/get-started/first_figure.py
+++ b/examples/get-started/first_figure.py
@@ -121,7 +121,7 @@ fig.show()
 # annotate the latitude and longitude of the region.
 #
 # The ``frame`` parameter is used to add a frame to the figure. For now, it
-# will be set to ``"a"`` to **a**nnotate the axes automatically.
+# will be set to ``"a"`` to **a**\ nnotate the axes automatically.
 
 fig = pygmt.Figure()
 fig.coast(

--- a/examples/get-started/first_figure.py
+++ b/examples/get-started/first_figure.py
@@ -147,8 +147,8 @@ fig.show()
 # the figure title.
 #
 # If the figure title has any spaces, the string to set the title needs to
-# use single-quotes, with the actual title set in double quotes (e.g. setting
-# the title to "Coastal Maine" would use the syntax ``'+t"Coastal Maine"'``.
+# be wrapped in single-quotes, while the actual title is set in double quotes
+# (e.g. setting the title to "A Title" would use the syntax ``'+t"A Title"'``.
 
 fig = pygmt.Figure()
 fig.coast(

--- a/examples/get-started/first_figure.py
+++ b/examples/get-started/first_figure.py
@@ -146,7 +146,7 @@ fig.show()
 # example below. This format uses ``frame`` to set both the axes gridlines and
 # the figure title.
 #
-# If the figure title has multiple words, the string to set the title needs to
+# If the figure title has any spaces, the string to set the title needs to
 # use single-quotes, with the actual title set in double quotes (e.g. setting
 # the title to "Coastal Maine" would use the syntax ``'+t"Coastal Maine"'``.
 

--- a/examples/get-started/first_figure.py
+++ b/examples/get-started/first_figure.py
@@ -121,8 +121,7 @@ fig.show()
 # annotate the latitude and longitude of the region.
 #
 # The ``frame`` parameter is used to add a frame to the figure. For now, it
-# will be set to ``True`` to use default settings, but later tutorials will
-# show how ``frame`` can be used to customize the axes, gridlines, and titles.
+# will be set to ``"a"`` to use automatic settings.
 
 fig = pygmt.Figure()
 fig.coast(
@@ -131,7 +130,34 @@ fig.coast(
     land="lightgreen",
     water="lightblue",
     projection="M10c",
-    frame=True,
+    frame="a",
+)
+fig.show()
+
+###############################################################################
+# Add a title
+# -----------
+#
+# The ``frame`` parameter can be used to add a title to the figure. The title
+# is set with by passing ``"+t"`` followed by the title (e.g. setting the map
+# title to "Title" would be ``"+tTitle"``).
+#
+# To pass multiple arguments to ``frame``, a list can be used, as shown in the
+# example below. This format uses ``frame`` to set both the axes gridlines and
+# the figure title.
+#
+# If the figure title has multiple words, the string to set the title needs to
+# use single-quotes, with the actual title set in double quotes (e.g. setting
+# the title to "Coastal Maine" would use the syntax ``'+t"Coastal Maine"'``.
+
+fig = pygmt.Figure()
+fig.coast(
+    region=[-69, -68, 43.75, 44.75],
+    shorelines=True,
+    land="lightgreen",
+    water="lightblue",
+    projection="M10c",
+    frame=["a", "+tMaine"],
 )
 fig.show()
 

--- a/examples/get-started/first_figure.py
+++ b/examples/get-started/first_figure.py
@@ -121,7 +121,7 @@ fig.show()
 # annotate the latitude and longitude of the region.
 #
 # The ``frame`` parameter is used to add a frame to the figure. For now, it
-# will be set to ``"a"`` to use automatic settings.
+# will be set to ``"a"`` to use automatic annotation settings.
 
 fig = pygmt.Figure()
 fig.coast(

--- a/examples/get-started/first_figure.py
+++ b/examples/get-started/first_figure.py
@@ -121,7 +121,7 @@ fig.show()
 # annotate the latitude and longitude of the region.
 #
 # The ``frame`` parameter is used to add a frame to the figure. For now, it
-# will be set to ``"a"`` to use automatic annotation settings.
+# will be set to ``"a"`` to **a**nnotate the axes automatically.
 
 fig = pygmt.Figure()
 fig.coast(


### PR DESCRIPTION
I originally intended to add a second page to the tutorial that covered adding a title, but changed my mind and think the title section would be more appropriate in first_figure.py rather than adding a separate page, which this PR does.

Additionally, to reduce confusion over switching between `frame=True` and frame=["a", "+tMaine"], this changes the frame example to use `frame="a"`.



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #770 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
