### PR TITLE
Fix default for `pen` parameter in API documentation

### DIFF
--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -85,8 +85,7 @@ def coast(self, **kwargs):
     rivers : int or str or list
         *river*\ [/*pen*].
         Draw rivers. Specify the type of rivers and [optionally] append
-        pen attributes [Default pen is width = default, color = black,
-        style = solid].
+        pen attributes [Default is ``"0.25p,black,solid"``].
 
         Choose from the list of river types below; pass a list to
         ``rivers`` to use multiple arguments.
@@ -133,8 +132,8 @@ def coast(self, **kwargs):
     borders : int or str or list
         *border*\ [/*pen*].
         Draw political boundaries. Specify the type of boundary and
-        [optionally] append pen attributes [Default pen is width = default,
-        color = black, style = solid].
+        [optionally] append pen attributes
+        [Default is ``"0.25p,black,solid"``].
 
         Choose from the list of boundaries below. Pass a list to
         ``borders`` to use multiple arguments.
@@ -152,7 +151,7 @@ def coast(self, **kwargs):
     shorelines : int or str or list
         [*level*\ /]\ *pen*.
         Draw shorelines [Default is no shorelines]. Append pen attributes
-        [Default is width = default, color = black, style = solid] which
+        [Default is ``"0.25p,black,solid"``] which
         apply to all four levels. To set the pen for a single level,
         pass a string with *level*\ /*pen*\ , where level is
         1-4 and represent coastline, lakeshore, island-in-lake shore, and

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -55,8 +55,7 @@ def solar(self, terminator="d", terminator_datetime=None, **kwargs):
     fill : str
         Color or pattern for filling of terminators.
     pen : str
-        Set pen attributes for lines. The default pen
-        is ``"0.25p,black,solid"``.
+        Set pen attributes for lines [Default is ``"0.25p,black,solid"``].
     {timestamp}
     {verbose}
     {xyshift}

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -144,8 +144,7 @@ def text_(
         for this line.
     pen : str
         Sets the pen used to draw a rectangle around the text string
-        (see ``clearance``) [Default is width = default, color = black,
-        style = solid].
+        (see ``clearance``) [Default is ``"0.25p,black,solid"``].
     no_clip : bool
         Do NOT clip text at map boundaries [Default is will clip].
     {timestamp}

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -213,7 +213,7 @@ def velo(self, data=None, **kwargs):
     pen : str
         [*pen*][**+c**\ [**f**\|\ **l**]].
         Set pen attributes for velocity arrows, ellipse circumference and fault
-        plane edges. [Defaults: width = default, color = black, style = solid].
+        plane edges [Default is ``"0.25p,black,solid"``].
         If the modifier **+cl** is appended then the color of the pen is
         updated from the CPT (see ``cmap``). If instead modifier **+cf** is
         appended then the color from the cpt file is applied to symbol fill


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix the default for the `pen` parameter  in the API documentation.

``Default pen: ``**``width = default``**``, color = black, style = solid``
also occurs in the upstream GMT documentation (e.g. https://docs.generic-mapping-tools.org/dev/coast.html#i). If the change to 
``Default pen: ``**``width = 0.25p``**``, color = black, style = solid``
is correct, I can try to open an corresponding PR in the next days.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
