### PR TITLE
Support passing data in numpy int8, int16, uint8 and uint16 dtypes to GMT

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -736,7 +736,7 @@ class Session:
         The dataset must be created by :meth:`pygmt.clib.Session.create_data`
         first. Use ``family='GMT_IS_DATASET|GMT_VIA_VECTOR'``.
 
-        Not at all numpy dtypes are supported, only: int8, int16, int32, int64,
+        Not all numpy dtypes are supported, only: int8, int16, int32, int64,
         uint8, uint16, uint32, uint64, float32, float64, str\_ and datetime64.
 
         .. warning::
@@ -860,8 +860,8 @@ class Session:
         The dataset must be created by :meth:`pygmt.clib.Session.create_data`
         first. Use ``|GMT_VIA_MATRIX'`` in the family.
 
-        Not at all numpy dtypes are supported, only: int8, int16, int32, int64,
-        uint8, uint16, uint32, uint64, float32, float64, str\_ and datetime64.
+        Not all numpy dtypes are supported, only: int8, int16, int32, int64,
+        uint8, uint16, uint32, uint64, float32 and float64.
 
         .. warning::
             The numpy array must be C contiguous in memory. Use

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -53,14 +53,18 @@ MODES = ["GMT_CONTAINER_ONLY", "GMT_IS_OUTPUT"]
 REGISTRATIONS = ["GMT_GRID_PIXEL_REG", "GMT_GRID_NODE_REG"]
 
 DTYPES = {
-    np.float64: "GMT_DOUBLE",
-    np.float32: "GMT_FLOAT",
-    np.int64: "GMT_LONG",
+    np.int8: "GMT_CHAR",
+    np.int16: "GMT_SHORT",
     np.int32: "GMT_INT",
-    np.uint64: "GMT_ULONG",
+    np.int64: "GMT_LONG",
+    np.uint8: "GMT_UCHAR",
+    np.uint16: "GMT_USHORT",
     np.uint32: "GMT_UINT",
-    np.datetime64: "GMT_DATETIME",
+    np.uint64: "GMT_ULONG",
+    np.float32: "GMT_FLOAT",
+    np.float64: "GMT_DOUBLE",
     np.str_: "GMT_TEXT",
+    np.datetime64: "GMT_DATETIME",
 }
 
 

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -736,8 +736,8 @@ class Session:
         The dataset must be created by :meth:`pygmt.clib.Session.create_data`
         first. Use ``family='GMT_IS_DATASET|GMT_VIA_VECTOR'``.
 
-        Not at all numpy dtypes are supported, only: float64, float32, int64,
-        int32, uint64, uint32, datetime64 and str\_.
+        Not at all numpy dtypes are supported, only: int8, int16, int32, int64,
+        uint8, uint16, uint32, uint64, float32, float64, str\_ and datetime64.
 
         .. warning::
             The numpy array must be C contiguous in memory. If it comes from a
@@ -860,8 +860,8 @@ class Session:
         The dataset must be created by :meth:`pygmt.clib.Session.create_data`
         first. Use ``|GMT_VIA_MATRIX'`` in the family.
 
-        Not at all numpy dtypes are supported, only: float64, float32, int64,
-        int32, uint64, and uint32.
+        Not at all numpy dtypes are supported, only: int8, int16, int32, int64,
+        uint8, uint16, uint32, uint64, float32, float64, str\_ and datetime64.
 
         .. warning::
             The numpy array must be C contiguous in memory. Use

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -36,6 +36,14 @@ def data():
     return np.loadtxt(POINTS_DATA)
 
 
