### PR TITLE
Remove title/label-whitespaces-trick from tests

### DIFF
--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -48,7 +48,7 @@ def test_basemap_power_axis():
     fig.basemap(
         region=[0, 100, 0, 5000],
         projection="x1p0.5/-0.001",
-        frame=['x1p+l"Crustal age"', "y500+lDepth"],
+        frame=["x1p+lCrustal age", "y500+lDepth"],
     )
     return fig
 

--- a/pygmt/tests/test_config.py
+++ b/pygmt/tests/test_config.py
@@ -14,21 +14,21 @@ def test_config():
     # Change global settings of current figure
     config(FONT_ANNOT_PRIMARY="blue")
     fig.basemap(
-        region=[0, 10, 0, 10], projection="X5c/5c", frame=["af", '+t"Blue Annotation"']
+        region=[0, 10, 0, 10], projection="X5c/5c", frame=["af", "+tBlue Annotation"]
     )
 
     with config(FONT_LABEL="red", FONT_ANNOT_PRIMARY="red"):
         fig.basemap(
             region=[0, 10, 0, 10],
             projection="X5c/5c",
-            frame=['xaf+l"red label"', "yaf", '+t"red annotation"'],
+            frame=["xaf+lred label", "yaf", "+tred annotation"],
             xshift="7c",
         )
 
     fig.basemap(
         region=[0, 10, 0, 10],
         projection="X5c/5c",
-        frame=["af", '+t"Blue Annotation"'],
+        frame=["af", "+tBlue Annotation"],
         xshift="7c",
     )
     # Revert to default settings in current figure


### PR DESCRIPTION
**Description of proposed changes**

This PR removes the double-quote-trick to use whitespaces in titles and labels from a few tests.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes https://github.com/GenericMappingTools/pygmt/pull/2018#issuecomment-1193254400, #2013

**Overview of affected tests**

- [x] tests/test_basemap.py
- [x] tests/test_config.py
- [ ] check if there are more affected tests

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
