### PR TITLE
Remove xfail marker from passing tests

### DIFF
--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -53,10 +53,6 @@ def fixture_ncfile():
     return which("@earth_relief_01d", download="a")
 
 
-@pytest.mark.xfail(
-    condition=gmt_version <= Version("6.2.0"),
-    reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/5893.",
-)
 def test_grdtrack_input_dataframe_and_dataarray(dataarray, dataframe):
     """
     Run grdtrack by passing in a pandas.DataFrame and xarray.DataArray as
@@ -70,10 +66,6 @@ def test_grdtrack_input_dataframe_and_dataarray(dataarray, dataframe):
     return output
 
 
-@pytest.mark.xfail(
-    condition=gmt_version <= Version("6.2.0"),
-    reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/5893.",
-)
 def test_grdtrack_input_csvfile_and_dataarray(dataarray, csvfile):
     """
     Run grdtrack by passing in a csvfile and xarray.DataArray as inputs.

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -304,10 +304,6 @@ def test_plot_sizes_colors_transparencies():
 
 @pytest.mark.mpl_image_compare(filename="test_plot_matrix.png")
 @pytest.mark.parametrize("color", ["#aaaaaa", 170])
-@pytest.mark.xfail(
-    condition=gmt_version <= Version("6.2.0"),
-    reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/5799.",
-)
 def test_plot_matrix(data, color):
     """
     Plot the data passing in a matrix and specifying columns.


### PR DESCRIPTION
**Description of proposed changes**

This PR removes the xfail marker from three tests that now pass with GMT 6.3. I missed them when creating https://github.com/GenericMappingTools/pygmt/issues/1644 because the tests now pass rather than xpass.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
