### PR TITLE
Fix typos in tutorial 'Making subplots'

### DIFF
--- a/examples/tutorials/advanced/subplots.py
+++ b/examples/tutorials/advanced/subplots.py
@@ -153,12 +153,12 @@ fig.show()
 #     before.
 
 ###############################################################################
-# Shared X- and Y-axis labels
+# Shared x- and y-axis labels
 # --------------------------
 # In the example above with the four subplots, the two subplots for each row
-# have the same Y-axis range, and the two subplots for each column have the
-# same X-axis range. You can use the ``sharex``/``sharey`` parameters to set a
-# common X-and/or Y-axis between subplots.
+# have the same y-axis range, and the two subplots for each column have the
+# same x-axis range. You can use the ``sharex``/``sharey`` parameters to set a
+# common x-and/or y-axis between subplots.
 
 fig = pygmt.Figure()
 with fig.subplot(

--- a/examples/tutorials/advanced/subplots.py
+++ b/examples/tutorials/advanced/subplots.py
@@ -115,7 +115,7 @@ fig.show()
 # 15 cm wide and 6 cm high (``figsize=["15c", "6c"]``). In addition, we use
 # some optional parameters to fine-tune some details of the figure creation:
 #
-# - ``autolabel=True``: Each subplot is automatically labelled abcd.
+# - ``autolabel=True``: Each subplot is automatically labelled 'abcd'.
 # - ``margins=["0.1c", "0.2c"]``: Adjusts the space between adjacent subplots.
 #   In this case, it is set as 0.1 cm in the x-direction and 0.2 cm in the
 #   y-direction.

--- a/examples/tutorials/advanced/subplots.py
+++ b/examples/tutorials/advanced/subplots.py
@@ -116,10 +116,10 @@ fig.show()
 # some optional parameters to fine-tune some details of the figure creation:
 #
 # - ``autolabel=True``: Each subplot is automatically labelled abcd
-# - ``margins=["0.1c", "0.2c"]``: adjusts the space between adjacent subplots.
+# - ``margins=["0.1c", "0.2c"]``: Adjusts the space between adjacent subplots.
 #   In this case, it is set as 0.1 cm in the x-direction and 0.2 cm in the
 #   y-direction.
-# - ``title="My Subplot Heading"``: adds a title on top of the whole figure.
+# - ``title="My Subplot Heading"``: Adds a title on top of the whole figure.
 #
 # Notice that each subplot was set to use a linear projection ``"X?"``.
 # Usually, we need to specify the width and height of the map frame, but it is

--- a/examples/tutorials/advanced/subplots.py
+++ b/examples/tutorials/advanced/subplots.py
@@ -153,7 +153,7 @@ fig.show()
 #     before.
 
 ###############################################################################
-# Shared x- and y-axis
+# Shared x- and y-axes
 # --------------------
 # In the example above with the four subplots, the two subplots for each row
 # have the same y-axis range, and the two subplots for each column have the

--- a/examples/tutorials/advanced/subplots.py
+++ b/examples/tutorials/advanced/subplots.py
@@ -184,9 +184,9 @@ fig.show()
 # subplots within a row will share the y-axis, and only the **l**\ eft axis is
 # displayed.
 #
-# Of course, instead of using the ``sharex``/``sharey`` option, you can also
-# set a different ``frame`` for each subplot to control the axis properties
-# individually for each subplot.
+# Of course, instead of using the ``sharex``/``sharey`` parameters, you can
+# also set a different ``frame`` for each subplot to control the axis
+# properties individually for each subplot.
 
 ###############################################################################
 # Advanced subplot layouts

--- a/examples/tutorials/advanced/subplots.py
+++ b/examples/tutorials/advanced/subplots.py
@@ -115,7 +115,7 @@ fig.show()
 # 15 cm wide and 6 cm high (``figsize=["15c", "6c"]``). In addition, we use
 # some optional parameters to fine-tune some details of the figure creation:
 #
-# - ``autolabel=True``: Each subplot is automatically labelled abcd
+# - ``autolabel=True``: Each subplot is automatically labelled abcd.
 # - ``margins=["0.1c", "0.2c"]``: Adjusts the space between adjacent subplots.
 #   In this case, it is set as 0.1 cm in the x-direction and 0.2 cm in the
 #   y-direction.

--- a/examples/tutorials/advanced/subplots.py
+++ b/examples/tutorials/advanced/subplots.py
@@ -158,7 +158,7 @@ fig.show()
 # In the example above with the four subplots, the two subplots for each row
 # have the same y-axis range, and the two subplots for each column have the
 # same x-axis range. You can use the ``sharex``/``sharey`` parameters to set a
-# common x-and/or y-axis between subplots.
+# common x- and/or y-axis between subplots.
 
 fig = pygmt.Figure()
 with fig.subplot(

--- a/examples/tutorials/advanced/subplots.py
+++ b/examples/tutorials/advanced/subplots.py
@@ -117,8 +117,8 @@ fig.show()
 #
 # - ``autolabel=True``: Each subplot is automatically labelled abcd
 # - ``margins=["0.1c", "0.2c"]``: adjusts the space between adjacent subplots.
-#   In this case, it is set as 0.1 cm in the X direction and 0.2 cm in the Y
-#   direction.
+#   In this case, it is set as 0.1 cm in the x-direction and 0.2 cm in the
+#   y-direction.
 # - ``title="My Subplot Heading"``: adds a title on top of the whole figure.
 #
 # Notice that each subplot was set to use a linear projection ``"X?"``.

--- a/examples/tutorials/advanced/subplots.py
+++ b/examples/tutorials/advanced/subplots.py
@@ -153,12 +153,12 @@ fig.show()
 #     before.
 
 ###############################################################################
-# Shared X and Y axis labels
+# Shared X- and Y-axis labels
 # --------------------------
 # In the example above with the four subplots, the two subplots for each row
 # have the same Y-axis range, and the two subplots for each column have the
 # same X-axis range. You can use the ``sharex``/``sharey`` parameters to set a
-# common X and/or Y axis between subplots.
+# common X-and/or Y-axis between subplots.
 
 fig = pygmt.Figure()
 with fig.subplot(

--- a/examples/tutorials/advanced/subplots.py
+++ b/examples/tutorials/advanced/subplots.py
@@ -153,8 +153,8 @@ fig.show()
 #     before.
 
 ###############################################################################
-# Shared x- and y-axis labels
-# --------------------------
+# Shared x- and y-axis
+# --------------------
 # In the example above with the four subplots, the two subplots for each row
 # have the same y-axis range, and the two subplots for each column have the
 # same x-axis range. You can use the ``sharex``/``sharey`` parameters to set a


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a few typos for the sake of consistency in the tutorial [Making subplots](https://www.pygmt.org/dev/tutorials/advanced/subplots.html#sphx-glr-tutorials-advanced-subplots-py). In case upper-case letters for `X`- / `Y`-axis / direction are preferred I can change this.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
