### PR TITLE
Update fixture import and docstring in test_filter1d.py

### DIFF
--- a/pygmt/tests/test_filter1d.py
+++ b/pygmt/tests/test_filter1d.py
@@ -16,7 +16,7 @@ from pygmt.src import which
 @pytest.fixture(scope="module", name="data")
 def fixture_table():
     """
-    Load the @MaunaLoa_CO2.txt datset as a pandas dataframe.
+    Load the @MaunaLoa_CO2.txt dataset as a pandas dataframe.
     """
     fname = which("@MaunaLoa_CO2.txt", download="c")
     data = pd.read_csv(

--- a/pygmt/tests/test_filter1d.py
+++ b/pygmt/tests/test_filter1d.py
@@ -16,7 +16,7 @@ from pygmt.src import which
 @pytest.fixture(scope="module", name="data")
 def fixture_table():
     """
-    Load the grid data from the sample earth_relief file.
+    Load the @MaunaLoa_CO2.txt datset as a pandas dataframe.
     """
     fname = which("@MaunaLoa_CO2.txt", download="c")
     data = pd.read_csv(

--- a/pygmt/tests/test_filter1d.py
+++ b/pygmt/tests/test_filter1d.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from pygmt import filter1d
+from pygmt.datasets import load_sample_data
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 from pygmt.src import which
@@ -18,11 +19,7 @@ def fixture_table():
     """
     Load the @MaunaLoa_CO2.txt dataset as a pandas dataframe.
     """
-    fname = which("@MaunaLoa_CO2.txt", download="c")
-    data = pd.read_csv(
-        fname, header=None, skiprows=1, sep=r"\s+", names=["date", "co2_ppm"]
-    )
-    return data
+    return load_sample_data(name="maunaloa_co2")
 
 
 def test_filter1d_no_outfile(data):

--- a/pygmt/tests/test_filter1d.py
+++ b/pygmt/tests/test_filter1d.py
@@ -11,7 +11,6 @@ from pygmt import filter1d
 from pygmt.datasets import load_sample_data
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
-from pygmt.src import which
 
 
 @pytest.fixture(scope="module", name="data")


### PR DESCRIPTION
I forgot to change the docstring in `fixture_table()` in `test_filter1d.py` from whatever grid loading function I copied it from. This updates the docstring to accurately describe the function.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
