### PR TITLE
Fix docs index for advanced tutorials

### DIFF
--- a/examples/tutorials/advanced/grid_equalization.py
+++ b/examples/tutorials/advanced/grid_equalization.py
@@ -1,6 +1,6 @@
 """
 Performing grid histogram equalization
---------------------------------------
+======================================
 The :meth:`pygmt.grdhisteq.equalize_grid` function creates a grid using
 statistics based on a cumulative distribution function.
 """


### PR DESCRIPTION
**Description of proposed changes**

Unfortunately the [advanced tutorial index](https://www.pygmt.org/latest/tutorials/index.html#advanced) is currently formatted wrong in the docs due to using the wrong H1 code in rst (sorry). This fixes that problem.

I'll look into whether we can add a style check for this when I have time.



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
