### PR TITLE
Figure.psconvert: Check if the given prefix is valid

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -244,10 +244,12 @@ class Figure:
         # Manually handle prefix -F argument so spaces aren't converted to \040
         # by build_arg_string function. For more information, see
         # https://github.com/GenericMappingTools/pygmt/pull/1487
-        try:
-            prefix_arg = f'-F"{kwargs.pop("F")}"'
-        except KeyError as err:
-            raise GMTInvalidInput("The 'prefix' must be specified.") from err
+        prefix = kwargs.pop("F", None)
+        if prefix in ["", None, False, True]:
+            raise GMTInvalidInput(
+                "The 'prefix' parameter must be specified with a valid value."
+            )
+        prefix_arg = f'-F"{prefix}"'
 
         with Session() as lib:
             lib.call_module(

--- a/pygmt/tests/test_psconvert.py
+++ b/pygmt/tests/test_psconvert.py
@@ -52,7 +52,7 @@ def test_psconvert_without_prefix():
 @pytest.mark.parametrize("prefix", ["", None, False, True])
 def test_psconvert_invalid_prefix(prefix):
     """
-    Call psconvert with a invalid 'prefix' argument.
+    Call psconvert with an invalid 'prefix' argument.
     """
     fig = Figure()
     with pytest.raises(GMTInvalidInput):

--- a/pygmt/tests/test_psconvert.py
+++ b/pygmt/tests/test_psconvert.py
@@ -42,8 +42,18 @@ def test_psconvert_twice():
 
 def test_psconvert_without_prefix():
     """
-    Call psconvert without the 'prefix' option.
+    Call psconvert without the 'prefix' parameter.
     """
     fig = Figure()
     with pytest.raises(GMTInvalidInput):
         fig.psconvert(fmt="g")
+
+
+@pytest.mark.parametrize("prefix", ["", None, False, True])
+def test_psconvert_invalid_prefix(prefix):
+    """
+    Call psconvert with a invalid 'prefix' argument.
+    """
+    fig = Figure()
+    with pytest.raises(GMTInvalidInput):
+        fig.psconvert(fmt="g", prefix=prefix)


### PR DESCRIPTION
**Description of proposed changes**

For `Figure.psconvert`, `prefix` can't be "", None, True or False.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
