### PR TITLE
load_earth_relief: Add the support of data source 'GEBCOSI'

### DIFF
--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -141,11 +141,15 @@ def load_earth_relief(
             f"{registration}-registered Earth relief data for "
             f"resolution '{resolution}' is not supported."
         )
-    earth_relief_sources = {"igpp": "earth_relief_", "gebco": "earth_gebco_"}
+    earth_relief_sources = {
+        "igpp": "earth_relief_",
+        "gebco": "earth_gebco_",
+        "gebcosi": "earth_gebcosi_",
+    }
     if data_source not in earth_relief_sources:
         raise GMTInvalidInput(
             f"Invalid earth relief 'data_source' {data_source}, "
-            "valid values are 'igpp' and 'gebco'."
+            "valid values are 'igpp', 'gebco', and 'gebcosi'."
         )
     if data_source != "igpp":
         with Session() as lib:

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -76,9 +76,16 @@ def load_earth_relief(
         - **igpp** : IGPP Global Earth Relief [Default option]. See
           :gmt-datasets:`earth-relief.html`.
 
+        - **synbath** : IGPP Global Earth Relief dataset that uses
+          stastical properties of young seafloor to provide more realistic
+          relief of young areas with small seamounts.
+
         - **gebco** : GEBCO Global Earth Relief with only observed relief and
           inferred relief via altimetric gravity. See
           :gmt-datasets:`earth-gebco.html`.
+
+        - **gebcosi** : GEBCO Global Earth Relief that gives sub-ice (si)
+          elevations.
 
     Returns
     -------

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -156,6 +156,8 @@ def download_test_data():
     datasets = [
         # Earth relief grids
         "@earth_gebco_01d_g",
+        "@earth_gebcosi_01d_g",
+        "earth_gebcosi_15m_p",
         "@earth_relief_01d_p",
         "@earth_relief_01d_g",
         "@earth_relief_30m_p",

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -157,7 +157,7 @@ def download_test_data():
         # Earth relief grids
         "@earth_gebco_01d_g",
         "@earth_gebcosi_01d_g",
-        "earth_gebcosi_15m_p",
+        "@earth_gebcosi_15m_p",
         "@earth_relief_01d_p",
         "@earth_relief_01d_g",
         "@earth_relief_30m_p",

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -114,6 +114,23 @@ def test_earth_relief_05m_with_region():
     assert data.sizes["lon"] == 481
 
 
+def test_earth_gebcosi_15m_with_region():
+    """
+    Test loading a subregion of 15 arc-minute resolution earth_gebcosi grid.
+    """
+    data = load_earth_relief(
+        resolution="15m",
+        region=[85, 87, -88, -84],
+        registration="pixel",
+        data_source="gebcosi",
+    )
+    assert data.shape == (16, 8)
+    npt.assert_allclose(data.lat, np.arange(-87.875, -84, 0.25))
+    npt.assert_allclose(data.lon, np.arange(85.125, 87, 0.25))
+    npt.assert_allclose(data.min(), -531)
+    npt.assert_allclose(data.max(), 474)
+
+
 def test_earth_relief_05m_without_region():
     """
     Test loading high-resolution earth relief without passing 'region'.

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -8,7 +8,7 @@ from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 
 
-@pytest.mark.parametrize("data_source", ["igpp", "gebco"])
+@pytest.mark.parametrize("data_source", ["igpp", "gebco", "gebcosi"])
 def test_earth_relief_fails(data_source):
     """
     Make sure earth relief fails for invalid resolutions.
@@ -35,12 +35,14 @@ def test_earth_relief_01d_igpp():
     npt.assert_allclose(data.max(), 5559.0)
 
 
-def test_earth_relief_01d_gebco():
+@pytest.mark.parametrize("data_source", ["gebco", "gebcosi"])
+def test_earth_relief_01d_gebco(data_source):
     """
-    Test some properties of the earth relief 01d data with GEBCO data.
+    Test some properties of the earth relief 01d data with GEBCO and GEBOCSI
+    data.
     """
     data = load_earth_relief(
-        resolution="01d", registration="gridline", data_source="gebco"
+        resolution="01d", registration="gridline", data_source=data_source
     )
     assert data.shape == (181, 361)
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -131,8 +131,8 @@ def test_earth_gebcosi_15m_with_region():
     npt.assert_allclose(data.lon, np.arange(85.125, 87, 0.25))
     npt.assert_allclose(data.min(), -531)
     npt.assert_allclose(data.max(), 474)
-    
-    
+
+
 def test_earth_relief_30s_synbath():
     """
     Test some properties of the earth relief 30s data with SYNBATH data.


### PR DESCRIPTION
This pull request adds the GEBCOSI data source to `load_earth_relief`

Addresses #1786


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
