### PR TITLE
Change test_grdinfo.py to use static_earth_relief

### DIFF
--- a/pygmt/tests/test_grdinfo.py
+++ b/pygmt/tests/test_grdinfo.py
@@ -4,8 +4,8 @@ Tests for grdinfo.
 import numpy as np
 import pytest
 from pygmt import grdinfo
-from pygmt.helpers.testing import load_static_earth_relief
 from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers.testing import load_static_earth_relief
 
 
 @pytest.fixture(scope="module", name="grid")
@@ -14,6 +14,7 @@ def fixture_grid():
     Load the grid data from the static_earth_relief file.
     """
     return load_static_earth_relief()
+
 
 def test_grdinfo(grid):
     """
@@ -35,5 +36,7 @@ def test_grdinfo_region(grid):
     """
     Check that the region argument works in grdinfo.
     """
-    result = grdinfo(grid=grid, force_scan=0, per_column="n", region=[-54, -50, -23, -20])
+    result = grdinfo(
+        grid=grid, force_scan=0, per_column="n", region=[-54, -50, -23, -20]
+    )
     assert result.strip() == "-54 -50 -23 -20 284.5 491 1 1 4 3 1 1"

--- a/pygmt/tests/test_grdinfo.py
+++ b/pygmt/tests/test_grdinfo.py
@@ -23,14 +23,6 @@ def test_grdinfo(grid):
     assert result.strip() == "-55 -47 -24 -10 190 981 1 1 8 14 1 1"
 
 
-def test_grdinfo_file():
-    """
-    Test grdinfo with file input.
-    """
-    result = grdinfo(grid="@static_earth_relief.nc", force_scan=0, per_column="n")
-    assert result.strip() == "-55 -47 -24 -10 190 981 1 1 8 14 1 1"
-
-
 def test_grdinfo_fails():
     """
     Check that grdinfo fails correctly.

--- a/pygmt/tests/test_grdinfo.py
+++ b/pygmt/tests/test_grdinfo.py
@@ -4,25 +4,31 @@ Tests for grdinfo.
 import numpy as np
 import pytest
 from pygmt import grdinfo
-from pygmt.datasets import load_earth_relief
+from pygmt.helpers.testing import load_static_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 
 
-def test_grdinfo():
+@pytest.fixture(scope="module", name="grid")
+def fixture_grid():
+    """
+    Load the grid data from the static_earth_relief file.
+    """
+    return load_static_earth_relief()
+
+def test_grdinfo(grid):
     """
     Make sure grdinfo works as expected.
     """
-    grid = load_earth_relief(registration="gridline")
     result = grdinfo(grid=grid, force_scan=0, per_column="n")
-    assert result.strip() == "-180 180 -90 90 -8592.5 5559 1 1 361 181 0 1"
+    assert result.strip() == "-55 -47 -24 -10 190 981 1 1 8 14 1 1"
 
 
 def test_grdinfo_file():
     """
     Test grdinfo with file input.
     """
-    result = grdinfo(grid="@earth_relief_01d", force_scan=0, per_column="n")
-    assert result.strip() == "-180 180 -90 90 -8182 5651.5 1 1 360 180 1 1"
+    result = grdinfo(grid="@static_earth_relief.nc", force_scan=0, per_column="n")
+    assert result.strip() == "-55 -47 -24 -10 190 981 1 1 8 14 1 1"
 
 
 def test_grdinfo_fails():
@@ -33,14 +39,9 @@ def test_grdinfo_fails():
         grdinfo(np.arange(10).reshape((5, 2)))
 
 
-def test_grdinfo_region():
+def test_grdinfo_region(grid):
     """
     Check that the region argument works in grdinfo.
     """
-    result = grdinfo(
-        grid="@earth_relief_01d",
-        force_scan=0,
-        per_column="n",
-        region=[-170, 170, -80, 80],
-    )
-    assert result.strip() == "-170 170 -80 80 -8182 5651.5 1 1 340 160 1 1"
+    result = grdinfo(grid=grid, force_scan=0, per_column="n", region=[-54, -50, -23, -20])
+    assert result.strip() == "-54 -50 -23 -20 284.5 491 1 1 4 3 1 1"


### PR DESCRIPTION
This modifies `test_grdinfo.py` to use `load_static_earth_relief`. This also removes `test_grdinfo_file()`, as file importing is tested elsewhere.

Addresses #1684 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
