### PR TITLE
Figure.histogram and Figure.ternary: Fix incorrect docstrings 'color' to 'fill'

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -47,6 +47,10 @@ COMMON_DOCSTRINGS = {
         color : str or 1d array
             Select color or pattern for filling of symbols or polygons. Default
             is no fill.""",
+    "fill": """\
+        fill : str or 1d array
+            Select color or pattern for filling of symbols or polygons. Default
+            is no fill.""",
     "spacing": r"""
         spacing : str
             *x_inc*\ [**+e**\|\ **n**][/\ *y_inc*\ [**+e**\|\ **n**]].

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -48,7 +48,7 @@ COMMON_DOCSTRINGS = {
             Select color or pattern for filling of symbols or polygons. Default
             is no fill.""",
     "fill": """\
-        fill : str or 1d array
+        fill : str
             Select color or pattern for filling of symbols or polygons. Default
             is no fill.""",
     "spacing": r"""

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -59,7 +59,7 @@ def histogram(self, data, **kwargs):
     {region}
     {frame}
     {cmap}
-    {color}
+    {fill}
     {pen}
     {panel}
     annotate : bool or str

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -53,7 +53,7 @@ def ternary(self, data, **kwargs):
         Give the min and max limits for each of the three axes **a**, **b**,
         and **c**.
     {cmap}
-    {color}
+    {fill}
     style : str
         *symbol*\[\ *size*].
         Plot individual symbols in a ternary diagram.


### PR DESCRIPTION
**Description of proposed changes**
In Figure.histogram and Figure.ternary, `-G` is aliased to `fill`, not `color`, so we should show the docstring of `fill` instead.

Address https://github.com/GenericMappingTools/pygmt/issues/1617.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
