### PR TITLE
Let slash command /test-gmt-dev report job URL

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -71,6 +71,14 @@ jobs:
           # fecth all history so that setuptools-scm works
           fetch-depth: 0
 
+      - name: Show job URL
+        uses: peter-evans/create-or-update-comment@v2
+        if: github.event_name == 'repository_dispatch' && (matrix.os == 'ubuntu-latest')
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+
       # Install Mambaforge with conda-forge dependencies
       - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v2.1.1
@@ -160,12 +168,3 @@ jobs:
         with:
           name: artifact-GMT-${{ matrix.gmt_git_ref }}-${{ runner.os }}
           path: tmp-test-dir-with-unique-name
-
-      - name: Add reaction
-        uses: peter-evans/create-or-update-comment@v2
-        if: github.event_name == 'repository_dispatch'
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          reaction-type: hooray

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
 
       - name: Show job URL
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v2.0.0
         if: github.event_name == 'repository_dispatch' && (matrix.os == 'ubuntu-latest')
         with:
           token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
**Description of proposed changes**

As reported in #1816:

> The /test-gmt-dev command, I think it does run (?), but you have to jump to the 'Actions' tab to see it run which is very inconvenient.

This PR fixes the problem by adding the job URL to the PR comment.

See the PR https://github.com/seisman/pygmt/pull/2 in my own fork for how it works:

<img width="904" alt="image" src="https://user-images.githubusercontent.com/3974108/161490485-025b6206-d2a8-4c26-9619-fdd3ce0ab879.png">


Fixes #1816.