### PR TITLE
Change test_grdvolume.py to use static_earth_relief

### DIFF
--- a/pygmt/tests/test_grdvolume.py
+++ b/pygmt/tests/test_grdvolume.py
@@ -21,6 +21,14 @@ def fixture_grid():
     return load_static_earth_relief()
 
 
+@pytest.fixture(scope="module", name="region")
+def fixture_region():
+    """
+    Set the data region for the tests.
+    """
+    return [-53, -50, -22, -20]
+
+
 @pytest.fixture(scope="module", name="data")
 def fixture_data():
     """
@@ -38,26 +46,15 @@ def fixture_data():
     return data
 
 
-def test_grdvolume_format(grid):
+def test_grdvolume_format(grid, region):
     """
     Test that correct formats are returned.
     """
-    grdvolume_default = grdvolume(
-        grid=grid,
-        region=[-53, -50, -22, -20],
-    )
+    grdvolume_default = grdvolume(grid=grid, region=region)
     assert isinstance(grdvolume_default, pd.DataFrame)
-    grdvolume_array = grdvolume(
-        grid=grid,
-        output_type="numpy",
-        region=[-53, -50, -22, -20],
-    )
+    grdvolume_array = grdvolume(grid=grid, output_type="numpy", region=region)
     assert isinstance(grdvolume_array, np.ndarray)
-    grdvolume_df = grdvolume(
-        grid=grid,
-        output_type="pandas",
-        region=[-53, -50, -22, -20],
-    )
+    grdvolume_df = grdvolume(grid=grid, output_type="pandas", region=region)
     assert isinstance(grdvolume_df, pd.DataFrame)
 
 
@@ -78,20 +75,17 @@ def test_grdvolume_no_outfile(grid):
         grdvolume(grid=grid, output_type="file")
 
 
-def test_grdvolume_no_outgrid(grid, data):
+def test_grdvolume_no_outgrid(grid, data, region):
     """
     Test the expected output of grdvolume with no output file set.
     """
     test_output = grdvolume(
-        grid=grid,
-        contour=[200, 400, 50],
-        output_type="numpy",
-        region=[-53, -50, -22, -20],
+        grid=grid, contour=[200, 400, 50], output_type="numpy", region=region
     )
     npt.assert_allclose(test_output, data)
 
 
-def test_grdvolume_outgrid(grid):
+def test_grdvolume_outgrid(grid, region):
     """
     Test the expected output of grdvolume with an output file set.
     """
@@ -101,7 +95,7 @@ def test_grdvolume_outgrid(grid):
             contour=[200, 400, 50],
             output_type="file",
             outfile=tmpfile.name,
-            region=[-53, -50, -22, -20],
+            region=region,
         )
         assert result is None  # return value is None
         assert os.path.exists(path=tmpfile.name)  # check that outfile exists

--- a/pygmt/tests/test_grdvolume.py
+++ b/pygmt/tests/test_grdvolume.py
@@ -8,9 +8,9 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from pygmt import grdvolume
-from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
+from pygmt.helpers.testing import load_static_earth_relief
 
 
 @pytest.fixture(scope="module", name="grid")
@@ -18,7 +18,7 @@ def fixture_grid():
     """
     Load the grid data from the sample earth_relief file.
     """
-    return load_earth_relief(resolution="01d", region=[-100, -95, 34, 39])
+    return load_static_earth_relief()
 
 
 @pytest.fixture(scope="module", name="data")
@@ -28,36 +28,11 @@ def fixture_data():
     """
     data = np.array(
         [
-            [
-                2.00000000e02,
-                1.59920815e11,
-                3.16386172e13,
-                1.97839269e02,
-            ],
-            [
-                2.50000000e02,
-                1.44365835e11,
-                2.38676788e13,
-                1.65327751e02,
-            ],
-            [
-                3.00000000e02,
-                1.23788259e11,
-                1.71278707e13,
-                1.38364259e02,
-            ],
-            [
-                3.50000000e02,
-                9.79597525e10,
-                1.15235913e13,
-                1.17635978e02,
-            ],
-            [
-                4.00000000e02,
-                7.26646663e10,
-                7.22303463e12,
-                9.94022955e01,
-            ],
+            [2.00000000e02, 2.30079975e10, 3.92142453e12, 1.70437454e02],
+            [2.50000000e02, 2.30079975e10, 2.77102465e12, 1.20437454e02],
+            [3.00000000e02, 2.30079975e10, 1.62062477e12, 7.04374542e01],
+            [3.50000000e02, 1.76916116e10, 4.53991397e11, 2.56613930e01],
+            [4.00000000e02, 2.81602292e09, 2.34764859e10, 8.33675242e00],
         ]
     )
     return data
@@ -67,11 +42,22 @@ def test_grdvolume_format(grid):
     """
     Test that correct formats are returned.
     """
-    grdvolume_default = grdvolume(grid=grid)
+    grdvolume_default = grdvolume(
+        grid=grid,
+        region=[-53, -50, -22, -20],
+    )
     assert isinstance(grdvolume_default, pd.DataFrame)
-    grdvolume_array = grdvolume(grid=grid, output_type="numpy")
+    grdvolume_array = grdvolume(
+        grid=grid,
+        output_type="numpy",
+        region=[-53, -50, -22, -20],
+    )
     assert isinstance(grdvolume_array, np.ndarray)
-    grdvolume_df = grdvolume(grid=grid, output_type="pandas")
+    grdvolume_df = grdvolume(
+        grid=grid,
+        output_type="pandas",
+        region=[-53, -50, -22, -20],
+    )
     assert isinstance(grdvolume_df, pd.DataFrame)
 
 
@@ -96,7 +82,12 @@ def test_grdvolume_no_outgrid(grid, data):
     """
     Test the expected output of grdvolume with no output file set.
     """
-    test_output = grdvolume(grid=grid, contour=[200, 400, 50], output_type="numpy")
+    test_output = grdvolume(
+        grid=grid,
+        contour=[200, 400, 50],
+        output_type="numpy",
+        region=[-53, -50, -22, -20],
+    )
     npt.assert_allclose(test_output, data)
 
 
@@ -106,7 +97,11 @@ def test_grdvolume_outgrid(grid):
     """
     with GMTTempFile(suffix=".csv") as tmpfile:
         result = grdvolume(
-            grid=grid, contour=[200, 400, 50], output_type="file", outfile=tmpfile.name
+            grid=grid,
+            contour=[200, 400, 50],
+            output_type="file",
+            outfile=tmpfile.name,
+            region=[-53, -50, -22, -20],
         )
         assert result is None  # return value is None
         assert os.path.exists(path=tmpfile.name)  # check that outfile exists


### PR DESCRIPTION
This modifies `test_grdvolume.py` to use `load_static_earth_relief`.

Addresses #1684 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
