### PR TITLE
Fix sphinx warnings about gmt term

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -126,8 +126,8 @@ Operations on tabular data
     surface
     xyz2grd
 
-Operations on grids
-~~~~~~~~~~~~~~~~~~~
+Operations on raster data
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autosummary::
     :toctree: generated

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -181,9 +181,9 @@ class Figure:
             adding margins. Append **+m** to specify extra margins to extend
             the bounding box. Give either one (uniform), two (x and y) or four
             (individual sides) margins; append unit [Default is set by
-            :term:`PROJ_LENGTH_UNIT`]. Append **+s**\ *width* to resize the
+            :gmt-term:`PROJ_LENGTH_UNIT`]. Append **+s**\ *width* to resize the
             output image to exactly *width* units. The default unit is set
-            by :term:`PROJ_LENGTH_UNIT` but you can append a new unit and/or
+            by :gmt-term:`PROJ_LENGTH_UNIT` but you can append a new unit and/or
             impose different width and height (**Note**: This may change the
             image aspect ratio). What happens here is that Ghostscript will do
             the re-interpolation work and the final image will retain the DPI

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -182,8 +182,8 @@ class Figure:
             the bounding box. Give either one (uniform), two (x and y) or four
             (individual sides) margins; append unit [Default is set by
             :gmt-term:`PROJ_LENGTH_UNIT`]. Append **+s**\ *width* to resize the
-            output image to exactly *width* units. The default unit is set
-            by :gmt-term:`PROJ_LENGTH_UNIT` but you can append a new unit and/or
+            output image to exactly *width* units. The default unit is set by
+            :gmt-term:`PROJ_LENGTH_UNIT` but you can append a new unit and/or
             impose different width and height (**Note**: This may change the
             image aspect ratio). What happens here is that Ghostscript will do
             the re-interpolation work and the final image will retain the DPI

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -195,7 +195,7 @@ class Figure:
         bb_style : str
             Set optional BoundingBox fill color, fading, or draw the outline
             of the BoundingBox. Append **+f**\ *fade* to fade the entire plot
-            towards black (100%) [no fading, 0]. Append **+g** \*paint* to
+            towards black (100%) [no fading, 0]. Append **+g**\ *paint* to
             paint the BoundingBox behind the illustration and append **+p**\
             [*pen*] to draw the BoundingBox outline (append a pen or accept
             the default pen of 0.25p,black). Note: If both **+g** and **+f**


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes two sphinx warnings from building the docs: `docstring of pygmt.figure.Figure.psconvert:44: WARNING: term not in glossary: PROJ_LENGTH_UNIT` and updates "grids" to "raster data" in the API index based on a previous recommendation from @weiji14.



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
