### PR TITLE
Fix blockm inline example missing doctest skip

### DIFF
--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -152,7 +152,9 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     -------
     >>> import pygmt  # doctest: +SKIP
     >>> # Load a table of ship observations of bathymetry off Baja California
-    >>> data = pygmt.datasets.load_sample_data(name="bathymetry")
+    >>> data = pygmt.datasets.load_sample_data(
+    ...     name="bathymetry"
+    ... )  # doctest: +SKIP
     >>> # Calculate block mean values within 5 by 5 minute bins
     >>> data_bmean = pygmt.blockmean(
     ...     data=data, region=[245, 255, 20, 30], spacing="5m"
@@ -240,7 +242,9 @@ def blockmedian(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     -------
     >>> import pygmt  # doctest: +SKIP
     >>> # Load a table of ship observations of bathymetry off Baja California
-    >>> data = pygmt.datasets.load_sample_data(name="bathymetry")
+    >>> data = pygmt.datasets.load_sample_data(
+    ...     name="bathymetry"
+    ... )  # doctest: +SKIP
     >>> # Calculate block median values within 5 by 5 minute bins
     >>> data_bmedian = pygmt.blockmedian(
     ...     data=data, region=[245, 255, 20, 30], spacing="5m"
@@ -328,7 +332,9 @@ def blockmode(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     -------
     >>> import pygmt  # doctest: +SKIP
     >>> # Load a table of ship observations of bathymetry off Baja California
-    >>> data = pygmt.datasets.load_sample_data(name="bathymetry")
+    >>> data = pygmt.datasets.load_sample_data(
+    ...     name="bathymetry"
+    ... )  # doctest: +SKIP
     >>> # Calculate block mode values within 5 by 5 minute bins
     >>> data_bmode = pygmt.blockmode(
     ...     data=data, region=[245, 255, 20, 30], spacing="5m"


### PR DESCRIPTION
The recently added inline examples for `blockm` are missing a `# doctest: +SKIP` on the lines that import the bathymetry sample data, resulting in test failurs as the `import pygmt` above is skipped. 

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
