### PR TITLE
Update GMT-6.4 baseline image for test_grdimage_global_subset

### DIFF
--- a/pygmt/tests/baseline/test_grdimage_global_subset.png.dvc
+++ b/pygmt/tests/baseline/test_grdimage_global_subset.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 8f38333a67076f0125cb2d1828aa244e
-  size: 39288
+- md5: 877e22361cb6d2ea1fe0efe3fa84a3e3
+  size: 39978
   path: test_grdimage_global_subset.png


### PR DESCRIPTION
The new baseline image is generated using the following script:
```
gmt begin test_grdimage_global_subset png
	gmt grdimage sliced_grid.nc -Cvik -Rg -JW0/3.5c -B
gmt end
```
The file `sliced_grid.nc` is generated by `fixture_grid_360` function.

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
