### PR TITLE
Update GMT-6.4 baseline image for test_grdimage_slice

### DIFF
--- a/pygmt/tests/baseline/test_grdimage_slice.png.dvc
+++ b/pygmt/tests/baseline/test_grdimage_slice.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: ea59acb8c1de63d6caba7df897c8f3ba
-  size: 67726
+- md5: 662b78f3bedde3ddf73647329bf3aab4
+  size: 72658
   path: test_grdimage_slice.png


### PR DESCRIPTION
The baseline image is generated using the following bash script:
```
gmt begin test_grdimage_slice png
    gmt grdcut @earth_relief_01d_g -R-180/180/-30/30 -Gslice.nc
    gmt grdimage slice.nc -Cearth -JM6i
gmt end show
```

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
