### PR TITLE
Update GMT-6.4 baseline image for test_grdimage_file

### DIFF
--- a/pygmt/tests/baseline/test_grdimage_file.png.dvc
+++ b/pygmt/tests/baseline/test_grdimage_file.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 0f1c4cc2bc2207c32cc5fb04fd75fcb7
-  size: 194595
+- md5: d7f7c58e200283b562fd70d7c22eaf51
+  size: 206241
   path: test_grdimage_file.png


### PR DESCRIPTION
The new baseline image is generated using:
```
gmt begin test_grdimage_file png
    gmt grdimage @earth_relief_01d_g -Cocean -R-180/180/-70/70 -JW0/10i -I
gmt end
```

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
