### PR TITLE
Split up functions for loading datasets

### DIFF
--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -66,19 +66,27 @@ def load_sample_data(name):
     if name not in names:
         raise GMTInvalidInput(f"Invalid dataset name '{name}'.")
 
-    load_func = {
+    # Dictionary of public load functions for backwards compatibility
+    load_func_old = {
         "bathymetry": load_sample_bathymetry,
-        "earth_relief_holes": _load_earth_relief_holes,
         "fractures": load_fractures_compilation,
         "hotspots": load_hotspots,
         "japan_quakes": load_japan_quakes,
         "mars_shape": load_mars_shape,
         "ocean_ridge_points": load_ocean_ridge_points,
-        "notre_dame_topography": _load_notre_dame_topography,
         "usgs_quakes": load_usgs_quakes,
     }
 
-    data = load_func[name](suppress_warning=True)
+    # Dictionary of private load functions
+    load_func = {
+        "earth_relief_holes": _load_earth_relief_holes,
+        "notre_dame_topography": _load_notre_dame_topography,
+    }
+
+    if name in load_func_old:
+        data = load_func_old[name](suppress_warning=True)
+    elif name in load_func:
+        data = load_func[name]()
 
     return data
 
@@ -350,7 +358,7 @@ def load_mars_shape(**kwargs):
     return data
 
 
-def _load_notre_dame_topography(**kwargs):  # pylint: disable=unused-argument
+def _load_notre_dame_topography():
     """
     Load Table 5.11 in Davis: Statistics and Data Analysis in Geology.
 
@@ -363,7 +371,7 @@ def _load_notre_dame_topography(**kwargs):  # pylint: disable=unused-argument
     return pd.read_csv(fname, sep=r"\s+", header=None, names=["x", "y", "z"])
 
 
-def _load_earth_relief_holes(**kwargs):  # pylint: disable=unused-argument
+def _load_earth_relief_holes():
     """
     Loads the remote file @earth_relief_20m_holes.grd.
 


### PR DESCRIPTION
As mentioned by @seisman in [this comment](https://github.com/GenericMappingTools/pygmt/pull/1921#discussion_r880629384), this splits up the dictionaries for loading functions between the public facing functions and the private ones. It eliminates the need to have the new dataset functions accept `**kwargs`.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
