### PR TITLE
Use GMT-related term 'annotations' in example 'Color points by categories'

### DIFF
--- a/examples/gallery/symbols/points_categorical.py
+++ b/examples/gallery/symbols/points_categorical.py
@@ -26,7 +26,7 @@ df.species = df.species.astype(dtype="category")
 # Make a list of the individual categories of the 'species' column
 # ['Adelie', 'Chinstrap', 'Gentoo']
 # They are (corresponding to the categorical number code) by default in
-# alphabetical order and later used for the colorbar labels
+# alphabetical order and later used for the colorbar annotations
 labels = list(df.species.cat.categories)
 
 # Use pygmt.info to get region bounds (xmin, xmax, ymin, ymax)

--- a/examples/gallery/symbols/points_categorical.py
+++ b/examples/gallery/symbols/points_categorical.py
@@ -27,7 +27,7 @@ df.species = df.species.astype(dtype="category")
 # ['Adelie', 'Chinstrap', 'Gentoo']
 # They are (corresponding to the categorical number code) by default in
 # alphabetical order and later used for the colorbar annotations
-cb_annot = list(df.species.cat.categories)
+cb_annots = list(df.species.cat.categories)
 
 # Use pygmt.info to get region bounds (xmin, xmax, ymin, ymax)
 # The below example will return a numpy array like [30.0, 60.0, 12.0, 22.0]
@@ -65,7 +65,7 @@ pygmt.makecpt(
     # to set the lowest_value and the highest_value of the CPT
     series=(df.species.cat.codes.min(), df.species.cat.codes.max(), 1),
     # convert ['Adelie', 'Chinstrap', 'Gentoo'] to 'Adelie,Chinstrap,Gentoo'
-    color_model="+c" + ",".join(cb_annot),
+    color_model="+c" + ",".join(cb_annots),
 )
 
 fig.plot(

--- a/examples/gallery/symbols/points_categorical.py
+++ b/examples/gallery/symbols/points_categorical.py
@@ -27,7 +27,7 @@ df.species = df.species.astype(dtype="category")
 # ['Adelie', 'Chinstrap', 'Gentoo']
 # They are (corresponding to the categorical number code) by default in
 # alphabetical order and later used for the colorbar annotations
-labels = list(df.species.cat.categories)
+cb_annot = list(df.species.cat.categories)
 
 # Use pygmt.info to get region bounds (xmin, xmax, ymin, ymax)
 # The below example will return a numpy array like [30.0, 60.0, 12.0, 22.0]
@@ -65,7 +65,7 @@ pygmt.makecpt(
     # to set the lowest_value and the highest_value of the CPT
     series=(df.species.cat.codes.min(), df.species.cat.codes.max(), 1),
     # convert ['Adelie', 'Chinstrap', 'Gentoo'] to 'Adelie,Chinstrap,Gentoo'
-    color_model="+c" + ",".join(labels),
+    color_model="+c" + ",".join(cb_annot),
 )
 
 fig.plot(


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to use the GMT-related term `annotations` in the gallery example [Color points by categories](https://www.pygmt.org/dev/gallery/symbols/points_categorical.html#sphx-glr-gallery-symbols-points-categorical-py). When making the changes in PR #1933 I used `labels`. This is not precise and inconsistent to the description for the colorbar added in PR #1267. I also renamed the corresponding variable. If there are any preferences or convention regarding variable names, I am happy to adjust or improve this.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
