### PR TITLE
Fix typos in subsection 'Code Style' of the Contributors Guide

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -491,7 +491,7 @@ For consistency, we also use UNIX-style line endings (`\n`) and file permission
 Don't worry if you forget to do it. Our continuous integration systems will
 warn us and you can make a new commit with the formatted code.
 Even better, you can just write `/format` in the first line of any comment in a
-Pull Request to lint the code automatically.
+pull request to lint the code automatically.
 
 When wrapping a new alias, use an underscore to separate words bridged by vowels
 (aeiou), such as `no_skip` and `z_only`. Do not use an underscore to separate

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -471,7 +471,7 @@ code, be sure to follow the general guidelines in the
 
 ### Code Style
 
-We use some tools to to format the code so we don't have to think about it:
+We use some tools to format the code so we don't have to think about it:
 
 - [Black](https://github.com/psf/black)
 - [blackdoc](https://github.com/keewis/blackdoc)


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix two typos in the [Code Style](https://www.pygmt.org/dev/contributing.html#code-style) subsection of the Contributors Guide.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