+@pytest.fixture(scope="module", name="dtypes")
+def fixture_dtypes():
+    """
+    List of supported numpy dtypes.
+    """
+    return "int8 int16 int32 int64 uint8 uint16 uint32 uint64 float32 float64".split()
+
+
 @contextmanager
 def mock(session, func, returns=None, mock_func=None):
     """
@@ -339,11 +347,10 @@ def test_create_data_fails():
                 )
 
 
-def test_virtual_file():
+def test_virtual_file(dtypes):
     """
     Test passing in data via a virtual file with a Dataset.
     """
-    dtypes = "float32 float64 int32 int64 uint32 uint64".split()
     shape = (5, 3)
     for dtype in dtypes:
         with clib.Session() as lib:
@@ -497,11 +504,10 @@ def test_virtualfile_from_data_fail_non_valid_data(data):
             )
 
 
-def test_virtualfile_from_vectors():
+def test_virtualfile_from_vectors(dtypes):
     """
     Test the automation for transforming vectors to virtual file dataset.
     """
-    dtypes = "float32 float64 int32 int64 uint32 uint64".split()
     size = 10
     for dtype in dtypes:
         x = np.arange(size, dtype=dtype)
@@ -588,11 +594,10 @@ def test_virtualfile_from_vectors_diff_size():
                 print("This should have failed")
 
 
-def test_virtualfile_from_matrix():
+def test_virtualfile_from_matrix(dtypes):
     """
     Test transforming a matrix to virtual file dataset.
     """
-    dtypes = "float32 float64 int32 int64 uint32 uint64".split()
     shape = (7, 5)
     for dtype in dtypes:
         data = np.arange(shape[0] * shape[1], dtype=dtype).reshape(shape)
@@ -606,11 +611,10 @@ def test_virtualfile_from_matrix():
             assert output == expected
 
 
-def test_virtualfile_from_matrix_slice():
+def test_virtualfile_from_matrix_slice(dtypes):
     """
     Test transforming a slice of a larger array to virtual file dataset.
     """
-    dtypes = "float32 float64 int32 int64 uint32 uint64".split()
     shape = (10, 6)
     for dtype in dtypes:
         full_data = np.arange(shape[0] * shape[1], dtype=dtype).reshape(shape)
@@ -627,11 +631,10 @@ def test_virtualfile_from_matrix_slice():
             assert output == expected
 
 
-def test_virtualfile_from_vectors_pandas():
+def test_virtualfile_from_vectors_pandas(dtypes):
     """
     Pass vectors to a dataset using pandas Series.
     """
-    dtypes = "float32 float64 int32 int64 uint32 uint64".split()
     size = 13
     for dtype in dtypes:
         data = pd.DataFrame(

--- a/pygmt/tests/test_clib_put_matrix.py
+++ b/pygmt/tests/test_clib_put_matrix.py
@@ -11,11 +11,18 @@ from pygmt.helpers import GMTTempFile
 from pygmt.tests.test_clib import mock
 
 
-def test_put_matrix():
+@pytest.fixture(scope="module", name="dtypes")
+def fixture_dtypes():
+    """
+    List of supported numpy dtypes.
+    """
+    return "int8 int16 int32 int64 uint8 uint16 uint32 uint64 float32 float64".split()
+
+
+def test_put_matrix(dtypes):
     """
     Check that assigning a numpy 2d array to a dataset works.
     """
-    dtypes = "float32 float64 int32 int64 uint32 uint64".split()
     shape = (3, 4)
     for dtype in dtypes:
         with clib.Session() as lib:
@@ -57,11 +64,10 @@ def test_put_matrix_fails():
                 lib.put_matrix(dataset=None, matrix=np.empty((10, 2)), pad=0)
 
 
-def test_put_matrix_grid():
+def test_put_matrix_grid(dtypes):
     """
     Check that assigning a numpy 2d array to an ASCII and NetCDF grid works.
     """
-    dtypes = "float32 float64 int32 int64 uint32 uint64".split()
     wesn = [10, 15, 30, 40, 0, 0]
     inc = [1, 1]
     shape = ((wesn[3] - wesn[2]) // inc[1] + 1, (wesn[1] - wesn[0]) // inc[0] + 1)

--- a/pygmt/tests/test_clib_put_vector.py
+++ b/pygmt/tests/test_clib_put_vector.py
@@ -12,11 +12,18 @@ from pygmt.exceptions import GMTCLibError, GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 
 
-def test_put_vector():
+@pytest.fixture(scope="module", name="dtypes")
+def fixture_dtypes():
+    """
+    List of supported numpy dtypes.
+    """
+    return "int8 int16 int32 int64 uint8 uint16 uint32 uint64 float32 float64".split()
+
+
+def test_put_vector(dtypes):
     """
     Check that assigning a numpy array to a dataset works.
     """
-    dtypes = "float32 float64 int32 int64 uint32 uint64".split()
     for dtype in dtypes:
         with clib.Session() as lib:
             dataset = lib.create_data(
@@ -50,13 +57,12 @@ def test_put_vector():
                 npt.assert_allclose(newz, z)
 
 
-def test_put_vector_mixed_dtypes():
+def test_put_vector_mixed_dtypes(dtypes):
     """
     Passing a numpy array of mixed dtypes to a dataset.
 
     See https://github.com/GenericMappingTools/pygmt/issues/255
     """
-    dtypes = "float32 float64 int32 int64 uint32 uint64".split()
     for dtypex, dtypey in itertools.permutations(dtypes, r=2):
         with clib.Session() as lib:
             dataset = lib.create_data(


### PR DESCRIPTION
**Description of proposed changes**

Support numpy data types `np.int8`, `np.int16`, `np.uint8`, and `np.uint16`.

**References:** 
- https://numpy.org/doc/stable/reference/arrays.scalars.html?highlight=uint32#sized-aliases
- https://github.com/GenericMappingTools/gmt/blob/b552be3a3f76455cd45f32202d468d14ce93cd28/src/gmt_resources.h#L83

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #1960.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
