### PR TITLE
Replace 'argument' by 'parameter' in tutorial 'Plotting Earth relief'

### DIFF
--- a/examples/tutorials/advanced/earth_relief.py
+++ b/examples/tutorials/advanced/earth_relief.py
@@ -31,7 +31,7 @@ fig.show()
 
 ###############################################################################
 #
-# :meth:`pygmt.Figure.grdimage` can take the optional argument ``projection``
+# :meth:`pygmt.Figure.grdimage` can take the optional parameter ``projection``
 # for the map. In the example below, the ``projection`` is set as ``R12c`` for
 # 12 centimeter figure with a Winkel Tripel projection. For a list of available
 # projections, see :gmt-docs:`cookbook/map-projections.html`.
@@ -44,7 +44,7 @@ fig.show()
 # Set a color map
 # ---------------
 #
-# :meth:`pygmt.Figure.grdimage` takes the ``cmap`` argument to set the CPT of
+# :meth:`pygmt.Figure.grdimage` takes the ``cmap`` parameter to set the CPT of
 # the figure. Examples of common CPTs for Earth relief are shown below.
 # A full list of CPTs can be found at :gmt-docs:`cookbook/cpts.html`.
 
@@ -70,7 +70,7 @@ fig.show()
 #
 # The :meth:`pygmt.Figure.colorbar` method displays the CPT and the associated
 # Z-values of the figure, and by default uses the same CPT set by the ``cmap``
-# argument for :meth:`pygmt.Figure.grdimage`. The ``frame`` argument for
+# parameter for :meth:`pygmt.Figure.grdimage`. The ``frame`` parameter for
 # :meth:`pygmt.Figure.colorbar` can be used to set the axis intervals and
 # labels. A list is used to pass multiple arguments to ``frame``. In the
 # example below, ``a2500`` sets the axis interval to 2,500, ``x+lElevation``
@@ -85,9 +85,9 @@ fig.show()
 # Create a region map
 # -------------------
 #
-# In addition to providing global data, the ``region`` argument for
+# In addition to providing global data, the ``region`` parameter for
 # :meth:`pygmt.datasets.load_earth_relief` can be used to provide data for a
-# specific area. The ``region`` argument is required for resolutions at 5 arc
+# specific area. The ``region`` parameter is required for resolutions at 5 arc
 # minutes or higher, and accepts a list (as in the example below) or a string.
 # The geographic ranges are passed as *xmin*/*xmax*/*ymin*/*ymax*.
 #


### PR DESCRIPTION
**Description of proposed changes**

Related to the decision in issue #886 this PR aims to update the tutorial [Plotting Earth relief](https://www.pygmt.org/dev/tutorials/advanced/earth_relief.html#sphx-glr-tutorials-advanced-earth-relief-py) to use 'parameter' instead of 'argument'. Only in the subsection [Add a color bar](https://www.pygmt.org/dev/tutorials/advanced/earth_relief.html#add-a-color-bar) 'argument' is kept: `A list is used to pass multiple arguments to frame.`.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
