### PR TITLE
Add optional dependencies to pyproject.toml

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -220,8 +220,8 @@ This installs the latest stable release from
 
 .. tip::
 
-   You can also run ``pip install pygmt[all]`` to install pygmt alongside with
-   all its optional dependencies.
+   You can also run ``pip install pygmt[all]`` to install pygmt with
+   all of its optional dependencies.
 
 Alternatively, you can install the latest development version from
 `TestPyPI <https://test.pypi.org/project/pygmt>`__::

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -218,6 +218,11 @@ This installs the latest stable release from
 
     pip install pygmt
 
+.. tips::
+
+   You can also run ``pip install pygmt[all]`` to install pygmt alongside with
+   all its optional dependencies.
+
 Alternatively, you can install the latest development version from
 `TestPyPI <https://test.pypi.org/project/pygmt>`__::
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -218,7 +218,7 @@ This installs the latest stable release from
 
     pip install pygmt
 
-.. tips::
+.. tip::
 
    You can also run ``pip install pygmt[all]`` to install pygmt alongside with
    all its optional dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 all = [
-    "geopandas"
+    "geopandas",
+    "ipython"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+all = [
+    "geopandas"
+]
+
 [project.urls]
 homepage = "https://www.pygmt.org"
 documentation = "https://www.pygmt.org"


### PR DESCRIPTION
**Description of proposed changes**

As suggested in https://github.com/GenericMappingTools/pygmt/pull/1848#discussion_r949080477, this PR adds `optional-dependencies` to pyproject.toml so that people can run `pip install pygmt[all]` to install pygmt with optional dependencies included. 

To test it locally, you can check out this branch, change into the root directory, and run
```
pip install .
```
and 
```
pip install .[all]
```
you should see that `pip install .[all]` also check if geopandas is installed while `pip install .` doesn't.

Address https://github.com/GenericMappingTools/pygmt/pull/1848#discussion_r949080477.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
