### PR TITLE
Fix typos in tutorial and docs "text.py"

### DIFF
--- a/examples/tutorials/basics/text.py
+++ b/examples/tutorials/basics/text.py
@@ -21,7 +21,7 @@ import pygmt
 # Here we create a simple map and add an annotation using the ``text``, ``x``,
 # and ``y`` parameters to specify the annotation text and position in the
 # projection frame. ``text`` accepts *str* types, while ``x``, and ``y``
-# accepts either *int* or *float* numbers, or a list/array of numbers.
+# accept either *int* or *float* numbers, or a list/array of numbers.
 
 fig = pygmt.Figure()
 with pygmt.config(MAP_FRAME_TYPE="plain"):

--- a/examples/tutorials/basics/text.py
+++ b/examples/tutorials/basics/text.py
@@ -117,8 +117,8 @@ fig.show()
 ###############################################################################
 # ``angle`` parameter
 # -------------------
-# ``angle`` is an optional parameter used to specify the clockwise rotation of
-# the text from the horizontal.
+# ``angle`` is an optional parameter used to specify the counter-clockwise
+# rotation of the text from the horizontal.
 
 fig = pygmt.Figure()
 fig.basemap(region=[0, 4, 0, 4], projection="X5c", frame="WSen")

--- a/examples/tutorials/basics/text.py
+++ b/examples/tutorials/basics/text.py
@@ -97,7 +97,7 @@ fig.show()
 # being added to a plot. The following code segment demonstrates the
 # positioning of the anchor point relative to the text.
 #
-# The anchor point is specified with a two letter (order independent) code,
+# The anchor point is specified with a two-letter (order independent) code,
 # chosen from:
 #
 # * Vertical anchor: **T**\(op), **M**\(iddle), **B**\(ottom)

--- a/examples/tutorials/basics/text.py
+++ b/examples/tutorials/basics/text.py
@@ -97,8 +97,8 @@ fig.show()
 # being added to a plot. The following code segment demonstrates the
 # positioning of the anchor point relative to the text.
 #
-# The anchor is specified with a two letter (order independent) code, chosen
-# from:
+# The anchor point is specified with a two letter (order independent) code,
+# chosen from:
 #
 # * Vertical anchor: **T**\(op), **M**\(iddle), **B**\(ottom)
 # * Horizontal anchor: **L**\(eft), **C**\(entre), **R**\(ight)

--- a/examples/tutorials/basics/text.py
+++ b/examples/tutorials/basics/text.py
@@ -28,10 +28,10 @@ with pygmt.config(MAP_FRAME_TYPE="plain"):
     fig.basemap(region=[108, 120, -5, 8], projection="M20c", frame="a")
 fig.coast(land="black", water="skyblue")
 
-# Plot text annotations using a single element
+# Plot text annotations using single arguments
 fig.text(text="SOUTH CHINA SEA", x=112, y=6)
 
-# Plot text annotations using lists of elements
+# Plot text annotations using lists of arguments
 fig.text(text=["CELEBES SEA", "JAVA SEA"], x=[119, 112], y=[3.25, -4.6])
 
 fig.show()

--- a/examples/tutorials/basics/text.py
+++ b/examples/tutorials/basics/text.py
@@ -2,7 +2,7 @@
 Plotting text
 =============
 
