### PR TITLE
Add inline code examples to contributing guidelines

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -317,9 +317,10 @@ Open `doc/_build/html/index.html` in your browser to view the pages. Follow the
 
 ### Adding example code
 
-Many of the PyGMT functions have example code in their documentation. To contribute an example, add an "Example header" 
-and put the example code below it. Have all lines begin with ">>>".  To keep this example code from being run during 
-testing, add the code "__doctest_skip__ = [function name]" to the top of the module. 
+Many of the PyGMT functions have example code in their documentation. To contribute an
+example, add an "Example" header and put the example code below it. Have all lines 
+begin with `>>>`.  To keep this example code from being run during testing, add the code
+`__doctest_skip__ = [function name]` to the top of the module. 
 
 **Inline code example**
 

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -315,6 +315,25 @@ This will build the HTML files in `doc/_build/html`.
 Open `doc/_build/html/index.html` in your browser to view the pages. Follow the
 [pull request workflow](contributing.md#pull-request-workflow) to submit your changes for review.
 
+### Adding example code
+
+Many of the PyGMT functions have example code in their documentation. To contribute an example, add an "Example header" 
+and put the example code below it. Have all lines begin with ">>>".  To keep this example code from being run during 
+testing, add the code "__doctest_skip__ = [function name]" to the top of the module. 
+
+**Inline code example**
+
+``
+__doctest_skip__ = ["module_name"]
+``
+
+    Example
+    -------
+    >>> import pygmt
+    >>> # Comment describing what is happening
+    >>> Code example
+
+
 ### Contributing Gallery Plots
 
 The gallery and tutorials are managed by

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -323,9 +323,13 @@ testing, add the code "__doctest_skip__ = [function name]" to the top of the mod
 
 **Inline code example**
 
+Below the import statements at the top of the file
+
 ``
 __doctest_skip__ = ["module_name"]
 ``
+
+At the end of the function's docstring
 
     Example
     -------


### PR DESCRIPTION
This adds to `contributing.md` to show how to add inline code examples. It also address [this comment](https://github.com/GenericMappingTools/pygmt/issues/1686#issuecomment-1061357814) to document `doctest_skip`.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
