### PR TITLE
Remove json files from paths-ignore list in workflows

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -10,7 +10,6 @@ on:
     paths-ignore:
       - 'pygmt/tests/**'
       - '*.md'
-      - '*.json'
       - 'LICENSE.txt'
       - '.gitignore'
   release:

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -11,7 +11,6 @@ on:
       - 'doc/**'
       - 'examples/**'
       - '*.md'
-      - '*.json'
       - 'README.rst'
       - 'LICENSE.txt'
       - '.gitignore'

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -11,7 +11,6 @@ on:
       - 'doc/**'
       - 'examples/**'
       - '*.md'
-      - '*.json'
       - 'README.rst'
       - 'LICENSE.txt'
       - '.gitignore'


### PR DESCRIPTION
**Description of proposed changes**

Our repository no longer have json files, so it's safe to remove it from the `paths-ignore` list in the workflows.
