### PR TITLE
Fix typos in API documentation

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -49,7 +49,7 @@ COMMON_OPTIONS = {
             is no fill.""",
     "I": r"""
         spacing : str
-            *xinc*\ [**+e**\|\ **n**][/\ *yinc*\ [**+e**\|\ **n**]].
+            *x_inc*\ [**+e**\|\ **n**][/\ *y_inc*\ [**+e**\|\ **n**]].
             *x_inc* [and optionally *y_inc*] is the grid spacing.
 
             - **Geographical (degrees) coordinates**: Optionally, append an

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -39,7 +39,7 @@ from pygmt.helpers import (
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def coast(self, **kwargs):
     r"""
-    Plot continents, shorelines, rivers, and borders on maps
+    Plot continents, shorelines, rivers, and borders on maps.
 
     Plots grayshaded, colored, or textured land-masses [or water-masses] on
     maps and [optionally] draws coastlines, rivers, and political

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -86,7 +86,7 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
     I : bool
         Color the triangles using CPT.
     triangular_mesh_pen : str
-        Pen to draw the underlying triangulation [Default is none].
+        Pen to draw the underlying triangulation [Default is None].
     no_clip : bool
         Do NOT clip contours or image at the boundaries [Default will clip
         to fit inside region].


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a few typos in the API documentation.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
