### PR TITLE
load_earth_relief: Add import statement to inline examples

### DIFF
--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -104,11 +104,11 @@ def load_earth_relief(
     --------
 
     >>> from pygmt.datasets import load_earth_relief
-    >>> # load the default grid (gridline-registered 01d grid)
+    >>> # load the default grid (gridline-registered 1 arc-degree grid)
     >>> grid = load_earth_relief()
-    >>> # load the 30m grid with "gridline" registration
+    >>> # load the 30 arc-minute grid with "gridline" registration
     >>> grid = load_earth_relief(resolution="30m", registration="gridline")
-    >>> # load high-resolution grid for a specific region
+    >>> # load high-resolution (5 arc-minute) grid for a specific region
     >>> grid = load_earth_relief(
     ...     resolution="05m",
     ...     region=[120, 160, 30, 60],

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -101,17 +101,20 @@ def load_earth_relief(
     Examples
     --------
 
+    >>> from pygmt.datasets import load_earth_relief
     >>> # load the default grid (gridline-registered 01d grid)
     >>> grid = load_earth_relief()
     >>> # load the 30m grid with "gridline" registration
-    >>> grid = load_earth_relief("30m", registration="gridline")
+    >>> grid = load_earth_relief(resolution="30m", registration="gridline")
     >>> # load high-resolution grid for a specific region
     >>> grid = load_earth_relief(
-    ...     "05m", region=[120, 160, 30, 60], registration="gridline"
+    ...     resolution="05m",
+    ...     region=[120, 160, 30, 60],
+    ...     registration="gridline",
     ... )
     >>> # load the original 3 arc-second land-only SRTM tiles from NASA
     >>> grid = load_earth_relief(
-    ...     "03s",
+    ...     resolution="03s",
     ...     region=[135, 136, 35, 36],
     ...     registration="gridline",
     ...     use_srtm=True,

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -10,6 +10,8 @@ from pygmt.datasets.load_remote_dataset import _load_remote_dataset
 from pygmt.exceptions import GMTInvalidInput, GMTVersionError
 from pygmt.helpers import kwargs_to_strings
 
+__doctest_skip__ = ["load_earth_relief"]
+
 
 @kwargs_to_strings(region="sequence")
 def load_earth_relief(


### PR DESCRIPTION
Add `from pygmt.datasets import load_earth_relief` to the top of the inline example in `earth_relief.py`.

This also adds `resolution=` before the resolution arguments in the example.

Addresses #2225 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
