### PR TITLE
Skip post setup mambaforge in Continuous Integration

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -33,6 +33,7 @@ jobs:
           miniforge-version: latest
           miniforge-variant: Mambaforge
           mamba-version: "*"
+          run-post: false
           use-mamba: true
 
       # Install GMT and other required dependencies from conda-forge

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -64,6 +64,7 @@ jobs:
           miniforge-version: latest
           miniforge-variant: Mambaforge
           mamba-version: "*"
+          run-post: false
           use-mamba: true
 
       # Install GMT and other required dependencies from conda-forge

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -84,6 +84,7 @@ jobs:
           miniforge-version: latest
           miniforge-variant: Mambaforge
           mamba-version: "*"
+          run-post: false
           use-mamba: true
 
       # Install GMT and other required dependencies from conda-forge

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -90,6 +90,7 @@ jobs:
           miniforge-version: latest
           miniforge-variant: Mambaforge
           mamba-version: "*"
+          run-post: false
           use-mamba: true
 
       # Install dependencies from conda-forge

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -58,6 +58,7 @@ jobs:
           miniforge-version: latest
           miniforge-variant: Mambaforge
           mamba-version: "*"
+          run-post: false
           use-mamba: true
 
       # Install GMT and other required dependencies from conda-forge


### PR DESCRIPTION
**Description of proposed changes**

Reduce time spent by `conda-incubator/setup-miniconda` on the 'Post Setup Mambaforge' step, especially on Windows which could take ~4-6 minutes.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This feature was added in https://github.com/conda-incubator/setup-miniconda/pull/234, and is available since `setup-miniconda=2.2.0` updated in #2203. Default setting is [`run-post: true`](https://github.com/conda-incubator/setup-miniconda/blob/7e642bb2e4ca56ff706818a0febf72bb226d348d/action.yml#L247-L252) which will do 'Removing uncompressed packages to trim down cache folder...'. Setting it to `run-post: false` shouldn't have any side effects since we're not using any cache.

- Potentially save up to ~6min for Windows Tests, e.g. at https://github.com/GenericMappingTools/pygmt/actions/runs/3611036309/jobs/6085238776#step:27:1, going from ~25min to ~19min.

  ![image](https://user-images.githubusercontent.com/23487320/205474868-715c8d47-5b50-4a69-acb9-88ce6fe6c6f0.png)

- Potentially save on ~4min for Windows Docs build, e.g. at https://github.com/GenericMappingTools/pygmt/actions/runs/3549154826/jobs/5961196871#step:23:1, going from ~19min to ~15min.

  ![image](https://user-images.githubusercontent.com/23487320/205474810-0117165f-77fc-473d-b999-76f311689847.png)

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Related to #584.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
