### PR TITLE
NEP29: Set minimum required version to NumPy 1.20+

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -40,11 +40,11 @@ jobs:
             isDraft: true
           - os: windows-latest
             isDraft: true
-        # Pair Python 3.8 with NumPy 1.19 and Python 3.10 with NumPy 1.22
+        # Pair Python 3.8 with NumPy 1.20 and Python 3.10 with NumPy 1.22
         # Only install optional packages on Python 3.10/NumPy 1.22
         include:
           - python-version: '3.8'
-            numpy-version: '1.19'
+            numpy-version: '1.20'
             optional-packages: ''
           - python-version: '3.10'
             numpy-version: '1.22'

--- a/README.rst
+++ b/README.rst
@@ -235,7 +235,7 @@ Compatibility with GMT/Python/NumPy versions
       - `Dev Documentation <https://www.pygmt.org/dev>`_ (reflects `main branch <https://github.com/GenericMappingTools/pygmt>`_)
       - >=6.3.0
       - >=3.8
-      - >=1.19
+      - >=1.20
     * - `v0.6.1 <https://github.com/GenericMappingTools/pygmt/releases/tag/v0.6.1>`_ (latest release)
       - `v0.6.1 Documentation <https://www.pygmt.org/v0.6.1>`_
       - >=6.3.0

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -98,7 +98,7 @@ Dependencies
 
 PyGMT requires the following libraries to be installed:
 
-* `numpy <https://numpy.org>`__ (>= 1.19)
+* `numpy <https://numpy.org>`__ (>= 1.20)
 * `pandas <https://pandas.pydata.org>`__
 * `xarray <https://xarray.pydata.org>`__
 * `netCDF4 <https://unidata.github.io/netcdf4-python>`__

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
     # Required dependencies
     - pip
     - gmt=6.3.0
-    - numpy>=1.19
+    - numpy>=1.20
     - pandas
     - xarray
     - netCDF4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Required packages
-numpy>=1.19
+numpy>=1.20
 pandas
 xarray
 netCDF4

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ CLASSIFIERS = [
 ]
 PLATFORMS = "Any"
 PYTHON_REQUIRES = ">=3.8"
-INSTALL_REQUIRES = ["numpy>=1.19", "pandas", "xarray", "netCDF4", "packaging"]
+INSTALL_REQUIRES = ["numpy>=1.20", "pandas", "xarray", "netCDF4", "packaging"]
 
 if __name__ == "__main__":
     setup(


### PR DESCRIPTION
**Description of proposed changes**

Following NEP29 policy where NumPy 1.19 is to be dropped on or after June. 21, 2022 (in a minor version increment, i.e. for PyGMT v0.7.0). Bumps minimum supported NumPy version to 1.20 in the setup.py, requirements.txt and environment.yml files. Also update installation documentation and set CI tests to run on NumPy 1.20.

xref https://github.com/GenericMappingTools/pygmt/pull/1675
<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
