### PR TITLE
CI: Pull baseline images before building GMT

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -96,6 +96,12 @@ jobs:
                         dvc ipython 'pytest>=6.0' pytest-cov \
                         pytest-mpl sphinx-gallery tomli
 
+      # Pull baseline image data from dvc remote (DAGsHub)
+      - name: Pull baseline image data from dvc remote
+        run: |
+          dvc pull
+          ls -lhR pygmt/tests/baseline/
+
       # Build and install latest GMT from GitHub
       - name: Install GMT ${{ matrix.gmt_git_ref }} branch (Linux/macOS)
         run: curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/build-gmt.sh | bash
@@ -126,11 +132,6 @@ jobs:
           touch ~/.gmt/server/gmt_data_server.txt ~/.gmt/server/gmt_hash_server.txt
           ls -lhR ~/.gmt
 
-      # Pull baseline image data from dvc remote (DAGsHub)
-      - name: Pull baseline image data from dvc remote
-        run: |
-          dvc pull
-          ls -lhR pygmt/tests/baseline/
 
       # Install the package that we want to test
       - name: Install the package


### PR DESCRIPTION
**Description of proposed changes**

The GMT dev test workflow is broken. The error is:

```
 ERROR: failed to pull data from the cloud - Checkout failed for following targets:
/Users/runner/work/pygmt/pygmt/gmt-install-dir/share/doc/examples/images
```

which shows that dvc is trying to pull the dvc tracked images for the GMT repository (added in https://github.com/GenericMappingTools/gmt/pull/6267) from the PyGMT DAGsHub repo. This PR moves the dvc pull step to before the build GMT step so that only the PyGMT baseline images are pulled. 

