### PR TITLE
Fix test_plot_shapefile by downloading cache files first

### DIFF
--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from pygmt import Figure
+from pygmt import Figure, which
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 
@@ -549,6 +549,8 @@ def test_plot_shapefile():
 
     See https://github.com/GenericMappingTools/pygmt/issues/1616.
     """
+    datasets = ["@RidgeTest" + suffix for suffix in [".shp", ".shx", ".dbf", "prj"]]
+    which(fname=datasets, download="a")
     fig = Figure()
     fig.plot(data="@RidgeTest.shp", pen="1p")
     return fig


### PR DESCRIPTION
**Description of proposed changes**

Fixes #1788


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
