### PR TITLE
Lint docstrings using docformatter 1.5.0

### DIFF
--- a/pygmt/src/filter1d.py
+++ b/pygmt/src/filter1d.py
@@ -106,7 +106,6 @@ def filter1d(data, output_type="pandas", outfile=None, **kwargs):
         - :class:`pandas.DataFrame` or :class:`numpy.ndarray` if ``outfile`` is
           not set (depends on ``output_type`` [Default is
           :class:`pandas.DataFrame`])
-
     """
     if kwargs.get("F") is None:
         raise GMTInvalidInput("Pass a required argument to 'filter_type'.")

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -43,8 +43,8 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
 )
 def histogram(self, data, **kwargs):
     r"""
-    Plots a histogram, and can read data from a file or
-    list, array, or dataframe.
+    Plots a histogram, and can read data from a file or list, array, or
+    dataframe.
 
     Full option list at :gmt-docs:`histogram.html`
 

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -38,7 +38,7 @@ __doctest_skip__ = ["nearneighbor"]
 @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma")
 def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
     r"""
-    Grid table data using a "Nearest neighbor" algorithm
+    Grid table data using a "Nearest neighbor" algorithm.
 
     **nearneighbor** reads arbitrarily located (*x,y,z*\ [,\ *w*]) triples
     [quadruplets] and uses a nearest neighbor algorithm to assign a weighted


### PR DESCRIPTION
**Description of proposed changes**

Docformatter v1.5.0 released 18 Aug 2022 has some stricter styles for the docstring. See https://github.com/PyCQA/docformatter/blob/master/CHANGELOG.md#v150-2022-08-11.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Specifically, this PR will remove an empty line in filter1d.py, edit a line wrapping in histogram.py and add a fullstop in nearneighbor.py

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes Style Checks error at https://github.com/GenericMappingTools/pygmt/runs/7928377646?check_suite_focus=true#step:5:15


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
