### PR TITLE
Fix typos in API documentation

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -309,7 +309,7 @@ COMMON_OPTIONS = {
               text, add the column **t**. Append the word number to **t** to
               write only a single word from the trailing text. Instead of
               specifying columns, use ``outcols="n"`` to simply read numerical
-              input and skip trailing text. *Note**: If ``incols`` is also
+              input and skip trailing text. **Note**: If ``incols`` is also
               used then the columns given to ``outcols`` correspond to the
               order after the ``incols`` selection has taken place.""",
     "p": r"""

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -70,7 +70,7 @@ COMMON_OPTIONS = {
               giving an increment you may specify the *number of nodes* desired
               by appending **+n** to the supplied integer argument; the
               increment is then recalculated from the number of nodes, the
-              *registration*, and the domain. The resulting increment value
+              ``registration``, and the domain. The resulting increment value
               depends on whether you have selected a gridline-registered or
               pixel-registered grid; see :gmt-docs:`GMT File Formats
               <cookbook/file-formats.html#gmt-file-formats>` for details.

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -63,7 +63,7 @@ def basemap(self, **kwargs):
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
         If set to ``True``, draws a rectangular border around the
         map scale or rose. Alternatively, specify a different pen with
-        **+p**\ *pen*. Add **+g**\ *fill* to fill the scale panel [default is
+        **+p**\ *pen*. Add **+g**\ *fill* to fill the scale panel [Default is
         no fill]. Append **+c**\ *clearance* where *clearance* is either gap,
         xgap/ygap, or lgap/rgap/bgap/tgap where these items are uniform,
         separate in x- and y-direction, or individual side spacings between
@@ -75,7 +75,7 @@ def basemap(self, **kwargs):
         Finally, append **+s** to draw an offset background shaded region.
         Here, *dx/dy* indicates the shift relative to the foreground frame
         [Default is 4p/-4p] and shade sets the fill style to use for shading
-        [default is gray50].
+        [Default is gray50].
     rose : str
         Draws a map directional rose on the map at the location defined by
         the reference and anchor points.

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -172,8 +172,8 @@ def coast(self, **kwargs):
         .\ *state*, (e.g, US.TX for Texas).  To specify a whole continent,
         prepend **=** to any of the continent codes (e.g. =EU for Europe).
         Append **+p**\ *pen* to draw polygon outlines
-        (Default is no outline) and **+g**\ *fill* to fill them
-        (Default is no fill). Append **+l**\|\ **+L** to =\ *continent* to
+        [Default is no outline] and **+g**\ *fill* to fill them
+        [Default is no fill]. Append **+l**\|\ **+L** to =\ *continent* to
         only list countries in that continent; repeat if more than one
         continent is requested.
     {XY}

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -172,8 +172,8 @@ def coast(self, **kwargs):
         .\ *state*, (e.g, US.TX for Texas).  To specify a whole continent,
         prepend **=** to any of the continent codes (e.g. =EU for Europe).
         Append **+p**\ *pen* to draw polygon outlines
-        (default is no outline) and **+g**\ *fill* to fill them
-        (default is no fill). Append **+l**\|\ **+L** to =\ *continent* to
+        (Default is no outline) and **+g**\ *fill* to fill them
+        (Default is no fill). Append **+l**\|\ **+L** to =\ *continent* to
         only list countries in that continent; repeat if more than one
         continent is requested.
     {XY}

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -44,11 +44,11 @@ def grdproject(grid, **kwargs):
     avoided by also forward projecting the input grid nodes. If two or more
     nodes are projected onto the same new node, their average will dominate in
     the calculation of the new node value. Interpolation and aliasing is
-    controlled with the ``interpolation`` option. The new node spacing may be
-    determined in one of several ways by specifying the grid spacing, number
-    of nodes, or resolution. Nodes not constrained by input data are set to
-    NaN. The ``region`` parameter can be used to select a map region larger or
-    smaller than that implied by the extent of the grid file.
+    controlled with the ``interpolation`` parameter. The new node spacing may
+    be determined in one of several ways by specifying the grid spacing,
+    number of nodes, or resolution. Nodes not constrained by input data are
+    set to NaN. The ``region`` parameter can be used to select a map region
+    large or smaller than that implied by the extent of the grid file.
 
     Full option list at :gmt-docs:`grdproject.html`
 


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a few typos in the API documentation.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
