### PR TITLE
load_earth_relief() now returns gridline-registrated grids by default in GMT 6.4

### DIFF
--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -15,7 +15,7 @@ class GMTDataArrayAccessor:
 
     >>> from pygmt.datasets import load_earth_relief
     >>> # Use the global Earth relief grid with 1 degree spacing
-    >>> grid = load_earth_relief(resolution="01d")
+    >>> grid = load_earth_relief(resolution="01d", registration="pixel")
 
     >>> # See if grid uses Gridline (0) or Pixel (1) registration
     >>> grid.gmt.registration

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -48,7 +48,7 @@ def dataarray_to_matrix(grid):
 
     >>> from pygmt.datasets import load_earth_relief
     >>> # Use the global Earth relief grid with 1 degree spacing
-    >>> grid = load_earth_relief(resolution="01d")
+    >>> grid = load_earth_relief(resolution="01d", registration="pixel")
     >>> matrix, region, inc = dataarray_to_matrix(grid)
     >>> print(region)
     [-180.0, 180.0, -90.0, 90.0]

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -46,13 +46,13 @@ def load_earth_relief(resolution="01d", region=None, registration=None, use_srtm
     registration : str
         Grid registration type. Either ``pixel`` for pixel registration or
         ``gridline`` for gridline registration. Default is ``None``, where
-        a pixel-registered grid is returned unless only the
-        gridline-registered grid is available.
+        a gridline-registered grid is returned unless only the pixel-registered
+        grid is available.
 
     use_srtm : bool
         By default, the land-only SRTM tiles from NASA are used to generate the
         ``'03s'`` and ``'01s'`` grids, and the missing ocean values are filled
-        by up-sampling the SRTM15+V2.1 tiles which have a resolution of 15
+        by up-sampling the SRTM15+ tiles which have a resolution of 15
         arc-second (i.e., ``'15s'``). If True, will only load the original
         land-only SRTM tiles.
 
@@ -71,7 +71,7 @@ def load_earth_relief(resolution="01d", region=None, registration=None, use_srtm
     Examples
     --------
 
-    >>> # load the default grid (pixel-registered 01d grid)
+    >>> # load the default grid (gridline-registered 01d grid)
     >>> grid = load_earth_relief()
     >>> # load the 30m grid with "gridline" registration
     >>> grid = load_earth_relief("30m", registration="gridline")

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -48,9 +48,9 @@ def load_earth_relief(resolution="01d", region=None, registration=None, use_srtm
         ``gridline`` for gridline registration. Default is ``None``, where
         a gridline-registered grid is returned unless only the pixel-registered
         grid is available.
-        
-        **Note:** For GMT 6.3, ``registration=None`` returns a pixel-registered grid
-        by default unless only the gridline-registered grid is available.
+
+        **Note:** For GMT 6.3, ``registration=None`` returns a pixel-registered
+        grid by default unless only the gridline-registered grid is available.
 
     use_srtm : bool
         By default, the land-only SRTM tiles from NASA are used to generate the

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -49,7 +49,7 @@ def load_earth_relief(resolution="01d", region=None, registration=None, use_srtm
         a gridline-registered grid is returned unless only the pixel-registered
         grid is available.
         
-        **Note:** For GMT<=6.3, ``registration=None`` returns a pixel-registered grid
+        **Note:** For GMT 6.3, ``registration=None`` returns a pixel-registered grid
         by default unless only the gridline-registered grid is available.
 
     use_srtm : bool

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -48,6 +48,9 @@ def load_earth_relief(resolution="01d", region=None, registration=None, use_srtm
         ``gridline`` for gridline registration. Default is ``None``, where
         a gridline-registered grid is returned unless only the pixel-registered
         grid is available.
+        
+        **Note:** For GMT<=6.3, ``registration=None`` returns a pixel-registered grid
+        by default unless only the gridline-registered grid is available.
 
     use_srtm : bool
         By default, the land-only SRTM tiles from NASA are used to generate the


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/GenericMappingTools/pygmt/issues/1929 for context.

Fixes https://github.com/GenericMappingTools/pygmt/issues/1929.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
