### PR TITLE
Remove tomli from GMT Tests and GMT Dev Tests workflows

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -93,7 +93,7 @@ jobs:
                         pandas xarray netCDF4 packaging \
                         ${{ matrix.optional-packages }} \
                         build dvc make pytest>=6.0 \
-                        pytest-cov pytest-doctestplus pytest-mpl sphinx-gallery tomli
+                        pytest-cov pytest-doctestplus pytest-mpl sphinx-gallery
 
       # Show installed pkg information for postmortem diagnostic
       - name: List installed packages

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -101,7 +101,7 @@ jobs:
           pip install --pre --prefer-binary \
                         numpy pandas xarray netCDF4 packaging \
                         build dvc ipython 'pytest>=6.0' pytest-cov \
-                        pytest-doctestplus pytest-mpl sphinx-gallery tomli
+                        pytest-doctestplus pytest-mpl sphinx-gallery
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote


### PR DESCRIPTION
**Description of proposed changes**

`tomli` was added as a CI dependency in https://github.com/GenericMappingTools/pygmt/pull/1564 and https://github.com/GenericMappingTools/pygmt/pull/1401 due to the issue https://github.com/GenericMappingTools/pygmt/issues/1392.

It seems now it's OK to remove it.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
