### PR TITLE
Replace "module" by "method" 

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -405,9 +405,9 @@ When editing documentation, use the following standards to demonstrate the examp
 
 The API reference is manually assembled in `doc/api/index.rst`.
 The *autodoc* sphinx extension will automatically create pages for each
-function/class/module listed there.
+function/class/module/method listed there.
 
-You can reference functions, classes, methods, and modules from anywhere
+You can reference functions, classes, modules, and methods from anywhere
 (including docstrings) using:
 
 - <code>:func:\`package.module.function\`</code>
@@ -435,7 +435,7 @@ For GMT configuration parameters, an example is
 {gmt-term}`https://docs.generic-mapping-tools.org/latest/gmt.conf#term-COLOR_FOREGROUND <COLOR_FOREGROUND>`.
 
 Sphinx will create a link to the automatically generated page for that
-function/class/module.
+function/class/module/method.
 
 ## Contributing Code
 
@@ -500,7 +500,7 @@ Tests also help us be confident that we won't break your code in the future.
 
 When writing tests, don't test everything that the GMT function already tests, such as
 the every unique combination arguments. An exception to this would be the most popular
-modules, such as `plot` and `basemap`. The highest priority for tests should be the
+methods, such as `plot` and `basemap`. The highest priority for tests should be the
 Python-specific code, such as numpy, pandas, and xarray objects and the virtualfile
 mechanism.
 

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -254,7 +254,7 @@ publishing the actual release notes at https://www.pygmt.org/latest/changes.html
    typo fixes, CI configuration, test updates due to GMT releases, etc).
 5. Sort the items within each section (i.e., New Features, Enhancements, etc.)
    such that similar items are located near each other (e.g., new wrapped
-   modules, gallery examples, API docs changes) and entries within each group
+   modules and methods, gallery examples, API docs changes) and entries within each group
    are alphabetical.
 6. Move a few important items from the main sections to the highlights section.
 7. Edit the list of people who contributed to the release, linking to their

--- a/examples/gallery/lines/vector_heads_tails.py
+++ b/examples/gallery/lines/vector_heads_tails.py
@@ -2,7 +2,7 @@ r"""
 Vector heads and tails
 ----------------------
 
-Many modules in PyGMT allow plotting vectors with individual
+Many methods in PyGMT allow plotting vectors with individual
 heads and tails. For this purpose, several modifiers may be appended to
 the corresponding vector-producing parameters for specifying the placement
 of vector heads and tails, their shapes, and the justification of the vector.
@@ -21,7 +21,7 @@ The angle of the vector head apex can be set using **+a**\ *angle*
 **+h**\ *shape* (e.g. ``+h0.5``).
 
 For further modifiers see the *Vector Attributes* subsection of the
-corresponding module.
+corresponding method.
 
 In the following we use the :meth:`pygmt.Figure.plot` method to plot vectors
 with individual heads and tails. We must specify the modifiers (together with

--- a/examples/get-started/README.txt
+++ b/examples/get-started/README.txt
@@ -13,5 +13,5 @@ This tutorial assumes that PyGMT has been successfully
 
 This tutorial will progressively cover PyGMT plotting concepts, and later
 examples will use concepts explained in previous examples. It will not
-cover all PyGMT modules.
+cover all PyGMT methods.
 

--- a/examples/get-started/first_figure.py
+++ b/examples/get-started/first_figure.py
@@ -4,7 +4,7 @@
 
 This tutorial page covers the basics of creating a figure using PyGMT - a
 Python wrapper for the Generic Mapping Tools (GMT). It will only use
-the ``coast`` module for plotting. Later examples will address other PyGMT
+the ``coast`` method for plotting. Later examples will address other PyGMT
 modules.
 """
 
@@ -38,14 +38,14 @@ fig = pygmt.Figure()
 
 ###############################################################################
 # To add to a plot object (``fig`` in this example), the PyGMT module is used
-# as a method on the class. This example will use the module ``coast``, which
-# can be used to create a map without any other modules or external data. The
-# ``coast`` module plots the coastlines, borders, and bodies of water using a
-# database that is included in GMT.
+# as a method on the class. This example will use the ``coast`` method, which
+# can be used to create a map without any other methods, modules or external 
+# data. The ``coast`` method plots the coastlines, borders, and bodies of water 
+# using a database that is included in GMT.
 #
 # First, a region for the figure must be selected. This example will plot some
 # of the coast of Maine in the northeastern US. A Python list can be passed to
-# the ``region`` argument with the minimum and maximum X-values (longitude)
+# the ``region`` parameter with the minimum and maximum X-values (longitude)
 # and the minimum and maximum Y-values (latitude). For this example, the
 # minimum (bottom left) coordinates are (N43.75, W69) and the maximum (top
 # right) coordinates are (N44.75, W68). Negative values can be passed for

--- a/examples/get-started/first_figure.py
+++ b/examples/get-started/first_figure.py
@@ -39,8 +39,8 @@ fig = pygmt.Figure()
 ###############################################################################
 # To add to a plot object (``fig`` in this example), the PyGMT module is used
 # as a method on the class. This example will use the ``coast`` method, which
-# can be used to create a map without any other methods, modules or external 
-# data. The ``coast`` method plots the coastlines, borders, and bodies of water 
+# can be used to create a map without any other methods, modules or external
+# data. The ``coast`` method plots the coastlines, borders, and bodies of water
 # using a database that is included in GMT.
 #
 # First, a region for the figure must be selected. This example will plot some

