### PR TITLE
Change "triple"/"quadruple" to "triplet"/"quadruplet" in the documentation

### DIFF
--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -14,8 +14,8 @@ the colorbar using the following options:
   ``position="jTR"`` for top right.
 - **g**: using map coordinates, e.g. ``position="g170/-45"`` for longitude
   170E, latitude 45S.
-- **x**: using paper coordinates, e.g. ``position="x5c/7c"`` for 5 cm, 7 cm from
-  anchor point.
+- **x**: using paper coordinates, e.g. ``position="x5c/7c"`` for 5 cm, 7 cm
+  from anchor point.
 - **n**: using normalized (0-1) coordinates, e.g. ``position="n0.4/0.8"``.
 
 Note that the anchor point defaults to the bottom left (**BL**). Append ``+h``

--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -14,7 +14,7 @@ the colorbar using the following options:
   ``position="jTR"`` for top right.
 - **g**: using map coordinates, e.g. ``position="g170/-45"`` for longitude
   170E, latitude 45S.
-- **x**: using paper coordinates, e.g. ``position="x5c/7c"`` for 5 cm,7 cm from
+- **x**: using paper coordinates, e.g. ``position="x5c/7c"`` for 5 cm, 7 cm from
   anchor point.
 - **n**: using normalized (0-1) coordinates, e.g. ``position="n0.4/0.8"``.
 

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -144,8 +144,8 @@ COMMON_DOCSTRINGS = {
         nodata : str
             **i**\|\ **o**\ *nodata*.
             Substitute specific values with NaN (for tabular data). For
-            example, ``d="-9999"`` will replace all values equal to -9999 with
-            NaN during input and all NaN values with -9999 during output.
+            example, ``nodata="-9999"`` will replace all values equal to -9999
+            with NaN during input and all NaN values with -9999 during output.
             Prepend **i** to the *nodata* value for input columns only. Prepend
             **o** to the *nodata* value for output columns only.""",
     "panel": r"""

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -17,8 +17,7 @@ __doctest_skip__ = ["blockmean", "blockmedian", "blockmode"]
 
 def _blockm(block_method, data, x, y, z, outfile, **kwargs):
     r"""
-    Block average (x, y, z) data tables by mean, median, or mode
-	estimation.
+    Block average (x, y, z) data tables by mean, median, or mode estimation.
 
     Reads arbitrarily located (x, y, z) triplets [or optionally weighted
     quadruples (x, y, z, w)] from a table and writes to the output a mean,

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -95,7 +95,7 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     for every non-empty block in a grid region defined by the ``region`` and
     ``spacing`` parameters.
 
-    Takes a matrix, xyz triplets, or a file name as input.
+    Takes a matrix, (x,y,z) triplets, or a file name as input.
 
     Must provide either ``data`` or ``x``, ``y``, and ``z``.
 
@@ -191,7 +191,7 @@ def blockmedian(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     for every non-empty block in a grid region defined by the ``region`` and
     ``spacing`` parameters.
 
-    Takes a matrix, xyz triplets, or a file name as input.
+    Takes a matrix, (x,y,z) triplets, or a file name as input.
 
     Must provide either ``data`` or ``x``, ``y``, and ``z``.
 
@@ -278,7 +278,7 @@ def blockmode(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     for every non-empty block in a grid region defined by the ``region`` and
     ``spacing`` parameters.
 
-    Takes a matrix, xyz triplets, or a file name as input.
+    Takes a matrix, (x,y,z) triplets, or a file name as input.
 
     Must provide either ``data`` or ``x``, ``y``, and ``z``.
 

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -20,7 +20,7 @@ def _blockm(block_method, data, x, y, z, outfile, **kwargs):
     Block average (x, y, z) data tables by mean, median, or mode estimation.
 
     Reads arbitrarily located (x, y, z) triplets [or optionally weighted
-    quadruples (x, y, z, w)] from a table and writes to the output a mean,
+    quadruplets (x, y, z, w)] from a table and writes to the output a mean,
     median, or mode (depending on ``block_method``) position and value for
     every non-empty block in a grid region defined by the ``region`` and
     ``spacing`` parameters.
@@ -92,9 +92,9 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     Block average (x, y, z) data tables by mean estimation.
 
     Reads arbitrarily located (x, y, z) triplets [or optionally weighted
-    quadruples (x, y, z, w)] and writes to the output a mean position and value
-    for every non-empty block in a grid region defined by the ``region`` and
-    ``spacing`` parameters.
+    quadruplets (x, y, z, w)] and writes to the output a mean position and
+    value for every non-empty block in a grid region defined by the ``region``
+    and ``spacing`` parameters.
 
     Takes a matrix, (x, y, z) triplets, or a file name as input.
 
@@ -188,7 +188,7 @@ def blockmedian(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     Block average (x, y, z) data tables by median estimation.
 
     Reads arbitrarily located (x, y, z) triplets [or optionally weighted
-    quadruples (x, y, z, w)] and writes to the output a median position and
+    quadruplets (x, y, z, w)] and writes to the output a median position and
     value for every non-empty block in a grid region defined by the ``region``
     and ``spacing`` parameters.
 
@@ -275,7 +275,7 @@ def blockmode(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     Block average (x, y, z) data tables by mode estimation.
 
     Reads arbitrarily located (x, y, z) triplets [or optionally weighted
-    quadruples (x, y, z, w)] and writes to the output a mode position and
+    quadruplets (x, y, z, w)] and writes to the output a mode position and
     value for every non-empty block in a grid region defined by the ``region``
     and ``spacing`` parameters.
 

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -18,7 +18,7 @@ def _blockm(block_method, data, x, y, z, outfile, **kwargs):
     r"""
     Block average (x,y,z) data tables by mean, median, or mode estimation.
 
-    Reads arbitrarily located (x,y,z) triples [or optionally weighted
+    Reads arbitrarily located (x,y,z) triplets [or optionally weighted
     quadruples (x,y,z,w)] from a table and writes to the output a mean,
     median, or mode (depending on ``block_method``) position and value for
     every non-empty block in a grid region defined by the ``region`` and
@@ -90,7 +90,7 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     r"""
     Block average (x,y,z) data tables by mean estimation.
 
-    Reads arbitrarily located (x,y,z) triples [or optionally weighted
+    Reads arbitrarily located (x,y,z) triplets [or optionally weighted
     quadruples (x,y,z,w)] and writes to the output a mean position and value
     for every non-empty block in a grid region defined by the ``region`` and
     ``spacing`` parameters.
@@ -186,7 +186,7 @@ def blockmedian(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     r"""
     Block average (x,y,z) data tables by median estimation.
 
-    Reads arbitrarily located (x,y,z) triples [or optionally weighted
+    Reads arbitrarily located (x,y,z) triplets [or optionally weighted
     quadruples (x,y,z,w)] and writes to the output a median position and value
     for every non-empty block in a grid region defined by the ``region`` and
     ``spacing`` parameters.
@@ -273,7 +273,7 @@ def blockmode(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     r"""
     Block average (x,y,z) data tables by mode estimation.
 
-    Reads arbitrarily located (x,y,z) triples [or optionally weighted
+    Reads arbitrarily located (x,y,z) triplets [or optionally weighted
     quadruples (x,y,z,w)] and writes to the output a mode position and value
     for every non-empty block in a grid region defined by the ``region`` and
     ``spacing`` parameters.

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -1,5 +1,6 @@
 """
-blockm - Block average (x,y,z) data tables by mean, median, or mode estimation.
+blockm - Block average (x, y, z) data tables by mean, median, or mode
+estimation.
 """
 import pandas as pd
 from pygmt.clib import Session
@@ -16,10 +17,11 @@ __doctest_skip__ = ["blockmean", "blockmedian", "blockmode"]
 
 def _blockm(block_method, data, x, y, z, outfile, **kwargs):
     r"""
-    Block average (x,y,z) data tables by mean, median, or mode estimation.
+    Block average (x, y, z) data tables by mean, median, or mode
+	estimation.
 
-    Reads arbitrarily located (x,y,z) triplets [or optionally weighted
-    quadruples (x,y,z,w)] from a table and writes to the output a mean,
+    Reads arbitrarily located (x, y, z) triplets [or optionally weighted
+    quadruples (x, y, z, w)] from a table and writes to the output a mean,
     median, or mode (depending on ``block_method``) position and value for
     every non-empty block in a grid region defined by the ``region`` and
     ``spacing`` parameters.
@@ -88,14 +90,14 @@ def _blockm(block_method, data, x, y, z, outfile, **kwargs):
 @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma", o="sequence_comma")
 def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     r"""
-    Block average (x,y,z) data tables by mean estimation.
+    Block average (x, y, z) data tables by mean estimation.
 
-    Reads arbitrarily located (x,y,z) triplets [or optionally weighted
-    quadruples (x,y,z,w)] and writes to the output a mean position and value
+    Reads arbitrarily located (x, y, z) triplets [or optionally weighted
+    quadruples (x, y, z, w)] and writes to the output a mean position and value
     for every non-empty block in a grid region defined by the ``region`` and
     ``spacing`` parameters.
 
-    Takes a matrix, (x,y,z) triplets, or a file name as input.
+    Takes a matrix, (x, y, z) triplets, or a file name as input.
 
     Must provide either ``data`` or ``x``, ``y``, and ``z``.
 
@@ -184,14 +186,14 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
 @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma", o="sequence_comma")
 def blockmedian(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     r"""
-    Block average (x,y,z) data tables by median estimation.
+    Block average (x, y, z) data tables by median estimation.
 
-    Reads arbitrarily located (x,y,z) triplets [or optionally weighted
-    quadruples (x,y,z,w)] and writes to the output a median position and value
-    for every non-empty block in a grid region defined by the ``region`` and
-    ``spacing`` parameters.
+    Reads arbitrarily located (x, y, z) triplets [or optionally weighted
+    quadruples (x, y, z, w)] and writes to the output a median position and
+    value for every non-empty block in a grid region defined by the ``region``
+    and ``spacing`` parameters.
 
-    Takes a matrix, (x,y,z) triplets, or a file name as input.
+    Takes a matrix, (x, y, z) triplets, or a file name as input.
 
     Must provide either ``data`` or ``x``, ``y``, and ``z``.
 
@@ -271,14 +273,14 @@ def blockmedian(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
 @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma", o="sequence_comma")
 def blockmode(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     r"""
-    Block average (x,y,z) data tables by mode estimation.
+    Block average (x, y, z) data tables by mode estimation.
 
-    Reads arbitrarily located (x,y,z) triplets [or optionally weighted
-    quadruples (x,y,z,w)] and writes to the output a mode position and value
-    for every non-empty block in a grid region defined by the ``region`` and
-    ``spacing`` parameters.
+    Reads arbitrarily located (x, y, z) triplets [or optionally weighted
+    quadruples (x, y, z, w)] and writes to the output a mode position and
+    value for every non-empty block in a grid region defined by the ``region``
+    and ``spacing`` parameters.
 
-    Takes a matrix, (x,y,z) triplets, or a file name as input.
+    Takes a matrix, (x, y, z) triplets, or a file name as input.
 
     Must provide either ``data`` or ``x``, ``y``, and ``z``.
 

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -38,8 +38,8 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
     r"""
     Contour table data by direct triangulation.
 
-    Takes a matrix, (x,y,z) triplets, or a file name as input and plots lines,
-    polygons, or symbols at those locations on a map.
+    Takes a matrix, (x, y, z) triplets, or a file name as input and plots,
+    lines, polygons, or symbols at those locations on a map.
 
     Must provide either ``data`` or ``x``/``y``/``z``.
 

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -41,7 +41,7 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
     Takes a matrix, (x, y, z) triplets, or a file name as input and plots,
     lines, polygons, or symbols at those locations on a map.
 
-    Must provide either ``data`` or ``x``/``y``/``z``.
+    Must provide either ``data`` or ``x``, ``y``, and ``z``.
 
     Full option list at :gmt-docs:`contour.html`
 

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -40,7 +40,7 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
     r"""
     Grid table data using a "Nearest neighbor" algorithm.
 
-    **nearneighbor** reads arbitrarily located (*x,y,z*\ [,\ *w*]) triplets
+    **nearneighbor** reads arbitrarily located (*x*, *y*, *z*\ [, *w*]) triplets
     [quadruplets] and uses a nearest neighbor algorithm to assign a weighted
     average value to each node that has one or more data points within a search
     radius centered on the node with adequate coverage across a subset of the

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -40,7 +40,7 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
     r"""
     Grid table data using a "Nearest neighbor" algorithm.
 
-    **nearneighbor** reads arbitrarily located (*x,y,z*\ [,\ *w*]) triples
+    **nearneighbor** reads arbitrarily located (*x,y,z*\ [,\ *w*]) triplets
     [quadruplets] and uses a nearest neighbor algorithm to assign a weighted
     average value to each node that has one or more data points within a search
     radius centered on the node with adequate coverage across a subset of the
@@ -67,7 +67,7 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
        Only the closest point in each sector (red circles) contribute to the
        weighted estimate.
 
-    Takes a matrix, xyz triples, or a file name as input.
+    Takes a matrix, xyz triplets, or a file name as input.
 
     Must provide either ``data`` or ``x``, ``y``, and ``z``.
 

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -67,7 +67,7 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
        Only the closest point in each sector (red circles) contribute to the
        weighted estimate.
 
-    Takes a matrix, xyz triplets, or a file name as input.
+    Takes a matrix, (x,y,z) triplets, or a file name as input.
 
     Must provide either ``data`` or ``x``, ``y``, and ``z``.
 

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -1,5 +1,5 @@
 """
-nearneighbor - Grid table data using a "Nearest neighbor" algorithm
+nearneighbor - Grid table data using a "Nearest neighbor" algorithm.
 """
 
 from pygmt.clib import Session

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -67,7 +67,7 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
        Only the closest point in each sector (red circles) contribute to the
        weighted estimate.
 
-    Takes a matrix, (x,y,z) triplets, or a file name as input.
+    Takes a matrix, (x, y, z) triplets, or a file name as input.
 
     Must provide either ``data`` or ``x``, ``y``, and ``z``.
 

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -61,10 +61,10 @@ def plot3d(
     Takes a matrix, (x, y, z) triplets, or a file name as input and plots
     lines, polygons, or symbols at those locations in 3-D.
 
-    Must provide either ``data`` or ``x``/``y``/``z``.
+    Must provide either ``data`` or ``x``, ``y``, and ``z``.
 
-    If providing data through ``x``/``y``/``z``, ``fill`` can be a 1d array
-    that will be mapped to a colormap.
+    If providing data through ``x``, ``y``, and ``z``, ``fill`` can be a
+    1d array that will be mapped to a colormap.
 
     If a symbol is selected and no symbol size given, then plot3d will
     interpret the fourth column of the input data as symbol size. Symbols

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -63,7 +63,7 @@ def plot3d(
 
     Must provide either ``data`` or ``x``/``y``/``z``.
 
-    If providing data through ``x/y/z``, ``fill`` can be a 1d array
+    If providing data through ``x``/``y``/``z``, ``fill`` can be a 1d array
     that will be mapped to a colormap.
 
     If a symbol is selected and no symbol size given, then plot3d will

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -58,7 +58,7 @@ def plot3d(
     r"""
     Plot lines, polygons, and symbols in 3-D.
 
-    Takes a matrix, (x,y,z) triplets, or a file name as input and plots
+    Takes a matrix, (x, y, z) triplets, or a file name as input and plots
     lines, polygons, or symbols at those locations in 3-D.
 
     Must provide either ``data`` or ``x``/``y``/``z``.

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -43,7 +43,7 @@ def project(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     the input (beyond the required :math:`x` and :math:`y` columns).
 
     Alternatively, ``project`` may be used to generate
-    :math:`(r, s, p)` triples at equal increments along a profile using the
+    :math:`(r, s, p)` triplets at equal increments along a profile using the
     ``generate`` parameter. In this case, the value of ``data`` is ignored
     (you can use, e.g., ``data=None``).
 

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -36,15 +36,15 @@ def surface(data=None, x=None, y=None, z=None, **kwargs):
     r"""
     Grids table data using adjustable tension continuous curvature splines.
 
-    Surface reads randomly-spaced (x,y,z) triplets and produces gridded values
-    z(x,y) by solving:
+    Surface reads randomly-spaced (x, y, z) triplets and produces gridded
+    values z(x,y) by solving:
 
     .. math::    (1 - t)\nabla^2(z)+t\nabla(z) = 0
 
     where :math:`t` is a tension factor between 0 and 1, and :math:`\nabla`
     indicates the Laplacian operator.
 
-    Takes a matrix, (x,y,z) triplets, or a file name as input.
+    Takes a matrix, (x, y, z) triplets, or a file name as input.
 
     Must provide either ``data`` or ``x``, ``y``, and ``z``.
 

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -36,7 +36,7 @@ def surface(data=None, x=None, y=None, z=None, **kwargs):
     r"""
     Grids table data using adjustable tension continuous curvature splines.
 
-    Surface reads randomly-spaced (x,y,z) triples and produces gridded values
+    Surface reads randomly-spaced (x,y,z) triplets and produces gridded values
     z(x,y) by solving:
 
     .. math::    (1 - t)\nabla^2(z)+t\nabla(z) = 0
@@ -44,7 +44,7 @@ def surface(data=None, x=None, y=None, z=None, **kwargs):
     where :math:`t` is a tension factor between 0 and 1, and :math:`\nabla`
     indicates the Laplacian operator.
 
-    Takes a matrix, xyz triples, or a file name as input.
+    Takes a matrix, xyz triplets, or a file name as input.
 
     Must provide either ``data`` or ``x``, ``y``, and ``z``.
 

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -44,7 +44,7 @@ def surface(data=None, x=None, y=None, z=None, **kwargs):
     where :math:`t` is a tension factor between 0 and 1, and :math:`\nabla`
     indicates the Laplacian operator.
 
-    Takes a matrix, xyz triplets, or a file name as input.
+    Takes a matrix, (x,y,z) triplets, or a file name as input.
 
     Must provide either ``data`` or ``x``, ``y``, and ``z``.
 

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -39,7 +39,7 @@ def wiggle(self, data=None, x=None, y=None, z=None, **kwargs):
     Takes a matrix, (x, y, z) triplets, or a file name as input and plots z
     as a function of distance along track.
 
-    Must provide either ``data`` or ``x``/``y``/``z``.
+    Must provide either ``data`` or ``x``, ``y``, and ``z``.
 
     Full option list at :gmt-docs:`wiggle.html`
 

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -36,8 +36,8 @@ def wiggle(self, data=None, x=None, y=None, z=None, **kwargs):
     r"""
     Plot z=f(x,y) anomalies along tracks.
 
-    Takes a matrix, (x,y,z) triplets, or a file name as input and plots z as a
-    function of distance along track.
+    Takes a matrix, (x, y, z) triplets, or a file name as input and plots z
+    as a function of distance along track.
 
     Must provide either ``data`` or ``x``/``y``/``z``.
 


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix some typos in the documentation as well as gallery examples.
Mainly "triple" / "quadruple" is changed to "triplet" / "quadruplet" (see discussion below).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
