### PR TITLE
Improve comments in example of Cartesian power projection

### DIFF
--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -21,6 +21,8 @@ fig.plot(
     # Set the power transformation of the x-axis, with a power of 0.5
     projection="X15cp0.5/10c",
     # Set the figures frame, color, and annotations
+    # The "p" forces to show only square numbers as annotations
+    # of the x-axis
     frame=["WSne+givory", "xa1p", "ya2f1"],
     # Set the line thickness to "thick" (equals "1p", i.e. 1 point)
     # Use the default color "black" and the default style "solid"

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -20,7 +20,7 @@ fig.plot(
     region=[0, 100, 0, 10],
     # Set the power transformation of the x-axis, with a power of 0.5
     projection="X15cp0.5/10c",
-    # Set the figures frame, color, and gridlines
+    # Set the figures frame, color, and annotations
     frame=["WSne+givory", "xa1p", "ya2f1"],
     # Set the line thickness to thick
     # Use the default color black and the default style solid

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -22,14 +22,14 @@ fig.plot(
     projection="X15cp0.5/10c",
     # Set the figures frame, color, and gridlines
     frame=["WSne+givory", "xa1p", "ya2f1"],
-    # Set the line thickness to *thick*
-    # Use the default color *black* and the default style *solid*
+    # Set the line thickness to thick
+    # Use the default color black and the default style solid
     pen="thick",
     x=xvalues,
     y=yvalues,
 )
 # Plot x,y values as points on the line
-# Style of points is 0.2 cm circles, color is *green* with a *black* outline
+# Style of points is 0.2 cm circles, color is green with a black outline
 # Points are not clipped if they go off the figure
 fig.plot(x=xvalues, y=yvalues, style="c0.2c", color="green", no_clip=True, pen="black")
 fig.show()

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -22,8 +22,8 @@ fig.plot(
     projection="X15cp0.5/10c",
     # Set the figures frame, color, and annotations
     frame=["WSne+givory", "xa1p", "ya2f1"],
-    # Set the line thickness to thick
-    # Use the default color black and the default style solid
+    # Set the line thickness to "thick" (equals "1p", i.e. 1 point)
+    # Use the default color "black" and the default style "solid"
     pen="thick",
     x=xvalues,
     y=yvalues,

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -29,7 +29,7 @@ fig.plot(
     y=yvalues,
 )
 # Plot x,y values as points on the line
-# Style of points is 0.2 cm circles, color is green with a black outline
+# Style of points is 0.2 cm circles, color is "green" with a "black" outline
 # Points are not clipped if they go off the figure
 fig.plot(x=xvalues, y=yvalues, style="c0.2c", color="green", no_clip=True, pen="black")
 fig.show()

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -3,9 +3,9 @@ Cartesian power
 ===============
 
 **X**\ *width*\ [**p**\ *pvalue*]/[*height*\ [**p**\ *pvalue*]]: Give the
-*width* of the figure and the optional argument *height*. The axis or axes with
-a logarithmic transformation requires **p** and the power transformation for
-that axis.
+*width* of the figure and the optional argument *height*. Each axis with
+a power transformation requires **p** and the exponent for that axis
+after its size argument.
 """
 import numpy as np
 import pygmt

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -26,8 +26,8 @@ fig.plot(
     # of the x-axis
     frame=["WSne+givory", "xa1p", "ya2f1"],
     # Set the line thickness to "thick" (equals "1p", i.e. 1 point)
-    # Use the default color "black" and the default style "solid"
-    pen="thick",
+    # Use as color "black" (default) and as style "solid" (default)
+    pen="thick,black,solid",
     x=xvalues,
     y=yvalues,
 )

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -20,7 +20,8 @@ fig.plot(
     region=[0, 100, 0, 10],
     # Set the power transformation of the x-axis, with a power of 0.5
     projection="X15cp0.5/10c",
-    # Set the figures frame, color, and annotations
+    # Set the figures frame and color as well as
+    # annotations and ticks
     # The "p" forces to show only square numbers as annotations
     # of the x-axis
     frame=["WSne+givory", "xa1p", "ya2f1"],

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -10,7 +10,7 @@ that axis.
 import numpy as np
 import pygmt
 
-# Create a list of y values 0-10
+# Create a list of y-values 0-10
 yvalues = np.arange(0, 11)
 # Create a list of x-values that are the square of the y-values
 xvalues = yvalues**2
@@ -28,7 +28,7 @@ fig.plot(
     x=xvalues,
     y=yvalues,
 )
-# Plot x,y values as points on the line
+# Plot x-, y-values as points on the line
 # Style of points is 0.2 cm circles, color is "green" with a "black" outline
 # Points are not clipped if they go off the figure
 fig.plot(x=xvalues, y=yvalues, style="c0.2c", color="green", no_clip=True, pen="black")


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to improve the comments in the example of the [Cartesian power projection](https://www.pygmt.org/dev/projections/nongeo/cartesian_power.html#sphx-glr-projections-nongeo-cartesian-power-py).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
