### PR TITLE
Add earth_relief_holes to load_sample_data()

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  # pull_request:
+  pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -3,7 +3,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  pull_request:
+  # pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -348,7 +348,7 @@ def load_mars_shape(**kwargs):
     return data
 
 
-def _load_earth_relief_holes(**kwargs):
+def _load_earth_relief_holes(**kwargs):  # pylint: disable=unused-argument
     """
     Loads the remote file @earth_relief_20m_holes.grd.
 

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -5,6 +5,7 @@ import warnings
 
 import pandas as pd
 from pygmt.exceptions import GMTInvalidInput
+from pygmt.io import load_dataarray
 from pygmt.src import which
 
 
@@ -23,6 +24,7 @@ def list_sample_data():
     """
     names = {
         "bathymetry": "Table of ship bathymetric observations off Baja California",
+        "earth_relief_holes": "Earth relief grid with holes",
         "fractures": "Table of hypothetical fracture lengths and azimuths",
         "hotspots": "Table of locations, names, and symbol sizes of hotpots from "
         " Mueller et al., 1993",
@@ -65,6 +67,7 @@ def load_sample_data(name):
 
     load_func = {
         "bathymetry": load_sample_bathymetry,
+        "earth_relief_holes": _load_earth_relief_holes,
         "fractures": load_fractures_compilation,
         "hotspots": load_hotspots,
         "japan_quakes": load_japan_quakes,
@@ -343,3 +346,18 @@ def load_mars_shape(**kwargs):
         fname, sep="\t", header=None, names=["longitude", "latitude", "radius(m)"]
     )
     return data
+
+
+def _load_earth_relief_holes(**kwargs):
+    """
+    Loads the remote file @earth_relief_20m_holes.grd.
+
+    Returns
+    -------
+    grid : :class:`xarray.DataArray`
+        The Earth relief grid. Coordinates are latitude and longitude in
+        degrees. Relief is in meters.
+    """
+    fname = which("@earth_relief_20m_holes.grd", download="a")
+    grid = load_dataarray(fname, engine="netcdf4")
+    return grid

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -358,6 +358,6 @@ def _load_earth_relief_holes(**kwargs):
         The Earth relief grid. Coordinates are latitude and longitude in
         degrees. Relief is in meters.
     """
-    fname = which("@earth_relief_20m_holes.grd", download="a")
+    fname = which("@earth_relief_20m_holes.grd", download="c")
     grid = load_dataarray(fname, engine="netcdf4")
     return grid

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -24,7 +24,7 @@ def list_sample_data():
     """
     names = {
         "bathymetry": "Table of ship bathymetric observations off Baja California",
-        "earth_relief_holes": "Earth relief grid with holes",
+        "earth_relief_holes": "Regional 20 arc-minute Earth relief grid with holes",
         "fractures": "Table of hypothetical fracture lengths and azimuths",
         "hotspots": "Table of locations, names, and symbol sizes of hotpots from "
         " Mueller et al., 1993",
@@ -359,5 +359,4 @@ def _load_earth_relief_holes(**kwargs):
         degrees. Relief is in meters.
     """
     fname = which("@earth_relief_20m_holes.grd", download="c")
-    grid = load_dataarray(fname, engine="netcdf4")
-    return grid
+    return load_dataarray(fname, engine="netcdf4")

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -171,6 +171,7 @@ def download_test_data():
         "@earth_age_01d_g",
         "@S90W180.earth_age_05m_g.nc",  # Specific grid for 05m test
         # Other cache files
+        "@earth_relief_20m_holes.grd"
         "@EGM96_to_36.txt",
         "@MaunaLoa_CO2.txt",
         "@RidgeTest.shp",

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -171,7 +171,7 @@ def download_test_data():
         "@earth_age_01d_g",
         "@S90W180.earth_age_05m_g.nc",  # Specific grid for 05m test
         # Other cache files
-        "@earth_relief_20m_holes.grd"
+        "@earth_relief_20m_holes.grd",
         "@EGM96_to_36.txt",
         "@MaunaLoa_CO2.txt",
         "@RidgeTest.shp",

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -1,6 +1,9 @@
 """
 Test basic functionality for loading sample datasets.
 """
+import math
+
+import numpy.testing as npt
 import pandas as pd
 import pytest
 from pygmt.datasets import (
@@ -145,3 +148,15 @@ def test_hotspots():
         "place_name",
     ]
     assert isinstance(data, pd.DataFrame)
+
+
+def test_earth_relief_holes():
+    """
+    Check that the @earth_relief_holes.txt dataset loads without errors.
+    """
+    grid = load_sample_data("earth_relief_holes")
+    assert grid.shape == (30, 30)
+    npt.assert_allclose(grid.max(), 1878)
+    npt.assert_allclose(grid.min(), -4947)
+    # Test for the NaN values in the remote file
+    assert math.isnan(grid[2, 19])

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -153,8 +153,8 @@ def test_earth_relief_holes():
     Check that the @earth_relief_20m_holes.grd dataset loads without errors.
     """
     grid = load_sample_data(name="earth_relief_holes")
-    assert grid.shape == (30, 30)
-    npt.assert_allclose(grid.max(), 1878)
-    npt.assert_allclose(grid.min(), -4947)
+    assert grid.shape == (31, 31)
+    npt.assert_allclose(grid.max(), 1601)
+    npt.assert_allclose(grid.min(), -4929.5)
     # Test for the NaN values in the remote file
-    assert grid[2, 19].isnull()
+    assert grid[2, 21].isnull()

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -1,8 +1,6 @@
 """
 Test basic functionality for loading sample datasets.
 """
-import math
-
 import numpy.testing as npt
 import pandas as pd
 import pytest
@@ -154,9 +152,9 @@ def test_earth_relief_holes():
     """
     Check that the @earth_relief_20m_holes.grd dataset loads without errors.
     """
-    grid = load_sample_data("earth_relief_holes")
+    grid = load_sample_data(name="earth_relief_holes")
     assert grid.shape == (30, 30)
     npt.assert_allclose(grid.max(), 1878)
     npt.assert_allclose(grid.min(), -4947)
     # Test for the NaN values in the remote file
-    assert math.isnan(grid[2, 19])
+    assert grid[2, 19].isnull()

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -152,7 +152,7 @@ def test_hotspots():
 
 def test_earth_relief_holes():
     """
-    Check that the @earth_relief_holes.txt dataset loads without errors.
+    Check that the @earth_relief_20m_holes.grd dataset loads without errors.
     """
     grid = load_sample_data("earth_relief_holes")
     assert grid.shape == (30, 30)


### PR DESCRIPTION
This adds a function to load the remote dataset `@earth_relief_20m_holes.grd` for use with the in-line example for `grdfill`.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
