### PR TITLE
Remove unused gmt_version variable in tests

### DIFF
--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -4,14 +4,10 @@ Test Figure.grdimage.
 import numpy as np
 import pytest
 import xarray as xr
-from packaging.version import Version
-from pygmt import Figure, clib
+from pygmt import Figure
 from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers.testing import check_figures_equal
-
-with clib.Session() as _lib:
-    gmt_version = Version(_lib.info["version"])
 
 
 @pytest.fixture(scope="module", name="grid")

--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -2,13 +2,9 @@
 Tests for legend.
 """
 import pytest
-from packaging.version import Version
-from pygmt import Figure, clib
+from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
-
-with clib.Session() as _lib:
-    gmt_version = Version(_lib.info["version"])
 
 
 @pytest.mark.mpl_image_compare


### PR DESCRIPTION
**Description of proposed changes**

`gmt_version` is no longer used in these tests and can be removed.