### PR TITLE
Figure.plot/plot3d: Remove parameter "sizes", use "size" instead

### DIFF
--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -7,7 +7,6 @@ from pygmt.helpers import (
     build_arg_string,
     check_data_input_order,
     data_kind,
-    deprecate_parameter,
     fmt_docstring,
     is_nonstr_iter,
     kwargs_to_strings,
@@ -17,7 +16,6 @@ from pygmt.src.which import which
 
 
 @fmt_docstring
-@deprecate_parameter("sizes", "size", "v0.4.0", remove_version="v0.6.0")
 @check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(
     A="straight_line",

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -7,7 +7,6 @@ from pygmt.helpers import (
     build_arg_string,
     check_data_input_order,
     data_kind,
-    deprecate_parameter,
     fmt_docstring,
     is_nonstr_iter,
     kwargs_to_strings,
@@ -17,7 +16,6 @@ from pygmt.src.which import which
 
 
 @fmt_docstring
-@deprecate_parameter("sizes", "size", "v0.4.0", remove_version="v0.6.0")
 @check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(
     A="straight_line",

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -452,30 +452,6 @@ def test_plot_datetime():
     return fig
 
 
-@pytest.mark.mpl_image_compare(filename="test_plot_sizes.png")
-def test_plot_deprecate_sizes_to_size(data, region):
-    """
-    Make sure that the old parameter "sizes" is supported and it reports a
-    warning.
-
-    Modified from the test_plot_sizes() test.
-    """
-    fig = Figure()
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        fig.plot(
-            x=data[:, 0],
-            y=data[:, 1],
-            sizes=0.5 * data[:, 2],
-            region=region,
-            projection="X10c",
-            style="cc",
-            color="blue",
-            frame="af",
-        )
-        assert len(record) == 1  # check that only one warning was raised
-    return fig
-
-
 @pytest.mark.mpl_image_compare
 def test_plot_ogrgmt_file_multipoint_default_style():
     """

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -423,33 +423,6 @@ def test_plot3d_scalar_xyz():
     return fig
 
 
-@pytest.mark.mpl_image_compare(filename="test_plot3d_sizes.png")
-def test_plot3d_deprecate_sizes_to_size(data, region):
-    """
-    Make sure that the old parameter "sizes" is supported and it reports an
-    warning.
-
-    Modified from the test_plot3d_sizes() test.
-    """
-    fig = Figure()
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        fig.plot3d(
-            x=data[:, 0],
-            y=data[:, 1],
-            z=data[:, 2],
-            zscale=5,
-            perspective=[225, 30],
-            sizes=0.5 * data[:, 2],
-            region=region,
-            projection="X10c",
-            style="ui",
-            color="blue",
-            frame=["af", "zaf"],
-        )
-        assert len(record) == 1  # check that only one warning was raised
-    return fig
-
-
 @pytest.mark.mpl_image_compare
 def test_plot3d_ogrgmt_file_multipoint_default_style():
     """


### PR DESCRIPTION
**Description of proposed changes**

Remove the parameter "sizes" in favour of "size" from `Figure.plot` and `Figure.plot3d`. Deprecation warning was added in v0.4.0 (xref #1254, #1258), and is to be fully removed in v0.6.0. 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Part of #1801.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
