### PR TITLE
Update GMT-6.4 baseline image for test_legend_specfile

### DIFF
--- a/pygmt/tests/baseline/test_legend_specfile.png.dvc
+++ b/pygmt/tests/baseline/test_legend_specfile.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 3f8466fcf78fc398e6764414505baf79
-  size: 52245
+- md5: cd750916aa10cc298edd16fee92a55f5
+  size: 52793
   path: test_legend_specfile.png


### PR DESCRIPTION
**Description of proposed changes**

GMT has updated the default symbol dimensions when no symbol information are given for auto-legend entries in https://github.com/GenericMappingTools/gmt/pull/6165.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
