### PR TITLE
Fix docs workflow on Windows

### DIFF
--- a/examples/tutorials/basics/plot.py
+++ b/examples/tutorials/basics/plot.py
@@ -14,7 +14,7 @@ import pygmt
 
 ###############################################################################
 # For example, let's load the sample dataset of tsunami generating earthquakes
-# around Japan (:func:`pygmt.datasets.load_sample_data(name="japan_quakes")`).
+# around Japan using :func:`pygmt.datasets.load_sample_data`.
 # The data is loaded as a :class:`pandas.DataFrame`.
 
 data = pygmt.datasets.load_sample_data(name="japan_quakes")


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes the docs workflow on Windows by removing the argument in the docstring reference to the load_sample_data function in the plotting data points tutorial.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
