### PR TITLE
Update GMT-6.4 baseline image for test_grdimage

### DIFF
--- a/pygmt/tests/baseline/test_grdimage.png.dvc
+++ b/pygmt/tests/baseline/test_grdimage.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 1540b29b9469db19bd65abd479cabb30
-  size: 172480
+- md5: ff6ea7953be2b98bf7b85f6ee04e23dd
+  size: 180338
   path: test_grdimage.png


### PR DESCRIPTION
The baseline image is generated using the following GMT CLI bash script:
```
gmt begin test_grdimage png
	gmt grdimage @earth_relief_01d_g -Cearth -JW0/6i
gmt end show
```

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
