### PR TITLE
NEP29: Test PyGMT on NumPy 1.23 and 1.21

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -40,11 +40,11 @@ jobs:
             isDraft: true
           - os: windows-latest
             isDraft: true
-        # Pair Python 3.8 with NumPy 1.20 and Python 3.10 with NumPy 1.23
+        # Pair Python 3.8 with NumPy 1.21 and Python 3.10 with NumPy 1.23
         # Only install optional packages on Python 3.10/NumPy 1.23
         include:
           - python-version: '3.8'
-            numpy-version: '1.20'
+            numpy-version: '1.21'
             optional-packages: ''
           - python-version: '3.10'
             numpy-version: '1.23'

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -40,14 +40,14 @@ jobs:
             isDraft: true
           - os: windows-latest
             isDraft: true
-        # Pair Python 3.8 with NumPy 1.20 and Python 3.10 with NumPy 1.22
-        # Only install optional packages on Python 3.10/NumPy 1.22
+        # Pair Python 3.8 with NumPy 1.20 and Python 3.10 with NumPy 1.23
+        # Only install optional packages on Python 3.10/NumPy 1.23
         include:
           - python-version: '3.8'
             numpy-version: '1.20'
             optional-packages: ''
           - python-version: '3.10'
-            numpy-version: '1.22'
+            numpy-version: '1.23'
             optional-packages: 'geopandas ipython'
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
**Description of proposed changes**

Bumps [numpy](https://github.com/numpy/numpy) from 1.22.4 to 1.23.2. NumPy 1.23.0 was released on 22 Jun 2022.
- [Release notes](https://github.com/numpy/numpy/releases)
- [Changelog](https://github.com/numpy/numpy/blob/v1.23.0/doc/changelog/1.23.0-changelog.rst)
- [Commits](https://github.com/numpy/numpy/compare/v1.22.4...v1.23.2)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This is in line with PyGMT's policy on [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) at https://www.pygmt.org/v0.7.0/maintenance.html#dependencies-policy, xref #1074.

Also setting minimum NumPy version on CI to 1.21, to bypass the `TypeError: <class 'numpy.typing._dtype_like._SupportsDType'> is not a generic class`  problem with NumPy 1.20 and `xarray==2022.6.0` so that unit tests pass. See also https://github.com/pydata/xarray/issues/6818

Note that the branch protection rules at https://github.com/GenericMappingTools/pygmt/settings/branches will need to be changed to use Python 3.10/Numpy 1.22 instead of Python 3.10/Numpy 1.23 before this Pull Request is merged.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Supersedes #1701

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
