### PR TITLE
Unpin dvc

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -97,7 +97,7 @@ jobs:
           mamba install gmt=6.3.0 numpy=${{ matrix.numpy-version }} \
                         pandas xarray netCDF4 packaging \
                         ${{ matrix.optional-packages }} \
-                        dvc=2.8.2 make pytest>=6.0 \
+                        dvc make pytest>=6.0 \
                         pytest-cov pytest-mpl sphinx-gallery tomli
 
       # Show installed pkg information for postmortem diagnostic


### PR DESCRIPTION
**Description of proposed changes**

xref: https://github.com/GenericMappingTools/pygmt/issues/1693#issuecomment-1012556983

As pinning dvc to v2.8.2 doesn't fix the original issue, it's better to unpin dvc to use the latest version and hope that future versions can fix it.

This PR partially reverts changes in #1694.