### PR TITLE
Set `Note` followed by a `:` into bold style in the documentation

### DIFF
--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -49,7 +49,7 @@ def load_earth_relief(resolution="01d", region=None, registration=None, use_srtm
         a gridline-registered grid is returned unless only the pixel-registered
         grid is available.
 
-        **Note:** For GMT 6.3, ``registration=None`` returns a pixel-registered
+        **Note**: For GMT 6.3, ``registration=None`` returns a pixel-registered
         grid by default unless only the gridline-registered grid is available.
 
     use_srtm : bool

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -309,7 +309,7 @@ COMMON_OPTIONS = {
               text, add the column **t**. Append the word number to **t** to
               write only a single word from the trailing text. Instead of
               specifying columns, use ``outcols="n"`` to simply read numerical
-              input and skip trailing text. *Note**: if ``incols`` is also
+              input and skip trailing text. *Note**: If ``incols`` is also
               used then the columns given to ``outcols`` correspond to the
               order after the ``incols`` selection has taken place.""",
     "p": r"""

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -309,9 +309,9 @@ COMMON_OPTIONS = {
               text, add the column **t**. Append the word number to **t** to
               write only a single word from the trailing text. Instead of
               specifying columns, use ``outcols="n"`` to simply read numerical
-              input and skip trailing text. Note: if ``incols`` is also used
-              then the columns given to ``outcols`` correspond to the order
-              after the ``incols`` selection has taken place.""",
+              input and skip trailing text. *Note**: if ``incols`` is also
+              used then the columns given to ``outcols`` correspond to the
+              order after the ``incols`` selection has taken place.""",
     "p": r"""
         perspective : list or str
             [**x**\|\ **y**\|\ **z**]\ *azim*\[/*elev*\[/*zlevel*]]\

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -95,10 +95,10 @@ def grdimage(self, grid, **kwargs):
         drivers. Append a **+c**\ *args* string where *args* is a list
         of one or more concatenated number of GDAL **-co** arguments. For
         example, to write a GeoPDF with the TerraGo format use
-        ``=PDF+cGEO_ENCODING=OGC_BP``. Notes: (1) If a tiff file (.tif) is
-        selected then we will write a GeoTiff image if the GMT projection
-        syntax translates into a PROJ syntax, otherwise a plain tiff file
-        is produced. (2) Any vector elements will be lost.
+        ``=PDF+cGEO_ENCODING=OGC_BP``. **Notes**: (1) If a tiff file (.tif)
+        is selected then we will write a GeoTiff image if the GMT
+        projection syntax translates into a PROJ syntax, otherwise a plain
+        tiff file is produced. (2) Any vector elements will be lost.
     {B}
     {CPT}
     img_in : str
@@ -138,9 +138,9 @@ def grdimage(self, grid, **kwargs):
         want a more specific intensity scenario then run
         :func:`pygmt.grdgradient` separately first. If we should derive
         intensities from another file than grid, specify the file with
-        suitable modifiers [Default is no illumination]. Note: If the input
-        data is an *image* then an *intensfile* or constant *intensity* must
-        be provided.
+        suitable modifiers [Default is no illumination]. **Note**: If the
+        input data is an *image* then an *intensfile* or constant *intensity*
+        must be provided.
     {J}
     monochrome : bool
         Force conversion to monochrome image using the (television) YIQ

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -38,7 +38,7 @@ def image(self, imagefile, **kwargs):
         This must be an Encapsulated PostScript (EPS) file or a raster
         image. An EPS file must contain an appropriate BoundingBox. A
         raster file can have a depth of 1, 8, 24, or 32 bits and is read
-        via GDAL. Note: If GDAL was not configured during GMT installation
+        via GDAL. **Note**: If GDAL was not configured during GMT installation
         then only EPS files are supported.
     {J}
     {R}

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -141,7 +141,7 @@ def project(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
         end point cannot be farther apart than :math:`2|\mbox{{colat}}|`.
         Finally, if you append **+h** then we will report the position of
         the pole as part of the segment header [Default is no header].
-        Note: No input is read and the value of ``data``, ``x``, ``y``,
+        **Note**: No input is read and the value of ``data``, ``x``, ``y``,
         and ``z`` is ignored if ``generate`` is used.
 
     length : str or list

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -173,13 +173,13 @@ def set_panel(self, panel=None, **kwargs):
     r"""
     Set the current subplot panel to plot on.
 
-    Before you start plotting you must first select the active subplot. Note:
-    If any *projection* option is passed with the question mark **?** as scale
-    or width when plotting subplots, then the dimensions of the map are
-    automatically determined by the subplot size and your region. For Cartesian
-    plots: If you want the scale to apply equally to both dimensions then you
-    must specify ``projection="x"`` [The default ``projection="X"`` will fill
-    the subplot by using unequal scales].
+    Before you start plotting you must first select the active subplot.
+    **Note**: If any *projection* option is passed with the question mark
+    **?** as scale or width when plotting subplots, then the dimensions of
+    the map are automatically determined by the subplot size and your
+    region. For Cartesian plots: If you want the scale to apply equally to
+    both dimensions then you must specify ``projection="x"`` [The default
+    ``projection="X"`` will fill the subplot by using unequal scales].
 
     {aliases}
 

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -69,9 +69,9 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
         follow sequentially. Surround the number or letter by parentheses on
         any side if these should be typeset as part of the tag. Use
         **+j**\|\ **J**\ *refpoint* to specify where the tag should be placed
-        in the subplot [TL]. Note: **+j** sets the justification of the tag to
-        *refpoint* (suitable for interior tags) while **+J** instead selects
-        the mirror opposite (suitable for exterior tags). Append
+        in the subplot [TL]. **Note**: **+j** sets the justification of the
+        tag to *refpoint* (suitable for interior tags) while **+J** instead
+        selects the mirror opposite (suitable for exterior tags). Append
         **+c**\ *dx*\[/*dy*] to set the clearance between the tag and a
         surrounding text box requested via **+g** or **+p** [3p/3p, i.e., 15%
         of the :gmt-term:`FONT_TAG` size dimension]. Append **+g**\ *fill* to

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -72,7 +72,7 @@ def wiggle(self, data=None, x=None, y=None, z=None, **kwargs):
         [Default is no fill]. Optionally, append **+p** to fill positive areas
         (this is the default behavior). Append **+n** to fill negative areas.
         Append **+n+p** to fill both positive and negative areas with the same
-        fill. Note: You will need to repeat the color parameter to select
+        fill. **Note**: You will need to repeat the color parameter to select
         different fills for the positive and negative wiggles.
 
     track : str

--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -98,9 +98,9 @@ def x2sys_cross(tracks=None, outfile=None, **kwargs):
         suffix specified for this TAG. Track files will be searched for first
         in the current directory and second in all directories listed in
         $X2SYS_HOME/TAG/TAG_paths.txt (if it exists). [If $X2SYS_HOME is not
-        set it will default to $GMT_SHAREDIR/x2sys]. (Note: MGD77 files will
-        also be looked for via $MGD77_HOME/mgd77_paths.txt and .gmt files
-        will be searched for via $GMT_SHAREDIR/mgg/gmtfile_paths).
+        set it will default to $GMT_SHAREDIR/x2sys]. (**Note**: MGD77 files
+        will also be looked for via $MGD77_HOME/mgd77_paths.txt and .gmt
+        files will be searched for via $GMT_SHAREDIR/mgg/gmtfile_paths).
 
     outfile : str
         Optional. The file name for the output ASCII txt file to store the


### PR DESCRIPTION
**Description of proposed changes**

Corresponding to https://github.com/GenericMappingTools/pygmt/pull/2096#discussion_r959775260 and https://github.com/GenericMappingTools/pygmt/pull/2096#discussion_r959892198 this PR aims to set `Note` followed by a `:` consistently into bold style in the API documentation.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
