### PR TITLE
WIP: Improve gallery example "meca.py"

### DIFF
--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -28,6 +28,12 @@ focal_mechanism = dict(strike=330, dip=30, rake=90, magnitude=3)
 
 # pass the focal mechanism data through the spec parameter. In addition provide
 # values for scale, event location, and event depth
-fig.meca(focal_mechanism, scale="1c", longitude=-124.3, latitude=48.1, depth=12.0)
+fig.meca(
+    spec=focal_mechanism,
+    scale="1c",
+    longitude=-124.3,
+    latitude=48.1,
+    depth=12.0,
+)
 
 fig.show()

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -4,8 +4,8 @@ Focal mechanisms
 
 The :meth:`pygmt.Figure.meca` method can plot focal mechanisms, or beachballs.
 We can specify the focal mechanism nodal planes or moment tensor components as
-a dict using the ``spec`` parameter (or they can be specified as a 1d or 2d
-array, or within a specified file). The size of plotted beachballs can be
+a dictionary using the ``spec`` parameter (or they can be specified as a 1d or
+2d array, or within a specified file). The size of plotted beachballs can be
 specified using the ``scale`` parameter.
 """
 
@@ -13,7 +13,7 @@ import pygmt
 
 fig = pygmt.Figure()
 
-# generate a basemap near Washington state showing coastlines, land, and water
+# generate a map near Washington State showing land, water, and shorelines
 fig.coast(
     region=[-125, -122, 47, 49],
     projection="M6c",
@@ -23,11 +23,11 @@ fig.coast(
     frame="a",
 )
 
-# store focal mechanisms parameters in a dict
+# store focal mechanism parameters in a dictionary based on the aki convention
 focal_mechanism = dict(strike=330, dip=30, rake=90, magnitude=3)
 
-# pass the focal mechanism data to meca in addition to the scale and event
-# location
+# pass the focal mechanism data through the spec parameter. In addition provide
+# values for scale, event location, and event depth
 fig.meca(focal_mechanism, scale="1c", longitude=-124.3, latitude=48.1, depth=12.0)
 
 fig.show()

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -2,7 +2,7 @@
 Focal mechanisms
 ----------------
 
-The :meth:`pygmt.Figure.meca` method can plot focal mechanisms, or beachballs.
+The :meth:`pygmt.Figure.meca` method can plot focal mechanisms or beachballs.
 We can specify the focal mechanism nodal planes or moment tensor components as
 a dictionary using the ``spec`` parameter (or they can be specified as a 1d or
 2d array, or within a specified file). The size of plotted beachballs can be
@@ -27,10 +27,10 @@ fig.coast(
 focal_mechanism = dict(strike=330, dip=30, rake=90, magnitude=3)
 
 # pass the focal mechanism data through the spec parameter. In addition provide
-# values for scale, event location, and event depth
+# scale, event location, and event depth
 fig.meca(
     spec=focal_mechanism,
-    scale="1c",
+    scale="1c",  # in centimeters
     longitude=-124.3,
     latitude=48.1,
     depth=12.0,

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -23,7 +23,8 @@ fig.coast(
     frame="a",
 )
 
-# store focal mechanism parameters in a dictionary based on the aki convention
+# store focal mechanism parameters in a dictionary based on the Aki & Richards
+# convention
 focal_mechanism = dict(strike=330, dip=30, rake=90, magnitude=3)
 
 # pass the focal mechanism data through the spec parameter. In addition provide


### PR DESCRIPTION
**Description of proposed changes**

This PR contains some improvement of the gallery example [Focal mechanisms](https://www.pygmt.org/dev/gallery/seismology/meca.html#sphx-glr-gallery-seismology-meca-py).
Now, the parameter word `spec` is explicitly used in the code, as this parameter name is explained in the text at the beginning.

I feel, it would be good to have a more detailed example or tutorial on plotting focal mechanisms. (See also the several posts/questions on the GMT forum).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
