### PR TITLE
Mark test_accessor_sliced_datacube as xfail due to upstream bug

### DIFF
--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -5,8 +5,12 @@ import os
 
 import pytest
 import xarray as xr
-from pygmt import which
+from packaging.version import Version
+from pygmt import clib, which
 from pygmt.exceptions import GMTInvalidInput
+
+with clib.Session() as _lib:
+    gmt_version = Version(_lib.info["version"])
 
 
 def test_accessor_gridline_cartesian():
@@ -70,6 +74,10 @@ def test_accessor_set_non_boolean():
         grid.gmt.gtype = 2
 
 
+@pytest.mark.skipif(
+    gmt_version < Version("6.4.0"),
+    reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/6615",
+)
 def test_accessor_sliced_datacube():
     """
     Check that a 2D grid which is sliced from an n-dimensional datacube works
@@ -87,6 +95,6 @@ def test_accessor_sliced_datacube():
             grid = dataset.sel(level=500, month=1, drop=True).z
 
         assert grid.gmt.registration == 0  # gridline registration
-        assert grid.gmt.gtype == 0  # cartesian coordinate type
+        assert grid.gmt.gtype == 1  # geographic coordinate type
     finally:
         os.remove(fname)


### PR DESCRIPTION
**Description of proposed changes**

GMT 6.3.0 doesn't work on 3D grid cubes (reported in https://github.com/GenericMappingTools/gmt/issues/6588#issuecomment-1106683645). 

In GMT 6.3.0, the `grdinfo` output is empty:
```
$ gmt grdinfo eraint_uvz.nc -Cn
grdinfo [WARNING]: Detected a data cube (eraint_uvz.nc) but -Q not set - skipping
```

After the upstream fix https://github.com/GenericMappingTools/gmt/pull/6615, the output is:
```
$ gmt grdinfo eraint_uvz.nc -Cn
-180	179.25	-90	90	66825.5	66825.5	0.75	0.75	480	241	0	1
```
From the output, it's clear that the grid cube has registration=0 and gtype=1.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
