### PR TITLE
Fix typo in Maintainers Guide

### DIFF
--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -201,7 +201,7 @@ When making incompatible changes, we should follow the process:
 
 To rename a function parameter, add the `@deprecate_parameter` decorator near
 the top after the `@fmt_docstring` decorator but before the `@use_alias`
-decorator (if those two exists). Here is an example:
+decorator (if those two exist). Here is an example:
 
 ```
 @fmt_docstring


### PR DESCRIPTION
**Description of proposed changes**
Fixes a typo in the Maintainers Guide in the section [backwards-compatibility-and-deprecation-policy](https://www.pygmt.org/dev/maintenance.html#backwards-compatibility-and-deprecation-policy).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
