### PR TITLE
Add badges for conda package version, license and twitter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ PyGMT
 .. image:: http://img.shields.io/pypi/v/pygmt.svg?style=flat-square
     :alt: Latest version on PyPI
     :target: https://pypi.python.org/pypi/pygmt
-.. image:: https://anaconda.org/conda-forge/pygmt/badges/installer/conda.svg
+.. image:: https://img.shields.io/conda/v/conda-forge/pygmt?style=flat-square
     :alt: Latest version on conda-forge
     :target: https://anaconda.org/conda-forge/pygmt
 .. image:: https://github.com/GenericMappingTools/pygmt/workflows/Tests/badge.svg
@@ -31,9 +31,15 @@ PyGMT
 .. image:: https://zenodo.org/badge/DOI/10.5281/3781524.svg
     :alt: Digital Object Identifier for the Zenodo archive
     :target: https://doi.org/10.5281/zenodo.3781524
+.. image:: https://img.shields.io/github/license/GenericMappingTools/pygmt?style=flat-square
+    :alt: GitHub license
+    :target: https://github.com/GenericMappingTools/pygmt/blob/main/LICENSE.txt
 .. image:: https://img.shields.io/badge/Contributor%20Covenant-v2.1%20adopted-ff69b4.svg
     :alt: Contributor Code of Conduct
     :target: CODE_OF_CONDUCT.md
+.. image:: https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2Fgmt_dev
+    :alt: Twitter URL
+    :target: https://twitter.com/gmt_dev
 
 .. placeholder-for-doc-index
 

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ PyGMT
 .. image:: https://img.shields.io/badge/Contributor%20Covenant-v2.1%20adopted-ff69b4.svg
     :alt: Contributor Code of Conduct
     :target: CODE_OF_CONDUCT.md
-.. image:: https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2Fgmt_dev
+.. image:: https://img.shields.io/twitter/follow/gmt_dev?style=social
     :alt: Twitter URL
     :target: https://twitter.com/gmt_dev
 


### PR DESCRIPTION
**Description of proposed changes**

1. Change the "Install with conda" badge to the "conda package version" badge so that we know the pygmt conda package is up-to-date
2. Add a badge for the project license
3. Add a social badge which is linked to twitter `@gmt_dev`

**Before:**
<img width="843" alt="image" src="https://user-images.githubusercontent.com/3974108/186553550-787e9547-87ed-436c-b784-bd87c951c2d1.png">

**After**

<img width="889" alt="image" src="https://user-images.githubusercontent.com/3974108/186553588-734d0722-d07d-49cc-9eaa-6273080fe540.png">

Edit:

New version:
<img width="890" alt="image" src="https://user-images.githubusercontent.com/3974108/186821476-862180b8-9c2d-4bec-a319-aaa8d952c4dd.png">
