### PR TITLE
Consistently use the load_sample_data function in tests

### DIFF
--- a/pygmt/tests/test_blockm.py
+++ b/pygmt/tests/test_blockm.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 from pygmt import blockmean, blockmode
-from pygmt.datasets import load_sample_bathymetry
+from pygmt.datasets import load_sample_data
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile, data_kind
 
@@ -17,9 +17,9 @@ from pygmt.helpers import GMTTempFile, data_kind
 @pytest.fixture(scope="module", name="dataframe")
 def fixture_dataframe():
     """
-    Load the grid data from the sample earth_relief file.
+    Load the table data from the sample bathymetry dataset.
     """
-    return load_sample_bathymetry()
+    return load_sample_data(name="bathymetry")
 
 
 def test_blockmean_input_dataframe(dataframe):

--- a/pygmt/tests/test_blockmedian.py
+++ b/pygmt/tests/test_blockmedian.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from pygmt import blockmedian
-from pygmt.datasets import load_sample_bathymetry
+from pygmt.datasets import load_sample_data
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile, data_kind
 
@@ -15,9 +15,9 @@ from pygmt.helpers import GMTTempFile, data_kind
 @pytest.fixture(scope="module", name="dataframe")
 def fixture_dataframe():
     """
-    Load the grid data from the sample earth_relief file.
+    Load the table data from the sample bathymetry dataset.
     """
-    return load_sample_bathymetry()
+    return load_sample_data(name="bathymetry")
 
 
 def test_blockmedian_input_dataframe(dataframe):

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -134,10 +134,10 @@ def test_grdimage_grid_and_shading_with_xarray(grid, xrgrid):
     """
     fig_ref, fig_test = Figure(), Figure()
     fig_ref.grdimage(
-        grid="@earth_relief_01d_g", region="GL", cmap="geo", shading=xrgrid, verbose="i"
+        grid="@earth_relief_01d_g", region="GL", cmap="geo", shading=xrgrid
     )
     fig_ref.colorbar()
-    fig_test.grdimage(grid=grid, region="GL", cmap="geo", shading=xrgrid, verbose="i")
+    fig_test.grdimage(grid=grid, region="GL", cmap="geo", shading=xrgrid)
     fig_test.colorbar()
     return fig_ref, fig_test
 

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from pygmt import grdtrack, which
-from pygmt.datasets import load_earth_relief, load_ocean_ridge_points
+from pygmt.datasets import load_earth_relief, load_sample_data
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import data_kind
 
@@ -30,7 +30,7 @@ def fixture_dataframe():
     """
     Load the ocean ridge file.
     """
-    return load_ocean_ridge_points()
+    return load_sample_data(name="ocean_ridge_points")
 
 
 @pytest.fixture(scope="module", name="csvfile")

--- a/pygmt/tests/test_nearneighbor.py
+++ b/pygmt/tests/test_nearneighbor.py
@@ -8,7 +8,7 @@ import numpy.testing as npt
 import pytest
 import xarray as xr
 from pygmt import nearneighbor
-from pygmt.datasets import load_sample_bathymetry
+from pygmt.datasets import load_sample_data
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile, data_kind
 
@@ -16,9 +16,9 @@ from pygmt.helpers import GMTTempFile, data_kind
 @pytest.fixture(scope="module", name="ship_data")
 def fixture_ship_data():
     """
-    Load the data from the sample bathymetry dataset.
+    Load the table data from the sample bathymetry dataset.
     """
-    return load_sample_bathymetry()
+    return load_sample_data(name="bathymetry")
 
 
 @pytest.mark.parametrize("array_func", [np.array, xr.Dataset])

--- a/pygmt/tests/test_rose.py
+++ b/pygmt/tests/test_rose.py
@@ -4,7 +4,7 @@ Tests for rose.
 import numpy as np
 import pytest
 from pygmt import Figure
-from pygmt.datasets import load_fractures_compilation
+from pygmt.datasets import load_sample_data
 
 
 @pytest.fixture(scope="module", name="data")
@@ -25,7 +25,7 @@ def fixture_data_fractures_compilation():
 
     Lengths are stored in the first column, azimuths in the second.
     """
-    return load_fractures_compilation()
+    return load_sample_data(name="fractures")
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_select.py
+++ b/pygmt/tests/test_select.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from pygmt import select
-from pygmt.datasets import load_sample_bathymetry
+from pygmt.datasets import load_sample_data
 from pygmt.helpers import GMTTempFile
 
 
@@ -16,7 +16,7 @@ def fixture_dataframe():
     """
     Load the table data from the sample bathymetry dataset.
     """
-    return load_sample_bathymetry()
+    return load_sample_data(name="bathymetry")
 
 
 def test_select_input_dataframe(dataframe):

--- a/pygmt/tests/test_sphinterpolate.py
+++ b/pygmt/tests/test_sphinterpolate.py
@@ -6,16 +6,16 @@ import os
 import numpy.testing as npt
 import pytest
 from pygmt import sphinterpolate
-from pygmt.datasets import load_mars_shape
+from pygmt.datasets import load_sample_data
 from pygmt.helpers import GMTTempFile
 
 
 @pytest.fixture(scope="module", name="mars")
 def fixture_mars_shape():
     """
-    Load the data from the sample bathymetry dataset.
+    Load the table data for the shape of Mars.
     """
-    return load_mars_shape()
+    return load_sample_data(name="mars_shape")
 
 
 def test_sphinterpolate_outgrid(mars):

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -10,7 +10,7 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from pygmt import x2sys_cross, x2sys_init
-from pygmt.datasets import load_sample_bathymetry
+from pygmt.datasets import load_sample_data
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import data_kind
 
@@ -29,7 +29,7 @@ def fixture_tracks():
     """
     Load track data from the sample bathymetry file.
     """
-    dataframe = load_sample_bathymetry()
+    dataframe = load_sample_data(name="bathymetry")
     dataframe.columns = ["x", "y", "z"]  # longitude, latitude, bathymetry
     return [dataframe.query(expr="z > -20")]  # reduce size of dataset
 

--- a/pygmt/tests/test_xyz2grd.py
+++ b/pygmt/tests/test_xyz2grd.py
@@ -14,7 +14,7 @@ from pygmt.helpers import GMTTempFile
 @pytest.fixture(scope="module", name="ship_data")
 def fixture_ship_data():
     """
-    Load the data from the sample bathymetry dataset.
+    Load the table data from the sample bathymetry dataset.
     """
     return load_sample_data(name="bathymetry")
 


### PR DESCRIPTION
**Description of proposed changes**

Use the new `load_sample_data` rather than other deprecated load_ functions, so we don't see a lot of deprecation warnings in tests. Some docstrings are also updated.