### PR TITLE
Fix typos in API documentation

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -50,7 +50,7 @@ top of the GitHub repository and click *New Issue*.
 * After submitting your bug report, try to answer any follow up questions about the bug
   as best as you can.
 
-#### Reporting upstream bugs
+#### Reporting Upstream Bugs
 
 If you are aware that a bug is caused by an upstream GMT issue rather than a
 PyGMT-specific issue, you can optionally take the following steps to help resolve

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -45,12 +45,12 @@ COMMON_DOCSTRINGS = {
            CPT from those colors automatically.""",
     "color": """\
         color : str or 1d array
-            Select color or pattern for filling of symbols or polygons. Default
-            is no fill.""",
+            Select color or pattern for filling of symbols or polygons [Default
+            is no fill].""",
     "fill": """\
         fill : str
-            Select color or pattern for filling of symbols or polygons. Default
-            is no fill.""",
+            Select color or pattern for filling of symbols or polygons [Default
+            is no fill].""",
     "spacing": r"""
         spacing : str
             *x_inc*\ [**+e**\|\ **n**][/\ *y_inc*\ [**+e**\|\ **n**]].

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -90,7 +90,7 @@ COMMON_DOCSTRINGS = {
             - **q** - Quiet, not even fatal error messages are produced
             - **e** - Error messages only
             - **w** - Warnings [Default]
-            - **t** - Timings (report runtimes for time-intensive algorithms);
+            - **t** - Timings (report runtimes for time-intensive algorithms)
             - **i** - Informational messages (same as ``verbose=True``)
             - **c** - Compatibility warnings
             - **d** - Debugging messages""",

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -348,8 +348,8 @@ COMMON_DOCSTRINGS = {
                   if values in all specified *cols* equal NaN].""",
     "transparency": """\
         transparency : int or float
-            Set transparency level, in [0-100] percent range.
-            Default is 0, i.e., opaque.
+            Set transparency level, in [0-100] percent range
+            [Default is 0, i.e., opaque].
             Only visible when PDF or raster format output is selected.
             Only the PNG format selection adds a transparency layer
             in the image (for further processing). """,

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -206,8 +206,9 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
     {label}
     {perspective}
     {transparency}
-        *transparency* can also be a 1d array to set varying transparency
-        for symbols, but this option is only valid if using x/y.
+        ``transparency`` can also be a 1d array to set varying
+        transparency for symbols, but this option is only valid if using
+        ``x``/``y``.
     {wrap}
     """
     # pylint: disable=too-many-locals

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -99,7 +99,8 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
     straight_line : bool or str
         [**m**\|\ **p**\|\ **x**\|\ **y**].
         By default, geographic line segments are drawn as great circle
-        arcs. To draw them as straight lines, use ``straight_line``.
+        arcs. To draw them as straight lines, use
+        ``straight_line=True``.
         Alternatively, add **m** to draw the line by first following a
         meridian, then a parallel. Or append **p** to start following a
         parallel, then a meridian. (This can be practical to draw a line

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -176,8 +176,9 @@ def plot3d(
     {label}
     {perspective}
     {transparency}
-        *transparency* can also be a 1d array to set varying transparency
-        for symbols, but this option is only valid if using x/y/z.
+        ``transparency`` can also be a 1d array to set varying
+        transparency for symbols, but this option is only valid if using
+        ``x``/``y``/``z``.
     {wrap}
     """
     # pylint: disable=too-many-locals

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -40,15 +40,15 @@ def solar(self, terminator="d", terminator_datetime=None, **kwargs):
     terminator : str
         Set the type of terminator displayed. Valid arguments are
         **day_night**, **civil**, **nautical**, and **astronomical**, which
-        can be set with either the full name or the first letter of the name.
-        [Default is **day_night**]
+        can be set with either the full name or the first letter of the name
+        [Default is **day_night**].
 
         Refer to https://en.wikipedia.org/wiki/Twilight for the definitions of
         different types of twilight.
     terminator_datetime : str or datetime object
-        Set the UTC date and time of the displayed terminator. It can be
+        Set the UTC date and time of the displayed terminator
+        [Default is the current UTC date and time]. It can be
         passed as a string or Python datetime object.
-        [Default is the current UTC date and time]
     {region}
     {projection}
     {frame}

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -160,8 +160,9 @@ def text_(
     {incols}
     {perspective}
     {transparency}
-        *transparency* can also be a 1d array to set varying transparency
-        for texts, but this option is only valid if using x/y/text.
+        ``transparency`` can also be a 1d array to set varying
+        transparency for texts, but this option is only valid if using
+        ``x``/``y`` and ``text``.
     {wrap}
     """
     # pylint: disable=too-many-branches

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -122,13 +122,14 @@ def text_(
         Adjust the clearance between the text and the surrounding box
         [Default is 15% of the font size]. Only used if ``pen`` or ``fill`` are
         specified. Append the unit you want (*c* for cm, *i* for inch, or *p*
-        for point; if not given we consult **PROJ_LENGTH_UNIT**) or *%* for a
-        percentage of the font size. Optionally, use modifier **+t** to set
-        the shape of the textbox when using ``fill`` and/or ``pen``. Append
-        lower case **o** to get a straight rectangle [Default is **o**]. Append
-        upper case **O** to get a rounded rectangle. In paragraph mode
-        (*paragraph*) you can also append lower case **c** to get a concave
-        rectangle or append upper case **C** to get a convex rectangle.
+        for point; if not given we consult :gmt_term:`PROJ_LENGTH_UNIT`)
+        or *%* for a percentage of the font size. Optionally, use modifier
+        **+t** to set the shape of the textbox when using ``fill`` and/or
+        ``pen``. Append lower case **o** to get a straight rectangle
+        [Default is **o**]. Append upper case **O** to get a rounded
+        rectangle. In paragraph mode (*paragraph*) you can also append lower
+        case **c** to get a concave rectangle or append upper case **C**
+        to get a convex rectangle.
     fill : str
         Sets the shade or color used for filling the text box [Default is
         no fill].

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -122,7 +122,7 @@ def text_(
         Adjust the clearance between the text and the surrounding box
         [Default is 15% of the font size]. Only used if ``pen`` or ``fill`` are
         specified. Append the unit you want (*c* for cm, *i* for inch, or *p*
-        for point; if not given we consult :gmt_term:`PROJ_LENGTH_UNIT`)
+        for point; if not given we consult :gmt-term:`PROJ_LENGTH_UNIT`)
         or *%* for a percentage of the font size. Optionally, use modifier
         **+t** to set the shape of the textbox when using ``fill`` and/or
         ``pen``. Append lower case **o** to get a straight rectangle

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -207,7 +207,7 @@ def velo(self, data=None, **kwargs):
         to set both pen and fill color.
     no_clip: bool or str
         Do NOT skip symbols that fall outside the frame boundary specified
-        by ``region``. [Default plots symbols inside frame only].
+        by ``region`` [Default plots symbols inside frame only].
     {timestamp}
     {verbose}
     pen : str


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix typos in the API documentation.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
