### PR TITLE
Fix the spacing parameter and check required parameters in xyz2grd

### DIFF
--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -2,6 +2,7 @@
 xyz2grd - Convert data table to a grid.
 """
 from pygmt.clib import Session
+from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     GMTTempFile,
     build_arg_string,
@@ -30,7 +31,7 @@ from pygmt.io import load_dataarray
     r="registration",
     w="wrap",
 )
-@kwargs_to_strings(R="sequence")
+@kwargs_to_strings(I="sequence", R="sequence")
 def xyz2grd(data=None, x=None, y=None, z=None, **kwargs):
     r"""
     Create a grid file from table data.
@@ -132,6 +133,9 @@ def xyz2grd(data=None, x=None, y=None, z=None, **kwargs):
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)
     """
+    if "I" not in kwargs or "R" not in kwargs:
+        raise GMTInvalidInput("Both 'region' and 'spacing' must be specified.")
+
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
             file_context = lib.virtualfile_from_data(

--- a/pygmt/tests/test_xyz2grd.py
+++ b/pygmt/tests/test_xyz2grd.py
@@ -68,13 +68,13 @@ def test_xyz2grd_input_array_file_out(ship_data, expected_grid):
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
-def test_xyz2grd_missing_region_spacing():
+def test_xyz2grd_missing_region_spacing(ship_data):
     """
     Test xyz2grd raise an exception if region or spacing is missing.
     """
     with pytest.raises(GMTInvalidInput):
-        result = xyz2grd(data=ship_data)
+        xyz2grd(data=ship_data)
     with pytest.raises(GMTInvalidInput):
-        result = xyz2grd(data=ship_data, region=[245, 255, 20, 30])
+        xyz2grd(data=ship_data, region=[245, 255, 20, 30])
     with pytest.raises(GMTInvalidInput):
-        result = xyz2grd(data=ship_data, spacing=5)
+        xyz2grd(data=ship_data, spacing=5)

--- a/pygmt/tests/test_xyz2grd.py
+++ b/pygmt/tests/test_xyz2grd.py
@@ -8,6 +8,7 @@ import pytest
 import xarray as xr
 from pygmt import load_dataarray, xyz2grd
 from pygmt.datasets import load_sample_data
+from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 
 
@@ -65,3 +66,15 @@ def test_xyz2grd_input_array_file_out(ship_data, expected_grid):
         assert os.path.exists(path=tmpfile.name)
         temp_grid = load_dataarray(tmpfile.name)
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
+
+
+def test_xyz2grd_missing_region_spacing():
+    """
+    Test xyz2grd raise an exception if region or spacing is missing.
+    """
+    with pytest.raises(GMTInvalidInput):
+        result = xyz2grd(data=ship_data)
+    with pytest.raises(GMTInvalidInput):
+        result = xyz2grd(data=ship_data, region=[245, 255, 20, 30])
+    with pytest.raises(GMTInvalidInput):
+        result = xyz2grd(data=ship_data, spacing=5)


### PR DESCRIPTION
**Description of proposed changes**

Address the issues found in https://github.com/GenericMappingTools/pygmt/pull/1719#issuecomment-1065155252 whereby using `spacing=(1.0, 0.5)` did not work, and no check was made to ensure both 'spacing' and 'region' are given to `xyz2grd`.

Patches #636.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
