### PR TITLE
meca: Fix the bug when passing a dict of scalar values to the spec parameter

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -283,9 +283,8 @@ def meca(
 
         # convert dict to pd.DataFrame so columns can be reordered
         if isinstance(spec, dict):
-            # convert values to ndarray so that pandas doesn't complain about
-            # "all scalar values".
-            # See https://github.com/GenericMappingTools/pygmt/pull/2174 for details.
+            # convert values to ndarray so pandas doesn't complain about "all
+            # scalar values". See issue #2174 for details.
             for key, value in spec.items():
                 spec[key] = np.atleast_1d(value)
             spec = pd.DataFrame(spec)

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -284,9 +284,9 @@ def meca(
         # convert dict to pd.DataFrame so columns can be reordered
         if isinstance(spec, dict):
             # convert values to ndarray so pandas doesn't complain about "all
-            # scalar values". See issue #2174 for details.
-            for key, value in spec.items():
-                spec[key] = np.atleast_1d(value)
+            # scalar values". See
+            # https://github.com/GenericMappingTools/pygmt/pull/2174
+            spec = {key: np.atleast_1d(value) for key, value in spec.items()}
             spec = pd.DataFrame(spec)
 
         # expected columns are:

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -283,6 +283,11 @@ def meca(
 
         # convert dict to pd.DataFrame so columns can be reordered
         if isinstance(spec, dict):
+            # convert values to ndarray so that pandas doesn't complain about
+            # "all scalar values".
+            # See https://github.com/GenericMappingTools/pygmt/pull/2174 for details.
+            for key, value in spec.items():
+                spec[key] = np.atleast_1d(value)
             spec = pd.DataFrame(spec)
 
         # expected columns are:

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -29,25 +29,6 @@ def test_meca_spec_dictionary():
     return fig
 
 
-@pytest.mark.mpl_image_compare(filename="test_meca_spec_dictionary.png")
-def test_meca_spec_dict_all_scalars():
-    """
-    Test supplying a dict with scalar values for all focal parameters.
-    """
-    fig = Figure()
-    # Right lateral strike slip focal mechanism
-    fig.meca(
-        spec=dict(
-            strike=0, dip=90, rake=0, magnitude=5, longitude=0, latitude=5, depth=0
-        ),
-        scale="2.5c",
-        region=[-1, 1, 4, 6],
-        projection="M14c",
-        frame=2,
-    )
-    return fig
-
-
 @pytest.mark.mpl_image_compare
 def test_meca_spec_dict_list():
     """
@@ -308,5 +289,28 @@ def test_meca_dict_offset_eventname():
         plot_longitude=-124.5,
         plot_latitude=47.5,
         event_name="Event20220311",
+    )
+    return fig
+
+
+@pytest.mark.mpl_image_compare(filename="test_meca_dict_eventname.png")
+def test_meca_spec_dict_all_scalars():
+    """
+    Test supplying a dict with scalar values for all focal parameters.
+    """
+    fig = Figure()
+    fig.basemap(region=[-125, -122, 47, 49], projection="M6c", frame=True)
+    fig.meca(
+        spec=dict(
+            strike=330,
+            dip=30,
+            rake=90,
+            magnitude=3,
+            longitude=-124,
+            latitude=48,
+            depth=12.0,
+            event_name="Event20220311",
+        ),
+        scale="1c",
     )
     return fig

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -29,6 +29,25 @@ def test_meca_spec_dictionary():
     return fig
 
 
+@pytest.mark.mpl_image_compare(filename="test_meca_spec_dictionary.png")
+def test_meca_spec_dict_all_scalars():
+    """
+    Test supplying a dict with scalar values for all focal parameters.
+    """
+    fig = Figure()
+    # Right lateral strike slip focal mechanism
+    fig.meca(
+        spec=dict(
+            strike=0, dip=90, rake=0, magnitude=5, longitude=0, latitude=5, depth=0
+        ),
+        scale="2.5c",
+        region=[-1, 1, 4, 6],
+        projection="M14c",
+        frame=2,
+    )
+    return fig
+
+
 @pytest.mark.mpl_image_compare
 def test_meca_spec_dict_list():
     """

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -297,6 +297,9 @@ def test_meca_dict_offset_eventname():
 def test_meca_spec_dict_all_scalars():
     """
     Test supplying a dict with scalar values for all focal parameters.
+
+    This is a regression test for
+    https://github.com/GenericMappingTools/pygmt/pull/2174
     """
     fig = Figure()
     fig.basemap(region=[-125, -122, 47, 49], projection="M6c", frame=True)


### PR DESCRIPTION
**Description of proposed changes**

Minimal example:
```
import pygmt

fig = pygmt.Figure()
fig.meca(
    spec=dict(strike=0, dip=90, rake=0, magnitude=5, longitude=0, latitude=5, depth=0),
    scale="2.5c",
    region=[-1, 1, 4, 6],
    projection="M14c",
    frame=2,
)
fig.savefig("meca.png")
```
Running the example above produces the following error messages:
```
Traceback (most recent call last):
  File "/Users/seisman/OSS/gmt/pygmt/workspace/test2.py", line 4, in <module>
    fig.meca(
  File "/Users/seisman/OSS/gmt/pygmt/pygmt/helpers/decorators.py", line 578, in new_module
    return module_func(*args, **kwargs)
  File "/Users/seisman/OSS/gmt/pygmt/pygmt/helpers/decorators.py", line 718, in new_module
    return module_func(*args, **kwargs)
  File "/Users/seisman/OSS/gmt/pygmt/pygmt/src/meca.py", line 286, in meca
    spec = pd.DataFrame(spec)
  File "/Users/seisman/opt/miniconda/lib/python3.9/site-packages/pandas/core/frame.py", line 636, in __init__
    mgr = dict_to_mgr(data, index, columns, dtype=dtype, copy=copy, typ=manager)
  File "/Users/seisman/opt/miniconda/lib/python3.9/site-packages/pandas/core/internals/construction.py", line 502, in dict_to_mgr
    return arrays_to_mgr(arrays, columns, index, dtype=dtype, typ=typ, consolidate=copy)
  File "/Users/seisman/opt/miniconda/lib/python3.9/site-packages/pandas/core/internals/construction.py", line 120, in arrays_to_mgr
    index = _extract_index(arrays)
  File "/Users/seisman/opt/miniconda/lib/python3.9/site-packages/pandas/core/internals/construction.py", line 664, in _extract_index
    raise ValueError("If using all scalar values, you must pass an index")
ValueError: If using all scalar values, you must pass an index
```
The error is raised when we try to convert a dict with scalar values to pandas.DataFrame. So, here is the real minimal example to reproduce the issue:
```
import pandas as pd
pd.DataFrame(dict(strike=0, dip=90, rake=0, magnitude=5, longitude=0, latitude=5, depth=0))
```

The solution here is to convert dict's values to ndarray before the converison.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
