### PR TITLE
Add inline example for grdcut

### DIFF
--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -90,15 +90,15 @@ def grdcut(grid, **kwargs):
 
     Examples
     --------
-    >>> import pygmt
+    >>> import pygmt # doctest: +SKIP
     >>> # Load a grid of @earth_relief_30m data, with an x-range of 10 to 30,
     >>> # and a y-range of 15 to 25
-    >>> grid = pygmt.datasets.load_earth_relief(
-    ...     resolution="30m", region=[10, 30, 15, 25]
-    ... )
+    >>> grid = pygmt.datasets.load_earth_relief( # doctest: +SKIP
+    ...     resolution="30m", region=[10, 30, 15, 25] # doctest: +SKIP
+    ... ) # doctest: +SKIP
     >>> # Create a new grid from an input grid, with an x-range of 12 to 15,
     >>> # and a y-range of 21 to 24
-    >>> new_grid = pygmt.grdcut(grid=grid, region=[12, 15, 21, 24])
+    >>> new_grid = pygmt.grdcut(grid=grid, region=[12, 15, 21, 24]) # doctest: +SKIP
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -91,7 +91,6 @@ def grdcut(grid, **kwargs):
     Examples
     --------
     >>> import pygmt
-
     >>> # Load a grid of @earth_relief_30m data, with an x-range of 10 to 30,
     >>> # and a y-range of 15 to 25
     >>> grid = pygmt.datasets.load_earth_relief(

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -90,15 +90,17 @@ def grdcut(grid, **kwargs):
 
     Examples
     --------
-    >>> import pygmt # doctest: +SKIP
+    >>> import pygmt  # doctest: +SKIP
     >>> # Load a grid of @earth_relief_30m data, with an x-range of 10 to 30,
     >>> # and a y-range of 15 to 25
-    >>> grid = pygmt.datasets.load_earth_relief( # doctest: +SKIP
-    ...     resolution="30m", region=[10, 30, 15, 25] # doctest: +SKIP
-    ... ) # doctest: +SKIP
+    >>> grid = pygmt.datasets.load_earth_relief(
+    ...     resolution="30m", region=[10, 30, 15, 25]
+    ... )  # doctest: +SKIP
     >>> # Create a new grid from an input grid, with an x-range of 12 to 15,
     >>> # and a y-range of 21 to 24
-    >>> new_grid = pygmt.grdcut(grid=grid, region=[12, 15, 21, 24]) # doctest: +SKIP
+    >>> new_grid = pygmt.grdcut(
+    ...     grid=grid, region=[12, 15, 21, 24]
+    ... )  # doctest: +SKIP
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -87,6 +87,19 @@ def grdcut(grid, **kwargs):
         - :class:`xarray.DataArray` if ``outgrid`` is not set
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)
+
+    Examples
+    --------
+    >>> import pygmt
+
+    >>> # Load a grid of @earth_relief_30m data, with an x-range of 10 to 30,
+    >>> # and a y-range of 15 to 25
+    >>> grid = pygmt.datasets.load_earth_relief(
+    ...     resolution="30m", region=[10, 30, 15, 25]
+    ... )
+    >>> # Create a new grid from an input grid, with an x-range of -3 to 1,
+    >>> # and a y-range of 2 to 5
+    >>> new_grid = pygmt.grdcut(grid=grid, region=[-3, 1, 2, 5])
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -96,9 +96,9 @@ def grdcut(grid, **kwargs):
     >>> grid = pygmt.datasets.load_earth_relief(
     ...     resolution="30m", region=[10, 30, 15, 25]
     ... )
-    >>> # Create a new grid from an input grid, with an x-range of -3 to 1,
-    >>> # and a y-range of 2 to 5
-    >>> new_grid = pygmt.grdcut(grid=grid, region=[-3, 1, 2, 5])
+    >>> # Create a new grid from an input grid, with an x-range of 12 to 15,
+    >>> # and a y-range of 21 to 24
+    >>> new_grid = pygmt.grdcut(grid=grid, region=[12, 15, 21, 24])
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:


### PR DESCRIPTION
This PR adds an inline code example to the docstring for `grdcut`.

Addresses #1686


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
