### PR TITLE
Fix typos in cylindrical projection examples

### DIFF
--- a/examples/projections/cyl/cyl_oblique_mercator_3.py
+++ b/examples/projections/cyl/cyl_oblique_mercator_3.py
@@ -18,7 +18,7 @@ with *scale* or *width*.
 import pygmt
 
 fig = pygmt.Figure()
-# Using the origin projection pole
+# Using the origin and projection pole
 fig.coast(
     projection="Oc280/25.5/22/69/12c",
     # Set bottom left and top right coordinates of the figure with "+r"

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -14,7 +14,7 @@ has been factored into the formulae. This makes the UTM projection a secant
 projection and not a tangent projection like the transverse Mercator above. The
 scale only varies by 1 part in 1,000 from true scale at equator. The
 ellipsoidal projection expressions are accurate for map areas that extend less
-than 10 away from the central meridian.
+than 10° away from the central meridian.
 
 **u**\ *zone/scale* or **U**\ *zone/width*
 

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -5,9 +5,9 @@ Universal Transverse Mercator
 A particular subset of the transverse Mercator is the Universal Transverse
 Mercator (UTM) which was adopted by the US Army for large-scale military maps.
 Here, the globe is divided into 60 zones between 84°S and 84°N, most of which
-are 6 wide. Each of these UTM zones have their unique central meridian.
-Furthermore, each zone is divided into latitude bands but these are not needed
-to specify the projection for most cases.
+are 6° (in longitude) wide. Each of these UTM zones have their unique central
+meridian. Furthermore, each zone is divided into latitude bands but these are
+not needed to specify the projection for most cases.
 
 In order to minimize the distortion in any given zone, a scale factor of 0.9996
 has been factored into the formulae. This makes the UTM projection a secant

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -18,7 +18,7 @@ than 10° away from the central meridian.
 
 **u**\ *zone/scale* or **U**\ *zone/width*
 
-the projection is set with **u** or **U**. *zone* sets the zone for the figure,
+The projection is set with **u** or **U**. *zone* sets the zone for the figure,
 and the figure size is set with *scale* or *width*.
 """
 import pygmt


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a few typos in the cylindrical projection examples.

--------------------
I am not totally sure about the second paragraph of the explanation of the UTM projection, see
https://www.pygmt.org/dev/projections/cyl/cyl_universal_transverse_mercator.html?highlight=10%20away

Maybe it is `... less than 10°  away ...` in the last line (the unit, probably [the] degree [sign], is missing)?

However, there is also no unit in the equivalent GMT documentation, see
https://docs.generic-mapping-tools.org/dev/cookbook/map-projections.html?highlight=10%20away#universal-transverse-mercator-utm-projection-ju-ju.

---------------------

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
