### PR TITLE
Fix an incorrect link in external resources page

### DIFF
--- a/doc/external_resources.md
+++ b/doc/external_resources.md
@@ -2,7 +2,7 @@
 
 Below is a curated collection of external PyGMT resources.
 
-*To add your contribution to this collection, follow [these instructions](https://github.com/GenericMappingTools/pygmt/blob/main/CONTRIBUTING.md#editing-the-documentation)
+*To add your contribution to this collection, follow [these instructions](contributing.md#contributing-documentation)
 to submit a pull request with your recommended addition to the
 [External Resources file](https://github.com/GenericMappingTools/pygmt/blob/main/doc/external_resources.md).*
 


### PR DESCRIPTION
**Description of proposed changes**

https://github.com/GenericMappingTools/pygmt/blob/main/CONTRIBUTING.md#editing-the-documentation is no longer a valid link. 

This PR replaces it with https://www.pygmt.org/latest/contributing.html#contributing-documentation.
