### PR TITLE
Replace single by double quotation marks in API documentation

### DIFF
--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -62,8 +62,8 @@ def grdcontour(self, grid, **kwargs):
           single annotation level +\ *annot_int*
         - Disable all annotation with  **-**
         - Optional label modifiers can be specified as a single string
-          ``'[annot_int]+e'``  or with a list of arguments
-          ``([annot_int], 'e', 'f10p', 'gred')``.
+          ``"[annot_int]+e"``  or with a list of arguments
+          ``([annot_int], "e", "f10p", "gred")``.
     limit : str or list of 2 ints
         *low*/*high*.
         Do no draw contours below `low` or above `high`, specify as string

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -94,7 +94,7 @@ def grdfilter(grid, **kwargs):
         4: grid (x,y) in degrees, *width* in km, Spherical distance
         calculation.
 
-        5: grid (x,y) in Mercator ``projection='m1'`` img units, *width* in km,
+        5: grid (x,y) in Mercator ``projection="m1"`` img units, *width* in km,
         Spherical distance calculation.
 
     {I}

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -108,9 +108,9 @@ def grdimage(self, grid, **kwargs):
         image formats you may need to explicitly set ``img_in``, which
         specifies that the grid is in fact an image file to be read via
         GDAL. Append **r** to assign the region specified by ``region``
-        to the image. For example, if you have used ``region='d'`` then the
-        image will be assigned a global domain. This mode allows you to
-        project a raw image (an image without referencing coordinates).
+        to the image. For example, if you have used ``region="d"`` then
+        the image will be assigned a global domain. This mode allows you
+        to project a raw image (an image without referencing coordinates).
     dpi : int
         [**i**\|\ *dpi*].
         Sets the resolution of the projected grid that will be created if a

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -90,7 +90,7 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
         The size of the data points in units specified using ``style``.
         Only valid if using ``x``/``y``.
     direction : list of two 1d arrays
-        If plotting vectors (using ``style='V'`` or ``style='v'``), then
+        If plotting vectors (using ``style="V"`` or ``style="v"``), then
         should be a list of two 1d arrays with the vector directions. These
         can be angle and length, azimuth and length, or x and y components,
         depending on the style options chosen.
@@ -146,7 +146,7 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
           incoming segment [Default].
         - **r** : Same as **s**, but the group reference point is reset
           after each record to the previous point (this method is only
-          available with the ``connection='r'`` scheme).
+          available with the ``connection="r"`` scheme).
 
         Instead of the codes **a**\|\ **f**\|\ **s**\|\ **r** you may append
         the coordinates of a *refpoint* which will serve as a fixed external
@@ -192,7 +192,7 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
         color lookup table via ``cmap``.  Alternatively, give the name of a
         *file* with one z-value (read from the last column) for each
         polygon in the input data. To apply it to the fill color, use
-        ``color='+z'``. To apply it to the pen color, append **+z** to
+        ``color="+z"``. To apply it to the pen color, append **+z** to
         ``pen``.
     {a}
     {b}

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -91,7 +91,7 @@ def plot3d(
         The size of the data points in units specified in ``style``.
         Only valid if using ``x``/``y``/``z``.
     direction : list of two 1d arrays
-        If plotting vectors (using ``style='V'`` or ``style='v'``), then
+        If plotting vectors (using ``style="V"`` or ``style="v"``), then
         should be a list of two 1d arrays with the vector directions. These
         can be angle and length, azimuth and length, or x and y components,
         depending on the style options chosen.
@@ -162,7 +162,7 @@ def plot3d(
         color lookup table via ``cmap``.  Alternatively, give the name of a
         *file* with one z-value (read from the last column) for each
         polygon in the input data. To apply it to the fill color, use
-        ``color='+z'``. To apply it to the pen color, append **+z** to
+        ``color="+z"``. To apply it to the pen color, append **+z** to
         ``pen``.
     {a}
     {b}


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to replace the single quotation marks (`'xxx'`) by double quotation marks (`"xxx"`) in the API documentation of some functions and methods: 
- [x] [pygmt.Figure.plot](https://www.pygmt.org/dev/api/generated/pygmt.Figure.plot.html#pygmt.Figure.plot)
- [x] [pygmt.Figure.plot3d](https://www.pygmt.org/dev/api/generated/pygmt.Figure.plot3d.html#pygmt.Figure.plot3d)
- [x] [pygmt.Figure.grdcontour](https://www.pygmt.org/dev/api/generated/pygmt.Figure.grdcontour.html#pygmt.Figure.grdcontour)
- [x] [pygmt.grdfilter](https://www.pygmt.org/dev/api/generated/pygmt.grdfilter.html#pygmt.grdfilter)
- [x] [pygmt.Figure.grdimage](https://www.pygmt.org/dev/api/generated/pygmt.Figure.grdimage.html#pygmt.Figure.grdimage)

--------------

Already updated in the API documentation:
- [x] [pygmt.Figure.rose](https://www.pygmt.org/dev/api/generated/pygmt.Figure.rose.html#pygmt.Figure.rose): PR #2090
- [x] [pygmt.Figure.velo](), [pygmt.grd2cpt](https://www.pygmt.org/dev/api/generated/pygmt.grd2cpt.html#pygmt.grd2cpt), [pygmt.Figure.subplot](https://www.pygmt.org/dev/api/generated/pygmt.Figure.subplot.html#pygmt.Figure.subplot): PR #2104
- [x] [pygmt.datasets.load_earth_age](https://www.pygmt.org/dev/api/generated/pygmt.datasets.load_earth_age.html#pygmt.datasets.load_earth_age), [pygmt.datasets.load_earth_relief](https://www.pygmt.org/dev/api/generated/pygmt.datasets.load_earth_relief.html#pygmt.datasets.load_earth_relief): PR #2101 

-----------------

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
