### PR TITLE
Fix Numpy to NumPy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -214,7 +214,7 @@ Compatibility with GMT/Python/NumPy versions
       - Documentation
       - GMT
       - Python
-      - Numpy
+      - NumPy
     * - `Dev <https://github.com/GenericMappingTools/pygmt/milestone/9>`_ (upcoming release)
       - `Dev Documentation <https://www.pygmt.org/dev>`_ (reflects `main branch <https://github.com/GenericMappingTools/pygmt>`_)
       - >=6.3.0

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -94,7 +94,7 @@ def show_versions():
 
     - PyGMT itself
     - System information (Python version, Operating System)
-    - Core dependency versions (Numpy, Pandas, Xarray, etc)
+    - Core dependency versions (NumPy, Pandas, Xarray, etc)
     - GMT library information
     """
 


### PR DESCRIPTION
**Description of proposed changes**

NumPy is the correct name.