### PR TITLE
Replace 'argument' by 'parameter' in 'contour_map.py' and 'lines.py'

### DIFF
--- a/examples/tutorials/advanced/contour_map.py
+++ b/examples/tutorials/advanced/contour_map.py
@@ -31,7 +31,7 @@ fig.show()
 # Contour line settings
 # ---------------------
 #
-# Use the ``annotation`` and ``interval`` arguments to adjust contour line
+# Use the ``annotation`` and ``interval`` parameters to adjust contour line
 # intervals. In the example below, there are contour intervals every 250 meters
 # and annotated contour lines every 1,000 meters.
 
@@ -47,8 +47,8 @@ fig.show()
 # Contour limits
 # --------------
 #
-# The ``limit`` argument sets the minimum and maximum values for the contour
-# lines. The argument takes the low and high values, and is either a list (as
+# The ``limit`` parameter sets the minimum and maximum values for the contour
+# lines. The parameter takes the low and high values, and is either a list (as
 # below) or a string ``limit="-4000/-2000"``.
 
 fig = pygmt.Figure()
@@ -64,7 +64,7 @@ fig.show()
 # Map settings
 # ------------
 #
-# The :meth:`pygmt.Figure.grdcontour` method accepts additional arguments,
+# The :meth:`pygmt.Figure.grdcontour` method accepts additional parameters,
 # including setting the projection and frame.
 
 fig = pygmt.Figure()
@@ -85,7 +85,7 @@ fig.show()
 # The :meth:`pygmt.Figure.grdimage` method can be used to add a
 # colormap to the contour map. It must be called prior to
 # :meth:`pygmt.Figure.grdcontour` to keep the contour lines visible on the
-# final map. If the ``projection`` argument is specified in the
+# final map. If the ``projection`` parameter is specified in the
 # :meth:`pygmt.Figure.grdimage` method, it does not need to be repeated in the
 # :meth:`pygmt.Figure.grdcontour` method.
 

--- a/examples/tutorials/basics/lines.py
+++ b/examples/tutorials/basics/lines.py
@@ -44,7 +44,7 @@ fig.show()
 
 ###############################################################################
 # To plot multiple lines, :meth:`pygmt.Figure.plot` needs to be used for each
-# additional line. Arguments such as ``region``, ``projection``, and ``frame``
+# additional line. Parameters such as ``region``, ``projection``, and ``frame``
 # do not need to be repeated in subsequent uses.
 
 fig = pygmt.Figure()


### PR DESCRIPTION
**Description of proposed changes**

Related to the decision in issue #886 this PR aims to update the tutorial [Creating a map with contour lines](https://www.pygmt.org/dev/tutorials/advanced/contour_map.html#sphx-glr-tutorials-advanced-contour-map-py) to use 'parameter' instead of 'argument'.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
