### PR TITLE
Use pytest-doctestplus to skip some inline doctests

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -97,7 +97,7 @@ jobs:
                         pandas xarray netCDF4 packaging \
                         ${{ matrix.optional-packages }} \
                         dvc make pytest>=6.0 \
-                        pytest-cov pytest-mpl sphinx-gallery tomli
+                        pytest-cov pytest-doctestplus pytest-mpl sphinx-gallery tomli
 
       # Show installed pkg information for postmortem diagnostic
       - name: List installed packages

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -93,7 +93,7 @@ jobs:
           pip install --pre --prefer-binary \
                         numpy pandas xarray netCDF4 packaging \
                         dvc ipython 'pytest>=6.0' pytest-cov \
-                        pytest-mpl sphinx-gallery tomli
+                        pytest-doctestplus pytest-mpl sphinx-gallery tomli
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ fulltest:
 	@echo ""
 	@cd $(TESTDIR); python -c "import $(PROJECT); $(PROJECT).show_versions()"
 	@echo ""
-	cd $(TESTDIR); PYGMT_USE_EXTERNAL_DISPLAY="false" pytest $(PYTEST_COV_ARGS) --doctest-modules $(PROJECT)
+	cd $(TESTDIR); PYGMT_USE_EXTERNAL_DISPLAY="false" pytest $(PYTEST_COV_ARGS) $(PROJECT)
 	cp $(TESTDIR)/coverage.xml .
 	cp -r $(TESTDIR)/htmlcov .
 	rm -r $(TESTDIR)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ help:
 	@echo ""
 	@echo "  install   install in editable mode"
 	@echo "  package   build source and wheel distributions"
-	@echo "  test      run the test suite (including doctests) and report coverage"
+	@echo "  test      run the test suite (including some doctests) and report coverage"
+	@echo "  fulltest  run the test suite (including all doctests) and report coverage"
 	@echo "  format    run black, blackdoc, docformatter and isort to automatically format the code"
 	@echo "  check     run code style and quality checks (black, blackdoc, docformatter, flake8 and isort)"
 	@echo "  lint      run pylint for a deeper (and slower) quality check"
@@ -36,7 +37,18 @@ test:
 	@echo ""
 	@cd $(TESTDIR); python -c "import $(PROJECT); $(PROJECT).show_versions()"
 	@echo ""
-	cd $(TESTDIR); PYGMT_USE_EXTERNAL_DISPLAY="false" pytest $(PYTEST_COV_ARGS) $(PROJECT)
+	cd $(TESTDIR); PYGMT_USE_EXTERNAL_DISPLAY="false" pytest $(PYTEST_COV_ARGS) --doctest-plus $(PROJECT)
+	cp $(TESTDIR)/coverage.xml .
+	cp -r $(TESTDIR)/htmlcov .
+	rm -r $(TESTDIR)
+
+fulltest:
+	# Run a tmp folder to make sure the tests are run on the installed version
+	mkdir -p $(TESTDIR)
+	@echo ""
+	@cd $(TESTDIR); python -c "import $(PROJECT); $(PROJECT).show_versions()"
+	@echo ""
+	cd $(TESTDIR); PYGMT_USE_EXTERNAL_DISPLAY="false" pytest $(PYTEST_COV_ARGS) --doctest-modules $(PROJECT)
 	cp $(TESTDIR)/coverage.xml .
 	cp -r $(TESTDIR)/htmlcov .
 	rm -r $(TESTDIR)

--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,7 @@ dependencies:
     - myst-parser
     - pylint
     - pytest-cov
+    - pytest-doctestplus
     - pytest-mpl
     - pytest>=6.0
     - sphinx

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -1,7 +1,6 @@
 """
 grdlandmask - Create a "wet-dry" mask grid from shoreline data base
 """
-
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -12,6 +11,8 @@ from pygmt.helpers import (
     use_alias,
 )
 from pygmt.io import load_dataarray
+
+__doctest_skip__ = ["grdlandmask"]
 
 
 @fmt_docstring
@@ -95,12 +96,10 @@ def grdlandmask(**kwargs):
 
     Example
     -------
-    >>> import pygmt  # doctest: +SKIP
+    >>> import pygmt
     >>> # Create a landmask grid with an x-range of 125 to 130,
     >>> # and a y-range of 30 to 35
-    >>> landmask = pygmt.grdlandmask(
-    ...     spacing=1, region=[125, 130, 30, 35]
-    ... )  # doctest: +SKIP
+    >>> landmask = pygmt.grdlandmask(spacing=1, region=[125, 130, 30, 35])
     """
     if "I" not in kwargs or "R" not in kwargs:
         raise GMTInvalidInput("Both 'region' and 'spacing' must be specified.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ omit = ["*/tests/*", "*pygmt/__init__.py"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--verbose --durations=0 --durations-min=0.2 --doctest-plus --mpl --mpl-results-path=results"
+addopts = "--verbose --durations=0 --durations-min=0.2 --mpl --mpl-results-path=results"
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ omit = ["*/tests/*", "*pygmt/__init__.py"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--verbose --durations=0 --durations-min=0.2 --doctest-modules --mpl --mpl-results-path=results"
+addopts = "--verbose --durations=0 --durations-min=0.2 --doctest-plus --mpl --mpl-results-path=results"
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ omit = ["*/tests/*", "*pygmt/__init__.py"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--verbose --durations=0 --durations-min=0.2 --mpl --mpl-results-path=results"
+addopts = "--verbose --durations=0 --durations-min=0.2 --doctest-modules --mpl --mpl-results-path=results"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
**Description of proposed changes**

We're adding more and more inline code examples in function docstrings as tracked in issue #1686. We don't want these new doctests slow down our CI, so we skip these doctests using the `# doctest: +SKIP` directive. Here is an example doctest in `grdlandmask`:
```
    >>> import pygmt  # doctest: +SKIP
    >>> # Create a landmask grid with an x-range of 125 to 130,
    >>> # and a y-range of 30 to 35
    >>> landmask = pygmt.grdlandmask(
    ...     spacing=1, region=[125, 130, 30, 35]
    ... )  # doctest: +SKIP
```
As you can see, there are many downsides for this kind of doctests:

1. `# doctest: +SKIP` only works for one single line, so we have to add `# doctest: +SKIP` many times
2. `  # doctest: +SKIP` has 18 characters. So even a short code like `landmask = pygmt.grdlandmask(spacing=1, region=[125, 130, 30, 35])` must be split into multiple lines
3. there is no simple way to run these tests

In this PR, the [`pytest-doctestplus`](https://github.com/astropy/pytest-doctestplus) plugin is  used to solve the problems above. For each module, we just need to define an internal variable `__doctest_skip__`, which contains a list of functions/classes whose tests should be skipped.
See the changes in `pygmt/src/grdlandmask.py` as an example and also the official documentation of [pytest-doctestplus](https://github.com/astropy/pytest-doctestplus#skip-unconditionally).

As you can see, it solves the problems 1 and 2 above. 

|Before | After |
|---|---|
|<img width="888" alt="image" src="https://user-images.githubusercontent.com/3974108/157038176-07940daf-66fc-46f3-b33a-0491bccfee17.png"> |<img width="886" alt="image" src="https://user-images.githubusercontent.com/3974108/157038280-70f6a72b-28b3-4716-b497-5d45f50b13a9.png">|

For problem 3, there is still no easy way, but I think it's possible to comment the `__doctest_skip__` line, run the tests, and then revert the changes.