### PR TITLE
Figure.contour/plot/plot3d/rose: Remove parameter "columns", use "incols" instead

### DIFF
--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -14,7 +14,6 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
-@deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
 @check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(
     A="annotation",

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -6,7 +6,6 @@ from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_string,
     check_data_input_order,
-    deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -18,7 +18,6 @@ from pygmt.src.which import which
 
 @fmt_docstring
 @deprecate_parameter("sizes", "size", "v0.4.0", remove_version="v0.6.0")
-@deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
 @check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(
     A="straight_line",

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -17,7 +17,6 @@ from pygmt.src.which import which
 
 
 @fmt_docstring
-@deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
 @deprecate_parameter("sizes", "size", "v0.4.0", remove_version="v0.6.0")
 @check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -6,7 +6,6 @@ from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_string,
     check_data_input_order,
-    deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
@@ -14,7 +13,6 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
-@deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
 @check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(
     A="sector",

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -76,10 +76,13 @@ def test_contour_from_file(region):
 
 
 @pytest.mark.mpl_image_compare(filename="test_contour_vec.png")
-def test_contour_deprecate_columns_to_incols(region):
+def test_contour_incols_transposed_data(region):
     """
-    Make sure that the old parameter "columns" is supported and it reports an
-    warning.
+    Make sure that transposing the data matrix still produces a correct result
+    with incols reordering the columns.
+
+    This is a regression test for
+    https://github.com/GenericMappingTools/pygmt/issues/1313
 
     Modified from the test_contour_vec() test.
     """
@@ -96,14 +99,12 @@ def test_contour_deprecate_columns_to_incols(region):
     # switch x and y from here onwards to simulate different column order
     data = np.array([y, x, z]).T
 
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        fig.contour(
-            data,
-            projection="X10c",
-            region=region,
-            frame="a",
-            pen=True,
-            columns=[1, 0, 2],
-        )
-        assert len(record) == 1  # check that only one warning was raised
+    fig.contour(
+        data,
+        projection="X10c",
+        region=region,
+        frame="a",
+        pen=True,
+        incols=[1, 0, 2],
+    )
     return fig

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -476,29 +476,6 @@ def test_plot_deprecate_sizes_to_size(data, region):
     return fig
 
 
-@pytest.mark.mpl_image_compare(filename="test_plot_from_file.png")
-def test_plot_deprecate_columns_to_incols(region):
-    """
-    Make sure that the old parameter "columns" is supported and it reports a
-    warning.
-
-    Modified from the test_plot_from_file() test.
-    """
-    fig = Figure()
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        fig.plot(
-            data=POINTS_DATA,
-            region=region,
-            projection="X10c",
-            style="d1c",
-            color="yellow",
-            frame=True,
-            columns=[0, 1],
-        )
-        assert len(record) == 1  # check that only one warning was raised
-    return fig
-
-
 @pytest.mark.mpl_image_compare
 def test_plot_ogrgmt_file_multipoint_default_style():
     """

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -450,31 +450,6 @@ def test_plot3d_deprecate_sizes_to_size(data, region):
     return fig
 
 
-@pytest.mark.mpl_image_compare(filename="test_plot3d_matrix.png")
-def test_plot3d_deprecate_columns_to_incols(data, region):
-    """
-    Make sure that the old parameter "columns" is supported and it reports an
-    warning.
-
-    Modified from the test_plot3d_matrix() test.
-    """
-    fig = Figure()
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        fig.plot3d(
-            data,
-            zscale=5,
-            perspective=[225, 30],
-            region=region,
-            projection="M20c",
-            style="c1c",
-            color="#aaaaaa",
-            frame=["a", "za"],
-            columns="0,1,2",
-        )
-        assert len(record) == 1  # check that only one warning was raised
-    return fig
-
-
 @pytest.mark.mpl_image_compare
 def test_plot3d_ogrgmt_file_multipoint_default_style():
     """

--- a/pygmt/tests/test_rose.py
+++ b/pygmt/tests/test_rose.py
@@ -184,37 +184,3 @@ def test_rose_bools(data_fractures_compilation):
         shift=False,
     )
     return fig
-
-
-@pytest.mark.mpl_image_compare(filename="test_rose_bools.png")
-def test_rose_deprecate_columns_to_incols(data_fractures_compilation):
-    """
-    Make sure that the old parameter "columns" is supported and it reports a
-    warning.
-
-    Modified from the test_rose_bools() test.
-    """
-
-    # swap data column order of the sample fractures compilation dataset,
-    # as the use of the 'columns' parameter will reverse this action
-    data = data_fractures_compilation[["azimuth", "length"]]
-
-    fig = Figure()
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        fig.rose(
-            data,
-            region=[0, 1, 0, 360],
-            sector=10,
-            columns=[1, 0],
-            diameter="10c",
-            frame=["x0.2g0.2", "y30g30", "+glightgray"],
-            color="red3",
-            pen="1p",
-            orientation=False,
-            norm=True,
-            vectors=True,
-            no_scale=True,
-            shift=False,
-        )
-        assert len(record) == 1  # check that only one warning was raised
-    return fig


### PR DESCRIPTION
**Description of proposed changes**

Remove the parameter "columns" in favour of "incols" from `Figure.contour`, `Figure.plot`, `Figure.plot3d` and `Figure.rose`. Deprecation warning was added in v0.4.0 (xref #1303, #1298, #1040, #1306), and is to be fully remove in v0.6.0. 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Note that there was a regression test for `fig.contour(..., incols=[1, 0, 2])` that I've kept (xref https://github.com/GenericMappingTools/pygmt/issues/1313).

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Part of #1801.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
