### PR TITLE
Wrap clip

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -44,6 +44,7 @@ Plotting tabular data
     Figure.contour
     Figure.histogram
     Figure.meca
+    Figure.clip
     Figure.plot
     Figure.plot3d
     Figure.rose

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -467,6 +467,7 @@ class Figure:
 
     from pygmt.src import (  # pylint: disable=import-outside-toplevel
         basemap,
+        clip,
         coast,
         colorbar,
         contour,

--- a/pygmt/src/__init__.py
+++ b/pygmt/src/__init__.py
@@ -5,6 +5,7 @@ Source code for PyGMT modules.
 
 from pygmt.src.basemap import basemap
 from pygmt.src.blockm import blockmean, blockmedian, blockmode
+from pygmt.src.clip import clip
 from pygmt.src.coast import coast
 from pygmt.src.colorbar import colorbar
 from pygmt.src.config import config

--- a/pygmt/src/clip.py
+++ b/pygmt/src/clip.py
@@ -83,6 +83,7 @@ def clip(self, data=None, x=None, y=None, **kwargs):
     ...     # Map elements under the "with" statement are clipped
     ...     fig.grdimage(grid=grid)
     ...
+    >>> fig.show()  # doctest: +SKIP
     <IPython.core.display.Image object>
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access

--- a/pygmt/src/clip.py
+++ b/pygmt/src/clip.py
@@ -1,0 +1,101 @@
+"""
+clip - Create a polygonal clip path.
+"""
+import contextlib
+
+from pygmt.clib import Session
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
+
+
+@fmt_docstring
+@contextlib.contextmanager
+@use_alias(
+    A="straight_line",
+    B="frame",
+    J="projection",
+    N="invert",
+    R="region",
+    W="pen",
+    V="verbose",
+)
+@kwargs_to_strings(R="sequence")
+def clip(self, data=None, x=None, y=None, **kwargs):
+    r"""
+    Create a polygonal clip path.
+
+    This function sets a clip path for the figure. The clip path is applied
+    to plotting functions that are called within the context manager.
+
+    Full option list at :gmt-docs:`clip.html`
+
+    {aliases}
+
+    Parameters
+    ----------
+    data : str or {table-like}
+        Pass in either a file name to an ASCII data table, a 2D
+        {table-classes}.
+    x/y : 1d arrays
+        The x and y coordinates of the clip path.
+    {B}
+    {J}
+    {R}
+    straight_line : bool or str
+        [**m**\|\ **p**\|\ **x**\|\ **y**\|\ **r**\|\ **t**].
+        By default, geographic line segments are connected as great circle
+        arcs. To connect them as straight lines, use ``straight_line``.
+        Alternatively, add **m** to connect the line by first following a
+        meridian, then a parallel. Or append **p** to start following a
+        parallel, then a meridian. (This can be practical to connect a line
+        along parallels, for example). For Cartesian data, points are
+        simply connected, unless you append **x** or **y** to draw
+        stair-case curves that whose first move is along *x* or *y*,
+        respectively. For polar projection, append **r** or **t** to connect
+        staircase curves whose first move is along *r* or *theta*,
+        respectively.
+    invert : bool
+        Invert the sense of what is inside and outside. For example, when
+        using a single clip path, use ``invert=True`` to only plot points
+        outside to path. Cannot be used with ``frame``.
+    {V}
+    pen : str
+        Draw the output of the clip path using the pen attributes before
+        clipping is initiated [Default is no outline].
+
+
+    Examples
+    --------
+    >>> import pygmt
+    >>>
+    >>> # Create x,y data for the clip path
+    >>> x = [-60, 60, 60, -60]
+    >>> y = [-30, -30, 30, 30]
+    >>>
+    >>> # Load the 1 degree global earth relief
+    >>> grid = pygmt.datasets.load_earth_relief()
+    >>>
+    >>> # Create a figure and draw the map frame
+    >>> fig = pygmt.Figure()
+    >>> fig.basemap(region="d", projection="W15c", frame=True)
+    >>>
+    >>> # Use a "with" statement to initialize the clip context manager
+    >>> with fig.clip(x=x, y=y):
+    ...     # Map elements under the "with" statement are clipped
+    ...     fig.grdimage(grid=grid)
+    ...
+    <IPython.core.display.Image object>
+    """
+    kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
+    with Session() as lib:
+        try:
+            file_context = lib.virtualfile_from_data(
+                check_kind="vector", data=data, x=x, y=y
+            )
+
+            with file_context as fname:
+                arg_str = " ".join([fname, build_arg_string(kwargs)])
+                lib.call_module("clip", arg_str)
+            yield
+        finally:
+            # End the top most clipping path
+            lib.call_module("clip", "-C1")

--- a/pygmt/tests/baseline/test_clip.png.dvc
+++ b/pygmt/tests/baseline/test_clip.png.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 449fec4d58132742abb615931e6e240a
+  size: 7968
+  path: test_clip.png

--- a/pygmt/tests/test_clip.py
+++ b/pygmt/tests/test_clip.py
@@ -1,0 +1,71 @@
+"""
+Tests for fig.clip.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from pygmt import Figure
+from pygmt.helpers.testing import load_static_earth_relief
+
+
+@pytest.fixture(scope="module", name="grid")
+def fixture_grid():
+    """
+    Load the grid data from the static_earth_relief file.
+    """
+    return load_static_earth_relief()
+
+
+@pytest.fixture(scope="module", name="dataframe")
+def fixture_dataframe():
+    """
+    Load the table data from the sample bathymetry dataset.
+    """
+    return pd.DataFrame(data={"x": [-52, -50, -50, -52], "y": [-20, -20, -16, -16]})
+
+
+@pytest.fixture(scope="module", name="region")
+def fixture_region():
+    """
+    Load the table data from the sample bathymetry dataset.
+    """
+    return [-55, -47, -24, -10]
+
+
+@pytest.mark.mpl_image_compare(filename="test_clip.png")
+def test_clip_xy(grid, dataframe, region):
+    """
+    Test clip with x,y input.
+    """
+    fig = Figure()
+    fig.basemap(region=region, frame=True)
+    with fig.clip(x=dataframe["x"], y=dataframe["y"]):
+        fig.grdimage(grid=grid)
+    return fig
+
+
+@pytest.mark.parametrize("array_func", [np.array, xr.Dataset])
+@pytest.mark.mpl_image_compare(filename="test_clip.png")
+def test_clip_matrix(array_func, dataframe, grid, region):
+    """
+    Test clip with matrix input for the clip path.
+    """
+    table = array_func(dataframe)
+    fig = Figure()
+    fig.basemap(region=region, frame=True)
+    with fig.clip(data=table):
+        fig.grdimage(grid=grid, region=region)
+    return fig
+
+
+@pytest.mark.mpl_image_compare(filename="test_clip.png")
+def test_clip_dataframe(grid, dataframe, region):
+    """
+    Test clip with dataframe input for the clip path.
+    """
+    fig = Figure()
+    fig.basemap(region=region, frame=True)
+    with fig.clip(data=dataframe):
+        fig.grdimage(grid=grid, region=region)
+    return fig

--- a/pygmt/tests/test_clip.py
+++ b/pygmt/tests/test_clip.py
@@ -32,6 +32,7 @@ def fixture_region():
     """
     return [-55, -47, -24, -10]
 
+
 @pytest.fixture(scope="module", name="projection")
 def fixture_projection():
     """

--- a/pygmt/tests/test_clip.py
+++ b/pygmt/tests/test_clip.py
@@ -32,14 +32,21 @@ def fixture_region():
     """
     return [-55, -47, -24, -10]
 
+@pytest.fixture(scope="module", name="projection")
+def fixture_projection():
+    """
+    Load the table data from the sample bathymetry dataset.
+    """
+    return "M4c"
+
 
 @pytest.mark.mpl_image_compare(filename="test_clip.png")
-def test_clip_xy(grid, dataframe, region):
+def test_clip_xy(grid, dataframe, region, projection):
     """
     Test clip with x,y input.
     """
     fig = Figure()
-    fig.basemap(region=region, frame=True)
+    fig.basemap(region=region, frame=True, projection=projection)
     with fig.clip(x=dataframe["x"], y=dataframe["y"]):
         fig.grdimage(grid=grid)
     return fig
@@ -47,25 +54,25 @@ def test_clip_xy(grid, dataframe, region):
 
 @pytest.mark.parametrize("array_func", [np.array, xr.Dataset])
 @pytest.mark.mpl_image_compare(filename="test_clip.png")
-def test_clip_matrix(array_func, dataframe, grid, region):
+def test_clip_matrix(array_func, dataframe, grid, region, projection):
     """
     Test clip with matrix input for the clip path.
     """
     table = array_func(dataframe)
     fig = Figure()
-    fig.basemap(region=region, frame=True)
+    fig.basemap(region=region, frame=True, projection=projection)
     with fig.clip(data=table):
         fig.grdimage(grid=grid, region=region)
     return fig
 
 
 @pytest.mark.mpl_image_compare(filename="test_clip.png")
-def test_clip_dataframe(grid, dataframe, region):
+def test_clip_dataframe(grid, dataframe, region, projection):
     """
     Test clip with dataframe input for the clip path.
     """
     fig = Figure()
-    fig.basemap(region=region, frame=True)
+    fig.basemap(region=region, frame=True, projection=projection)
     with fig.clip(data=dataframe):
         fig.grdimage(grid=grid, region=region)
     return fig


### PR DESCRIPTION
**Description of proposed changes**

Following a couple comments at https://github.com/GenericMappingTools/pygmt/pull/1706, this PR suggests an implementation of GMT's clip module using a `with` statement/context manager. It uses the same style as the subplot and inset methods of pygmt.Figure. Here is an example:

```python
import pygmt
x = [1, 1, 2, 3, 3, 1]
y = [1, 2, 2, 3, 1, 1]
fig = pygmt.Figure()
# Plot the original data
fig.plot(data="@tut_data.txt", style="c0.5c", color="red", frame=True, region=[0, 6, 0, 6], projection="X5c")
# Setup a clip path
with fig.clip(x=x, y=y, pen="1p"):
    # Plot the data with a green fill
    fig.plot(data="@tut_data.txt", style="c0.5c", color="green")
fig.show()
```
![clip](https://user-images.githubusercontent.com/14077947/156261586-1dabb9a9-8627-4191-b2d0-d536766c4a50.png)

To do:
- [ ] Decide whether this function should remain as a context manager
- [ ] Decide how to organize this function relative to other clipping modules in GMT
- [ ] Add more robust tests (e.g., multiple clipping paths, geodataframe input, ogrfile, polygon clip + coast clip)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
