### PR TITLE
Add static_earth_relief to grd2cpt tests

### DIFF
--- a/pygmt/tests/baseline/test_grd2cpt.png.dvc
+++ b/pygmt/tests/baseline/test_grd2cpt.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 305e3650aa4ed9a56bec58be3a0d752b
-  size: 22460
+- md5: fb08cbce34046c341a5f68d45cd7aa6e
+  size: 20443
   path: test_grd2cpt.png

--- a/pygmt/tests/baseline/test_grd2cpt.png.dvc
+++ b/pygmt/tests/baseline/test_grd2cpt.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: fb08cbce34046c341a5f68d45cd7aa6e
-  size: 20443
+- md5: 6d535fbb53a470a3a12fafeab1cf4f66
+  size: 22230
   path: test_grd2cpt.png

--- a/pygmt/tests/test_grd2cpt.py
+++ b/pygmt/tests/test_grd2cpt.py
@@ -5,7 +5,7 @@ import os
 
 import pytest
 from pygmt import Figure, grd2cpt
-from pygmt.datasets import load_earth_relief
+from pygmt.helpers.testing import load_static_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 
@@ -15,7 +15,7 @@ def fixture_grid():
     """
     Load the grid data from the sample earth_relief file.
     """
-    return load_earth_relief()
+    return load_static_earth_relief()
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_grd2cpt.py
+++ b/pygmt/tests/test_grd2cpt.py
@@ -5,9 +5,9 @@ import os
 
 import pytest
 from pygmt import Figure, grd2cpt
-from pygmt.helpers.testing import load_static_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
+from pygmt.helpers.testing import load_static_earth_relief
 
 
 @pytest.fixture(scope="module", name="grid")

--- a/pygmt/tests/test_grd2cpt.py
+++ b/pygmt/tests/test_grd2cpt.py
@@ -27,7 +27,7 @@ def test_grd2cpt(grid):
     fig = Figure()
     fig.basemap(frame="a", projection="W0/15c", region="d")
     grd2cpt(grid=grid)
-    fig.colorbar(frame="a2000")
+    fig.colorbar(frame="a")
     return fig
 
 


### PR DESCRIPTION
This modifies `test_grd2cpt.py` to use `load_static_earth_relief`.

Addresses #1684 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
