### PR TITLE
Add inline example for grdclip

### DIFF
--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -77,6 +77,20 @@ def grdclip(grid, **kwargs):
         - :class:`xarray.DataArray` if ``outgrid`` is not set
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)
+
+    Examples
+    --------
+    >>> import pygmt  # doctest: +SKIP
+    >>> # Load a grid of @earth_relief_30m data, with an x-range of 10 to 30,
+    >>> # and a y-range of 15 to 25
+    >>> grid = pygmt.datasets.load_earth_relief(
+    ...     resolution="30m", region=[10, 30, 15, 25]
+    ... )  # doctest: +SKIP
+    >>> # Create a new grid from an input grid. Set all values below 1,000 to
+    >>> # 0 and all values above 1,500 to 10,000
+    >>> new_grid = pygmt.grdclip(
+    ...     grid=grid, below=[1000, 0], above=[1500, 10000]
+    ... )  # doctest: +SKIP
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -86,11 +86,17 @@ def grdclip(grid, **kwargs):
     >>> grid = pygmt.datasets.load_earth_relief(
     ...     resolution="30m", region=[10, 30, 15, 25]
     ... )  # doctest: +SKIP
+    >>> # Report the minimum and maximum data values
+    >>> [grid.data.min(), grid.data.max()]  # doctest: +SKIP
+    [179.0, 2103.0]
     >>> # Create a new grid from an input grid. Set all values below 1,000 to
     >>> # 0 and all values above 1,500 to 10,000
     >>> new_grid = pygmt.grdclip(
     ...     grid=grid, below=[1000, 0], above=[1500, 10000]
     ... )  # doctest: +SKIP
+    >>> # Report the minimum and maximum data values
+    >>> [new_grid.data.min(), new_grid.data.max()]  # doctest: +SKIP
+    [0.0, 10000.0]
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:


### PR DESCRIPTION
This PR adds an inline example for `grdclip`.

Addresses: #1686 



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
