### PR TITLE
Remove unnecessary typecheck settings for pylint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,9 +121,3 @@ max-module-lines=2000
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
 disable=["duplicate-code", "import-error"]
-
-[tool.pylint.TYPECHECK]
-# List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E1101 when accessed. Python regular
-# expressions are accepted.
-generated-members="pandas.*"


### PR DESCRIPTION
**Description of proposed changes**

We added pylint settings `generated-members="pandas.*"` in https://github.com/GenericMappingTools/pygmt/pull/1755#discussion_r806882150 to silent annoying pylint messages. It seems recent versions of pylint no longer report these messages, so we can remove the settings.