### PR TITLE
Replace "option" by "parameter" in tests

### DIFF
--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -61,7 +61,7 @@ def test_coast_dcw_single():
 @pytest.mark.mpl_image_compare
 def test_coast_dcw_list():
     """
-    Test passing a list of country codes and fill options to dcw.
+    Test passing a list of country codes and fill arguments to dcw.
     """
     fig = Figure()
     fig.coast(

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -165,7 +165,7 @@ def test_info_1d_array():
 
 def test_info_per_column():
     """
-    Make sure the per_column option works.
+    Make sure the per_column parameter works.
     """
     output = info(data=POINTS_DATA, per_column=True)
     npt.assert_allclose(
@@ -175,7 +175,7 @@ def test_info_per_column():
 
 def test_info_per_column_with_time_inputs():
     """
-    Make sure the per_column option works with time inputs.
+    Make sure the per_column parameter works with time inputs.
     """
     table = pd.date_range(start="2020-01-01", periods=5).to_numpy()
     output = info(data=table, per_column=True)
@@ -186,7 +186,7 @@ def test_info_per_column_with_time_inputs():
 
 def test_info_spacing():
     """
-    Make sure the spacing option works.
+    Make sure the spacing parameter works.
     """
     output = info(data=POINTS_DATA, spacing=0.1)
     npt.assert_allclose(actual=output, desired=[11.5, 61.8, -3, 7.9])
@@ -194,7 +194,7 @@ def test_info_spacing():
 
 def test_info_spacing_bounding_box():
     """
-    Make sure the spacing option for writing a bounding box works.
+    Make sure the spacing parameter for writing a bounding box works.
     """
     output = info(data=POINTS_DATA, spacing="b")
     npt.assert_allclose(
@@ -211,7 +211,7 @@ def test_info_spacing_bounding_box():
 
 def test_info_per_column_spacing():
     """
-    Make sure the per_column and spacing options work together.
+    Make sure the per_column and spacing parameters work together.
     """
     output = info(data=POINTS_DATA, per_column=True, spacing=0.1)
     npt.assert_allclose(actual=output, desired=[11.5, 61.8, -3, 7.9, 0.1412, 0.9338])
@@ -219,7 +219,7 @@ def test_info_per_column_spacing():
 
 def test_info_nearest_multiple():
     """
-    Make sure the nearest_multiple option works.
+    Make sure the nearest_multiple parameter works.
     """
     output = info(data=POINTS_DATA, nearest_multiple=0.1)
     npt.assert_allclose(actual=output, desired=[11.5, 61.8, 0.1])

--- a/pygmt/tests/test_solar.py
+++ b/pygmt/tests/test_solar.py
@@ -84,7 +84,7 @@ def test_invalid_parameter():
     """
     fig = Figure()
     with pytest.raises(GMTInvalidInput):
-        # Use single-letter option 'T' for testing
+        # Use single-letter parameter 'T' for testing
         fig.solar(
             region="d", projection="W0/15c", frame="a", T="d+d1990-02-17T04:25:00"
         )


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to replace `option` by `parameter` in some tests.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
