### PR TITLE
Need to specificy the python version in the setup-python action

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -22,6 +22,8 @@ jobs:
 
       # Setup Python environment
       - uses: actions/setup-python@v4.0.0
+        with:
+          python-version: '3.10'
 
       # Install formatting tools
       - name: Install formatting tools


### PR DESCRIPTION
**Description of proposed changes**

The `/format` slash command fails (https://github.com/GenericMappingTools/pygmt/runs/7246723842?check_suite_focus=true) with the following error:
```
Run actions/setup-python@v4.0.0
  with:
    token: ***
Error: The specified python version file at: /home/runner/work/pygmt/pygmt/.python-version does not exist
```
