### PR TITLE
basemap: Plotting frames if required parameters are not given

### DIFF
--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -3,7 +3,6 @@ basemap - Plot base maps and frames for the figure.
 """
 
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     args_in_kwargs,
     build_arg_string,
@@ -42,9 +41,6 @@ def basemap(self, **kwargs):
     map projections are available, and the user may specify separate
     tick-mark intervals for boundary annotation, ticking, and [optionally]
     gridlines. A simple map scale or directional rose may also be plotted.
-
-    At least one of the parameters ``frame``, ``map_scale``, ``rose`` or
-    ``compass`` must be specified.
 
     Full option list at :gmt-docs:`basemap.html`
 
@@ -96,8 +92,6 @@ def basemap(self, **kwargs):
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
     if not args_in_kwargs(args=["B", "L", "Td", "Tm", "c"], kwargs=kwargs):
-        raise GMTInvalidInput(
-            "At least one of frame, map_scale, compass, rose, or panel must be specified."
-        )
+        kwargs["B"] = True  # Plotting frames if required arguments not given
     with Session() as lib:
         lib.call_module("basemap", build_arg_string(kwargs))

--- a/pygmt/tests/baseline/test_basemap_required_args.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_required_args.png.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 36f8200a27d23e19951c2a3823a28faa
+  size: 6163
+  path: test_basemap_required_args.png

--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -8,7 +8,7 @@ from pygmt import Figure
 @pytest.mark.mpl_image_compare
 def test_basemap_required_args():
     """
-    Autmatically set `frame=True` when required arguments are not given.
+    Automatically set `frame=True` when required arguments are not given.
     """
     fig = Figure()
     fig.basemap(region=[10, 70, -3, 8], projection="X8c/6c")

--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -3,16 +3,16 @@ Tests Figure.basemap.
 """
 import pytest
 from pygmt import Figure
-from pygmt.exceptions import GMTInvalidInput
 
 
+@pytest.mark.mpl_image_compare
 def test_basemap_required_args():
     """
-    Figure.basemap fails when not given required arguments.
+    Autmatically set `frame=True` when required arguments are not given.
     """
     fig = Figure()
-    with pytest.raises(GMTInvalidInput):
-        fig.basemap(region=[10, 70, -3, 8], projection="X8c/6c")
+    fig.basemap(region=[10, 70, -3, 8], projection="X8c/6c")
+    return fig
 
 
 @pytest.mark.mpl_image_compare


### PR DESCRIPTION
**Description of proposed changes**

When required parameters are not given, `basemap` should set `frame=True` by default. 

Implement the feature request in https://github.com/GenericMappingTools/pygmt/issues/1665#issuecomment-1086881221.

Fixes #1665.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
