### PR TITLE
Improve comments in example of Cartesian logarthmic projection

### DIFF
--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -27,8 +27,8 @@ fig.plot(
     frame=["WSne+gbisque", "x2g3", "ya2f1g2"],
     x=xline,
     y=yline,
-    # Set the line thickness to 1p, the color to blue, and the style to
-    # dash
+    # Set the line thickness to "1p", the color to "blue",
+    # and the style to "-", i.e. "dashed"
     pen="1p,blue,-",
 )
 # Plot square root values as points on the line

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -32,7 +32,7 @@ fig.plot(
     pen="1p,blue,-",
 )
 # Plot square root values as points on the line
-# Style of points is 0.3 cm square, color is red with a black outline
+# Style of points is 0.3 cm squares, color is "red" with a "black" outline
 # Points are not clipped if they go off the figure
 fig.plot(x=xpoints, y=ypoints, style="s0.3c", color="red", no_clip=True, pen="black")
 fig.show()

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -9,11 +9,11 @@ requires **l** after its size argument.
 import numpy as np
 import pygmt
 
-# Create a list of x values 0-100
+# Create a list of x-values 0-100
 xline = np.arange(0, 101)
 # Create a list of y-values that are the square root of the x-values
 yline = xline**0.5
-# Create a list of x values for every 10 in 0-100
+# Create a list of x-values for every 10 in 0-100
 xpoints = np.arange(0, 101, 10)
 # Create a list of y-values that are the square root of the x-values
 ypoints = xpoints**0.5

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -23,7 +23,8 @@ fig.plot(
     region=[1, 100, 0, 10],
     # Set a logarithmic transformation on the x-axis
     projection="X15cl/10c",
-    # Set the figures frame, color, annotations, and gridlines
+    # Set the figures frame and color as well as
+    # annotations, ticks, and gridlines
     frame=["WSne+gbisque", "xa2g3", "ya2f1g2"],
     x=xline,
     y=yline,

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -3,7 +3,7 @@ Cartesian logarithmic
 =====================
 
 **X**\ *width*\ [**l**]/[*height*\ [**l**]]: Give the *width* of the figure and
-the optional *height*. The axis or axes with a logarithmic transformation
+the optional *height*. Each axis with a logarithmic transformation
 requires **l** after its size argument.
 """
 import numpy as np

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -24,7 +24,7 @@ fig.plot(
     # Set a logarithmic transformation on the x-axis
     projection="X15cl/10c",
     # Set the figures frame, color, annotations, and gridlines
-    frame=["WSne+gbisque", "x2g3", "ya2f1g2"],
+    frame=["WSne+gbisque", "xa2g3", "ya2f1g2"],
     x=xline,
     y=yline,
     # Set the line thickness to "1p", the color to "blue",

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -27,12 +27,12 @@ fig.plot(
     frame=["WSne+gbisque", "x2g3", "ya2f1g2"],
     x=xline,
     y=yline,
-    # Set the line thickness to *1p*, the color to *blue*, and the style to
-    # *dash*
+    # Set the line thickness to 1p, the color to blue, and the style to
+    # dash
     pen="1p,blue,-",
 )
 # Plot square root values as points on the line
-# Style of points is 0.3 cm square, color is *red* with a *black* outline
+# Style of points is 0.3 cm square, color is red with a black outline
 # Points are not clipped if they go off the figure
 fig.plot(x=xpoints, y=ypoints, style="s0.3c", color="red", no_clip=True, pen="black")
 fig.show()

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -23,7 +23,7 @@ fig.plot(
     region=[1, 100, 0, 10],
     # Set a logarithmic transformation on the x-axis
     projection="X15cl/10c",
-    # Set the figures frame, color, and gridlines
+    # Set the figures frame, color, annotations, and gridlines
     frame=["WSne+gbisque", "x2g3", "ya2f1g2"],
     x=xline,
     y=yline,


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to improve the comments in the example of the [Cartesian logarithmic projection](https://www.pygmt.org/dev/projections/nongeo/cartesian_logarithmic.html#sphx-glr-projections-nongeo-cartesian-logarithmic-py).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
