### PR TITLE
Use 'Note' rather than 'Notes' as docstring section header

### DIFF
--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -54,8 +54,8 @@ def load_earth_age(resolution="01d", region=None, registration=None):
         The Earth seafloor crustal age grid. Coordinates are latitude and
         longitude in degrees. Age is in millions of years (Myr).
 
-    Notes
-    -----
+    Note
+    ----
     The :class:`xarray.DataArray` grid doesn't support slice operation, for
     Earth seafloor crustal age with resolutions of 5 arc-minutes or higher,
     which are stored as smaller tiles.

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -62,8 +62,8 @@ def load_earth_relief(resolution="01d", region=None, registration=None, use_srtm
         The Earth relief grid. Coordinates are latitude and longitude in
         degrees. Relief is in meters.
 
-    Notes
-    -----
+    Note
+    ----
     The :class:`xarray.DataArray` grid doesn't support slice operation, for
     Earth relief data with resolutions of 5 arc-minutes or higher, which are
     stored as smaller tiles.

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -202,8 +202,8 @@ class grdhisteq:  # pylint: disable=invalid-name
         -------
         :meth:`pygmt.grd2cpt`
 
-        Notes
-        -----
+        Note
+        ----
         This method does a weighted histogram equalization for geographic
         grids to account for node area varying with latitude.
         """
@@ -312,8 +312,8 @@ class grdhisteq:  # pylint: disable=invalid-name
         -------
         :meth:`pygmt.grd2cpt`
 
-        Notes
-        -----
+        Note
+        ----
         This method does a weighted histogram equalization for geographic
         grids to account for node area varying with latitude.
         """


### PR DESCRIPTION
**Description of proposed changes**

This PR updates docstring section headers from "Notes" to "Note" for improved formatting.

| Before | After |
|----|----|
| <img width="500" alt="image" src="https://user-images.githubusercontent.com/14077947/158077239-977b6948-554d-4fa0-a00b-d3110d7731ec.png"> | <img width="500" alt="image" src="https://user-images.githubusercontent.com/14077947/158077293-ffc11be3-8254-4c47-ab9c-a23e2f843f32.png"> |


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
