### PR TITLE
Fix pathlib support for plot and plot3d

### DIFF
--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -226,7 +226,7 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
         and data.geom_type.isin(["Point", "MultiPoint"]).all()
     ):  # checking if the geometry of a geoDataFrame is Point or MultiPoint
         kwargs["S"] = "s0.2c"
-    elif "S" not in kwargs and kind == "file" and data.endswith(".gmt"):
+    elif "S" not in kwargs and kind == "file" and str(data).endswith(".gmt"):
         # checking that the data is a file path to set default style
         try:
             with open(which(data), mode="r", encoding="utf8") as file:

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -196,7 +196,7 @@ def plot3d(
         and data.geom_type.isin(["Point", "MultiPoint"]).all()
     ):  # checking if the geometry of a geoDataFrame is Point or MultiPoint
         kwargs["S"] = "u0.2c"
-    elif "S" not in kwargs and kind == "file" and data.endswith(".gmt"):
+    elif "S" not in kwargs and kind == "file" and str(data).endswith(".gmt"):
         # checking that the data is a file path to set default style
         try:
             with open(which(data), mode="r", encoding="utf8") as file:

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -4,6 +4,7 @@ Tests plot.
 """
 import datetime
 import os
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -452,8 +453,11 @@ def test_plot_datetime():
     return fig
 
 
-@pytest.mark.mpl_image_compare
-def test_plot_ogrgmt_file_multipoint_default_style():
+@pytest.mark.mpl_image_compare(
+    filename="test_plot_ogrgmt_file_multipoint_default_style.png"
+)
+@pytest.mark.parametrize("func", [str, Path])
+def test_plot_ogrgmt_file_multipoint_default_style(func):
     """
     Make sure that OGR/GMT files with MultiPoint geometry are plotted as
     squares and not as line (default GMT style).
@@ -467,7 +471,9 @@ def test_plot_ogrgmt_file_multipoint_default_style():
         with open(tmpfile.name, "w", encoding="utf8") as file:
             file.write(gmt_file)
         fig = Figure()
-        fig.plot(data=tmpfile.name, region=[0, 2, 1, 3], projection="X2c", frame=True)
+        fig.plot(
+            data=func(tmpfile.name), region=[0, 2, 1, 3], projection="X2c", frame=True
+        )
         return fig
 
 

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -2,6 +2,7 @@
 Tests plot3d.
 """
 import os
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -423,8 +424,11 @@ def test_plot3d_scalar_xyz():
     return fig
 
 
-@pytest.mark.mpl_image_compare
-def test_plot3d_ogrgmt_file_multipoint_default_style():
+@pytest.mark.mpl_image_compare(
+    filename="test_plot3d_ogrgmt_file_multipoint_default_style.png"
+)
+@pytest.mark.parametrize("func", [str, Path])
+def test_plot3d_ogrgmt_file_multipoint_default_style(func):
     """
     Make sure that OGR/GMT files with MultiPoint geometry are plotted as cubes
     and not as line (default GMT style).
@@ -440,7 +444,7 @@ def test_plot3d_ogrgmt_file_multipoint_default_style():
             file.write(gmt_file)
         fig = Figure()
         fig.plot3d(
-            data=tmpfile.name,
+            data=func(tmpfile.name),
             perspective=[315, 25],
             region=[0, 2, 0, 2, 0, 2],
             projection="X2c",


### PR DESCRIPTION
**Description of proposed changes**

Minimal example to reproduce the issue:
```
import pygmt
from pathlib import Path

fig = pygmt.Figure()
fig.plot(data=Path("abc.txt"))
fig.show()
```

Error messages:
```
Traceback (most recent call last):
  File "/Users/user/pygmt/issues/plot-pathlib/test.py", line 5, in <module>
    fig.plot(data=Path("abc.txt"))
  File "/Users/user/pygmt/pygmt/helpers/decorators.py", line 872, in new_module
    return module_func(*args, **kwargs)
  File "/Users/user/pygmt/pygmt/helpers/decorators.py", line 585, in new_module
    return module_func(*args, **kwargs)
  File "/Users/user/pygmt/pygmt/helpers/decorators.py", line 725, in new_module
    return module_func(*args, **kwargs)
  File "/Users/user/pygmt/pygmt/src/plot.py", line 229, in plot
    elif "S" not in kwargs and kind == "file" and data.endswith(".gmt"):
AttributeError: 'PosixPath' object has no attribute 'endswith'
```

This PR fixes the bug.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
