### PR TITLE
Change session.py to use static_earth_relief

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -99,9 +99,9 @@ class Session:
     Examples
     --------
 
-    >>> from pygmt.datasets import load_earth_relief
+    >>> from pygmt.helpers.testing import load_static_earth_relief
     >>> from pygmt.helpers import GMTTempFile
-    >>> grid = load_earth_relief()
+    >>> grid = load_static_earth_relief()
     >>> type(grid)
     <class 'xarray.core.dataarray.DataArray'>
     >>> # Create a session and destroy it automatically when exiting the "with"
@@ -117,7 +117,7 @@ class Session:
     ...             # Read the contents of the temp file before it's deleted.
     ...             print(fout.read().strip())
     ...
-    -180 180 -90 90 -8182 5651.5 1 1 360 180 1 1
+    -55 -47 -24 -10 190 981 1 1 8 14 1 1
     """
 
     # The minimum version of GMT required
@@ -1295,17 +1295,17 @@ class Session:
         Examples
         --------
 
-        >>> from pygmt.datasets import load_earth_relief
+        >>> from pygmt.helpers.testing import load_static_earth_relief
         >>> from pygmt.helpers import GMTTempFile
-        >>> data = load_earth_relief(resolution="01d")
+        >>> data = load_static_earth_relief()
         >>> print(data.shape)
-        (180, 360)
+        (14, 8)
         >>> print(data.lon.values.min(), data.lon.values.max())
-        -179.5 179.5
+        -54.5 -47.5
         >>> print(data.lat.values.min(), data.lat.values.max())
-        -89.5 89.5
+        -23.5 -10.5
         >>> print(data.values.min(), data.values.max())
-        -8182.0 5651.5
+        190.0 981.0
         >>> with Session() as ses:
         ...     with ses.virtualfile_from_grid(data) as fin:
         ...         # Send the output to a file so that we can read it
@@ -1314,7 +1314,7 @@ class Session:
         ...             ses.call_module("grdinfo", args)
         ...             print(fout.read().strip())
         ...
-        -180 180 -90 90 -8182 5651.5 1 1 360 180 1 1
+        -55 -47 -24 -10 190 981 1 1 8 14 1 1
         >>> # The output is: w e s n z0 z1 dx dy n_columns n_rows reg gtype
         """
         _gtype = {0: "GMT_GRID_IS_CARTESIAN", 1: "GMT_GRID_IS_GEO"}[grid.gmt.gtype]


### PR DESCRIPTION
This modifies `session.py` to use `load_static_earth_relief`. This also removes `test_grdinfo_file()`, as file importing is tested elsewhere.

Addresses #1684 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
