### PR TITLE
Fix typos in documentation for Polar projection

### DIFF
--- a/examples/projections/nongeo/polar.py
+++ b/examples/projections/nongeo/polar.py
@@ -23,7 +23,7 @@ The following customizing modifiers are available:
   definition); **+a** indicates that the input data is rotated clockwise
   relative to the north direction (geographical azimuth angle).
 
-- **+r**\ *offset*: represents the offset of the r axis. This modifier allows
+- **+r**\ *offset*: represents the offset of the r-axis. This modifier allows
   you to offset the center of the circle from r=0.
 
 - **+t**\ *origin*: sets the angle corresponding to the east direction which is
@@ -37,10 +37,10 @@ The following customizing modifiers are available:
     range of the r-axis should be between 0 and 90.
   - Appending **p** sets the current earth radius (determined by
     :gmt-term:`PROJ_ELLIPSOID`)
-    to the maximum value of the r axis when the r axis is reversed.
-  - Append *radius* to set the maximum value of the r axis.
+    to the maximum value of the r-axis when the r-axis is reversed.
+  - Append *radius* to set the maximum value of the r-axis.
 
-- **+z**: indicates that the r axis is marked as depth instead of radius (e.g.
+- **+z**: indicates that the r-axis is marked as depth instead of radius (e.g.
   *r = radius - z*).
 
   - Append **p** to set radius to the current earth radius.

--- a/examples/projections/nongeo/polar.py
+++ b/examples/projections/nongeo/polar.py
@@ -150,7 +150,7 @@ fig.basemap(
     region=[0, 90, 3480, 6371],
     # set map width to 5 cm and interpret input data as geographic azimuth
     # instead of standard angle, rotate coordinate system counterclockwise by
-    # 45 degrees, r axis is marked as depth
+    # 45 degrees, r-axis is marked as depth
     projection="P5c+a+t45+z",
     # set the frame and color
     frame=["xa30f", "ya", "WNse+gbisque"],

--- a/examples/projections/nongeo/polar.py
+++ b/examples/projections/nongeo/polar.py
@@ -34,7 +34,7 @@ The following customizing modifiers are available:
 - **+f**: reverses the radial direction.
 
   - Append **e** to indicate that the r-axis is an elevation angle, and the
-    range of the r-axis should be between 0 and 90.
+    range of the r-axis should be between 0° and 90°.
   - Appending **p** sets the current earth radius (determined by
     :gmt-term:`PROJ_ELLIPSOID`)
     to the maximum value of the r-axis when the r-axis is reversed.

--- a/examples/projections/nongeo/polar.py
+++ b/examples/projections/nongeo/polar.py
@@ -35,7 +35,7 @@ The following customizing modifiers are available:
 
   - Append **e** to indicate that the r-axis is an elevation angle, and the
     range of the r-axis should be between 0° and 90°.
-  - Appending **p** sets the current earth radius (determined by
+  - Appending **p** sets the current Earth radius (determined by
     :gmt-term:`PROJ_ELLIPSOID`)
     to the maximum value of the r-axis when the r-axis is reversed.
   - Append *radius* to set the maximum value of the r-axis.
@@ -43,7 +43,7 @@ The following customizing modifiers are available:
 - **+z**: indicates that the r-axis is marked as depth instead of radius (e.g.
   *r = radius - z*).
 
-  - Append **p** to set radius to the current earth radius.
+  - Append **p** to set radius to the current Earth radius.
   - Append *radius* to set the value of the radius.
 
 """


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a few typos in the documentation for the [Polar projection](https://www.pygmt.org/dev/projections/nongeo/polar.html).
In case 'r axis' (no hyphen) is preferred instead of 'r-axis', I can change this. Following PR https://github.com/GenericMappingTools/pygmt/pull/2028 'Earth' is  capitalized.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
