### PR TITLE
Update GMT-6.4 baseline image for test_makecpt_categorical

### DIFF
--- a/pygmt/tests/baseline/test_makecpt_categorical.png.dvc
+++ b/pygmt/tests/baseline/test_makecpt_categorical.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 49bc3322fbb073626fe5f61b92a473fb
-  size: 4692
+- md5: 703142a6ca0fbf079f82d9287631ad83
+  size: 1955
   path: test_makecpt_categorical.png

--- a/pygmt/tests/test_makecpt.py
+++ b/pygmt/tests/test_makecpt.py
@@ -147,7 +147,7 @@ def test_makecpt_categorical(position):
     Use static color palette table that is categorical.
     """
     fig = Figure()
-    makecpt(cmap="categorical", categorical=True)
+    makecpt(cmap="categorical", categorical=True, series=[0, 6, 1])
     fig.colorbar(cmap=True, frame=True, position=position)
     return fig
 


### PR DESCRIPTION
**Description of proposed changes**

The test `test_makecpt_categorical` fails due to the upstream changes in https://github.com/GenericMappingTools/gmt/pull/6360.

Here is the old baseline image for GMT 6.3.0:
![baseline](https://user-images.githubusercontent.com/3974108/165265620-ab29bb53-9b4d-4497-b95c-2e8c8aa88cac.png)

Here is the new baseline image for GMT 6.4:

![result](https://user-images.githubusercontent.com/3974108/165265706-927ff3f7-7301-4f65-8cb5-de17efc4ea1c.png)

Here is the differences between the two baseline images: 
![result-failed-diff](https://user-images.githubusercontent.com/3974108/165265745-fe01cf5d-15a2-44fa-87bb-ebb67c639af0.png)

The baseline image contains too many colors, making it difficult to verify its correctness by eyes. This PR modifies the test so that only six colors are plotted. Here is the new baseline image:

![test_makecpt_categorical](https://user-images.githubusercontent.com/3974108/165266474-e6a7a32f-68ce-4f70-8171-e6897037b3f9.png)




**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
