### PR TITLE
Update GMT-6.4 baseline image for test_grdimage_over_dateline

### DIFF
--- a/pygmt/tests/baseline/test_grdimage_over_dateline.png.dvc
+++ b/pygmt/tests/baseline/test_grdimage_over_dateline.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 9fde25c97659e17430eff8f6f66a9412
-  size: 10988
+- md5: cfd6484e1e2eddea0d4b56df54aabe05
+  size: 10854
   path: test_grdimage_over_dateline.png


### PR DESCRIPTION
The baseline image is generated using the following bash script:
```
gmt begin test_grdimage_over_dateline png
    gmt grdimage xrgrid.nc -Rg -JA0/0/1c
gmt end
```
The grid file `xrgrid.nc` is generated by the `fixture_xrgrid` function.

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
