### PR TITLE
Remove Liam's talk from the overview page

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -41,18 +41,6 @@ Presentations
 These are conference presentations about the development of PyGMT (previously
 "GMT/Python"):
 
-* "Remote Online Sessions for Emerging Seismologists (ROSES): Unit 8 - PyGMT".
-  2020.
-  Liam Toney.
-  Presented at *ROSES 2020*.
-  url: https://www.iris.edu/hq/inclass/lesson/728
-
-.. figure:: https://img.youtube.com/vi/SSIGJEe0BIk/maxresdefault.jpg
-    :target: https://www.youtube.com/watch?v=SSIGJEe0BIk
-    :width: 80%
-    :align: center
-    :alt: ROSES 2020 youtube video
-
 * "PyGMT: Accessing the Generic Mapping Tools from Python".
   2019.
   Leonardo Uieda and Paul Wessel.


### PR DESCRIPTION
**Description of proposed changes**

The overview page lists conference presentations about the development of PyGMT, but Liam's talk is a tutorial. I think we should remove it from the list.