### PR TITLE
Pull baseline images from the gmt-6.4 branch only for scheduled jobs

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -110,6 +110,7 @@ jobs:
         run: |
           ORIGINAL_BRANCH=$(git branch --show-current)
           # Pull down GMT 6.4 baseline images from the gmt-6.4 branch
+          # https://github.com/GenericMappingTools/pygmt/pull/1883
           git checkout gmt-6.4
           dvc pull
           ls -lhR pygmt/tests/baseline/

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -106,6 +106,7 @@ jobs:
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote
+        if: github.event_name == 'schedule'
         run: |
           ORIGINAL_BRANCH=$(git branch --show-current)
           # Pull down GMT 6.4 baseline images from the gmt-6.4 branch
@@ -113,6 +114,13 @@ jobs:
           dvc pull
           ls -lhR pygmt/tests/baseline/
           git checkout ${ORIGINAL_BRANCH}
+
+      # Pull baseline image data from dvc remote (DAGsHub)
+      - name: Pull baseline image data from dvc remote
+        if: github.event_name != 'schedule'
+        run: |
+          dvc pull
+          ls -lhR pygmt/tests/baseline/
 
       # Build and install latest GMT from GitHub
       - name: Install GMT ${{ matrix.gmt_git_ref }} branch (Linux/macOS)


### PR DESCRIPTION
**Description of proposed changes**

Currently, the workflow always pull baseline images from the gmt-6.4 branch. It makes it difficult to verify if changes in PRs like https://github.com/GenericMappingTools/pygmt/pull/1791 are correct or not.

Patches #1865