### PR TITLE
pygmt.surface: Remove parameter 'outfile', use 'outgrid' instead

### DIFF
--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -18,7 +18,6 @@ __doctest_skip__ = ["surface"]
 
 
 @fmt_docstring
-@deprecate_parameter("outfile", "outgrid", "v0.5.0", remove_version="v0.7.0")
 @check_data_input_order("v0.5.0", remove_version="v0.7.0")
 @use_alias(
     I="spacing",

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -7,7 +7,6 @@ from pygmt.helpers import (
     GMTTempFile,
     build_arg_string,
     check_data_input_order,
-    deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -145,25 +145,3 @@ def test_surface_with_outgrid_param(data, region, spacing, expected_grid):
         assert os.path.exists(path=tmpfile.name)  # check that outgrid exists at path
         with xr.open_dataarray(tmpfile.name) as grid:
             check_values(grid, expected_grid)
-
-
-def test_surface_deprecate_outfile_to_outgrid(data, region, spacing, expected_grid):
-    """
-    Make sure that the old parameter "outfile" is supported and it reports a
-    warning.
-    """
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        data = data.values  # convert pandas.DataFrame to numpy.ndarray
-        with GMTTempFile(suffix=".nc") as tmpfile:
-            output = surface(
-                data=data,
-                spacing=spacing,
-                region=region,
-                outfile=tmpfile.name,
-                verbose="e",  # Suppress warnings for IEEE 754 rounding
-            )
-            assert output is None  # check that output is None since outfile is set
-            assert os.path.exists(path=tmpfile.name)  # check that file exists at path
-            with xr.open_dataarray(tmpfile.name) as grid:
-                check_values(grid, expected_grid)
-        assert len(record) == 1  # check that only one warning was raised


### PR DESCRIPTION
**Description of proposed changes**

Related to https://github.com/GenericMappingTools/pygmt/issues/1966.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
