### PR TITLE
Use remove_version keyword arguments in the deprecate_parameter decorator

### DIFF
--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -16,7 +16,7 @@ from pygmt.src.which import which
 
 
 @fmt_docstring
-@deprecate_parameter("color", "fill", "v0.8.0", "v0.12.0")
+@deprecate_parameter("color", "fill", "v0.8.0", remove_version="v0.12.0")
 @use_alias(
     A="straight_line",
     B="frame",

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -16,7 +16,7 @@ from pygmt.src.which import which
 
 
 @fmt_docstring
-@deprecate_parameter("color", "fill", "v0.8.0", "v0.12.0")
+@deprecate_parameter("color", "fill", "v0.8.0", remove_version="v0.12.0")
 @use_alias(
     A="straight_line",
     B="frame",

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -13,7 +13,7 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
-@deprecate_parameter("color", "fill", "v0.8.0", "v0.12.0")
+@deprecate_parameter("color", "fill", "v0.8.0", remove_version="v0.12.0")
 @use_alias(
     A="sector",
     B="frame",

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -15,8 +15,10 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
-@deprecate_parameter("color", "fill", "v0.8.0", "v0.12.0")
-@deprecate_parameter("uncertaintycolor", "uncertaintyfill", "v0.8.0", "v0.12.0")
+@deprecate_parameter("color", "fill", "v0.8.0", remove_version="v0.12.0")
+@deprecate_parameter(
+    "uncertaintycolor", "uncertaintyfill", "v0.8.0", remove_version="v0.12.0"
+)
 @use_alias(
     A="vector",
     B="frame",


### PR DESCRIPTION
**Description of proposed changes**

So that we can use `grep --include="*.py" -r 'remove_version="vX.Y.Z"'` to find the deprecated parameters that should be removed when making a new release.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
