### PR TITLE
Added alias for F in basemap

### DIFF
--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -65,7 +65,7 @@ def basemap(self, **kwargs):
     box : bool or str
         [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]]\
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
-        If set to ``True``, draws a rectangular border around the map inset,
+        If set to ``True``, draws a rectangular border around the
         map scale or rose. Alternatively, specify a different pen with
         **+p**\ *pen*. Add **+g**\ *fill* to fill the scale panel [default is
         no fill]. Append **+c**\ *clearance* where *clearance* is either gap,

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -65,20 +65,21 @@ def basemap(self, **kwargs):
     box : bool or str
         [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]]\
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
-        If set to ``True``, draws a rectangular border around the map scale.
-        Alternatively, specify a different pen with **+p**\ *pen*. Add
-        **+g**\ *fill* to fill the scale panel [default is no fill]. Append
-        **+c**\ *clearance* where *clearance* is either gap, xgap/ygap, or
-        lgap/rgap/bgap/tgap where these items are uniform, separate in x- and
-        y-direction, or individual side spacings between scale and border.
-        Append **+i** to draw a secondary, inner border as well. We use a
-        uniform gap between borders of 2p and the :gmt-term:`MAP_DEFAULTS_PEN`
-        unless other values are specified. Append **+r** to draw rounded
-        rectangular borders instead, with a 6p corner radius. You can override
-        this radius by appending another value. Finally, append **+s** to draw
-        an offset background shaded region. Here, *dx/dy* indicates the shift
-        relative to the foreground frame [4p/-4p] and shade sets the fill
-        style to use for shading [default is gray50].
+        If set to ``True``, draws a rectangular border around the map inset,
+        map scale or rose. Alternatively, specify a different pen with
+        **+p**\ *pen*. Add **+g**\ *fill* to fill the scale panel [default is
+        no fill]. Append **+c**\ *clearance* where *clearance* is either gap,
+        xgap/ygap, or lgap/rgap/bgap/tgap where these items are uniform,
+        separate in x- and y-direction, or individual side spacings between
+        scale and border. Append **+i** to draw a secondary, inner border as
+        well. We use a uniform gap between borders of 2p and the
+        :gmt-term:`MAP_DEFAULTS_PEN` unless other values are specified. Append
+        **+r** to draw rounded rectangular borders instead, with a 6p corner
+        radius. You can override this radius by appending another value.
+        Finally, append **+s** to draw an offset background shaded region.
+        Here, *dx/dy* indicates the shift relative to the foreground frame
+        [4p/-4p] and shade sets the fill style to use for shading
+        [default is gray50].
     rose : str
         Draws a map directional rose on the map at the location defined by
         the reference and anchor points.

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -65,7 +65,7 @@ def basemap(self, **kwargs):
     box : bool or str
         [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]]\
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
-        If set to ``True``, draws a rectangular border around the color scale.
+        If set to ``True``, draws a rectangular border around the map scale.
         Alternatively, specify a different pen with **+p**\ *pen*. Add
         **+g**\ *fill* to fill the scale panel [default is no fill]. Append
         **+c**\ *clearance* where *clearance* is either gap, xgap/ygap, or

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -78,7 +78,7 @@ def basemap(self, **kwargs):
         radius. You can override this radius by appending another value.
         Finally, append **+s** to draw an offset background shaded region.
         Here, *dx/dy* indicates the shift relative to the foreground frame
-        [4p/-4p] and shade sets the fill style to use for shading
+        [Default is 4p/-4p] and shade sets the fill style to use for shading
         [default is gray50].
     rose : str
         Draws a map directional rose on the map at the location defined by

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -62,6 +62,23 @@ def basemap(self, **kwargs):
         [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\
         **+w**\ *length*.
         Draws a simple map scale centered on the reference point specified.
+    box : bool or str
+        [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]]\
+        [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
+        If set to ``True``, draws a rectangular border around the color scale.
+        Alternatively, specify a different pen with **+p**\ *pen*. Add
+        **+g**\ *fill* to fill the scale panel [default is no fill]. Append
+        **+c**\ *clearance* where *clearance* is either gap, xgap/ygap, or
+        lgap/rgap/bgap/tgap where these items are uniform, separate in x- and
+        y-direction, or individual side spacings between scale and border.
+        Append **+i** to draw a secondary, inner border as well. We use a
+        uniform gap between borders of 2p and the :gmt-term:`MAP_DEFAULTS_PEN`
+        unless other values are specified. Append **+r** to draw rounded
+        rectangular borders instead, with a 6p corner radius. You can override
+        this radius by appending another value. Finally, append **+s** to draw
+        an offset background shaded region. Here, *dx/dy* indicates the shift
+        relative to the foreground frame [4p/-4p] and shade sets the fill
+        style to use for shading [default is gray50].
     rose : str
         Draws a map directional rose on the map at the location defined by
         the reference and anchor points.

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -21,6 +21,7 @@ from pygmt.helpers import (
     JZ="zsize",
     B="frame",
     L="map_scale",
+    F="box",
     Td="rose",
     Tm="compass",
     U="timestamp",


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->
Adds an alias for "box" so that backgrounds and frames for map_scales can be generated more easily.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1893 


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
