### PR TITLE
Remove grdimage, legend and plot3d xfail markers

### DIFF
--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -77,11 +77,6 @@ def test_grdimage_slice(grid):
 
 
 @pytest.mark.mpl_image_compare
-@pytest.mark.xfail(
-    condition=gmt_version > Version("6.3.0"),
-    reason="Grid extension bug affects baseline image; "
-    "fixed in https://github.com/GenericMappingTools/gmt/pull/6175.",
-)
 def test_grdimage_file():
     """
     Plot an image using file input.

--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -12,10 +12,6 @@ with clib.Session() as _lib:
 
 
 @pytest.mark.mpl_image_compare
-@pytest.mark.xfail(
-    condition=gmt_version > Version("6.3.0"),
-    reason="Defaults updated in https://github.com/GenericMappingTools/gmt/pull/6165",
-)
 def test_legend_position():
     """
     Test that plots a position with each of the four legend coordinate systems.
@@ -31,10 +27,6 @@ def test_legend_position():
 
 
 @pytest.mark.mpl_image_compare
-@pytest.mark.xfail(
-    condition=gmt_version > Version("6.3.0"),
-    reason="Defaults updated in https://github.com/GenericMappingTools/gmt/pull/6165",
-)
 def test_legend_default_position():
     """
     Test using the default legend position.
@@ -51,10 +43,6 @@ def test_legend_default_position():
 
 
 @pytest.mark.mpl_image_compare
-@pytest.mark.xfail(
-    condition=gmt_version > Version("6.3.0"),
-    reason="Defaults updated in https://github.com/GenericMappingTools/gmt/pull/6165",
-)
 def test_legend_entries():
     """
     Test different marker types/shapes.
@@ -76,10 +64,6 @@ def test_legend_entries():
 
 
 @pytest.mark.mpl_image_compare
-@pytest.mark.xfail(
-    condition=gmt_version > Version("6.3.0"),
-    reason="Defaults updated in https://github.com/GenericMappingTools/gmt/pull/6165",
-)
 def test_legend_specfile():
     """
     Test specfile functionality.

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -2,7 +2,6 @@
 Tests plot3d.
 """
 import os
-import sys
 
 import numpy as np
 import pytest
@@ -334,10 +333,6 @@ def test_plot3d_matrix(data, region, color):
     return fig
 
 
-@pytest.mark.xfail(
-    condition=sys.platform == "win32",
-    reason="Wrong plot generated on Windows due to incorrect -i parameter parsing",
-)
 @pytest.mark.mpl_image_compare
 def test_plot3d_matrix_color(data, region):
     """


### PR DESCRIPTION
**Description of proposed changes**

- The `test_plot3d_matrix_color` xfail on Windows should be addressed in the discussions in https://github.com/GenericMappingTools/pygmt/pull/1322.
- The `legend` and `grdimages` tests were marked as xfail because the baseline images should be updated due to upstream changes. However, now we have ~60 failures with the GMT dev branch (tracked in https://github.com/GenericMappingTools/pygmt/pull/1791), we should also remove the xfail markers for these tests.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
