### PR TITLE
Update load_earth_relief tests for SRTM15+V2.3

### DIFF
--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -28,7 +28,7 @@ def test_earth_relief_01d():
     assert data.shape == (181, 361)
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -8592.5)
+    npt.assert_allclose(data.min(), -8600.5)
     npt.assert_allclose(data.max(), 5559.0)
 
 
@@ -42,7 +42,7 @@ def test_earth_relief_01d_with_region():
     assert data.shape == (11, 21)
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -5145)
+    npt.assert_allclose(data.min(), -5147)
     npt.assert_allclose(data.max(), 805.5)
 
 
@@ -54,7 +54,7 @@ def test_earth_relief_30m():
     assert data.shape == (361, 721)
     npt.assert_allclose(data.lat, np.arange(-90, 90.5, 0.5))
     npt.assert_allclose(data.lon, np.arange(-180, 180.5, 0.5))
-    npt.assert_allclose(data.min(), -9460.5)
+    npt.assert_allclose(data.min(), -9454.5)
     npt.assert_allclose(data.max(), 5887.5)
 
 


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes 3 of the 44 tests that are failing since the update of the `@earth_relief` remote dataset for SRTM15+V2.3. The remainder of the failing tests are tracked in https://github.com/GenericMappingTools/pygmt/issues/1684.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
