### PR TITLE
Standardize output types for grdhisteq methods

### DIFF
--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -215,9 +215,7 @@ class grdhisteq:  # pylint: disable=invalid-name
                 output_type = "xarray"
                 outgrid = tmpfile.name
             else:
-                raise GMTInvalidInput(
-                    "Must specify 'outgrid' as a string or None."
-                )
+                raise GMTInvalidInput("Must specify 'outgrid' as a string or None.")
             return grdhisteq._grdhisteq(
                 grid=grid,
                 output_type=output_type,

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -163,7 +163,7 @@ class grdhisteq:  # pylint: disable=invalid-name
         ----------
         grid : str or xarray.DataArray
             The file name of the input grid or the grid loaded as a DataArray.
-        outgrid : str or bool or None
+        outgrid : str or None
             The name of the output netCDF file with extension .nc to store the
             grid in.
         divisions : int
@@ -183,7 +183,7 @@ class grdhisteq:  # pylint: disable=invalid-name
         ret: xarray.DataArray or None
             Return type depends on the ``outgrid`` parameter:
 
-            - xarray.DataArray if ``outgrid`` is True or None
+            - xarray.DataArray if ``outgrid`` is None
             - None if ``outgrid`` is a str (grid output is stored in
               ``outgrid``)
 
@@ -211,9 +211,13 @@ class grdhisteq:  # pylint: disable=invalid-name
         with GMTTempFile(suffix=".nc") as tmpfile:
             if isinstance(outgrid, str):
                 output_type = "file"
-            else:
+            elif outgrid is None:
                 output_type = "xarray"
                 outgrid = tmpfile.name
+            else:
+                raise GMTInvalidInput(
+                    "Must specify 'output_type' either as 'numpy', 'pandas' or 'file'."
+                )
             return grdhisteq._grdhisteq(
                 grid=grid,
                 output_type=output_type,
@@ -281,12 +285,12 @@ class grdhisteq:  # pylint: disable=invalid-name
 
         Returns
         -------
-        ret: pandas.DataFrame or None
-            Return type depends on the ``outfile`` parameter:
-
-            - pandas.DataFrame if ``outfile`` is True or None
-            - None if ``outfile`` is a str (file output is stored in
+        ret : pandas.DataFrame or numpy.ndarray or None
+            Return type depends on ``outfile`` and ``output_type``:
+            - None if ``outfile`` is set (output will be stored in file set by
               ``outfile``)
+            - :class:`pandas.DataFrame` or :class:`numpy.ndarray` if
+              ``outfile`` is not set (depends on ``output_type``)
 
         Example
         -------

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -216,7 +216,7 @@ class grdhisteq:  # pylint: disable=invalid-name
                 outgrid = tmpfile.name
             else:
                 raise GMTInvalidInput(
-                    "Must specify 'output_type' either as 'numpy', 'pandas' or 'file'."
+                    "Must specify 'outgrid' as a string or None."
                 )
             return grdhisteq._grdhisteq(
                 grid=grid,

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -287,6 +287,7 @@ class grdhisteq:  # pylint: disable=invalid-name
         -------
         ret : pandas.DataFrame or numpy.ndarray or None
             Return type depends on ``outfile`` and ``output_type``:
+
             - None if ``outfile`` is set (output will be stored in file set by
               ``outfile``)
             - :class:`pandas.DataFrame` or :class:`numpy.ndarray` if

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -141,7 +141,7 @@ class grdhisteq:  # pylint: disable=invalid-name
     def equalize_grid(
         grid,
         *,
-        outgrid=True,
+        outgrid=None,
         divisions=None,
         region=None,
         gaussian=None,

--- a/pygmt/tests/test_grdhisteq.py
+++ b/pygmt/tests/test_grdhisteq.py
@@ -66,13 +66,12 @@ def test_equalize_grid_outgrid_file(grid, expected_grid, region):
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
-@pytest.mark.parametrize("outgrid", [True, None])
-def test_equalize_grid_outgrid(grid, outgrid, expected_grid, region):
+def test_equalize_grid_outgrid(grid, expected_grid, region):
     """
-    Test grdhisteq.equalize_grid with ``outgrid=True`` and ``outgrid=None``.
+    Test grdhisteq.equalize_grid with ``outgrid=None``.
     """
     temp_grid = grdhisteq.equalize_grid(
-        grid=grid, divisions=2, region=region, outgrid=outgrid
+        grid=grid, divisions=2, region=region, outgrid=None
     )
     assert temp_grid.gmt.gtype == 1  # Geographic grid
     assert temp_grid.gmt.registration == 1  # Pixel registration
@@ -135,3 +134,11 @@ def test_compute_bins_invalid_format(grid):
         grdhisteq.compute_bins(grid=grid, output_type=1)
     with pytest.raises(GMTInvalidInput):
         grdhisteq.compute_bins(grid=grid, output_type="pandas", header="o+c")
+
+
+def test_equalize_grid_invalid_format(grid):
+    """
+    Test that equalize_grid fails with incorrect format.
+    """
+    with pytest.raises(GMTInvalidInput):
+        grdhisteq.equalize_grid(grid=grid, outgrid=True)


### PR DESCRIPTION
**Description of proposed changes**

This PR makes two updates to the recently added grdhisteq methods:

1. Return an xarray.DataArray only if ``outgrid`` is None (xref https://github.com/GenericMappingTools/pygmt/issues/1807)
  2. Update the docstring returns section for ``compute_bins`` to clarify the dependence on ``output_type``.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
