### PR TITLE
Fix the broken links for 'Improve this page'

### DIFF
--- a/doc/_templates/breadcrumbs.html
+++ b/doc/_templates/breadcrumbs.html
@@ -5,7 +5,7 @@
 {% block breadcrumbs_aside %}
     <li class="source-link">
         {% if hasdoc(pagename) %}
-            {% if pagename.startswith("api/generated") or suffix == ".ipynb" %}
+            {% if pagename.startswith("api/generated") or page_source_suffix == ".ipynb" %}
                 {% set title = "Suggested improvement for " + pagename %}
                 {% set body = "Please describe what could be improved about this page or the typo/mistake that you found:" %}
                 <a href="https://github.com/{{ github_repo }}/issues/new?title={{ title|urlencode }}&body={{ body|urlencode }}"
@@ -21,7 +21,7 @@
                 <a href="https://github.com/{{ github_repo }}/edit/{{ github_version }}/{{ doc_path }}/{{ example_script }}"
                    class="fa fa-github"> Improve this page</a>
             {% else %}
-                <a href="https://github.com/{{ github_repo }}/edit/{{ github_version }}/{{ doc_path }}/{{ pagename }}{{ suffix }}"
+                <a href="https://github.com/{{ github_repo }}/edit/{{ github_version }}/{{ doc_path }}/{{ pagename }}{{ page_source_suffix }}"
                    class="fa fa-github"> Improve this page</a>
             {% endif %}
         {% endif %}


### PR DESCRIPTION
**Description of proposed changes**

`suffix` is not a sphinx global variable. Instead, it's a variable defined by the sphinx_rtd

Related to upstream changes in https://github.com/readthedocs/sphinx_rtd_theme/pull/1104.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
