### PR TITLE
Test test_accessor_sliced_datacube now passes with GMT 6.5.0

### DIFF
--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -79,9 +79,8 @@ def test_accessor_set_non_boolean():
     reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/6615",
 )
 @pytest.mark.xfail(
-    condition=sys.platform == "win32",
-    reason="PermissionError on Windows when deleting eraint_uvz.nc file; "
-    "see https://github.com/GenericMappingTools/pygmt/pull/2073",
+    condition=sys.platform == "win32" and Version(__gmt_version__) < Version("6.5.0"),
+    reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/7573",
 )
 def test_accessor_sliced_datacube():
     """


### PR DESCRIPTION
**Description of proposed changes**

Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/7573.

Related to #2062

The test:

- pass on Linux/macOS for GMT 6.4
- xfail on Windows for GMT 6.4
- pass on Linux/macOS/Windows for GMT dev (6.5.0) after https://github.com/GenericMappingTools/gmt/pull/7573