### PR TITLE
Format with black 22.1.0

### DIFF
--- a/examples/gallery/3d_plots/grdview_surface.py
+++ b/examples/gallery/3d_plots/grdview_surface.py
@@ -23,7 +23,7 @@ import xarray as xr
 # https://en.wikipedia.org/wiki/Ackley_function
 def ackley(x, y):
     return (
-        -20 * np.exp(-0.2 * np.sqrt(0.5 * (x ** 2 + y ** 2)))
+        -20 * np.exp(-0.2 * np.sqrt(0.5 * (x**2 + y**2)))
         - np.exp(0.5 * (np.cos(2 * np.pi * x) + np.cos(2 * np.pi * y)))
         + np.exp(1)
         + 20

--- a/examples/gallery/basemaps/double_y_axes.py
+++ b/examples/gallery/basemaps/double_y_axes.py
@@ -23,7 +23,7 @@ import pygmt
 # Generate two sample Y data from one common X data
 x = np.linspace(1.0, 9.0, num=9)
 y1 = x
-y2 = x ** 2 + 110
+y2 = x**2 + 110
 
 fig = pygmt.Figure()
 

--- a/examples/gallery/images/contours.py
+++ b/examples/gallery/images/contours.py
@@ -25,7 +25,7 @@ import pygmt
 
 # build the contours underlying data with the function z = x^2 + y^2
 X, Y = np.meshgrid(np.linspace(-10, 10, 50), np.linspace(-10, 10, 50))
-Z = X ** 2 + Y ** 2
+Z = X**2 + Y**2
 x, y, z = X.flatten(), Y.flatten(), Z.flatten()
 
 

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -12,11 +12,11 @@ import pygmt
 # Create a list of x values 0-100
 xline = np.arange(0, 101)
 # Create a list of y-values that are the square root of the x-values
-yline = xline ** 0.5
+yline = xline**0.5
 # Create a list of x values for every 10 in 0-100
 xpoints = np.arange(0, 101, 10)
 # Create a list of y-values that are the square root of the x-values
-ypoints = xpoints ** 0.5
+ypoints = xpoints**0.5
 
 fig = pygmt.Figure()
 fig.plot(

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -13,7 +13,7 @@ import pygmt
 # Create a list of y values 0-10
 yvalues = np.arange(0, 11)
 # Create a list of x-values that are the square of the y-values
-xvalues = yvalues ** 2
+xvalues = yvalues**2
 
 fig = pygmt.Figure()
 fig.plot(

--- a/examples/tutorials/basics/plot.py
+++ b/examples/tutorials/basics/plot.py
@@ -57,7 +57,7 @@ fig.coast(land="black", water="skyblue")
 fig.plot(
     x=data.longitude,
     y=data.latitude,
-    size=0.02 * (2 ** data.magnitude),
+    size=0.02 * (2**data.magnitude),
     style="cc",
     color="white",
     pen="black",
@@ -85,7 +85,7 @@ pygmt.makecpt(cmap="viridis", series=[data.depth_km.min(), data.depth_km.max()])
 fig.plot(
     x=data.longitude,
     y=data.latitude,
-    size=0.02 * 2 ** data.magnitude,
+    size=0.02 * 2**data.magnitude,
     color=data.depth_km,
     cmap=True,
     style="cc",

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -142,9 +142,9 @@ class TestLibgmtBrokenLibs:
         # pylint: disable=protected-access
         lib_fullnames = [self.faked_libgmt1, self.faked_libgmt2]
         msg_regex = (
-            fr"Error loading GMT shared library at '{self.faked_libgmt1._name}'.\n"
-            fr"Error loading '{self.faked_libgmt1._name}'. Couldn't access.*\n"
-            fr"Error loading GMT shared library at '{self.faked_libgmt2._name}'.\n"
+            rf"Error loading GMT shared library at '{self.faked_libgmt1._name}'.\n"
+            rf"Error loading '{self.faked_libgmt1._name}'. Couldn't access.*\n"
+            rf"Error loading GMT shared library at '{self.faked_libgmt2._name}'.\n"
             f"Error loading '{self.faked_libgmt2._name}'. Couldn't access.*"
         )
         with pytest.raises(GMTCLibNotFoundError, match=msg_regex):
@@ -162,9 +162,9 @@ class TestLibgmtBrokenLibs:
         # pylint: disable=protected-access
         lib_fullnames = [self.faked_libgmt1, self.invalid_path]
         msg_regex = (
-            fr"Error loading GMT shared library at '{self.faked_libgmt1._name}'.\n"
-            fr"Error loading '{self.faked_libgmt1._name}'. Couldn't access.*\n"
-            fr"Error loading GMT shared library at '{self.invalid_path}'.\n"
+            rf"Error loading GMT shared library at '{self.faked_libgmt1._name}'.\n"
+            rf"Error loading '{self.faked_libgmt1._name}'. Couldn't access.*\n"
+            rf"Error loading GMT shared library at '{self.invalid_path}'.\n"
             f"Unable to find '{self.invalid_path}'"
         )
         with pytest.raises(GMTCLibNotFoundError, match=msg_regex):

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -41,8 +41,8 @@ def test_contour_vec(region):
     )
     x = x.flatten()
     y = y.flatten()
-    z = (x - 0.5 * (region[0] + region[1])) ** 2 + 4 * y ** 2
-    z = np.exp(-z / 10 ** 2 * np.log(2))
+    z = (x - 0.5 * (region[0] + region[1])) ** 2 + 4 * y**2
+    z = np.exp(-z / 10**2 * np.log(2))
     fig.contour(x=x, y=y, z=z, projection="X10c", region=region, frame="a", pen=True)
     return fig
 
@@ -89,8 +89,8 @@ def test_contour_deprecate_columns_to_incols(region):
     )
     x = x.flatten()
     y = y.flatten()
-    z = (x - 0.5 * (region[0] + region[1])) ** 2 + 4 * y ** 2
-    z = np.exp(-z / 10 ** 2 * np.log(2))
+    z = (x - 0.5 * (region[0] + region[1])) ** 2 + 4 * y**2
+    z = np.exp(-z / 10**2 * np.log(2))
 
     # generate dataframe
     # switch x and y from here onwards to simulate different column order


### PR DESCRIPTION
**Description of proposed changes**

Using the first stable release of black released on 29 Jan 2022! See changelog at https://github.com/psf/black/releases/tag/22.1.0

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Remove spaces around power operators if both operands are simple, and normalize raw f-strings as 'rf' instead of 'fr'.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes Style Checks errors at https://github.com/GenericMappingTools/pygmt/runs/4999696246?check_suite_focus=true

```
black --check pygmt setup.py doc/conf.py examples
would reformat examples/gallery/3d_plots/grdview_surface.py
would reformat examples/gallery/basemaps/double_y_axes.py
would reformat examples/gallery/images/contours.py
would reformat examples/projections/nongeo/cartesian_logarithmic.py
would reformat examples/projections/nongeo/cartesian_power.py
would reformat examples/tutorials/basics/plot.py
would reformat pygmt/tests/test_clib_loading.py
would reformat pygmt/tests/test_contour.py

Oh no! 💥 💔 💥
8 files would be reformatted, 220 files would be left unchanged.
make: *** [Makefile:53: check] Error 1
```


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
