### PR TITLE
Mark test_grdimage_file as xfail for GMT Dev Tests

### DIFF
--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -4,11 +4,14 @@ Test Figure.grdimage.
 import numpy as np
 import pytest
 import xarray as xr
-from pygmt import Figure
+from packaging.version import Version
+from pygmt import Figure, clib
 from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers.testing import check_figures_equal
 
+with clib.Session() as _lib:
+    gmt_version = Version(_lib.info["version"])
 
 @pytest.fixture(scope="module", name="grid")
 def fixture_grid():
@@ -73,6 +76,10 @@ def test_grdimage_slice(grid):
 
 
 @pytest.mark.mpl_image_compare
+@pytest.mark.xfail(
+    condition=gmt_version > Version("6.3.0"),
+    reason="Grid extension bug affects baseline image; fixed in https://github.com/GenericMappingTools/gmt/pull/6175.",
+)
 def test_grdimage_file():
     """
     Plot an image using file input.

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -13,6 +13,7 @@ from pygmt.helpers.testing import check_figures_equal
 with clib.Session() as _lib:
     gmt_version = Version(_lib.info["version"])
 
+
 @pytest.fixture(scope="module", name="grid")
 def fixture_grid():
     """
@@ -78,7 +79,8 @@ def test_grdimage_slice(grid):
 @pytest.mark.mpl_image_compare
 @pytest.mark.xfail(
     condition=gmt_version > Version("6.3.0"),
-    reason="Grid extension bug affects baseline image; fixed in https://github.com/GenericMappingTools/gmt/pull/6175.",
+    reason="Grid extension bug affects baseline image; "
+    "fixed in https://github.com/GenericMappingTools/gmt/pull/6175.",
 )
 def test_grdimage_file():
     """


### PR DESCRIPTION
**Description of proposed changes**

https://github.com/GenericMappingTools/gmt/pull/6175 adjusted the padding for regions, which leads to this failure on the GMT Dev Tests workflow. This PR adds an xfail mark to the test for GMT > 6.3.

Note that the padding for regions may change again due to the bug reported in https://github.com/GenericMappingTools/gmt/issues/6218, however that shouldn't impact the xfail mark since the baseline image has not been updated.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
