### PR TITLE
Update GMT-6.4 baseline image for test_plot_shapefile (#1888)

### DIFF
--- a/pygmt/tests/baseline/test_plot_shapefile.png.dvc
+++ b/pygmt/tests/baseline/test_plot_shapefile.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 75277741d098cf7a0bad7869b574afc9
-  size: 24178
+- md5: 38165732ffb4777c648fdaa2f843f049
+  size: 32662
   path: test_plot_shapefile.png

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -511,7 +511,7 @@ def test_plot_shapefile():
     datasets = ["@RidgeTest" + suffix for suffix in [".shp", ".shx", ".dbf", ".prj"]]
     which(fname=datasets, download="a")
     fig = Figure()
-    fig.plot(data="@RidgeTest.shp", pen="1p")
+    fig.plot(data="@RidgeTest.shp", pen="1p", frame=True)
     return fig
 
 


### PR DESCRIPTION
**Description of proposed changes**

The test `test_plot_shapefile` fails because the line width is slightly different for GMT 6.3 and 6.4. It's more obvious to see why it differs if we add the frames by setting `frame=True`.

Here are the two baseline images:

| GMT 6.3 | GMT 6.4 |
|---|---|
| ![line-6 3 0](https://user-images.githubusercontent.com/3974108/165109677-77d7f7c1-0272-4d37-9283-22aa90701b57.png)| ![line-6 4 0](https://user-images.githubusercontent.com/3974108/165109709-48155811-55de-4b1a-a7a4-a0d4218394db.png)|

Apparently, in GMT 6.3, the shapefile `RidgeTest.shp` is plotted as a Cartesian dataset, while in GMT 6.4, it's plotted as a geographic dataset. The change is likely made in https://github.com/GenericMappingTools/gmt/pull/6057. 

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
