### PR TITLE
Replace 'option' by 'parameter' in documentation of `pygmt.Figure.velo`, `pygmt.select`, `pygmt.which`

### DIFF
--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -56,7 +56,7 @@ def select(data=None, outfile=None, **kwargs):
     7. inside bins of a grid mask whose nodes are non-zero
 
     The sense of the tests can be reversed for each of these 7 criteria by
-    using the ``reverse`` option.
+    using the ``reverse`` parameter.
 
     Full option list at :gmt-docs:`gmtselect.html`
 

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -79,9 +79,9 @@ def velo(self, data=None, **kwargs):
           confidence ellipse. Use **+f** to set the font and size of the text
           [Default is 9p,Helvetica,black]; give **+f**\ 0 to deactivate
           labeling. The arrow will be drawn with the pen attributes specified
-          by the ``pen`` option and the arrow-head can be colored via
+          by the ``pen`` parameter and the arrow-head can be colored via
           ``color``. The ellipse will be filled with the color or shade
-          specified by the ``uncertaintycolor`` option [Default is
+          specified by the ``uncertaintycolor`` parameter [Default is
           transparent], and its outline will be drawn if ``line`` is selected
           using the pen selected (by ``pen`` if not given by ``line``).
           Parameters are expected to be in the following columns:
@@ -112,9 +112,9 @@ def velo(self, data=None, **kwargs):
           confidence ellipse. Use **+f** to set the font and size of the text
           [Default is 9p,Helvetica,black]; give **+f**\ 0 to deactivate
           labeling. The arrow will be drawn with the pen attributes specified
-          by the ``pen`` option and the arrow-head can be colored via
+          by the ``pen`` parameter and the arrow-head can be colored via
           ``color``. The ellipse will be filled with the color or shade
-          specified by the ``uncertaintycolor`` option [Default is
+          specified by the ``uncertaintycolor`` parameter [Default is
           transparent], and its outline will be drawn if ``line`` is selected
           using the pen selected (by ``pen`` if not given by ``line``).
           Parameters are expected to be in the following columns:

--- a/pygmt/src/which.py
+++ b/pygmt/src/which.py
@@ -25,7 +25,7 @@ def which(fname, **kwargs):
 
     ``fname`` can also be a downloadable file (either a full URL, a
     `@file` special file for downloading from the GMT Site Cache, or
-    `@earth_relief_*` topography grids). In these cases, use option
+    `@earth_relief_*` topography grids). In these cases, use parameter
     ``download`` to set the desired behavior. If ``download`` is not used
     (or False), the file will not be found.
 
@@ -53,7 +53,7 @@ def which(fname, **kwargs):
     Returns
     -------
     path : str or list
-        The path(s) to the file(s), depending on the options used.
+        The path(s) to the file(s), depending on the parameters used.
 
     Raises
     ------


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to replace `option` by `parameter` in the API documentation of [pygmt.Figure.velo](https://www.pygmt.org/dev/api/generated/pygmt.Figure.velo.html#pygmt.Figure.velo), [pygmt.select](https://www.pygmt.org/dev/api/generated/pygmt.select.html#pygmt.select), and [pygmt.which](https://www.pygmt.org/dev/api/generated/pygmt.which.html#pygmt.which) as mention in https://github.com/GenericMappingTools/pygmt/pull/2082#issuecomment-1230847484.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
