### PR TITLE
Fix typos in API documentation

### DIFF
--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -204,7 +204,7 @@ decorator (if those two exist). Here is an example:
 @fmt_docstring
 @deprecate_parameter("columns", "incols", "v0.4.0", remove_version="v0.6.0")
 @use_alias(J="projection", R="region", V="verbose", i="incols")
-@kwargs_to_strings(R="sequence", i='sequence_comma')
+@kwargs_to_strings(R="sequence", i="sequence_comma")
 def plot(self, x=None, y=None, data=None, size=None, direction=None, **kwargs):
     pass
 ```

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -188,7 +188,7 @@ When making incompatible changes, we should follow the process:
 
 - Discuss whether the incompatible changes are necessary on GitHub.
 - Make the changes in a backwards compatible way, and raise a `FutureWarning`
-  warning for old usage. At least one test using the old usage should be added.
+  warning for the old usage. At least one test using the old usage should be added.
 - The warning message should clearly explain the changes and include the versions
   in which the old usage is deprecated and is expected to be removed.
 - The `FutureWarning` warning should appear for 2-4 minor versions, depending on

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -38,7 +38,7 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
     r"""
     Contour table data by direct triangulation.
 
-    Takes a matrix, (x,y,z) pairs, or a file name as input and plots lines,
+    Takes a matrix, (x,y,z) triplets, or a file name as input and plots lines,
     polygons, or symbols at those locations on a map.
 
     Must provide either ``data`` or ``x``/``y``/``z``.

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -59,7 +59,7 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
     {region}
     annotation : str or int
         Specify or disable annotated contour levels, modifies annotated
-        contours specified in ``interval``.
+        contours specified in ``levels``.
 
         - Specify a fixed annotation interval *annot_int* or a
           single annotation level +\ *annot_int*.

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -52,7 +52,7 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
     data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2D
-        {table-classes}
+        {table-classes}.
     x/y/z : 1d arrays
         Arrays of x and y coordinates and values z of the data points.
     {projection}
@@ -71,9 +71,9 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
           be used as contour levels.
         - The file name of a 2 (or 3) column file containing the contour
           levels (col 1), (**C**)ontour or (**A**)nnotate (col 2), and optional
-          angle (col 3)
+          angle (col 3).
         - A fixed contour interval *cont_int* or a single contour with
-          +\ *cont_int*
+          +\ *cont_int*.
     D : str
         Dump contour coordinates.
     E : str

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -51,16 +51,16 @@ def grdcontour(self, grid, **kwargs):
           be used as contour levels.
         - The file name of a 2 (or 3) column file containing the contour
           levels (col 1), (**C**)ontour or (**A**)nnotate (col 2), and optional
-          angle (col 3)
+          angle (col 3).
         - A fixed contour interval *cont_int* or a single contour with
-          +\ *cont_int*
+          +\ *cont_int*.
     annotation : str,  int, or list
         Specify or disable annotated contour levels, modifies annotated
         contours specified in ``interval``.
 
         - Specify a fixed annotation interval *annot_int* or a
-          single annotation level +\ *annot_int*
-        - Disable all annotation with  **-**
+          single annotation level +\ *annot_int*.
+        - Disable all annotation with  **-**.
         - Optional label modifiers can be specified as a single string
           ``"[annot_int]+e"``  or with a list of arguments
           ``([annot_int], "e", "f10p", "gred")``.


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix some typos in the API documentation.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
