### PR TITLE
Let GMTDataArrayAccessor check if the grid source file exists

### DIFF
--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -1,6 +1,8 @@
 """
 GMT accessor methods.
 """
+from pathlib import Path
+
 import xarray as xr
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.src.grdinfo import grdinfo
@@ -29,6 +31,8 @@ class GMTDataArrayAccessor:
         self._obj = xarray_obj
         try:
             self._source = self._obj.encoding["source"]  # filepath to NetCDF source
+            if not Path(self._source).exists():
+                raise ValueError(f"Grid source file {self._source} doesn't exist.")
             # Get grid registration and grid type from the last two columns of
             # the shortened summary information of `grdinfo`.
             self._registration, self._gtype = map(


### PR DESCRIPTION
**Description of proposed changes**

If the netCDF source file doesn't exist, running `grdinfo` on the netCDF source file gives the following error:
```
grdinfo [ERROR]: Cannot find file /tmp/xxx/xxx.nc
grdinfo [ERROR]: Must specify one or more input files
```
The error is unfriendly and confusing. Instead, we can check if the netCDF source file exists. If it doesn't exist, we raise a `ValueError` exception and fallback to registration=0 and gtype=0/ 

Partially address https://github.com/GenericMappingTools/pygmt/issues/1984 and https://github.com/GenericMappingTools/pygmt/issues/524#issuecomment-1121803929

Please note that this PR doesn't solve the problems in #1984 and #524, because the registration and gtype information are incorrect. 