### PR TITLE
Add +n modifier to vector style in tests

### DIFF
--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -376,7 +376,7 @@ def test_plot_vectors():
         direction=(azimuth, lengths),
         region="-2/2/-2/2",
         projection="X10c",
-        style="V0.2c+e",
+        style="V0.2c+e+n",
         color="black",
         frame="af",
     )

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -399,7 +399,7 @@ def test_plot3d_vectors():
         direction=(azimuth, lengths),
         region=[-2, 2, -2, 2, -2, 2],
         projection="X10c",
-        style="V1c+e",
+        style="V1c+e+n",
         color="black",
         frame=["af", "zaf"],
     )


### PR DESCRIPTION
**Description of proposed changes**

https://github.com/GenericMappingTools/gmt/pull/6161 fixed an issue where the head of a vector could plot over the entire stem. After that PR, the default will not plot the vector head if the vector head is larger than the vector stem. The consequences for two tests that fail with the GMT Dev tests workflow are shown below. This PR adds the +n modifier to the argument for the ``style`` parameter for those tests, which has no impact for 6.3 tests and reverts the plot to the old default (passing) for the GMT Dev tests.

**pygmt/tests/test_plot.py::test_plot_vectors**

| 6.3 | 6.4 (without +n modifier) |
|----|-------------------------|
| ![baseline](https://user-images.githubusercontent.com/14077947/149409522-4369f6d0-83ef-4ef1-b806-a5b37d3b325c.png) | ![result](https://user-images.githubusercontent.com/14077947/149409532-8520822f-91b1-4f8a-88f0-cf22a13407ad.png) | 

**pygmt/tests/test_plot3d.py::test_plot3d_vectors**

| 6.3 | 6.4 (without +n modifier) |
|----|-------------------------|
| ![baseline](https://user-images.githubusercontent.com/14077947/149409750-aebcf130-cffa-42f9-b1ed-fb83720c90c7.png) | ![result](https://user-images.githubusercontent.com/14077947/149409793-05c3e25c-8545-4327-9512-71c84003d3db.png) | 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
