### PR TITLE
Figure.savefig: Raise a FileNotFoundError if the parent directory doesn't exist

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -244,8 +244,9 @@ class Figure:
 
         # check if the parent directory exists
         if kwargs.get("F") and not Path(kwargs.get("F")).parent.exists():
+            directory = Path(kwargs.get("F")).parent
             raise FileNotFoundError(
-                f"No such directory: '{Path(kwargs.get('F')).parent}'"
+                f"No such directory: '{directory}', please create it first."
             )
 
         # Manually handle prefix -F argument so spaces aren't converted to \040

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -4,6 +4,7 @@ Define the Figure class that handles all plotting.
 import base64
 import os
 import warnings
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 try:
@@ -240,6 +241,12 @@ class Figure:
                 kwargs["N"] = "+i"
             else:
                 kwargs["N"] += "+i"
+
+        # check if the parent directory exists
+        if kwargs.get("F") and not Path(kwargs.get("F")).parent.exists():
+            raise FileNotFoundError(
+                f"No such directory: '{Path(kwargs.get('F')).parent}'"
+            )
 
         # Manually handle prefix -F argument so spaces aren't converted to \040
         # by build_arg_string function. For more information, see

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -242,13 +242,6 @@ class Figure:
             else:
                 kwargs["N"] += "+i"
 
-        # check if the parent directory exists
-        if kwargs.get("F") and not Path(kwargs.get("F")).parent.exists():
-            directory = Path(kwargs.get("F")).parent
-            raise FileNotFoundError(
-                f"No such directory: '{directory}', please create it first."
-            )
-
         # Manually handle prefix -F argument so spaces aren't converted to \040
         # by build_arg_string function. For more information, see
         # https://github.com/GenericMappingTools/pygmt/pull/1487
@@ -258,6 +251,13 @@ class Figure:
                 "The 'prefix' parameter must be specified with a valid value."
             )
         prefix_arg = f'-F"{prefix}"'
+
+        # check if the parent directory exists
+        prefix_path = Path(prefix).parent
+        if not prefix_path.exists():
+            raise FileNotFoundError(
+                f"No such directory: '{prefix_path}', please create it first."
+            )
 
         with Session() as lib:
             lib.call_module(

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -89,6 +89,17 @@ def test_figure_savefig_exists():
         os.remove(fname)
 
 
+def test_figure_savefig_directory_nonexists():
+    """
+    Make sure that Figure.savefig() raises a FileNotFoundError when the parent
+    directory doesn't exist.
+    """
+    fig = Figure()
+    fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
+    with pytest.raises(FileNotFoundError, match="No such directory:"):
+        fig.savefig("a-nonexist-directory/test_figure_savefig_directory_nonexists.png")
+
+
 def test_figure_savefig_unknown_extension():
     """
     Check that an error is raised when an unknown extension is passed.


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes https://github.com/GenericMappingTools/pygmt/issues/2092.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
