### PR TITLE
Add static_earth_relief to grdcut tests

### DIFF
--- a/pygmt/tests/test_grdcut.py
+++ b/pygmt/tests/test_grdcut.py
@@ -7,9 +7,9 @@ import numpy as np
 import pytest
 import xarray as xr
 from pygmt import grdcut, load_dataarray
-from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
+from pygmt.helpers.testing import load_static_earth_relief
 
 
 @pytest.fixture(scope="module", name="grid")
@@ -17,7 +17,7 @@ def fixture_grid():
     """
     Load the grid data from the sample earth_relief file.
     """
-    return load_earth_relief(registration="pixel")
+    return load_static_earth_relief()
 
 
 @pytest.fixture(scope="module", name="expected_grid")
@@ -27,11 +27,11 @@ def fixture_grid_result():
     """
     return xr.DataArray(
         data=[
-            [-5069.5, -5105.0, -4937.0, -4708.0],
-            [-4115.5, -4996.0, -4762.0, -4599.0],
-            [-656.0, -160.0, -3484.5, -3897.5],
+            [446.5, 481.5, 439.5, 553.0],
+            [757.0, 570.5, 538.5, 524.0],
+            [796.0, 886.0, 571.5, 638.5],
         ],
-        coords=dict(lon=[-2.5, -1.5, -0.5, 0.5], lat=[2.5, 3.5, 4.5]),
+        coords=dict(lon=[-52.5, -51.5, -50.5, -49.5], lat=[-19.5, -18.5, -17.5]),
         dims=["lat", "lon"],
     )
 
@@ -41,7 +41,9 @@ def test_grdcut_file_in_file_out(expected_grid):
     grdcut an input grid file, and output to a grid file.
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
-        result = grdcut("@earth_relief_01d", outgrid=tmpfile.name, region=[-3, 1, 2, 5])
+        result = grdcut(
+            "@static_earth_relief.nc", outgrid=tmpfile.name, region=[-53, -49, -20, -17]
+        )
         assert result is None  # return value is None
         assert os.path.exists(path=tmpfile.name)  # check that outgrid exists
         temp_grid = load_dataarray(tmpfile.name)
@@ -52,7 +54,7 @@ def test_grdcut_file_in_dataarray_out(expected_grid):
     """
     grdcut an input grid file, and output as DataArray.
     """
-    outgrid = grdcut("@earth_relief_01d", region=[-3, 1, 2, 5])
+    outgrid = grdcut("@static_earth_relief.nc", region=[-53, -49, -20, -17])
     assert isinstance(outgrid, xr.DataArray)
     assert outgrid.gmt.registration == 1  # Pixel registration
     assert outgrid.gmt.gtype == 1  # Geographic type
@@ -65,7 +67,7 @@ def test_grdcut_dataarray_in_file_out(grid, expected_grid):
     grdcut an input DataArray, and output to a grid file.
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
-        result = grdcut(grid, outgrid=tmpfile.name, region=[-3, 1, 2, 5])
+        result = grdcut(grid, outgrid=tmpfile.name, region=[-53, -49, -20, -17])
         assert result is None  # grdcut returns None if output to a file
         temp_grid = load_dataarray(tmpfile.name)
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
@@ -75,7 +77,7 @@ def test_grdcut_dataarray_in_dataarray_out(grid, expected_grid):
     """
     grdcut an input DataArray, and output as DataArray.
     """
-    outgrid = grdcut(grid, region=[-3, 1, 2, 5])
+    outgrid = grdcut(grid, region=[-53, -49, -20, -17])
     assert isinstance(outgrid, xr.DataArray)
     xr.testing.assert_allclose(a=outgrid, b=expected_grid)
 


### PR DESCRIPTION
This modifies `test_grdcut.py` to use `load_static_earth_relief`.

Addresses #1684 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
