### PR TITLE
Add reference to special symbols in text tutorial

### DIFF
--- a/examples/tutorials/basics/text.py
+++ b/examples/tutorials/basics/text.py
@@ -141,6 +141,7 @@ fig.show()
 # Advanced configuration
 # ----------------------
 #
-# For crafting more advanced styles, be sure to check out the GMT documentation
+# For crafting more advanced styles, including using special symbols and
+# other character sets, be sure to check out the GMT documentation
 # at :gmt-docs:`text.html` and also the cookbook at
 # :gmt-docs:`cookbook/features.html#placement-of-text`. Good luck!


### PR DESCRIPTION
**Description of proposed changes**

Adds the reference to special symbols suggested in https://forum.generic-mapping-tools.org/t/improve-the-plotting-text-tutorial-add-a-link-to-the-matching-doc/3166 to the text tutorial

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
