### PR TITLE
Remove the GMT6.0 dependency information from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,10 +63,6 @@ publication quality maps and figures. It provides a Pythonic interface for the
 `Generic Mapping Tools (GMT) <https://github.com/GenericMappingTools/gmt>`__, a
 command-line program widely used in the Earth Sciences.
 
-We rely heavily on new features that have been implemented in GMT 6.0. In particular,
-a new *modern execution mode* that greatly simplifies figure creation. **These features
-are not available in the 5.4 version of GMT**.
-
 Project goals
 -------------
 


### PR DESCRIPTION
**Description of proposed changes**

> We rely heavily on new features that have been implemented in GMT 6.0. In particular,
> a new *modern execution mode* that greatly simplifies figure creation. **These features
> are not available in the 5.4 version of GMT**.

I'd like to remove the above sentence from the README file, due to the following reasons:

1. PyGMT now relies on GMT 6.3, so the sentence gives misleading information
2. We already have a compatibility table at the end of the README file, so no need to mention that PyGMT doesn't work with GMT 5.4 here
3. This sentence mentions the GMT6 *modern execution mode*. It makes little sense to users who never used GMT and may cause more confusion.