### PR TITLE
Update GMT-6.4 baseline image for test_config tests

### DIFF
--- a/pygmt/tests/baseline/test_config_font_annot.png.dvc
+++ b/pygmt/tests/baseline/test_config_font_annot.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 5db66e9f22ef896d1689513026036ec1
-  size: 69927
+- md5: a066694400a86dffa1d23dd34e0f35ab
+  size: 51676
   path: test_config_font_annot.png

--- a/pygmt/tests/baseline/test_config_font_one.png.dvc
+++ b/pygmt/tests/baseline/test_config_font_one.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 6969208b1b1852a0b08cd67263966fdc
-  size: 83228
+- md5: 9ece40bb8efebf6467680db606fc560b
+  size: 54820
   path: test_config_font_one.png

--- a/pygmt/tests/test_config.py
+++ b/pygmt/tests/test_config.py
@@ -46,8 +46,8 @@ def test_config_font_one():
     """
     fig = Figure()
     with config(FONT="8p,red"):
-        fig.basemap(region=[0, 9, 0, 9], projection="C3/3/9c", compass="jTL+w4c+d4.5+l")
-    fig.basemap(compass="jBR+w5c+d-4.5+l")
+        fig.basemap(region=[0, 9, 0, 9], projection="C3/3/9c", compass="jTL+w3c+d4.5+l")
+    fig.basemap(compass="jBR+w3.5c+d-4.5+l")
     return fig
 
 
@@ -59,8 +59,8 @@ def test_config_font_annot():
     """
     fig = Figure()
     with config(FONT_ANNOT="6p,red"):
-        fig.basemap(region=[0, 9, 0, 9], projection="C3/3/9c", compass="jTL+w4c+d4.5")
-    fig.basemap(compass="jBR+w5c+d-4.5")
+        fig.basemap(region=[0, 9, 0, 9], projection="C3/3/9c", compass="jTL+w3c+d4.5")
+    fig.basemap(compass="jBR+w3.5c+d-4.5")
     return fig
 
 


### PR DESCRIPTION
**Description of proposed changes**

The two test_config tests fail due to the upstream changes in rose placements (see https://github.com/GenericMappingTools/gmt/issues/6213, https://github.com/GenericMappingTools/gmt/pull/6215, and https://github.com/GenericMappingTools/gmt/pull/6626).


| **Name**| **OLD** | **NEW** |
|---|---|---|
|`test_config_font_annot` | ![baseline](https://user-images.githubusercontent.com/3974108/165332451-5d6e40bf-47f5-4a30-8bee-b630be152570.png) | ![result](https://user-images.githubusercontent.com/3974108/165332472-c23e1e12-9527-4a5d-9baa-3b901ecf3873.png)|
|`test_config_font_one`|![baseline](https://user-images.githubusercontent.com/3974108/165332496-3aa7ab84-c03e-489b-ba31-c31518d859b2.png)|![result](https://user-images.githubusercontent.com/3974108/165332555-8d612e2a-982f-4cda-8ef3-838b3cbfaa76.png)|

As you can see, with GMT 6.4, the two map roses overlap, so I modify the two tests to make sure  they are well separated.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
