### PR TITLE
Set setuptools_scm fallback_version to follow  PEP440

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 local_scheme = "node-and-date"
-fallback_version = "unknown"
+fallback_version = "9999.9999.9999"
 
 [tool.coverage.run]
 omit = ["*/tests/*", "*pygmt/__init__.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 local_scheme = "node-and-date"
-fallback_version = "9999.9999.9999"
+fallback_version = "999.999.999+unknown"
 
 [tool.coverage.run]
 omit = ["*/tests/*", "*pygmt/__init__.py"]


### PR DESCRIPTION
**Description of proposed changes**

Address comment https://github.com/GenericMappingTools/pygmt/pull/1784#issuecomment-1148925436 and https://github.com/GenericMappingTools/pygmt/pull/1848#discussion_r891579228.

To test it, try:
```
pip install https://github.com/GenericMappingTools/pygmt/archive/refs/heads/fallback_version.zip
```