### PR TITLE
Correct syntax for `error_bar` of `pygmt.Figure.plot`

### DIFF
--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -116,8 +116,8 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
         *dx/dy* [Default is no offset]. If *dy* is not given it is set
         equal to *dx*.
     error_bar : bool or str
-        [**+b**\|\ **d**\|\ **D**][**+xl**\|\ **r**\|\ *x0*]\
-        [**+yl**\|\ **r**\|\ *y0*][**+p**\ *pen*].
+        [**x**\|\ **y**\|\ **X**\|\ **Y**][**+a**\|\ **A**]\
+        [**+cl**\|\ **f**][**+n**][**+w**\ *cap*][**+p**\ *pen*].
         Draw symmetrical error bars. Full documentation is at
         :gmt-docs:`plot.html#e`.
     connection : str

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -118,7 +118,7 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
     error_bar : bool or str
         [**x**\|\ **y**\|\ **X**\|\ **Y**][**+a**\|\ **A**]\
         [**+cl**\|\ **f**][**+n**][**+w**\ *cap*][**+p**\ *pen*].
-        Draw symmetrical error bars. Full documentation is at
+        Draw error bars. Full documentation is at
         :gmt-docs:`plot.html#e`.
     connection : str
         [**c**\|\ **n**\|\ **r**]\


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to correct the syntax for the `error_bar` parameter of [`pygmt.Figure.plot`](https://www.pygmt.org/dev/api/generated/pygmt.Figure.plot.html#pygmt.Figure.plot) following the upstream GMT documentation https://docs.generic-mapping-tools.org/dev/plot.html#e.

For context see https://github.com/GenericMappingTools/pygmt/issues/2182#issuecomment-1304620327.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
