### PR TITLE
Simplify TestPyPI install instructions to just extra-index-url

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -137,7 +137,7 @@ This installs the latest stable release from
 Alternatively, you can install the latest development version from
 `TestPyPI <https://test.pypi.org/project/pygmt>`__::
 
-    pip install --pre --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple pygmt
+    pip install --pre --extra-index-url https://test.pypi.org/simple/ pygmt
 
 To upgrade the installed stable release or development version to be the latest
 one, just add ``--upgrade`` to the corresponding command above.


### PR DESCRIPTION
**Description of proposed changes**

The default `--index-url` is https://pypi.org/simple, so just need to set `--extra-index-url` to point to TestPyPI.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

To test locally, do:

```
mamba create --name testpypi -y python=3.9
mamba activate testpypi
pip install --pre --extra-index-url https://test.pypi.org/simple/ pygmt
```

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Patches #865


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
