### PR TITLE
Figure.meca: Refactor the tests for pass a single focal mechanism to spec

### DIFF
--- a/pygmt/tests/baseline/test_meca_spec_1d_array.png.dvc
+++ b/pygmt/tests/baseline/test_meca_spec_1d_array.png.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 916dd79b35defcb6b6c1464f4a279790
-  size: 3216
-  path: test_meca_spec_1d_array.png

--- a/pygmt/tests/baseline/test_meca_spec_dict.png.dvc
+++ b/pygmt/tests/baseline/test_meca_spec_dict.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 8581943564134f58b295ec633acb8d1e
-  size: 17901
+- md5: a5abdacee354bac190b3b07777603478
+  size: 23952
   path: test_meca_spec_dict.png

--- a/pygmt/tests/baseline/test_meca_spec_dict.png.dvc
+++ b/pygmt/tests/baseline/test_meca_spec_dict.png.dvc
@@ -1,4 +1,4 @@
 outs:
 - md5: 8581943564134f58b295ec633acb8d1e
   size: 17901
-  path: test_meca_spec_dictionary.png
+  path: test_meca_spec_dict.png

--- a/pygmt/tests/baseline/test_meca_spec_file.png.dvc
+++ b/pygmt/tests/baseline/test_meca_spec_file.png.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: ad602355748d74a76edfa5cef4100b13
-  size: 3179
-  path: test_meca_spec_file.png

--- a/pygmt/tests/baseline/test_meca_spec_two_dataframe.png.dvc
+++ b/pygmt/tests/baseline/test_meca_spec_two_dataframe.png.dvc
@@ -1,4 +1,4 @@
 outs:
 - md5: b40481dd506db95c617978fe41ca9f9c
   size: 4583
-  path: test_meca_spec_dataframe.png
+  path: test_meca_spec_two_dataframe.png

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -24,7 +24,7 @@ def test_meca_spec_dict():
         scale="2.5c",
         region=[-1, 1, 4, 6],
         projection="M14c",
-        frame=2,
+        frame=True,
     )
     return fig
 

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -29,6 +29,26 @@ def test_meca_spec_dict():
     return fig
 
 
+@pytest.mark.mpl_image_compare(filename="test_meca_spec_dict.png")
+def test_meca_spec_1darray():
+    """
+    Test supplying a 1D numpy array containing a single focal mechanism to the
+    spec parameter.
+    """
+    fig = Figure()
+    fig.meca(
+        # The columns are:
+        # longitude, latitude, depth, strike, dip, rake, magnitude
+        spec=np.array([0, 5, 0, 0, 90, 0, 5]),
+        convention="aki",
+        region=[-1, 1, 4, 6],
+        scale="2.5c",
+        projection="M14c",
+        frame=True,
+    )
+    return fig
+
+
 @pytest.mark.mpl_image_compare
 def test_meca_spec_dict_list():
     """
@@ -75,44 +95,6 @@ def test_meca_spec_dataframe():
     fig.meca(
         spec=pd.DataFrame(data=focal_mechanisms),
         region=[-125, -122, 47, 49],
-        scale="2c",
-        projection="M14c",
-    )
-    return fig
-
-
-@pytest.mark.mpl_image_compare
-def test_meca_spec_1d_array():
-    """
-    Test supplying a 1D numpy array containing focal mechanisms and locations
-    to the spec parameter.
-    """
-    fig = Figure()
-    # supply focal mechanisms to meca as a 1D numpy array, here we are using
-    # the Harvard CMT zero trace convention but the focal mechanism
-    # parameters may be specified any of the available conventions. Since we
-    # are not using a dict or dataframe the convention and component should
-    # be specified.
-    focal_mechanism = [
-        -127.40,  # longitude
-        40.87,  # latitude
-        12,  # depth
-        -3.19,  # mrr
-        0.16,  # mtt
-        3.03,  # mff
-        -1.02,  # mrt
-        -3.93,  # mrf
-        -0.02,  # mtf
-        23,  # exponent
-        0,  # plot_lon, 0 to plot at event location
-        0,  # plot_lat, 0 to plot at event location
-    ]
-    focal_mech_array = np.asarray(focal_mechanism)
-    fig.meca(
-        spec=focal_mech_array,
-        convention="mt",
-        component="full",
-        region=[-128, -127, 40, 41],
         scale="2c",
         projection="M14c",
     )

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -49,6 +49,30 @@ def test_meca_spec_1darray():
     return fig
 
 
+@pytest.mark.mpl_image_compare(filename="test_meca_spec_dict.png")
+def test_meca_spec_file():
+    """
+    Test supplying a file containing a single focal mechanism to the spec
+    parameter.
+    """
+    fig = Figure()
+    focal_mechanism = [0, 5, 0, 0, 90, 0, 5]
+    # writes temp file to pass to gmt
+    with GMTTempFile() as temp:
+        with open(temp.name, mode="w", encoding="utf8") as temp_file:
+            temp_file.write(" ".join([str(x) for x in focal_mechanism]))
+        # supply focal mechanisms to meca as a file
+        fig.meca(
+            spec=temp.name,
+            convention="aki",
+            region=[-1, 1, 4, 6],
+            scale="2.5c",
+            projection="M14c",
+            frame=True,
+        )
+    return fig
+
+
 @pytest.mark.mpl_image_compare
 def test_meca_spec_dict_list():
     """
