### PR TITLE
Figure.histogram and pygmt.info: Remove parameter 'table', use 'data' instead

### DIFF
--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -2,13 +2,7 @@
 Histogram - Create a histogram
 """
 from pygmt.clib import Session
-from pygmt.helpers import (
-    build_arg_string,
-    deprecate_parameter,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 
 @fmt_docstring

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -12,7 +12,6 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
-@deprecate_parameter("table", "data", "v0.5.0", remove_version="v0.7.0")
 @use_alias(
     A="horizontal",
     B="frame",

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -14,7 +14,6 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
-@deprecate_parameter("table", "data", "v0.5.0", remove_version="v0.7.0")
 @use_alias(
     C="per_column",
     I="spacing",

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -6,7 +6,6 @@ from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,
     build_arg_string,
-    deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -31,23 +31,6 @@ def test_info():
     assert output == expected_output
 
 
-def test_info_deprecate_table_to_data():
-    """
-    Make sure that the old parameter "table" is supported and it reports a
-    warning.
-    """
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        output = info(table=POINTS_DATA)  # pylint: disable=no-value-for-parameter
-        expected_output = (
-            f"{POINTS_DATA}: N = 20 "
-            "<11.5309/61.7074> "
-            "<-2.9289/7.8648> "
-            "<0.1412/0.9338>\n"
-        )
-        assert output == expected_output
-        assert len(record) == 1  # check that only one warning was raised
-
-
 @pytest.mark.parametrize(
     "table",
     [


### PR DESCRIPTION
**Description of proposed changes**

Related to https://github.com/GenericMappingTools/pygmt/issues/1966.



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
