### PR TITLE
Fix typo in 'contributing.md'

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -422,7 +422,7 @@ When editing documentation, use the following standards to demonstrate the examp
 3. Optional arguments are wrapped with [ ] (square brackets).
 4. Arguments that are mutually exclusive are separated with a | (bar) to denote "or".
 5. Default arguments for parameters and configuration settings are wrapped
-   with [ ] (square brackers) with the prefix "Default is". Example: [Default is
+   with [ ] (square brackets) with the prefix "Default is". Example: [Default is
    **p**].
 
 ### Cross-referencing with Sphinx


### PR DESCRIPTION
**Description of proposed changes**

This PR aims the fix a typo in the section ['Standards for Example Code'](https://www.pygmt.org/dev/contributing.html#standards-for-example-code) of 'contributing.md'.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