@@ -128,30 +152,6 @@ def test_meca_spec_2d_array():
         scale="2c",
         projection="M14c",
     )
-    return fig
-
-
-@pytest.mark.mpl_image_compare
-def test_meca_spec_file():
-    """
-    Test supplying a file containing focal mechanisms and locations to the spec
-    parameter.
-    """
-    fig = Figure()
-    focal_mechanism = [-127.43, 40.81, 12, -3.19, 1.16, 3.93, -1.02, -3.93, -1.02, 23]
-    # writes temp file to pass to gmt
-    with GMTTempFile() as temp:
-        with open(temp.name, mode="w", encoding="utf8") as temp_file:
-            temp_file.write(" ".join([str(x) for x in focal_mechanism]))
-        # supply focal mechanisms to meca as a file
-        fig.meca(
-            spec=temp.name,
-            convention="mt",
-            component="full",
-            region=[-128, -127, 40, 41],
-            scale="2c",
-            projection="M14c",
-        )
     return fig
 
 

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -9,7 +9,7 @@ from pygmt.helpers import GMTTempFile
 
 
 @pytest.mark.mpl_image_compare
-def test_meca_spec_dictionary():
+def test_meca_spec_dict():
     """
     Test supplying a dictionary containing a single focal mechanism to the spec
     parameter.

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -73,6 +73,26 @@ def test_meca_spec_file():
     return fig
 
 
+@pytest.mark.mpl_image_compare(filename="test_meca_spec_dict.png")
+def test_meca_spec_dataframe():
+    """
+    Test supplying a dictionary containing a single focal mechanism to the spec
+    parameter.
+    """
+    fig = Figure()
+    fig.meca(
+        spec=pd.DataFrame(dict(strike=0, dip=90, rake=0, magnitude=5), index=[0]),
+        longitude=0,
+        latitude=5,
+        depth=0,
+        scale="2.5c",
+        region=[-1, 1, 4, 6],
+        projection="M14c",
+        frame=True,
+    )
+    return fig
+
+
 @pytest.mark.mpl_image_compare
 def test_meca_spec_dict_list():
     """

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -98,7 +98,7 @@ def test_meca_spec_dict_list():
 
 
 @pytest.mark.mpl_image_compare
-def test_meca_spec_dataframe():
+def test_meca_spec_two_dataframe():
     """
     Test supplying a pandas.DataFrame containing focal mechanisms and locations
     to the spec parameter.


### PR DESCRIPTION
**Description of proposed changes**

The `Figure.meca` tests are a little messy and difficult to maintain because each test uses different focal mechanisms and event information. I plan to refactor the tests and this PR is the first step. 

This PR focuses on testing passing a single focal mechanism to the `spec` parameter using different data types (dict, file, 1darray and DataFrame). Note that all tests now single a single baseline image `test_meca_spec_dict.png`.


Changes in this PR:

- Rename the test test_meca_spec_dictionary to test_meca_spec_dict
- Improve the test_meca_spec_dict test with a better baseline image
- Rewrite test_meca_spec_1d_array test to use the existing baseline image
- Rewrite the test_meca_spec_file test to reuse the existing baseline image
- Rename the test test_meca_spec_dataframe to test_meca_spec_two_dataframe
- Add a new test test_meca_spec_dataframe to test passing a dataframe to meca