### PR TITLE
WIP: Debug Windows docs build by showing execution traceback in sphinx log

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -33,7 +33,7 @@ jobs:
         exclude:
           - os: macOS-latest
             isDraft: true
-          - os: windows-latest
+          - os: ubuntu-latest
             isDraft: true
     timeout-minutes: 30
     defaults:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -33,7 +33,7 @@ html: api
 	@echo "Building HTML files."
 	@echo
 	# Set PYGMT_USE_EXTERNAL_DISPLAY to "false" to disable external display
-	PYGMT_USE_EXTERNAL_DISPLAY="false" $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	PYGMT_USE_EXTERNAL_DISPLAY="false" $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -v
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -125,6 +125,7 @@ sphinx_gallery_conf = {
 # Sphinx project configuration
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "**.ipynb_checkpoints"]
+execution_show_tb = True
 source_suffix = ".rst"
 needs_sphinx = "1.8"
 # The encoding of source files.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -125,7 +125,6 @@ sphinx_gallery_conf = {
 # Sphinx project configuration
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "**.ipynb_checkpoints"]
-execution_show_tb = True
 source_suffix = ".rst"
 needs_sphinx = "1.8"
 # The encoding of source files.


### PR DESCRIPTION
**Description of proposed changes**

Windows docs build is failing occasionally sometimes, but we can't see much from the GitHub Actions CI logs. ~~See if setting sphinx config `execution_show_tb = True` will help.~~ Nope, might only work for myst-nb, not rst files, so trying `sphinx-build -v` instead

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Full traceback (not particularly informative) from https://github.com/GenericMappingTools/pygmt/runs/7928433059?check_suite_focus=true#step:10:50:

<details>

```python-traceback
Run make -C doc clean all
make: Entering directory 'D:/a/pygmt/pygmt/doc'
rm -rf _build
rm -rf api/generated
rm -rf gallery
rm -rf tutorials
rm -rf get-started
rm -rf projections

Generating rst source files of API documentation.

sphinx-autogen -i -t _templates -o api/generated api/*.rst
[autosummary] generating autosummary for: api/index.rst
[autosummary] writing to api/generated
[autosummary] generating autosummary for: api/generated\pygmt.Figure.basemap.rst, api/generated\pygmt.Figure.coast.rst, api/generated\pygmt.Figure.colorbar.rst, api/generated\pygmt.Figure.contour.rst, api/generated\pygmt.Figure.grdcontour.rst, api/generated\pygmt.Figure.grdimage.rst, api/generated\pygmt.Figure.grdview.rst, api/generated\pygmt.Figure.histogram.rst, api/generated\pygmt.Figure.image.rst, api/generated\pygmt.Figure.inset.rst, ..., api/generated\pygmt.sphinterpolate.rst, api/generated\pygmt.surface.rst, api/generated\pygmt.test.rst, api/generated\pygmt.triangulate.delaunay_triples.rst, api/generated\pygmt.triangulate.regular_grid.rst, api/generated\pygmt.triangulate.rst, api/generated\pygmt.which.rst, api/generated\pygmt.x2sys_cross.rst, api/generated\pygmt.x2sys_init.rst, api/generated\pygmt.xyz2grd.rst
[autosummary] writing to api/generated

Building HTML files.

# Set PYGMT_USE_EXTERNAL_DISPLAY to "false" to disable external display
PYGMT_USE_EXTERNAL_DISPLAY="false" sphinx-build -b html -d _build/doctrees  -j auto . _build/html
Running Sphinx v5.1.1
making output directory... done
myst v0.18.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=['colon_fence'], disable_syntax=[], all_links_external=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, highlight_code_blocks=True, number_code_blocks=[], title_to_header=False, heading_anchors=4, heading_slug_func=None, footnote_transition=True, words_per_minute=200, sub_delimiters=('{', '}'), linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area')
WARNING: extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'.
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
loading intersphinx inventory from https://geopandas.org/en/stable/objects.inv...
loading intersphinx inventory from https://numpy.org/doc/stable/objects.inv...
loading intersphinx inventory from https://pandas.pydata.org/pandas-docs/stable/objects.inv...
loading intersphinx inventory from https://xarray.pydata.org/en/stable/objects.inv...
intersphinx inventory has moved: https://xarray.pydata.org/en/stable/objects.inv -> https://docs.xarray.dev/en/stable/objects.inv
generating gallery...
Using Sphinx-Gallery to convert rst text blocks to markdown for .ipynb files.
generating gallery for gallery\maps... [ 33%] land_and_water.py                
generating gallery for gallery\maps... [ 66%] borders.py                       
generating gallery for gallery\maps... [100%] shorelines.py                    

generating gallery for gallery\lines... [ 12%] vector_styles.py                
generating gallery for gallery\lines... [ 25%] great_circles.py                
generating gallery for gallery\lines... [ 37%] line_custom_cpt.py              
generating gallery for gallery\lines... [ 50%] linefronts.py                   
generating gallery for gallery\lines... [ 62%] linestyles.py                   
generating gallery for gallery\lines... [ 75%] roads.py                        
make: *** [Makefile:36: html] Error 127
generating gallery for gallery\lines... [ 87%] vector_heads_tails.py           
make: Leaving directory 'D:/a/pygmt/pygmt/doc'
Error: Process completed with exit code 2.
```

</details>

References:
- https://jupyterbook.org/en/stable/content/execute.html#execution-tracebacks-in-the-terminal
- https://myst-nb.readthedocs.io/en/v0.16.0/configuration.html#id1

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
