### PR TITLE
Add static_earth_relief to grd2xyz tests

### DIFF
--- a/pygmt/tests/test_grd2xyz.py
+++ b/pygmt/tests/test_grd2xyz.py
@@ -7,17 +7,17 @@ import numpy as np
 import pandas as pd
 import pytest
 from pygmt import grd2xyz
-from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
+from pygmt.helpers.testing import load_static_earth_relief
 
 
 @pytest.fixture(scope="module", name="grid")
 def fixture_grid():
     """
-    Load the grid data from the sample earth_relief file.
+    Load the grid data from the static_earth_relief file.
     """
-    return load_earth_relief(resolution="01d", region=[-1, 1, 3, 5])
+    return load_static_earth_relief()
 
 
 def test_grd2xyz(grid):
@@ -25,19 +25,19 @@ def test_grd2xyz(grid):
     Make sure grd2xyz works as expected.
     """
     xyz_data = grd2xyz(grid=grid, output_type="numpy")
-    assert xyz_data.shape == (4, 3)
+    assert xyz_data.shape == (112, 3)
 
 
 def test_grd2xyz_format(grid):
     """
     Test that correct formats are returned.
     """
-    lon = -0.5
-    lat = 3.5
+    lon = -50.5
+    lat = -18.5
     orig_val = grid.sel(lon=lon, lat=lat).to_numpy()
     xyz_default = grd2xyz(grid=grid)
     xyz_val = xyz_default[(xyz_default["lon"] == lon) & (xyz_default["lat"] == lat)][
-        "elevation"
+        "z"
     ].to_numpy()
     assert isinstance(xyz_default, pd.DataFrame)
     assert orig_val.size == 1
@@ -47,7 +47,7 @@ def test_grd2xyz_format(grid):
     assert isinstance(xyz_array, np.ndarray)
     xyz_df = grd2xyz(grid=grid, output_type="pandas")
     assert isinstance(xyz_df, pd.DataFrame)
-    assert list(xyz_df.columns) == ["lon", "lat", "elevation"]
+    assert list(xyz_df.columns) == ["lon", "lat", "z"]
 
 
 def test_grd2xyz_file_output(grid):


### PR DESCRIPTION
This modifies `test_grd2xyz.py` to use `load_static_earth_relief`.

Addresses #1684 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
