### PR TITLE
Complete inline example of `pygmt.Figure` class

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -61,7 +61,7 @@ class Figure:
 
     >>> import pygmt
     >>> fig = pygmt.Figure()
-    >>> fig.basemap(region=[0, 360, -90, 90], projection="W7i", frame=True)
+    >>> fig.basemap(region=[0, 360, -90, 90], projection="W15c", frame=True)
     >>> fig.savefig("my-figure.png")
     >>> # Make sure the figure file is generated and clean it up
     >>> import os
@@ -74,7 +74,7 @@ class Figure:
 
     >>> import pygmt
     >>> fig = pygmt.Figure()
-    >>> fig.basemap(region="JP", projection="M3i", frame=True)
+    >>> fig.basemap(region="JP", projection="M7c", frame=True)
     >>> # The fig.region attribute shows the WESN bounding box for the figure
     >>> print(", ".join(f"{i:.2f}" for i in fig.region))
     122.94, 145.82, 20.53, 45.52

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -59,7 +59,8 @@ class Figure:
     Examples
     --------
 
-    >>> fig = Figure()
+    >>> import pygmt
+    >>> fig = pygmt.Figure()
     >>> fig.basemap(region=[0, 360, -90, 90], projection="W7i", frame=True)
     >>> fig.savefig("my-figure.png")
     >>> # Make sure the figure file is generated and clean it up
@@ -71,7 +72,8 @@ class Figure:
     The plot region can be specified through ISO country codes (for example,
     ``'JP'`` for Japan):
 
-    >>> fig = Figure()
+    >>> import pygmt
+    >>> fig = pygmt.Figure()
     >>> fig.basemap(region="JP", projection="M3i", frame=True)
     >>> # The fig.region attribute shows the WESN bounding box for the figure
     >>> print(", ".join(f"{i:.2f}" for i in fig.region))


### PR DESCRIPTION
**Description of proposed changes**

Fixes #2084 

-------------------
I decided for 
```python
import pygmt
fig = pygmt.Figure()
```
. In case
```python
from pygmt import Figure
fig = Figure()
```
is preferred, I can change this.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
