### PR TITLE
doc: Set different html_baseurl for stable and dev versions

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -137,9 +137,11 @@ project = "PyGMT"
 copyright = f"2017-{year}, The PyGMT Developers"  # pylint: disable=redefined-builtin
 if len(__version__.split("+")) > 1 or __version__ == "unknown":
     version = "dev"
+    # Set base_url for stable version
     html_baseurl = "https://pygmt.org/dev/"
 else:
     version = __version__
+    # Set base_url for dev version
     html_baseurl = "https://pygmt.org/latest/"
 release = __version__
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -137,8 +137,10 @@ project = "PyGMT"
 copyright = f"2017-{year}, The PyGMT Developers"  # pylint: disable=redefined-builtin
 if len(__version__.split("+")) > 1 or __version__ == "unknown":
     version = "dev"
+    html_baseurl = "https://pygmt.org/dev/"
 else:
     version = __version__
+    html_baseurl = "https://pygmt.org/latest/"
 release = __version__
 
 # These enable substitutions using |variable| in the rst files
@@ -146,7 +148,6 @@ rst_epilog = f"""
 .. |year| replace:: {year}
 """
 
-html_baseurl = "https://pygmt.org/latest/"
 html_last_updated_fmt = "%b %d, %Y"
 html_title = "PyGMT"
 html_short_title = "PyGMT"


### PR DESCRIPTION
**Description of proposed changes**

Following the comment https://github.com/GenericMappingTools/pygmt/issues/2151#issuecomment-1275616076.


Fixes #2151.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
