### PR TITLE
Change test_grdfill.py to use static_earth_relief

### DIFF
--- a/pygmt/tests/test_grdfill.py
+++ b/pygmt/tests/test_grdfill.py
@@ -7,20 +7,20 @@ import numpy as np
 import pytest
 import xarray as xr
 from pygmt import grdfill, load_dataarray
-from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
+from pygmt.helpers.testing import load_static_earth_relief
 
 
 @pytest.fixture(scope="module", name="grid")
 def fixture_grid():
     """
-    Load the grid data from the sample earth_relief file and set value(s) to
-    NaN.
+    Load the grid data from the static_earth_relief file and set value(s) to
+    NaN and inf.
     """
-    grid = load_earth_relief(registration="pixel", region=[125, 130, -25, -20])
-    grid[2:4, 1:3] = np.nan
-    grid[0:2, 2:4] = np.inf
+    grid = load_static_earth_relief()
+    grid[3:6, 3:5] = np.nan
+    grid[6:8, 2:4] = np.inf
     return grid
 
 
@@ -31,15 +31,39 @@ def fixture_grid_result():
     """
     return xr.DataArray(
         data=[
-            [442.5, 439.0, np.inf, np.inf, 508.0],
-            [393.0, 364.5, np.inf, np.inf, 506.5],
-            [362.0, 20.0, 20.0, 373.5, 402.5],
-            [321.5, 20.0, 20.0, 356.0, 422.5],
-            [282.5, 318.0, 326.5, 379.5, 383.5],
+            [347.5, 344.5, 386.0, 640.5, 617.0, 579.0, 646.5, 671.0],
+            [383.0, 284.5, 344.5, 394.0, 491.0, 556.5, 578.5, 618.5],
+            [373.0, 367.5, 349.0, 352.5, 419.5, 428.0, 570.0, 667.5],
+            [557.0, 435.0, 385.5, 20.0, 20.0, 496.0, 519.5, 833.5],
+            [561.5, 539.0, 446.5, 20.0, 20.0, 553.0, 726.5, 981.0],
+            [310.0, 521.5, 757.0, 20.0, 20.0, 524.0, 686.5, 794.0],
+            [521.5, 682.5, np.inf, np.inf, 571.5, 638.5, 739.5, 881.5],
+            [308.0, 595.5, np.inf, np.inf, 580.0, 770.0, 927.0, 920.0],
+            [601.0, 526.5, 535.0, 299.0, 398.5, 645.0, 797.5, 964.0],
+            [494.5, 488.5, 357.0, 254.5, 286.0, 484.5, 653.5, 930.0],
+            [450.5, 395.5, 366.0, 248.0, 250.0, 354.5, 550.0, 797.5],
+            [345.5, 320.0, 335.0, 292.0, 207.5, 247.0, 325.0, 346.5],
+            [349.0, 313.0, 325.5, 247.0, 191.0, 225.0, 260.0, 452.5],
+            [347.5, 331.5, 309.0, 282.0, 190.0, 208.0, 299.5, 348.0],
         ],
         coords=dict(
-            lon=[125.5, 126.5, 127.5, 128.5, 129.5],
-            lat=[-24.5, -23.5, -22.5, -21.5, -20.5],
+            lon=[-54.5, -53.5, -52.5, -51.5, -50.5, -49.5, -48.5, -47.5],
+            lat=[
+                -23.5,
+                -22.5,
+                -21.5,
+                -20.5,
+                -19.5,
+                -18.5,
+                -17.5,
+                -16.5,
+                -15.5,
+                -14.5,
+                -13.5,
+                -12.5,
+                -11.5,
+                -10.5,
+            ],
         ),
         dims=["lat", "lon"],
     )


### PR DESCRIPTION
This modifies `test_grdfill.py` to use `load_static_earth_relief`.

Addresses #1684 



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
