### PR TITLE
Replace single by double quotation marks in documentation of `pygmt.Figure.velo`, `pygmt.grd2cpt`, `pygmt.Figure.subplot`

### DIFF
--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -86,10 +86,10 @@ def grd2cpt(grid, **kwargs):
     background : bool or str
         Select the back- and foreground colors to match the colors for lowest
         and highest *z*-values in the output CPT [Default (``background=True``
-        or ``background='o'``) uses the colors specified in the master file, or
+        or ``background="o"``) uses the colors specified in the master file, or
         those defined by the parameters :gmt-term:`COLOR_BACKGROUND`,
         :gmt-term:`COLOR_FOREGROUND`, and :gmt-term:`COLOR_NAN`]. Use
-        ``background='i'`` to match the colors for the lowest and highest
+        ``background="i"`` to match the colors for the lowest and highest
         values in the input (instead of the output) CPT.
     color_model :
         [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*]].
@@ -153,7 +153,7 @@ def grd2cpt(grid, **kwargs):
         Do not interpolate the input color table but pick the output colors
         starting at the beginning of the color table, until colors for all
         intervals are assigned. This is particularly useful in combination with
-        a categorical color table, like ``cmap='categorical'``.
+        a categorical color table, like ``cmap="categorical"``.
     cyclic : bool
         Produce a wrapped (cyclic) color table that endlessly repeats its
         range. Note that ``cyclic=True`` cannot be set together with

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -92,7 +92,7 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
         **s** and **n**. No *side* means all sides (i.e. ``clearance="1c"``
         would set a clearance of 1 cm on all sides). The option is repeatable
         to set aside space on more than one side (e.g.
-        ``clearance=["w1c","s2c"]`` would set a clearance of 1 cm on west
+        ``clearance=["w1c", "s2c"]`` would set a clearance of 1 cm on west
         side and 2 cm on south side). Such space will be left untouched by
         the main map plotting but can be accessed by methods that plot
         scales, bars, text, etc.
@@ -104,9 +104,9 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
 
         - a single value (for same margin on all sides). E.g. ``"5c"``.
         - a pair of values (for setting separate horizontal and vertical
-          margins). E.g. ``["5c","3c"]``.
+          margins). E.g. ``["5c", "3c"]``.
         - a set of four values (for setting separate left, right, bottom, and
-          top margins). E.g. ``["1c","2c","3c","4c"]``.
+          top margins). E.g. ``["1c", "2c", "3c", "4c"]``.
 
         The actual gap created is always a sum of the margins for the two
         opposing sides (e.g., east plus west or south plus north margins)

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -89,10 +89,10 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
         Reserve a space of dimension *clearance* between the margin and the
         subplot on the specified side, using *side* values from **w**, **e**,
         **s**, or **n**; or **x** for both **w** and **e**; or **y** for both
-        **s** and **n**. No *side* means all sides (i.e. ``clearance='1c'``
+        **s** and **n**. No *side* means all sides (i.e. ``clearance="1c"``
         would set a clearance of 1 cm on all sides). The option is repeatable
-        to set aside space on more than one side (e.g. ``clearance=['w1c',
-        's2c']`` would set a clearance of 1 cm on west side and 2 cm on south
+        to set aside space on more than one side (e.g. ``clearance=["w1c",
+        "s2c"]`` would set a clearance of 1 cm on west side and 2 cm on south
         side). Such space will be left untouched by the main map plotting but
         can be accessed by methods that plot scales, bars, text, etc.
     {J}
@@ -101,11 +101,11 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
         the interior margins) in addition to the automatic space added for tick
         marks, annotations, and labels. The margins can be specified as either:
 
-        - a single value (for same margin on all sides). E.g. '5c'.
+        - a single value (for same margin on all sides). E.g. "5c".
         - a pair of values (for setting separate horizontal and vertical
-          margins). E.g. ['5c', '3c'].
+          margins). E.g. ["5c", "3c"].
         - a set of four values (for setting separate left, right, bottom, and
-          top margins). E.g. ['1c', '2c', '3c', '4c'].
+          top margins). E.g. ["1c", "2c", "3c", "4c"].
 
         The actual gap created is always a sum of the margins for the two
         opposing sides (e.g., east plus west or south plus north margins)
@@ -116,7 +116,7 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
         Set subplot layout for shared x-axes. Use when all subplots in a column
         share a common *x*-range. If ``sharex=True``, the first (i.e.,
         **t**\ op) and the last (i.e., **b**\ ottom) rows will have
-        *x*-annotations; use ``sharex='t'`` or ``sharex='b'`` to select only
+        *x*-annotations; use ``sharex="t"`` or ``sharex="b"`` to select only
         one of those two rows [both]. Append **+l** if annotated *x*-axes
         should have a label [none]; optionally append the label if it is the
         same for the entire subplot. Append **+t** to make space for subplot
@@ -126,7 +126,7 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
         Set subplot layout for shared y-axes. Use when all subplots in a row
         share a common *y*-range. If ``sharey=True``, the first (i.e.,
         **l**\ eft) and the last (i.e., **r**\ ight) columns will have