-It is often useful to add annotations to a map plot. This is handled by
+It is often useful to add annotations to a plot. This is handled by
 :meth:`pygmt.Figure.text`.
 """
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/tutorials/basics/text.py
+++ b/examples/tutorials/basics/text.py
@@ -61,7 +61,7 @@ fig.show()
 # -------------------------
 #
 # It is also possible to add annotations from a file containing ``x``, ``y``,
-# and ``text`` fields. Here we give a complete example.
+# and ``text`` columns. Here we give a complete example.
 
 fig = pygmt.Figure()
 with pygmt.config(MAP_FRAME_TYPE="plain"):

--- a/examples/tutorials/basics/text.py
+++ b/examples/tutorials/basics/text.py
@@ -20,7 +20,7 @@ import pygmt
 #
 # Here we create a simple map and add an annotation using the ``text``, ``x``,
 # and ``y`` parameters to specify the annotation text and position in the
-# projection frame. ``text`` accepts *str* types, while ``x``, and ``y``
+# projection frame. ``text`` accepts *str* types, while ``x`` and ``y``
 # accept either *int* or *float* numbers, or a list/array of numbers.
 
 fig = pygmt.Figure()

--- a/examples/tutorials/basics/text.py
+++ b/examples/tutorials/basics/text.py
@@ -118,7 +118,7 @@ fig.show()
 # ``angle`` parameter
 # -------------------
 # ``angle`` is an optional parameter used to specify the counter-clockwise
-# rotation of the text from the horizontal.
+# rotation in degrees of the text from the horizontal.
 
 fig = pygmt.Figure()
 fig.basemap(region=[0, 4, 0, 4], projection="X5c", frame="WSen")

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -126,7 +126,7 @@ def text_(
         specified. Append the unit you want (*c* for cm, *i* for inch, or *p*
         for point; if not given we consult :gmt-term:`PROJ_LENGTH_UNIT`)
         or *%* for a percentage of the font size. Optionally, use modifier
-        **+t** to set the shape of the textbox when using ``fill`` and/or
+        **+t** to set the shape of the text box when using ``fill`` and/or
         ``pen``. Append lower case **o** to get a straight rectangle
         [Default is **o**]. Append upper case **O** to get a rounded
         rectangle. In paragraph mode (*paragraph*) you can also append lower

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -149,7 +149,7 @@ def text_(
         Sets the pen used to draw a rectangle around the text string
         (see ``clearance``) [Default is ``"0.25p,black,solid"``].
     no_clip : bool
-        Do NOT clip text at map boundaries [Default is will clip].
+        Do NOT clip text at map boundaries [Default is with clip].
     {timestamp}
     {verbose}
     {xyshift}

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -137,7 +137,7 @@ def text_(
         no fill].
     offset : str
         [**j**\|\ **J**]\ *dx*\[/*dy*][**+v**\[*pen*]].
-        Offsets the text from the projected (x,y) point by *dx*,\ *dy* [0/0].
+        Offsets the text from the projected (x,y) point by *dx*/\ *dy* [0/0].
         If *dy* is not specified then it is set equal to *dx*. Use **j** to
         offset the text away from the point instead (i.e., the text
         justification will determine the direction of the shift). Using

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -81,11 +81,11 @@ def text_(
         records with (x, y[, angle, font, justify], text).
     x/y : float or 1d arrays
         The x and y coordinates, or an array of x and y coordinates to plot
-        the text
+        the text.
     position : str
-        Sets reference point on the map for the text by using x,y
+        Sets reference point on the map for the text by using x, y
         coordinates extracted from ``region`` instead of providing them
-        through ``x``/``y``. Specify with a two letter (order independent)
+        through ``x``/``y``. Specify with a two-letter (order independent)
         code, chosen from:
 
         * Horizontal: **L**\ (eft), **C**\ (entre), **R**\ (ight)
@@ -94,7 +94,7 @@ def text_(
         For example, ``position="TL"`` plots the text at the Upper Left corner
         of the map.
     text : str or 1d array
-        The text string, or an array of strings to plot on the figure
+        The text string, or an array of strings to plot on the figure.
     angle: int, float, str or bool
         Set the angle measured in degrees counter-clockwise from
         horizontal (e.g. 30 sets the text at 30 degrees). If no angle is

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -137,7 +137,8 @@ def text_(
         no fill].
     offset : str
         [**j**\|\ **J**]\ *dx*\[/*dy*][**+v**\[*pen*]].
-        Offsets the text from the projected (x, y) point by *dx*/\ *dy* [0/0].
+        Offsets the text from the projected (x, y) point by *dx*/\ *dy*
+        [Default is ``"0/0"``].
         If *dy* is not specified then it is set equal to *dx*. Use **j** to
         offset the text away from the point instead (i.e., the text
         justification will determine the direction of the shift). Using

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -110,7 +110,7 @@ def text_(
         columns.
     justify : str or bool
         Set the alignment which refers to the part of the text string that
-        will be mapped onto the (x,y) point. Choose a two-letter
+        will be mapped onto the (x, y) point. Choose a two-letter
         combination of **L**, **C**, **R** (for left, center, or right) and
         **T**, **M**, **B** (for top, middle, or bottom). E.g., **BL** for
         bottom left. If no justification is explicitly given
@@ -137,7 +137,7 @@ def text_(
         no fill].
     offset : str
         [**j**\|\ **J**]\ *dx*\[/*dy*][**+v**\[*pen*]].
-        Offsets the text from the projected (x,y) point by *dx*/\ *dy* [0/0].
+        Offsets the text from the projected (x, y) point by *dx*/\ *dy* [0/0].
         If *dy* is not specified then it is set equal to *dx*. Use **j** to
         offset the text away from the point instead (i.e., the text
         justification will determine the direction of the shift). Using

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -91,7 +91,7 @@ def text_(
         * Horizontal: **L**\ (eft), **C**\ (entre), **R**\ (ight)
         * Vertical: **T**\ (op), **M**\ (iddle), **B**\ (ottom)
 
-        For example, ``position="TL"`` plots the text at the Upper Left corner
+        For example, ``position="TL"`` plots the text at the Top Left corner
         of the map.
     text : str or 1d array
         The text string, or an array of strings to plot on the figure.

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -110,11 +110,12 @@ def text_(
         columns.
     justify : str or bool
         Set the alignment which refers to the part of the text string that
-        will be mapped onto the (x,y) point. Choose a 2 character
+        will be mapped onto the (x,y) point. Choose a two-letter
         combination of **L**, **C**, **R** (for left, center, or right) and
-        **T**, **M**, **B** for top, middle, or bottom. E.g., **BL** for lower
-        left. If no justification is explicitly given (i.e. ``justify=True``),
-        then the input to ``textfiles`` must have this as a column.
+        **T**, **M**, **B** (for top, middle, or bottom). E.g., **BL** for
+        bottom left. If no justification is explicitly given
+        (i.e. ``justify=True``), then the input to ``textfiles`` must have
+        this as a column.
     {projection}
     {region}
         *Required if this is the first plot command.*


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix some typos in the tutorial [text.py](https://www.pygmt.org/dev/tutorials/basics/text.html) and the related API documentation for [pygmt.Figure.text](https://www.pygmt.org/dev/api/generated/pygmt.Figure.text.html).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
