### PR TITLE
Fix typos in docs and examples

### DIFF
--- a/examples/gallery/lines/wiggle.py
+++ b/examples/gallery/lines/wiggle.py
@@ -23,11 +23,11 @@ fig.wiggle(
     x=x,
     y=y,
     z=z,
-    # Set anomaly scale to "20c"
+    # Set anomaly scale to 20 centimeters
     scale="20c",
     # Fill positive and negative areas red and gray, respectively
     color=["red+p", "gray+n"],
-    # Set the outline width to "1.0p"
+    # Set the outline width to 1 point
     pen="1.0p",
     # Draw a blue track with a width of 0.5 points
     track="0.5p,blue",

--- a/examples/gallery/lines/wiggle.py
+++ b/examples/gallery/lines/wiggle.py
@@ -27,7 +27,7 @@ fig.wiggle(
     scale="20c",
     # Fill positive and negative areas red and gray, respectively
     color=["red+p", "gray+n"],
-    # Set the outline width to 1 point
+    # Set the outline width to 1.0 point
     pen="1.0p",
     # Draw a blue track with a width of 0.5 points
     track="0.5p,blue",

--- a/examples/tutorials/basics/regions.py
+++ b/examples/tutorials/basics/regions.py
@@ -38,7 +38,7 @@ fig.show()
 ###############################################################################
 #
 # The coordinates can be passed to ``region`` as a list, in the form of
-# [*xmin*,\ *xmax*,\ *ymin*,\ *ymax*].
+# [*xmin*, *xmax*, *ymin*, *ymax*].
 
 fig = pygmt.Figure()
 fig.coast(

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -45,7 +45,7 @@ def legend(self, spec=None, position="JTR+jTR+o0.2c", box="+gwhite+p1p", **kwarg
     Parameters
     ----------
     spec : None or str
-        Either ``None`` [default] for using the automatically generated legend
+        Either ``None`` [Default] for using the automatically generated legend
         specification file, or a *filename* pointing to the legend
         specification file.
     {J}

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -55,7 +55,7 @@ def legend(self, spec=None, position="JTR+jTR+o0.2c", box="+gwhite+p1p", **kwarg
         **+w**\ *width*\ [/*height*]\ [**+j**\ *justify*]\ [**+l**\ *spacing*]\
         [**+o**\ *dx*\ [/*dy*]].
         Defines the reference point on the map for the
-        legend. By default, uses **JTR**\ +\ **jTR**\ +\ **o**\ *0.2c* which
+        legend. By default, uses **JTR**\ +\ **jTR**\ +\ **o**\ 0.2c which
         places the legend at the top-right corner inside the map frame, with a
         0.2 cm offset.
     box : bool or str

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -55,7 +55,7 @@ def legend(self, spec=None, position="JTR+jTR+o0.2c", box="+gwhite+p1p", **kwarg
         **+w**\ *width*\ [/*height*]\ [**+j**\ *justify*]\ [**+l**\ *spacing*]\
         [**+o**\ *dx*\ [/*dy*]].
         Defines the reference point on the map for the
-        legend. By default, uses **JTR**\ +\ **jTR**\ +\ **o**\ 0.2c which
+        legend. By default, uses **JTR**\ **+jTR**\ **+o**\ 0.2c which
         places the legend at the top-right corner inside the map frame, with a
         0.2 cm offset.
     box : bool or str

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -56,7 +56,7 @@ def solar(self, terminator="d", terminator_datetime=None, **kwargs):
         Color or pattern for filling of terminators.
     pen : str
         Set pen attributes for lines. The default pen
-        is ``default,black,solid``.
+        is ``"0.25p,black,solid"``.
     {U}
     {V}
     {XY}

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -77,7 +77,7 @@ def wiggle(self, data=None, x=None, y=None, z=None, **kwargs):
 
     track : str
         Draw track [Default is no track]. Append pen attributes to use
-        [Default is **0.25p,black,solid**].
+        [Default is ``"0.25p,black,solid"``].
     {U}
     {V}
     pen : str


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a few typos in the API documentation and the tutorial and gallery examples.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
