### PR TITLE
Mark tests test_accessor_sliced_datacube and test_grdview_drapegrid_dataarray as xfail

### DIFF
--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -6,8 +6,12 @@ import sys
 
 import pytest
 import xarray as xr
-from pygmt import which
+from packaging.version import Version
+from pygmt import clib, which
 from pygmt.exceptions import GMTInvalidInput
+
+with clib.Session() as _lib:
+    gmt_version = Version(_lib.info["version"])
 
 
 def test_accessor_gridline_cartesian():
@@ -71,6 +75,10 @@ def test_accessor_set_non_boolean():
         grid.gmt.gtype = 2
 
 
+@pytest.mark.skipif(
+    gmt_version == Version("6.3.0"),
+    reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/6615",
+)
 @pytest.mark.xfail(
     condition=sys.platform == "win32",
     reason="PermissionError on Windows when deleting eraint_uvz.nc file; "

--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -2,6 +2,7 @@
 Test the behaviour of the GMTDataArrayAccessor class.
 """
 import os
+import sys
 
 import pytest
 import xarray as xr
@@ -70,7 +71,11 @@ def test_accessor_set_non_boolean():
         grid.gmt.gtype = 2
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(
+    condition=sys.platform == "win32",
+    reason="PermissionError on Windows when deleting eraint_uvz.nc file; "
+    "see https://github.com/GenericMappingTools/pygmt/pull/2073",
+)
 def test_accessor_sliced_datacube():
     """
     Check that a 2D grid which is sliced from an n-dimensional datacube works

--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -5,12 +5,8 @@ import os
 
 import pytest
 import xarray as xr
-from packaging.version import Version
-from pygmt import clib, which
+from pygmt import which
 from pygmt.exceptions import GMTInvalidInput
-
-with clib.Session() as _lib:
-    gmt_version = Version(_lib.info["version"])
 
 
 def test_accessor_gridline_cartesian():
@@ -74,10 +70,7 @@ def test_accessor_set_non_boolean():
         grid.gmt.gtype = 2
 
 
-@pytest.mark.skipif(
-    gmt_version < Version("6.4.0"),
-    reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/6615",
-)
+@pytest.mark.xfail
 def test_accessor_sliced_datacube():
     """
     Check that a 2D grid which is sliced from an n-dimensional datacube works

--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -76,7 +76,7 @@ def test_accessor_set_non_boolean():
 
 
 @pytest.mark.skipif(
-    gmt_version < Version("6.3.0"),
+    gmt_version < Version("6.4.0"),
     reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/6615",
 )
 @pytest.mark.xfail(

--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -76,7 +76,7 @@ def test_accessor_set_non_boolean():
 
 
 @pytest.mark.skipif(
-    gmt_version == Version("6.3.0"),
+    gmt_version < Version("6.3.0"),
     reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/6615",
 )
 @pytest.mark.xfail(

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -214,7 +214,10 @@ def test_grdview_on_a_plane_styled_with_facadepen(xrgrid):
     return fig
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(
+    reason="Generated images are different from the baseline images on three platforms. "
+    "See https://github.com/GenericMappingTools/pygmt/issues/2062#issuecomment-1220680290"
+)
 @pytest.mark.mpl_image_compare
 def test_grdview_drapegrid_dataarray(xrgrid):
     """

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -214,6 +214,7 @@ def test_grdview_on_a_plane_styled_with_facadepen(xrgrid):
     return fig
 
 
+@pytest.mark.xfail
 @pytest.mark.mpl_image_compare
 def test_grdview_drapegrid_dataarray(xrgrid):
     """


### PR DESCRIPTION
**Description of proposed changes**

Closes https://github.com/GenericMappingTools/pygmt/issues/1989.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
