### PR TITLE
Allow passing None explicitly to pygmt functions Part 2

### DIFF
--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -139,8 +139,8 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
             )
             with table_context as infile:
-                if "G" not in kwargs:  # if outgrid is unset, output to tmpfile
-                    kwargs.update({"G": tmpfile.name})
+                if (outgrid := kwargs.get("G")) is None: # if outgrid is unset, output to tmpfile
+                    kwargs["G"] = outgrid = tmpfile.name
                 outgrid = kwargs["G"]
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module(module="nearneighbor", args=arg_str)

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -139,8 +139,8 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
             )
             with table_context as infile:
-                if (outgrid := kwargs.get("G")) is None: # if outgrid is unset, output to tmpfile
-                    kwargs["G"] = outgrid = tmpfile.name
+                if (outgrid := kwargs.get("G")) is None:
+                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module(module="nearneighbor", args=arg_str)
 

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -141,7 +141,6 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
             with table_context as infile:
                 if (outgrid := kwargs.get("G")) is None: # if outgrid is unset, output to tmpfile
                     kwargs["G"] = outgrid = tmpfile.name
-                outgrid = kwargs["G"]
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module(module="nearneighbor", args=arg_str)
 

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -108,9 +108,8 @@ def sphdistance(data=None, x=None, y=None, **kwargs):
                 check_kind="vector", data=data, x=x, y=y
             )
             with file_context as infile:
-                if "G" not in kwargs:  # if outgrid is unset, output to tempfile
-                    kwargs.update({"G": tmpfile.name})
-                outgrid = kwargs["G"]
+                if (outgrid := kwargs.get("G")) is None: # if outgrid is unset, output to tmpfile
+                    kwargs["G"] = outgrid = tmpfile.name
                 arg_str = build_arg_string(kwargs)
                 arg_str = " ".join([infile, arg_str])
                 lib.call_module("sphdistance", arg_str)

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -108,8 +108,8 @@ def sphdistance(data=None, x=None, y=None, **kwargs):
                 check_kind="vector", data=data, x=x, y=y
             )
             with file_context as infile:
-                if (outgrid := kwargs.get("G")) is None: # if outgrid is unset, output to tmpfile
-                    kwargs["G"] = outgrid = tmpfile.name
+                if (outgrid := kwargs.get("G")) is None:
+                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 arg_str = build_arg_string(kwargs)
                 arg_str = " ".join([infile, arg_str])
                 lib.call_module("sphdistance", arg_str)

--- a/pygmt/src/sphinterpolate.py
+++ b/pygmt/src/sphinterpolate.py
@@ -60,9 +60,8 @@ def sphinterpolate(data, **kwargs):
         with Session() as lib:
             file_context = lib.virtualfile_from_data(check_kind="vector", data=data)
             with file_context as infile:
-                if "G" not in kwargs:  # if outgrid is unset, output to tempfile
-                    kwargs.update({"G": tmpfile.name})
-                outgrid = kwargs["G"]
+                if (outgrid := kwargs.get("G")) is None: # if outgrid is unset, output to tmpfile
+                    kwargs["G"] = outgrid = tmpfile.name
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("sphinterpolate", arg_str)
 

--- a/pygmt/src/sphinterpolate.py
+++ b/pygmt/src/sphinterpolate.py
@@ -60,8 +60,8 @@ def sphinterpolate(data, **kwargs):
         with Session() as lib:
             file_context = lib.virtualfile_from_data(check_kind="vector", data=data)
             with file_context as infile:
-                if (outgrid := kwargs.get("G")) is None: # if outgrid is unset, output to tmpfile
-                    kwargs["G"] = outgrid = tmpfile.name
+                if (outgrid := kwargs.get("G")) is None:
+                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("sphinterpolate", arg_str)
 

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -98,9 +98,8 @@ def surface(data=None, x=None, y=None, z=None, **kwargs):
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
             )
             with file_context as infile:
-                if "G" not in kwargs:  # if outgrid is unset, output to tmpfile
-                    kwargs.update({"G": tmpfile.name})
-                outgrid = kwargs["G"]
+                if (outgrid := kwargs.get("G")) is None: # if outgrid is unset, output to tmpfile
+                    kwargs["G"] = outgrid = tmpfile.name
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module(module="surface", args=arg_str)
 

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -98,8 +98,8 @@ def surface(data=None, x=None, y=None, z=None, **kwargs):
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
             )
             with file_context as infile:
-                if (outgrid := kwargs.get("G")) is None: # if outgrid is unset, output to tmpfile
-                    kwargs["G"] = outgrid = tmpfile.name
+                if (outgrid := kwargs.get("G")) is None:
+                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module(module="surface", args=arg_str)
 

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -184,7 +184,7 @@ def text_(
         raise GMTInvalidInput("Must provide text with x/y pairs or position")
 
     # Build the -F option in gmt text.
-    if "F" not in kwargs and (
+    if kwargs.get("F") is None and (
         (
             position is not None
             or angle is not None
@@ -215,7 +215,7 @@ def text_(
     extra_arrays = []
     # If an array of transparency is given, GMT will read it from
     # the last numerical column per data record.
-    if "t" in kwargs and is_nonstr_iter(kwargs["t"]):
+    if kwargs.get("t") is not None and is_nonstr_iter(kwargs["t"]):
         extra_arrays.append(kwargs["t"])
         kwargs["t"] = ""
 

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -157,8 +157,8 @@ def xyz2grd(data=None, x=None, y=None, z=None, **kwargs):
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
             )
             with file_context as infile:
-                if (outgrid := kwargs.get("G")) is None: # if outgrid is unset, output to tmpfile
-                    kwargs["G"] = outgrid = tmpfile.name
+                if (outgrid := kwargs.get("G")) is None:
+                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("xyz2grd", arg_str)
 

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -157,9 +157,8 @@ def xyz2grd(data=None, x=None, y=None, z=None, **kwargs):
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
             )
             with file_context as infile:
-                if "G" not in kwargs:  # if outgrid is unset, output to tempfile
-                    kwargs.update({"G": tmpfile.name})
-                outgrid = kwargs["G"]
+                if (outgrid := kwargs.get("G")) is None: # if outgrid is unset, output to tmpfile
+                    kwargs["G"] = outgrid = tmpfile.name
                 arg_str = " ".join([infile, build_arg_string(kwargs)])
                 lib.call_module("xyz2grd", arg_str)
 


### PR DESCRIPTION
**Description of proposed changes**

Second part of https://github.com/GenericMappingTools/pygmt/pull/1857 following checklist in https://github.com/GenericMappingTools/pygmt/pull/1857#issuecomment-1083466287, which allows passing None as arguments to pygmt functions:

- nearneighbor
- sphdistance
- sphinterpolate
- surface
- text
- xyz2grd

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
