### PR TITLE
Remove the feedback call for whoever building the GMT sources

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -88,8 +88,7 @@ Compiled conda packages of GMT for Linux, macOS and Windows are provided
 through `conda-forge <https://anaconda.org/conda-forge/gmt>`__.
 Advanced users can also
 `build GMT from source <https://github.com/GenericMappingTools/gmt/blob/master/BUILDING.md>`__
-instead, which is not so recommended but we would love to get feedback from
-anyone who tries.
+instead.
 
 We recommend following the instructions further on to install GMT 6.
 


### PR DESCRIPTION
**Description of proposed changes**

I've been building the GMT dev source codes and running PyGMT on both Linux and macOS. They all work well without any problems, as expected, so I think we can remove the feedback call. 

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
