### PR TITLE
Fix typo in 'vectors.py'

### DIFF
--- a/examples/tutorials/advanced/vectors.py
+++ b/examples/tutorials/advanced/vectors.py
@@ -218,7 +218,8 @@ y = np.linspace(39, 39, 5)  # y values = [39. 39. 39. 39.]
 direction = np.linspace(-90, -90, 5)  # direction values = [-90. -90. -90. -90.]
 length = np.linspace(1.5, 1.5, 5)  # length values = [1.5 1.5 1.5 1.5]
 
-# Create a plot with coast, Mercator projection (M) over the continental US
+# Create a plot with coast,
+# Transverse Mercator projection (T) over Turkey and Syria
 fig = pygmt.Figure()
 fig.coast(
     region=[20, 50, 30, 45],


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a typo regarding the description of projection and region in ['vectors.py'](https://www.pygmt.org/dev/tutorials/advanced/vectors.html#sphx-glr-tutorials-advanced-vectors-py).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
