### PR TITLE
Mark 4 legend tests as xfail for GMT Dev Tests

### DIFF
--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -2,12 +2,20 @@
 Tests for legend.
 """
 import pytest
-from pygmt import Figure
+from packaging.version import Version
+from pygmt import Figure, clib
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 
+with clib.Session() as _lib:
+    gmt_version = Version(_lib.info["version"])
+
 
 @pytest.mark.mpl_image_compare
+@pytest.mark.xfail(
+    condition=gmt_version > Version("6.3.0"),
+    reason="Defaults updated in https://github.com/GenericMappingTools/gmt/pull/6165",
+)
 def test_legend_position():
     """
     Test that plots a position with each of the four legend coordinate systems.
@@ -23,6 +31,10 @@ def test_legend_position():
 
 
 @pytest.mark.mpl_image_compare
+@pytest.mark.xfail(
+    condition=gmt_version > Version("6.3.0"),
+    reason="Defaults updated in https://github.com/GenericMappingTools/gmt/pull/6165",
+)
 def test_legend_default_position():
     """
     Test using the default legend position.
@@ -39,6 +51,10 @@ def test_legend_default_position():
 
 
 @pytest.mark.mpl_image_compare
+@pytest.mark.xfail(
+    condition=gmt_version > Version("6.3.0"),
+    reason="Defaults updated in https://github.com/GenericMappingTools/gmt/pull/6165",
+)
 def test_legend_entries():
     """
     Test different marker types/shapes.
@@ -60,6 +76,10 @@ def test_legend_entries():
 
 
 @pytest.mark.mpl_image_compare
+@pytest.mark.xfail(
+    condition=gmt_version > Version("6.3.0"),
+    reason="Defaults updated in https://github.com/GenericMappingTools/gmt/pull/6165",
+)
 def test_legend_specfile():
     """
     Test specfile functionality.


### PR DESCRIPTION
**Description of proposed changes**

https://github.com/GenericMappingTools/gmt/pull/6165 adjusted the default characteristics for automatically generated legend symbols, which causes 4 test failures in the GMT Dev test workflow. This PR adds an xfail mark to those tests.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
