### PR TITLE
Fix typos in earth_age.py

### DIFF
--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -78,12 +78,12 @@ def load_earth_age(resolution="01d", region=None, registration=None):
         )
 
     if resolution not in non_tiled_resolutions + tiled_resolutions:
-        raise GMTInvalidInput(f"Invalid Earth relief resolution '{resolution}'.")
+        raise GMTInvalidInput(f"Invalid Earth age resolution '{resolution}'.")
 
-    # Choose earth relief data prefix
+    # Choose earth age data prefix
     earth_age_prefix = "earth_age_"
 
-    # different ways to load tiled and non-tiled earth relief data
+    # different ways to load tiled and non-tiled earth age data
     # Known issue: tiled grids don't support slice operation
     # See https://github.com/GenericMappingTools/pygmt/issues/524
     if region is None:


### PR DESCRIPTION
This corrects three uses of "Earth relief" that should be "Earth age" in the comments and an error message in `earth_age.py`.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
