### PR TITLE
Move matplotlib import inside the check_figures_equal function

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  # pull_request:
+  pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  pull_request:
+  # pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           mamba install gmt=6.3.0 numpy pandas xarray netCDF4 packaging \
-                        build matplotlib
+                        build
 
       # Install the package that we want to test
       - name: Install the package

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -5,7 +5,6 @@ import inspect
 import os
 import string
 
-from matplotlib.testing.compare import compare_images
 from pygmt.exceptions import GMTImageComparisonFailure
 from pygmt.io import load_dataarray
 from pygmt.src import which
@@ -77,7 +76,9 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
     KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
 
     def decorator(func):
-        import pytest  # pylint: disable=import-outside-toplevel
+        # pylint: disable=import-outside-toplevel
+        import pytest
+        from matplotlib.testing.compare import compare_images
 
         os.makedirs(result_dir, exist_ok=True)
         old_sig = inspect.signature(func)


### PR DESCRIPTION
**Description of proposed changes**

Move matplotlib import statement inside the check_figures_equal function, so that the `cache_data` workflow doesn't need matplotlib installed.


Address https://github.com/GenericMappingTools/pygmt/pull/1823#discussion_r830000054

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
