### PR TITLE
Remove unused gmtplot CSS styles

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -33,24 +33,6 @@ p {
     font-size: 1.05em;
 }
 
-.gmtplot-output {
-    width: 100%;
-    overflow: auto;
-}
-
-.gmtplot-output img {
-    max-width: 700px;
-    width: 100%;
-}
-
-.gmtplot-output pre {
-    color: #888888;
-}
-
-.gmtplot-output-figure {
-    margin-bottom: 50px;
-}
-
 .sidebar-title {
     margin-top: 10px;
     margin-bottom: 0px;


### PR DESCRIPTION
**Description of proposed changes**

These CSS styles were added in https://github.com/GenericMappingTools/pygmt/pull/208, and were used to control the appearance of the `gmtplot` extension. 

The `gmtplot` extension has been moved to the repo https://github.com/GenericMappingTools/sphinx_gmt and is no longer used in this project. So these CSS styles can be removed.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
