### PR TITLE
Fix typos in coastlines.py, grd2cpt.py, and earth_age.py

### DIFF
--- a/examples/tutorials/basics/coastlines.py
+++ b/examples/tutorials/basics/coastlines.py
@@ -28,7 +28,7 @@ fig.show()
 # 4. lake-in-island-in-lake shore
 #
 # You can specify which level you want to plot by passing the level number and
-# a GMT pen configuration. For example, to plot just the coastlines with 0.5
+# a GMT pen configuration. For example, to plot just the coastlines with 0.5p
 # thickness and black lines:
 
 fig = pygmt.Figure()

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -32,7 +32,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     ----------
     resolution : str
         The grid resolution. The suffix ``d`` and ``m`` stand for
-        arc-degree, arc-minute and arc-second. It can be ``"01d"``, ``"30m"``,
+        arc-degree and arc-minute. It can be ``"01d"``, ``"30m"``,
         ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``,
         ``"03m"``, ``"02m"``, or ``"01m"``.
 

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -124,7 +124,7 @@ def grd2cpt(grid, **kwargs):
         also :gmt-docs:`cookbook/features.html#manipulating-cpts`.
     output : str
         Optional parameter to set the file name with extension .cpt to store
-        the generated CPT file. If not given or False (Default), saves the CPT
+        the generated CPT file. If not given or False [Default], saves the CPT
         as the session current CPT.
     reverse : str
         Set this to True or c [Default] to reverse the sense of color


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix some typos.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
