### PR TITLE
NEP29: Run PyGMT tests and docs build on Python 3.10

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -24,12 +24,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # Is it a draft Pull Request (true or false)?
         isDraft:
           - ${{ github.event.pull_request.draft }}
-        # Only run one job (Ubuntu + Python 3.9) for draft PRs
+        # Only run one job (Ubuntu + Python 3.10) for draft PRs
         exclude:
           - os: macOS-latest
             isDraft: true

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -29,12 +29,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9']
+        python-version: ['3.8', '3.10']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # Is it a draft Pull Request (true or false)?
         isDraft:
           - ${{ github.event.pull_request.draft }}
-        # Only run one job (Ubuntu + Python 3.9) for draft PRs
+        # Only run one job (Ubuntu + Python 3.10) for draft PRs
         exclude:
           - os: macOS-latest
             isDraft: true
@@ -43,13 +43,13 @@ jobs:
           # - os: ubuntu-latest
           #   python-version: 3.7
           #   isDraft: true
-        # Pair Python 3.8 with NumPy 1.19 and Python 3.9 with NumPy 1.22
-        # Only install optional packages on Python 3.9/NumPy 1.22
+        # Pair Python 3.8 with NumPy 1.19 and Python 3.10 with NumPy 1.22
+        # Only install optional packages on Python 3.10/NumPy 1.22
         include:
           - python-version: '3.8'
             numpy-version: '1.19'
             optional-packages: ''
-          - python-version: '3.9'
+          - python-version: '3.10'
             numpy-version: '1.22'
             optional-packages: 'geopandas ipython'
     timeout-minutes: 30


### PR DESCRIPTION
**Description of proposed changes**

Bumps [python](https://github.com/python/cpython) from 3.9.12 to 3.10.4.
  - [Release notes](https://github.com/python/cpython/releases/tag/v3.10.4)
  - [Changelog](https://docs.python.org/3/whatsnew/3.10.html)
  - [Commits](https://github.com/python/cpython/compare/v3.9.12...v3.10.4)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Supersedes #1577 which only used Python 3.10 on the GMT Dev Tests. This PR uses Python 3.10 on the standard/non-dev Tests.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
