### PR TITLE
Add L alias for ternary.py

### DIFF
--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -11,6 +11,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     C="cmap",
     G="fill",
     JX="width",
+    L="label",
     R="region",
     S="style",
     U="timestamp",
@@ -53,6 +54,11 @@ def ternary(self, data, **kwargs):
         Give the min and max limits for each of the three axes **a**, **b**,
         and **c**.
     {cmap}
+    label : str
+        *a*/*b*/*c*. Set the labels for the three diagram vertices where the 
+        component is 100% [none]. These are placed at a distance of three 
+        times the MAP_LABEL_OFFSET setting from their respective corners. 
+        To skip any one of them, specify that label as -.
     {fill}
     style : str
         *symbol*\[\ *size*].


### PR DESCRIPTION
**Description of proposed changes**

This PR adds an alias for the missing -L flag in ternary. 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
