### PR TITLE
Add inline example for grdsample

### DIFF
--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -73,6 +73,20 @@ def grdsample(grid, **kwargs):
         - :class:`xarray.DataArray` if ``outgrid`` is not set
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)
+
+    Example
+    -------
+    >>> import pygmt  # doctest: +SKIP
+    >>> # Load a grid of @earth_relief_30m data, with an x-range of 10 to 30,
+    >>> # and a y-range of 15 to 25
+    >>> grid = pygmt.datasets.load_earth_relief(
+    ...     resolution="30m", region=[10, 30, 15, 25]
+    ... )  # doctest: +SKIP
+    >>> # Create a new grid from an input grid, change the registration,
+    >>> # and set the x-spacing to 1 degree and the y-spacing to 0.5 degrees
+    >>> new_grid = pygmt.grdsample(
+    ...     grid=grid, translate=True, spacing=[1, 0.5]
+    ... )  # doctest: +SKIP
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -83,9 +83,9 @@ def grdsample(grid, **kwargs):
     ...     resolution="30m", region=[10, 30, 15, 25]
     ... )  # doctest: +SKIP
     >>> # Create a new grid from an input grid, change the registration,
-    >>> # and set the x-spacing to 1 degree and the y-spacing to 0.5 degrees
+    >>> # and set both x- and y-spacing to 0.5 degrees
     >>> new_grid = pygmt.grdsample(
-    ...     grid=grid, translate=True, spacing=[1, 0.5]
+    ...     grid=grid, translate=True, spacing=[0.5, 0.5]
     ... )  # doctest: +SKIP
     """
     with GMTTempFile(suffix=".nc") as tmpfile:


### PR DESCRIPTION
This PR adds an inline code example to the docstring for `grdsample`.

Addresses #1686

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