--- a/examples/get-started/first_figure.py
+++ b/examples/get-started/first_figure.py
@@ -5,7 +5,7 @@
 This tutorial page covers the basics of creating a figure using PyGMT - a
 Python wrapper for the Generic Mapping Tools (GMT). It will only use
 the ``coast`` method for plotting. Later examples will address other PyGMT
-modules.
+methods.
 """
 
 ###############################################################################
@@ -21,7 +21,7 @@ modules.
 # Loading the library
 # -------------------
 #
-# The first step is to import ``pygmt``. All modules and figure generation is
+# The first step is to import ``pygmt``. All methods and figure generation is
 # accessible from the :mod:`pygmt` top level package.
 
 # sphinx_gallery_thumbnail_number = 4

--- a/examples/projections/README.txt
+++ b/examples/projections/README.txt
@@ -2,7 +2,7 @@ Projections
 ===========
 
 PyGMT support many map projections. Use the ``projection`` parameter to specify which
-one you want to use in all plotting modules. The projection is specified by a one
+one you want to use in all plotting methods. The projection is specified by a one
 letter code along with (sometimes optional) reference longitude and latitude and the
 width of the map (for example, **A**\ *lon0/lat0*\ [*/horizon*\ ]\ */width*). The map
 height is determined based on the region and projection.

--- a/examples/tutorials/basics/frames.py
+++ b/examples/tutorials/basics/frames.py
@@ -22,7 +22,7 @@ fig.show()
 
 ###############################################################################
 # To add the default GMT frame to the plot, use ``frame="f"`` in
-# :meth:`pygmt.Figure.basemap` or any other plotting module:
+# :meth:`pygmt.Figure.basemap` or any other plotting method:
 
 fig = pygmt.Figure()
 fig.coast(shorelines="1/0.5p", region=[-180, 180, -60, 60], projection="M25c")

--- a/pygmt/src/__init__.py
+++ b/pygmt/src/__init__.py
@@ -1,5 +1,5 @@
 """
-Source code for PyGMT modules.
+Source code for PyGMT methods.
 """
 # pylint: disable=import-outside-toplevel
 

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -33,7 +33,7 @@ def grd2cpt(grid, **kwargs):
     r"""
     Make GMT color palette tables from a grid file.
 
-    This is a module that will help you make static color palette tables
+    This is a method that will help you make static color palette tables
     (CPTs). By default, the CPT will simply be saved to the current session,
     but you can use ``output`` to save it to a file. The CPT is based on an
     existing dynamic master CPT of your choice, and the mapping from data value

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -133,7 +133,7 @@ def grdimage(self, grid, **kwargs):
         ambient light). Alternatively, derive an intensity grid from the input
         data grid via a call to :meth:`pygmt.grdgradient`; append
         **+a**\ *azimuth*, **+n**\ *args*, and **+m**\ *ambient* to specify
-        azimuth, intensity, and ambient arguments for that module, or just give
+        azimuth, intensity, and ambient arguments for that method, or just give
         **+d** to select the default arguments (``+a-45+nt1+m0``). If you want
         a more specific intensity scenario then run :meth:`pygmt.grdgradient`
         separately first. If we should derive intensities from another file

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -35,7 +35,7 @@ def grdproject(grid, **kwargs):
     r"""
     Change projection of gridded data between geographical and rectangular.
 
-    This module will project a geographical gridded data set onto a
+    This method will project a geographical gridded data set onto a
     rectangular grid. If ``inverse`` is ``True``, it will project a
     rectangular coordinate system to a geographic system. To obtain the value
     at each new node, its location is inversely projected back onto the input

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -110,7 +110,7 @@ def grdview(self, grid, **kwargs):
         ambient light). Alternatively, derive an intensity grid from the
         input data grid reliefgrid via a call to ``grdgradient``; append
         **+a**\ *azimuth*, **+n**\ *args*, and **+m**\ *ambient* to specify
-        azimuth, intensity, and ambient arguments for that module, or just give
+        azimuth, intensity, and ambient arguments for that method, or just give
         **+d** to select the default arguments
         [Default is **+a**\ -45\ **+nt**\ 1\ **+m**\ 0].
     {V}

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -29,7 +29,7 @@ def makecpt(**kwargs):
     r"""
     Make GMT color palette tables.
 
-    This is a module that will help you make static color palette tables
+    This is a method that will help you make static color palette tables
     (CPTs). By default, the CPT will simply be saved to the current session,
     but you can use ``output`` to save it to a file. You define an equidistant
     set of contour intervals or pass your own z-table or list, and create a new

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -210,7 +210,7 @@ def set_panel(self, panel=None, **kwargs):
         **s**, or **n**. The option is repeatable to set aside space on more
         than one side (e.g. ``clearance=['w1c', 's2c']`` would set a clearance
         of 1 cm on west side and 2 cm on south side). Such space will be left
-        untouched by the main map plotting but can be accessed by modules that
+        untouched by the main map plotting but can be accessed by methods that
         plot scales, bars, text, etc. This setting overrides the common
         clearances set by ``clearance`` in the initial
         :meth:`pygmt.Figure.subplot` call.

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -94,7 +94,7 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
         to set aside space on more than one side (e.g. ``clearance=['w1c',
         's2c']`` would set a clearance of 1 cm on west side and 2 cm on south
         side). Such space will be left untouched by the main map plotting but
-        can be accessed by modules that plot scales, bars, text, etc.
+        can be accessed by methods that plot scales, bars, text, etc.
     {J}
     margins : str or list
         This is margin space that is added between neighboring subplots (i.e.,


### PR DESCRIPTION
**Description of proposed changes**

This PR addresses #1828 and replaces the term "module" by "method" in several cases.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
