### PR TITLE
Add two new PyGMT tutorials to external resources

### DIFF
--- a/doc/external_resources.md
+++ b/doc/external_resources.md
@@ -71,6 +71,26 @@ MIGG-NTU
 +++
 Wei Ji Leong
 ::::
+
+::::{grid-item-card} Crafting 3D maps of Antarctica with PyGMT and the IBCSO V2
+:link: https://github.com/andrebelem/3D-Antarctic-maps
+:text-align: center
+:margin: 0 3 0 0
+
+![](https://github.com/andrebelem/3D-Antarctic-maps/raw/main/3D-Antarctic-Maps.png)
++++
+Andre Belem
+::::
+
+::::{grid-item-card} Planetary Maps (in PyGMT)
+:link: https://github.com/andrebelem/PlanetaryMaps
+:text-align: center
+:margin: 0 3 0 0
+
+![](https://github.com/andrebelem/MarsMaps/raw/main/JezeroCrater.png)
++++
+Andre Belem
+::::
 :::::
 
 ## Examples from Publications and Posters


### PR DESCRIPTION
**Description of proposed changes**
Per suggestion made in the thread discussion at https://forum.generic-mapping-tools.org/t/some-3d-maps-using-pygmt-and-the-new-ibcso-data/3017, I suggest adding two GitHub repositories with examples of 3D maps, explained through instructional notebooks.