### PR TITLE
Fix tiny typo in syntax in documentation of `pygmt.Figure.meca`

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -204,7 +204,7 @@ def meca(
         ``event_name`` values in ``spec`` if ``spec`` is a dict or
         pd.DataFrame.
     offset: bool or str
-        [**+p**\ *pen*][**+s**\ *size].
+        [**+p**\ *pen*][**+s**\ *size*].
         Offsets beachballs to the longitude, latitude specified in the last two
         columns of the input file or array, or by ``plot_longitude`` and
         ``plot_latitude`` if provided. A small circle is plotted at the initial


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a very tiny typo in the syntax in the API documentation of [pygmt.Figure.meca](https://www.pygmt.org/dev/api/generated/pygmt.Figure.meca.html#pygmt.Figure.meca).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
