### PR TITLE
Use SI units in gallery example 'Legend' and test example in Contributors Guide

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -579,7 +579,7 @@ returning the `pygmt.Figure` object:
 def test_my_plotting_case():
     "Test that my plotting method works"
     fig = Figure()
-    fig.basemap(region=[0, 360, -90, 90], projection='W7i', frame=True)
+    fig.basemap(region=[0, 360, -90, 90], projection='W15c', frame=True)
     return fig
 ```
 

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -579,7 +579,7 @@ returning the `pygmt.Figure` object:
 def test_my_plotting_case():
     "Test that my plotting method works"
     fig = Figure()
-    fig.basemap(region=[0, 360, -90, 90], projection='W15c', frame=True)
+    fig.basemap(region=[0, 360, -90, 90], projection="W15c", frame=True)
     return fig
 ```
 

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -14,13 +14,13 @@ fig.basemap(projection="x2c", region=[0, 7, 3, 7], frame=True)
 
 fig.plot(
     data="@Table_5_11.txt",
-    style="c0.15i",
+    style="c0.40c",
     color="lightgreen",
     pen="faint",
     label="Apples",
 )
 fig.plot(data="@Table_5_11.txt", pen="1.5p,gray", label="My lines")
-fig.plot(data="@Table_5_11.txt", style="t0.15i", color="orange", label="Oranges")
+fig.plot(data="@Table_5_11.txt", style="t0.40c", color="orange", label="Oranges")
 
 fig.legend(position="JTR+jTR+o0.2c", box=True)
 

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -10,7 +10,7 @@ import pygmt
 
 fig = pygmt.Figure()
 
-fig.basemap(projection="x1i", region=[0, 7, 3, 7], frame=True)
+fig.basemap(projection="x2c", region=[0, 7, 3, 7], frame=True)
 
 fig.plot(
     data="@Table_5_11.txt",


### PR DESCRIPTION
**Description of proposed changes**

Corresponding to https://github.com/GenericMappingTools/pygmt/pull/2105#discussion_r960285584 and https://github.com/GenericMappingTools/pygmt/pull/2105#discussion_r961225341 this PR aims to use SI units in the [gallery example 'Legend'](https://www.pygmt.org/dev/gallery/embellishments/legend.html#sphx-glr-gallery-embellishments-legend-py) and a [test example in the Contributors Guide](https://www.pygmt.org/dev/contributing.html#using-mpl-image-compare).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
