### PR TITLE
Add regression test for grdfill crash

### DIFF
--- a/pygmt/tests/test_grdfill.py
+++ b/pygmt/tests/test_grdfill.py
@@ -92,8 +92,10 @@ def test_grdfill_dataarray_out(grid, expected_grid):
 )
 def test_grdfill_asymmetric_pad(grid, expected_grid):
     """
-    Test grdfill using a region that boarders the edge of the grid.
-    Regression test for https://github.com/GenericMappingTools/pygmt/issues/1745.
+    Test grdfill using a region that includes the edge of the grid.
+
+    Regression test for
+    https://github.com/GenericMappingTools/pygmt/issues/1745.
     """
     result = grdfill(grid=grid, mode="c20", region=[-55, -50, -24, -16])
     # check information of the output grid

--- a/pygmt/tests/test_grdfill.py
+++ b/pygmt/tests/test_grdfill.py
@@ -6,10 +6,14 @@ import os
 import numpy as np
 import pytest
 import xarray as xr
-from pygmt import grdfill, load_dataarray
+from packaging.version import Version
+from pygmt import clib, grdfill, load_dataarray
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import load_static_earth_relief
+
+with clib.Session() as _lib:
+    gmt_version = Version(_lib.info["version"])
 
 
 @pytest.fixture(scope="module", name="grid")
@@ -80,6 +84,26 @@ def test_grdfill_dataarray_out(grid, expected_grid):
     assert result.gmt.registration == 1  # Pixel registration
     # check information of the output grid
     xr.testing.assert_allclose(a=result, b=expected_grid)
+
+
+@pytest.mark.skipif(
+    gmt_version < Version("6.4.0"),
+    reason="Upstream bug/crash fixed in https://github.com/GenericMappingTools/gmt/pull/6418.",
+)
+def test_grdfill_asymmetric_pad(grid, expected_grid):
+    """
+    Test grdfill using a region that boarders the edge of the grid.
+    Regression test for https://github.com/GenericMappingTools/pygmt/issues/1745.
+    """
+    result = grdfill(grid=grid, mode="c20", region=[-55, -50, -24, -16])
+    # check information of the output grid
+    assert isinstance(result, xr.DataArray)
+    assert result.gmt.gtype == 1  # Geographic grid
+    assert result.gmt.registration == 1  # Pixel registration
+    # check information of the output grid
+    xr.testing.assert_allclose(
+        a=result, b=expected_grid.sel(lon=slice(-55, -50), lat=slice(-24, -16))
+    )
 
 
 def test_grdfill_file_out(grid, expected_grid):


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a regression test for https://github.com/GenericMappingTools/pygmt/issues/1745, which was fixed by https://github.com/GenericMappingTools/gmt/pull/6418.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Closes #1745 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
