### PR TITLE
Fix typos in  `psconvert` in the file `figure.py`

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -176,7 +176,7 @@ class Figure:
             but without extension. Extension is still determined automatically.
         resize : str
             [**+m**\ *margins*][**+s**\ [**m**]\ *width*\
-            [/\ *height*]][**+S**\ *scale*] ].
+            [/\ *height*]][**+S**\ *scale*].
             Adjust the BoundingBox and HiResBoundingBox by scaling and/or
             adding margins. Append **+m** to specify extra margins to extend
             the bounding box. Give either one (uniform), two (x and y) or four

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -198,9 +198,9 @@ class Figure:
             towards black (100%) [no fading, 0]. Append **+g**\ *paint* to
             paint the BoundingBox behind the illustration and append **+p**\
             [*pen*] to draw the BoundingBox outline (append a pen or accept
-            the default pen of 0.25p,black). Note: If both **+g** and **+f**
-            are used then we use paint as the fade color instead of black.
-            Append **+i** to enforce gray-shades by using ICC profiles.
+            the default pen of 0.25p,black). **Note**: If both **+g** and
+            **+f** are used then we use paint as the fade color instead of
+            black. Append **+i** to enforce gray-shades by using ICC profiles.
         anti_aliasing : str
             [**g**\|\ **p**\|\ **t**\][**1**\|\ **2**\|\ **4**].
             Set the anti-aliasing options for **g**\ raphics or **t**\ ext.

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -145,7 +145,7 @@ class Figure:
         PDF, PNG, PPM, SVG, TIFF) using GhostScript.
 
         If no input files are given, will convert the current active figure
-        (see :func:`pygmt.figure`). In this case, an output name must be given
+        (see :func:`pygmt.Figure`). In this case, an output name must be given
         using parameter *prefix*.
 
         Full option list at :gmt-docs:`psconvert.html`

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -167,7 +167,7 @@ class Figure:
             Specify a single, custom option that will be passed on to
             GhostScript as is.
         dpi : int
-            Set raster resolution in dpi. Default = 720 for PDF, 300 for
+            Set raster resolution in dpi. Default is 720 for PDF, 300 for
             others.
         prefix : str
             Force the output file name. By default output names are constructed


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix typos in the API documentation of [`pygmt.Figure.psconvert`](https://www.pygmt.org/dev/api/generated/pygmt.Figure.psconvert.html#pygmt.Figure.psconvert) in the file `figure.py`.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
