### PR TITLE
Run GMT Dev Tests on Monday, Wednesday and Friday only

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -17,9 +17,9 @@ on:
       - '.gitignore'
   repository_dispatch:
     types: [test-gmt-dev-command]
-  # Schedule daily tests
+  # Schedule tests on Monday/Wednesday/Friday
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 1,3,5'
 
 jobs:
   test_gmt_dev:

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -108,8 +108,8 @@ There are 11 configuration files located in `.github/workflows`:
 4. `ci_tests_dev.yaml` (GMT Dev Tests on Linux/macOS/Windows).
 
    This is triggered when a PR is marked as "ready for review", or using the
-   slash command `/test-gmt-dev`. It is also scheduled to run daily on the
-   *main* branch.
+   slash command `/test-gmt-dev`. It is also scheduled to run on Monday,
+   Wednesday and Friday on the *main* branch.
 
 5. `cache_data.yaml` (Caches GMT remote data files needed for GitHub Actions CI)
 


### PR DESCRIPTION
**Description of proposed changes**

Updating the cron tab to run GMT Dev Tests on [Monday/Wednesday/Friday](https://stackoverflow.com/questions/31260837/how-to-run-a-cron-job-on-every-monday-wednesday-and-friday) instead of daily. A bit annoying to have the tests failing everyday, especially during the weekend. See also https://github.com/GenericMappingTools/pygmt/pull/1833#issuecomment-1073488403 about having less frequent tests.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