-        *y*-annotations; use ``sharey='l'`` or ``sharey='r'`` to select only
+        *y*-annotations; use ``sharey="l"`` or ``sharey="r"`` to select only
         one of those two columns [both]. Append **+l** if annotated *y*-axes
         will have a label [none]; optionally, append the label if it is the
         same for the entire subplot. Append **+p** to make all annotations
@@ -208,7 +208,7 @@ def set_panel(self, panel=None, **kwargs):
         Reserve a space of dimension *clearance* between the margin and the
         subplot on the specified side, using *side* values from **w**, **e**,
         **s**, or **n**. The option is repeatable to set aside space on more
-        than one side (e.g. ``clearance=['w1c', 's2c']`` would set a clearance
+        than one side (e.g. ``clearance=["w1c", "s2c"]`` would set a clearance
         of 1 cm on west side and 2 cm on south side). Such space will be left
         untouched by the main map plotting but can be accessed by methods that
         plot scales, bars, text, etc. This setting overrides the common

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -101,11 +101,11 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
         the interior margins) in addition to the automatic space added for tick
         marks, annotations, and labels. The margins can be specified as either:
 
-        - a single value (for same margin on all sides). E.g. "5c".
+        - a single value (for same margin on all sides). E.g. ``"5c"``.
         - a pair of values (for setting separate horizontal and vertical
-          margins). E.g. ["5c", "3c"].
+          margins). E.g. ``["5c", "3c"]``.
         - a set of four values (for setting separate left, right, bottom, and
-          top margins). E.g. ["1c", "2c", "3c", "4c"].
+          top margins). E.g. ``["1c", "2c", "3c", "4c"]``.
 
         The actual gap created is always a sum of the margins for the two
         opposing sides (e.g., east plus west or south plus north margins)

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -91,10 +91,11 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
         **s**, or **n**; or **x** for both **w** and **e**; or **y** for both
         **s** and **n**. No *side* means all sides (i.e. ``clearance="1c"``
         would set a clearance of 1 cm on all sides). The option is repeatable
-        to set aside space on more than one side (e.g. ``clearance=["w1c",
-        "s2c"]`` would set a clearance of 1 cm on west side and 2 cm on south
-        side). Such space will be left untouched by the main map plotting but
-        can be accessed by methods that plot scales, bars, text, etc.
+        to set aside space on more than one side (e.g.
+        ``clearance=["w1c","s2c"]`` would set a clearance of 1 cm on west
+        side and 2 cm on south side). Such space will be left untouched by
+        the main map plotting but can be accessed by methods that plot
+        scales, bars, text, etc.
     {J}
     margins : str or list
         This is margin space that is added between neighboring subplots (i.e.,
@@ -103,9 +104,9 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
 
         - a single value (for same margin on all sides). E.g. ``"5c"``.
         - a pair of values (for setting separate horizontal and vertical
-          margins). E.g. ``["5c", "3c"]``.
+          margins). E.g. ``["5c","3c"]``.
         - a set of four values (for setting separate left, right, bottom, and
-          top margins). E.g. ``["1c", "2c", "3c", "4c"]``.
+          top margins). E.g. ``["1c","2c","3c","4c"]``.
 
         The actual gap created is always a sum of the margins for the two
         opposing sides (e.g., east plus west or south plus north margins)

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -164,15 +164,15 @@ def velo(self, data=None, **kwargs):
     {B}
     {CPT}
     rescale : str
-        can be used to rescale the uncertainties of velocities (``spec='e'``
-        and ``spec='r'``) and rotations (``spec='w'``). Can be combined with
+        can be used to rescale the uncertainties of velocities (``spec="e"``
+        and ``spec="r"``) and rotations (``spec="w"``). Can be combined with
         the ``confidence`` variable.
     uncertaintycolor : str
         Sets the color or shade used for filling uncertainty wedges
-        (``spec='w'``) or velocity error ellipses (``spec='e'`` or
-        ``spec='r'``). If ``uncertaintycolor`` is not specified, the
+        (``spec="w"``) or velocity error ellipses (``spec="e"`` or
+        ``spec="r"``). If ``uncertaintycolor`` is not specified, the
         uncertainty regions will be transparent. **Note**: Using ``cmap`` and
-        ``zvalue='+e'`` will update the uncertainty fill color based on the
+        ``zvalue="+e"`` will update the uncertainty fill color based on the
         selected measure in ``zvalue`` [magnitude error]. More details at
         :gmt-docs:`cookbook/features.html#gfill-attrib`.
     color : str


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to replace the single quotation marks (`'xxx'`) by double quotation marks (`"xxx"`) in the API documentation of [pygmt.Figure.velo](https://www.pygmt.org/dev/api/generated/pygmt.Figure.velo.html#pygmt.Figure.velo), [pygmt.grd2cpt](https://www.pygmt.org/dev/api/generated/pygmt.grd2cpt.html#pygmt.grd2cpt), and [pygmt.Figure.subplot](https://www.pygmt.org/dev/api/generated/pygmt.Figure.subplot.html#pygmt.Figure.subplot).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
