### PR TITLE
Increase code coverage for grdtrack tests

### DIFF
--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -89,18 +89,14 @@ def test_grdtrack_input_dataframe_and_ncfile(dataframe, expected_array):
     npt.assert_allclose(np.array(output), expected_array)
 
 
-def test_grdtrack_input_csvfile_and_ncfile(expected_array):
+def test_grdtrack_input_csvfile_and_ncfile_to_dataframe(expected_array):
     """
-    Run grdtrack by passing in a csvfile and netcdf file as inputs.
+    Run grdtrack by passing in a csvfile and netcdf file as inputs with a
+    pandas.DataFrame output.
     """
-    with GMTTempFile() as tmpfile:
-        output = grdtrack(
-            points=POINTS_DATA, grid="@static_earth_relief.nc", outfile=tmpfile.name
-        )
-        assert output is None  # check that output is None since outfile is set
-        assert os.path.exists(path=tmpfile.name)  # check that outfile exists at path
-        output = np.loadtxt(tmpfile.name)
-        npt.assert_allclose(np.array(output), expected_array)
+    output = grdtrack(points=POINTS_DATA, grid="@static_earth_relief.nc")
+    assert isinstance(output, pd.DataFrame)
+    npt.assert_allclose(np.array(output), expected_array)
 
 
 def test_grdtrack_wrong_kind_of_points_input(dataarray, dataframe):

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -91,7 +91,7 @@ def test_grdtrack_input_dataframe_and_ncfile(dataframe, expected_array):
 
 def test_grdtrack_input_csvfile_and_ncfile_to_dataframe(expected_array):
     """
-    Run grdtrack by passing in a csvfile and netcdf file as inputs with a
+    Run grdtrack by passing in a csv file and netcdf file as inputs with a
     pandas.DataFrame output.
     """
     output = grdtrack(points=POINTS_DATA, grid="@static_earth_relief.nc")


### PR DESCRIPTION
**Description of proposed changes**

This PR modifies one of the grdtrack tests to return a pandas.DataFrame when ``points`` is a filepath, in order to increase the test coverage to 100% (missed on past PRs because codecov requires passing tests to run).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
