### PR TITLE
Add inline example for grdgradient

### DIFF
--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -148,6 +148,19 @@ def grdgradient(grid, **kwargs):
         - :class:`xarray.DataArray` if ``outgrid`` is not set
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)
+
+
+    Example
+    -------
+    >>> import pygmt  # doctest: +SKIP
+    >>> # Load a grid of @earth_relief_30m data, with an x-range of 10 to 30,
+    >>> # and a y-range of 15 to 25
+    >>> grid = pygmt.datasets.load_earth_relief(
+    ...     resolution="30m", region=[10, 30, 15, 25]
+    ... )  # doctest: +SKIP
+    >>> # Create a new grid from an input grid, set the azimuth to 10 degrees,
+    >>> # and the direction to "c" for Cartesian coordinates
+    >>> new_grid = pygmt.grdgradient(grid=grid, azimuth=10, direction="c")  # doctest: +SKIP
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         if "Q" in kwargs and "N" not in kwargs:


### PR DESCRIPTION
This PR adds an inline example for `grdgradient`.

Addresses: #1686 



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
