### PR TITLE
Fix typos in API documentation

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -216,7 +216,7 @@ class Figure:
             **E** means EPS with PageSize command, **f** means PDF, **F** means
             multi-page PDF, **j** means JPEG, **g** means PNG, **G** means
             transparent PNG (untouched regions are transparent), **m** means
-            PPM, **s** means SVG, and **t** means TIFF [default is JPEG]. To
+            PPM, **s** means SVG, and **t** means TIFF [Default is JPEG]. To
             **b**\|\ **j**\|\ **g**\|\ **t**\ , optionally append **+m** in
             order to get a monochrome (grayscale) image. The EPS format can be
             combined with any of the other formats. For example, **ef** creates

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -340,7 +340,7 @@ class Figure:
         for the current figure. Parameters ``dpi`` and ``width`` can be used
         to control the resolution and dimension of the figure in the notebook.
 
-        Note: The external viewer can be disabled by setting the
+        **Note**: The external viewer can be disabled by setting the
         PYGMT_USE_EXTERNAL_DISPLAY environment variable to **false**.
         This is useful when running unit tests and building the documentation
         in consoles without a Graphical User Interface.

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -360,8 +360,8 @@ class Figure:
         method : str
             How the current figure will be displayed. Options are
 
-            - **external**: PDF preview in an external program [default]
-            - **notebook**: PNG preview [default in Jupyter notebooks]
+            - **external**: PDF preview in an external program [Default]
+            - **notebook**: PNG preview [Default in Jupyter notebooks]
             - **none**: Disable image preview
         waiting : float
             Suspend the execution of the current process for a given number of
@@ -527,8 +527,8 @@ def set_display(method=None):
     method : str or None
         The method to display an image. Choose from:
 
-        - **external**: PDF preview in an external program [default]
-        - **notebook**: PNG preview [default in Jupyter notebooks]
+        - **external**: PDF preview in an external program [Default]
+        - **notebook**: PNG preview [Default in Jupyter notebooks]
         - **none**: Disable image preview
     """
     if method in ["notebook", "external", "none"]:

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -70,7 +70,7 @@ class Figure:
     >>> os.remove("my-figure.png")
 
     The plot region can be specified through ISO country codes (for example,
-    ``'JP'`` for Japan):
+    ``"JP"`` for Japan):
 
     >>> import pygmt
     >>> fig = pygmt.Figure()

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -67,9 +67,9 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
     levels : str or int
         Specify the contour lines to generate.
 
-        - The filename of a CPT file where the color boundaries will
+        - The file name of a CPT file where the color boundaries will
           be used as contour levels.
-        - The filename of a 2 (or 3) column file containing the contour
+        - The file name of a 2 (or 3) column file containing the contour
           levels (col 1), (**C**)ontour or (**A**)nnotate (col 2), and optional
           angle (col 3)
         - A fixed contour interval *cont_int* or a single contour with

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -47,9 +47,9 @@ def grdcontour(self, grid, **kwargs):
     interval : str or int
         Specify the contour lines to generate.
 
-        - The filename of a CPT file where the color boundaries will
+        - The file name of a CPT file where the color boundaries will
           be used as contour levels.
-        - The filename of a 2 (or 3) column file containing the contour
+        - The file name of a 2 (or 3) column file containing the contour
           levels (col 1), (**C**)ontour or (**A**)nnotate (col 2), and optional
           angle (col 3)
         - A fixed contour interval *cont_int* or a single contour with

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -72,7 +72,7 @@ def grdtrack(grid, points=None, newcolname=None, outfile=None, **kwargs):
     Parameters
     ----------
     grid : xarray.DataArray or str
-        Gridded array from which to sample values from, or a filename (netcdf
+        Gridded array from which to sample values from, or a file name (netcdf
         format).
 
     points : str or {table-like}
@@ -210,7 +210,7 @@ def grdtrack(grid, points=None, newcolname=None, outfile=None, **kwargs):
         - **+a** : Append stacked values to all cross-profiles.
         - **+d** : Append stack deviations to all cross-profiles.
         - **+r** : Append data residuals (data - stack) to all cross-profiles.
-        - **+s**\ [*file*] : Save stacked profile to *file* [Default filename
+        - **+s**\ [*file*] : Save stacked profile to *file* [Default file name
           is grdtrack_stacked_profile.txt].
         - **+c**\ *fact* : Compute envelope on stacked profile as
           ±\ *fact* \*\ *deviation* [Default fact value is 2].

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -214,7 +214,7 @@ def meca(
         is 0.25p].
     no_clip : bool
         Does NOT skip symbols that fall outside frame boundary specified by
-        *region* [Default is False, i.e. plot symbols inside map frame only].
+        ``region`` [Default is False, i.e. plot symbols inside map frame only].
     {J}
     {R}
     {B}

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -76,7 +76,7 @@ def text_(
     Parameters
     ----------
     textfiles : str or list
-        A text data file name, or a list of filenames containing 1 or more
+        A text data file name, or a list of file names containing 1 or more
         records with (x, y[, angle, font, justify], text).
     x/y : float or 1d arrays
         The x and y coordinates, or an array of x and y coordinates to plot

--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -94,7 +94,7 @@ def x2sys_cross(tracks=None, outfile=None, **kwargs):
         or file names. Supported file formats are ASCII, native binary, or
         COARDS netCDF 1-D data. More columns may also be present.
 
-        If the filenames are missing their file extension, we will append the
+        If the file names are missing their file extension, we will append the
         suffix specified for this TAG. Track files will be searched for first
         in the current directory and second in all directories listed in
         $X2SYS_HOME/TAG/TAG_paths.txt (if it exists). [If $X2SYS_HOME is not
@@ -118,7 +118,7 @@ def x2sys_cross(tracks=None, outfile=None, **kwargs):
 
     runtimes : bool or str
         Compute and append the processing run-time for each pair to the
-        progress message (use ``runtimes=True``). Pass in a filename (e.g.
+        progress message (use ``runtimes=True``). Pass in a file name (e.g.
         ``runtimes="file.txt"``) to save these run-times to file. The idea here
         is to use the knowledge of run-times to split the main process in a
         number of sub-processes that can each be launched in a different


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a few typos in the API documentation regarding consistency.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
