### PR TITLE
Add an empty setup.cfg file for backward compatibility with pip<21.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+# An emtpy setup.cfg file for backward compatibility with pip<21.3.
+# See https://github.com/GenericMappingTools/pygmt/issues/2100 for the issue report.


### PR DESCRIPTION
**Description of proposed changes**

Closes https://github.com/GenericMappingTools/pygmt/issues/2100.

`setup.cfg` was removed in #1847 which is not included in any release yet, so this commit is a patch and should not be included in the changelog.