### PR TITLE
Figure.meca: Fix typos in docs

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -164,6 +164,7 @@ def meca(
         magnitude = 5 (i.e. scalar seismic moment M0 = 4.0E23 dynes-cm).
     convention: str
         Focal mechanism convention. Choose from:
+
         - ``"aki"`` (Aki & Richards)
         - ``"gcmt"`` (global CMT)
         - ``"mt"`` (seismic moment tensor)

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -117,7 +117,7 @@ def meca(
         ``spec`` can be specified in either of the following types:
 
         - ``str``: a file name containing focal mechanism parameters as
-          columns. The meanings of each column is:
+          columns. The meaning of each column is:
 
           - Columns 1 and 2: event longitude and latitude
           - Column 3: event depth (in km)

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -169,7 +169,7 @@ def meca(
         - ``"gcmt"`` (global CMT)
         - ``"mt"`` (seismic moment tensor)
         - ``"partial"`` (partial focal mechanism)
-        - ``"principal_axis"`` (principal axis).
+        - ``"principal_axis"`` (principal axis)
 
         Ignored if ``spec`` is a dictionary or pd.DataFrame.
     component: str

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -128,7 +128,7 @@ def meca(
             beachball. Using ``0 0`` will plot the beachball at the longitude,
             latitude given in columns 1 and 2. [optional and requires
             ``offset=True`` to take effect].
-          - Text string to appear near the beach ball [optional].
+          - Text string to appear near the beachball [optional].
 
         - **1D array**: focal mechanism parameters of a single event.
           The meanings of columns are the same as above.
@@ -200,7 +200,7 @@ def meca(
         as the number of events. Will override the ``plot_latitude`` values in
         ``spec`` if ``spec`` is a dict or pd.DataFrame.
     event_name : str or list of str, or 1d numpy array
-        Text strings (e.g., event names) to appear near the beach ball. List
+        Text strings (e.g., event names) to appear near the beachball. List
         must be the same length as the number of events. Will override the
         ``event_name`` values in ``spec`` if ``spec`` is a dict or
         pd.DataFrame.

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -116,7 +116,7 @@ def meca(
 
         ``spec`` can be specified in either of the following types:
 
-        - ``str``: a file name containing focal mechanism parameters as
+        - *str*: a file name containing focal mechanism parameters as
           columns. The meaning of each column is:
 
           - Columns 1 and 2: event longitude and latitude
@@ -130,11 +130,11 @@ def meca(
             ``offset=True`` to take effect].
           - Text string to appear near the beachball [optional].
 
-        - **1D array**: focal mechanism parameters of a single event.
+        - *1D array*: focal mechanism parameters of a single event.
           The meanings of columns are the same as above.
-        - **2D array**: focal mechanim parameters of multiple events.
+        - *2D array*: focal mechanim parameters of multiple events.
           The meanings of columns are the same as above.
-        - dict or pd.DataFrame: The dict keys or pd.DataFrame column names
+        - *dict or pd.DataFrame*: The dict keys or pd.DataFrame column names
           determine the focal mechanims convention. For different conventions,
           the following combination of keys are allowed:
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -153,9 +153,9 @@ def meca(
           ``latitude``, ``longitude``, ``depth``, ``plot_longitude``,
           ``plot_latitude``, and/or ``event_name``.
 
-          For ``spec`` in either a str, a 1D array or a 2D array, the
+          If ``spec`` is either a str, a 1D array or a 2D array, the
           ``convention`` parameter is required so we know how to interpret the
-          columns. For ``spec`` in a dict or a pd.DataFrame, ``convention`` is
+          columns. If ``spec`` is a dict or a pd.DataFrame, ``convention`` is
           not needed and is ignored if specified.
 
     scale: str


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix tiny typos in the documentation of [pygmt.Figure.meca](https://www.pygmt.org/dev/api/generated/pygmt.Figure.meca.html#pygmt.Figure.meca).
(I am sorry for the misleading commit message for commit https://github.com/GenericMappingTools/pygmt/pull/2197/commits/5639ad521a2534b076d0465faa200632af58cbe7. Actually I changed it to singular.)

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
