### PR TITLE
Figure.velo: Deprecate parameters "color" to "fill" and "uncertaintycolor" to "uncertaintyfill" (remove in v0.12.0)

### DIFF
--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -16,12 +16,13 @@ from pygmt.helpers import (
 
 @fmt_docstring
 @deprecate_parameter("color", "fill", "v0.8.0", "v0.12.0")
+@deprecate_parameter("uncertaintycolor", "uncertaintyfill", "v0.8.0", "v0.12.0")
 @use_alias(
     A="vector",
     B="frame",
     C="cmap",
     D="rescale",
-    E="uncertaintycolor",
+    E="uncertaintyfill",
     G="fill",
     H="scale",
     I="shading",
@@ -86,7 +87,7 @@ def velo(self, data=None, **kwargs):
           labeling. The arrow will be drawn with the pen attributes specified
           by the ``pen`` parameter and the arrow-head can be colored via
           ``fill``. The ellipse will be filled with the color or shade
-          specified by the ``uncertaintycolor`` parameter [Default is
+          specified by the ``uncertaintyfill`` parameter [Default is
           transparent], and its outline will be drawn if ``line`` is selected
           using the pen selected (by ``pen`` if not given by ``line``).
           Parameters are expected to be in the following columns:
@@ -119,7 +120,7 @@ def velo(self, data=None, **kwargs):
           labeling. The arrow will be drawn with the pen attributes specified
           by the ``pen`` parameter and the arrow-head can be colored via
           ``fill``. The ellipse will be filled with the color or shade
-          specified by the ``uncertaintycolor`` parameter [Default is
+          specified by the ``uncertaintyfill`` parameter [Default is
           transparent], and its outline will be drawn if ``line`` is selected
           using the pen selected (by ``pen`` if not given by ``line``).
           Parameters are expected to be in the following columns:
@@ -138,7 +139,7 @@ def velo(self, data=None, **kwargs):
           extra column. Rotation values are multiplied by *wedgemag* before
           plotting. For example, setting *wedgemag* to 1.e7 works well for
           rotations of the order of 100 nanoradians/yr. Use ``fill`` to set
-          the fill color or shade for the wedge, and ``uncertaintycolor`` to
+          the fill color or shade for the wedge, and ``uncertaintyfill`` to
           set the color or shade for the uncertainty. Parameters are expected
           to be in the following columns:
 
@@ -172,10 +173,10 @@ def velo(self, data=None, **kwargs):
         can be used to rescale the uncertainties of velocities (``spec="e"``
         and ``spec="r"``) and rotations (``spec="w"``). Can be combined with
         the ``confidence`` variable.
-    uncertaintycolor : str
+    uncertaintyfill : str
         Sets the color or shade used for filling uncertainty wedges
         (``spec="w"``) or velocity error ellipses (``spec="e"`` or
-        ``spec="r"``). If ``uncertaintycolor`` is not specified, the
+        ``spec="r"``). If ``uncertaintyfill`` is not specified, the
         uncertainty regions will be transparent. **Note**: Using ``cmap`` and
         ``zvalue="+e"`` will update the uncertainty fill color based on the
         selected measure in ``zvalue`` [magnitude error]. More details at

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -5,17 +5,24 @@ import numpy as np
 import pandas as pd
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
+from pygmt.helpers import (
+    build_arg_string, 
+    deprecate_parameter, 
+    fmt_docstring, 
+    kwargs_to_strings, 
+    use_alias,
+)
 
 
 @fmt_docstring
+@deprecate_parameter("color", "fill", "v0.8.0", "v0.12.0")
 @use_alias(
     A="vector",
     B="frame",
     C="cmap",
     D="rescale",
     E="uncertaintycolor",
-    G="color",
+    G="fill",
     H="scale",
     I="shading",
     J="projection",
@@ -78,7 +85,7 @@ def velo(self, data=None, **kwargs):
           [Default is 9p,Helvetica,black]; give **+f**\ 0 to deactivate
           labeling. The arrow will be drawn with the pen attributes specified
           by the ``pen`` parameter and the arrow-head can be colored via
-          ``color``. The ellipse will be filled with the color or shade
+          ``fill``. The ellipse will be filled with the color or shade
           specified by the ``uncertaintycolor`` parameter [Default is
           transparent], and its outline will be drawn if ``line`` is selected
           using the pen selected (by ``pen`` if not given by ``line``).
@@ -111,7 +118,7 @@ def velo(self, data=None, **kwargs):
           [Default is 9p,Helvetica,black]; give **+f**\ 0 to deactivate
           labeling. The arrow will be drawn with the pen attributes specified
           by the ``pen`` parameter and the arrow-head can be colored via
-          ``color``. The ellipse will be filled with the color or shade
+          ``fill``. The ellipse will be filled with the color or shade
           specified by the ``uncertaintycolor`` parameter [Default is
           transparent], and its outline will be drawn if ``line`` is selected
           using the pen selected (by ``pen`` if not given by ``line``).
@@ -130,7 +137,7 @@ def velo(self, data=None, **kwargs):
           *wedgescale* is not given then we read it from the data file as an
           extra column. Rotation values are multiplied by *wedgemag* before
           plotting. For example, setting *wedgemag* to 1.e7 works well for
-          rotations of the order of 100 nanoradians/yr. Use ``color`` to set
+          rotations of the order of 100 nanoradians/yr. Use ``fill`` to set
           the fill color or shade for the wedge, and ``uncertaintycolor`` to
           set the color or shade for the uncertainty. Parameters are expected
           to be in the following columns:
@@ -173,7 +180,7 @@ def velo(self, data=None, **kwargs):
         ``zvalue="+e"`` will update the uncertainty fill color based on the
         selected measure in ``zvalue`` [magnitude error]. More details at
         :gmt-docs:`cookbook/features.html#gfill-attrib`.
-    color : str
+    fill : str
         Select color or pattern for filling of symbols [Default is no fill].
         **Note**: Using ``cmap`` (and optionally ``zvalue``) will update the
         symbol fill color based on the selected measure in ``zvalue``

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -6,10 +6,10 @@ import pandas as pd
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
-    build_arg_string, 
-    deprecate_parameter, 
-    fmt_docstring, 
-    kwargs_to_strings, 
+    build_arg_string,
+    deprecate_parameter,
+    fmt_docstring,
+    kwargs_to_strings,
     use_alias,
 )
 

--- a/pygmt/tests/test_velo.py
+++ b/pygmt/tests/test_velo.py
@@ -77,7 +77,7 @@ def test_velo_pandas_dataframe(dataframe):
         region=[-10, 8, -10, 6],
         projection="x0.8c",
         pen="0.6p,red",
-        uncertaintycolor="lightblue1",
+        uncertaintyfill="lightblue1",
         line=True,
     )
     return fig


### PR DESCRIPTION
Addresses #1617 

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
