### PR TITLE
Update GMT-6.4 baseline images for basemap tests

### DIFF
--- a/pygmt/tests/baseline/test_basemap_compass.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_compass.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 5212622b9bc57723ee11de53b817b8dc
-  size: 76589
+- md5: 0dc332834d1c765b51d93f1a4f7254e8
+  size: 71151
   path: test_basemap_compass.png

--- a/pygmt/tests/baseline/test_basemap_polar.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_polar.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 35573412a627fc004e0107434afec496
-  size: 31804
+- md5: ded4dba2d1c780b85f256eaad2e268f5
+  size: 31886
   path: test_basemap_polar.png

--- a/pygmt/tests/baseline/test_basemap_utm_projection.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_utm_projection.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: e6984efed2a94673754cc7f1f1d74832
-  size: 9069
+- md5: 05267ec2d3c26463c79603a2527cc5a9
+  size: 9070
   path: test_basemap_utm_projection.png


### PR DESCRIPTION
**Description of proposed changes**

The big changes in `pygmt/tests/baseline/test_basemap_compass.png` is likely due to the font size change in https://github.com/GenericMappingTools/gmt/pull/6215.

Other two baseline images are updated due to tiny line changes.

Address #1885.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
