### PR TITLE
WIP: Check colorbar kwargs for region argument if required

### DIFF
--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -3,6 +3,7 @@ colorbar - Plot a colorbar.
 """
 
 from pygmt.clib import Session
+from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 
@@ -106,5 +107,11 @@ def colorbar(self, **kwargs):
     {t}
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
+    if "D" in kwargs and "R" not in kwargs:
+        if kwargs["D"][0] in ["g", "j", "J", "n"]:
+            raise GMTInvalidInput(
+                "An argument for region is required to plot position with "
+                "'g', 'j', 'J', or 'n'."
+            )
     with Session() as lib:
         lib.call_module("colorbar", build_arg_string(kwargs))

--- a/pygmt/tests/test_colorbar.py
+++ b/pygmt/tests/test_colorbar.py
@@ -3,6 +3,7 @@ Tests colorbar.
 """
 import pytest
 from pygmt import Figure
+from pygmt.exceptions import GMTInvalidInput
 
 
 @pytest.mark.mpl_image_compare
@@ -65,3 +66,12 @@ def test_colorbar_shading_list():
     fig.basemap(region=[0, 10, 0, 10], projection="X15c", frame="a")
     fig.colorbar(cmap="geo", shading=[-0.7, 0.2], frame=True)
     return fig
+
+
+def test_colorbar_missing_region():
+    """
+    Test that colorbar fails if region is not set when required.
+    """
+    with pytest.raises(GMTInvalidInput):
+        fig = Figure()
+        fig.colorbar(cmap="rainbow", box="+gorange", position="JBC")


### PR DESCRIPTION
As discussed in [#1748 (comment)](https://github.com/GenericMappingTools/pygmt/pull/1748#discussion_r806053532), passing an argument to `position` for colorbar starting with anything but `x` requires an argument for `region` as well. This adds a check to see if an argument for `region` is present when required.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
