### PR TITLE
Fix workflows for slash commands /format and /test-gmt-dev

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -67,7 +67,7 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref }}
           # fecth all history so that setuptools-scm works
           fetch-depth: 0
 

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
       # Setup Python environment
       - uses: actions/setup-python@v3.0.0


### PR DESCRIPTION
**Description of proposed changes**

As reported in #1816, slash commands `/format` and `/test-gmt-dev` no longer works as expected.

The main cause is that the two workflows always check out the main branch because `ref : ${{ github.event.pull_request.head.sha }}` is empty for a `repository_dispatch` workflow. 

This PR fixes the issue by changing the `ref` to `${{ github.event.client_payload.pull_request.head.ref }}`.

Address #1816.

---

It's impossible to test this PR without merging it because `repository_dispatch` triggered by slash commands can only run workflows in the main branch. 

To test changes in this PR, I have made [the same changes to the main branch of my fork](https://github.com/seisman/pygmt/commit/6c47f7dc69135b4b8a544f2bbdef797656d25ef0) (actually more changes are made because my fork can't use `tibdex/github-app-token`). A sample PR is available at https://github.com/seisman/pygmt/pull/2. As you can see, both commands now work (see https://github.com/seisman/pygmt/actions/runs/2033270957 and https://github.com/seisman/pygmt/actions/runs/2033287345).


