### PR TITLE
Fix the grid accessor (grid registration and type) for 3D grids

### DIFF
--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -29,10 +29,10 @@ class GMTDataArrayAccessor:
         self._obj = xarray_obj
         try:
             self._source = self._obj.encoding["source"]  # filepath to NetCDF source
-            # From the shortened summary information of `grdinfo`,
-            # get grid registration in column 10, and grid type in column 11
+            # Get grid registration and grid type from the last two columns of
+            # the shortened summary information of `grdinfo`.
             self._registration, self._gtype = map(
-                int, grdinfo(self._source, per_column="n", o="10,11").split()
+                int, grdinfo(self._source, per_column="n").split()[-2:]
             )
         except (KeyError, ValueError):
             self._registration = 0  # Default to Gridline registration


### PR DESCRIPTION
**Description of proposed changes**

As mentioned in https://github.com/GenericMappingTools/gmt/issues/6588#issuecomment-1115541413, the `grdinfo` output for a 3D grid was wrong in old GMT versions.

After the upstream fix, the grdinfo output is:
```
$ gmt grdinfo -Cn eraint_uvz.nc     
grdinfo [WARNING]: No 3-D array in file eraint_uvz.nc.  Selecting first 3-D slice in the 4-D array z
-180	179.25	-90	90	200	850	66825.5	66825.5	0.75	0.75	0	480	241	3	0	1
```
which has 16 columns, instead of 12 columns for 2D grids. Thus, we cannot get the grid registration and type information from columes 11 and 12. Instead, we should use the last two columns instead.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
