### PR TITLE
Figure.meca: Fix beachball offsetting with dict/pandas inputs

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -189,11 +189,11 @@ def meca(
         Depth(s) of event location in kilometers. Must be the same length as
         the number of events. Will override the ``depth`` values in ``spec``
         if ``spec`` is a dict or pd.DataFrame.
-    plot_longitude: int, float, list, or 1d numpy array
+    plot_longitude: int, float, str, list, or 1d numpy array
         Longitude(s) at which to place beachball. Must be the same length as
         the number of events. Will override the ``plot_longitude`` values in
         ``spec`` if ``spec`` is a dict or pd.DataFrame.
-    plot_latitude: int, float, list, or 1d numpy array
+    plot_latitude: int, float, str, list, or 1d numpy array
         Latitude(s) at which to place beachball. List must be the same length
         as the number of events. Will override the ``plot_latitude`` values in
         ``spec`` if ``spec`` is a dict or pd.DataFrame.

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -272,9 +272,9 @@ def meca(
             spec["latitude"] = np.atleast_1d(latitude)
         if depth is not None:
             spec["depth"] = np.atleast_1d(depth)
-        if plot_longitude is not None:  # must be in string type
+        if plot_longitude is not None:
             spec["plot_longitude"] = np.atleast_1d(plot_longitude)
-        if plot_latitude is not None:  # must be in string type
+        if plot_latitude is not None:
             spec["plot_latitude"] = np.atleast_1d(plot_latitude)
         if event_name is not None:
             spec["event_name"] = np.atleast_1d(event_name).astype(str)

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -273,9 +273,9 @@ def meca(
         if depth is not None:
             spec["depth"] = np.atleast_1d(depth)
         if plot_longitude is not None:  # must be in string type
-            spec["plot_longitude"] = np.atleast_1d(plot_longitude).astype(str)
+            spec["plot_longitude"] = np.atleast_1d(plot_longitude)
         if plot_latitude is not None:  # must be in string type
-            spec["plot_latitude"] = np.atleast_1d(plot_latitude).astype(str)
+            spec["plot_latitude"] = np.atleast_1d(plot_latitude)
         if event_name is not None:
             spec["event_name"] = np.atleast_1d(event_name).astype(str)
 
@@ -293,9 +293,13 @@ def meca(
         newcols = ["longitude", "latitude", "depth"] + param_conventions[convention]
         if "plot_longitude" in spec.columns and "plot_latitude" in spec.columns:
             newcols += ["plot_longitude", "plot_latitude"]
+            spec[["plot_longitude", "plot_latitude"]] = spec[
+                ["plot_longitude", "plot_latitude"]
+            ].astype(str)
             kwargs["A"] = True
         if "event_name" in spec.columns:
             newcols += ["event_name"]
+            spec["event_name"] = spec["event_name"].astype(str)
         # reorder columns in DataFrame
         spec = spec.reindex(newcols, axis=1)
     elif isinstance(spec, np.ndarray) and spec.ndim == 1:

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -253,6 +253,34 @@ def test_meca_dict_offset():
     return fig
 
 
+@pytest.mark.mpl_image_compare(filename="test_meca_dict_offset.png")
+def test_meca_dict_offset_in_dict():
+    """
+    Test offsetting beachballs for a dict input with offset parameters in the
+    dict.
+
+    See https://github.com/GenericMappingTools/pygmt/issues/2016.
+    """
+    fig = Figure()
+    focal_mechanism = dict(
+        strike=330,
+        dip=30,
+        rake=90,
+        magnitude=3,
+        plot_longitude=-124.5,
+        plot_latitude=47.5,
+    )
+    fig.basemap(region=[-125, -122, 47, 49], projection="M6c", frame=True)
+    fig.meca(
+        spec=focal_mechanism,
+        scale="1c",
+        longitude=-124,
+        latitude=48,
+        depth=12.0,
+    )
+    return fig
+
+
 @pytest.mark.mpl_image_compare
 def test_meca_dict_eventname():
     """


### PR DESCRIPTION
**Description of proposed changes**

Address https://github.com/GenericMappingTools/pygmt/issues/2016.

Due to how the GMT API works, the "plot_longitude", "plot_latitude", "event_name" columns must be in string type before passing to the GMT API.

The original code doesn't convert the columns to string type when these parameters are stored in dict/pandas inputs.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
