### PR TITLE
load_earth_relief: Move parameter use_srtm after data_source

### DIFF
--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -60,13 +60,6 @@ def load_earth_relief(
         **Note**: For GMT 6.3, ``registration=None`` returns a pixel-registered
         grid by default unless only the gridline-registered grid is available.
 
-    use_srtm : bool
-        By default, the land-only SRTM tiles from NASA are used to generate the
-        ``"03s"`` and ``"01s"`` grids, and the missing ocean values are filled
-        by up-sampling the SRTM15 tiles which have a resolution of 15
-        arc-second (i.e., ``"15s"``). If True, will only load the original
-        land-only SRTM tiles. Only works when ``data_source="igpp"``.
-
     data_source : str
         Select the source for the Earth relief data.
 
@@ -85,6 +78,13 @@ def load_earth_relief(
 
         - **gebcosi** : GEBCO Global Earth Relief that gives sub-ice (si)
           elevations.
+
+    use_srtm : bool
+        By default, the land-only SRTM tiles from NASA are used to generate the
+        ``"03s"`` and ``"01s"`` grids, and the missing ocean values are filled
+        by up-sampling the SRTM15 tiles which have a resolution of 15
+        arc-second (i.e., ``"15s"``). If True, will only load the original
+        land-only SRTM tiles. Only works when ``data_source="igpp"``.
 
     Returns
     -------

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -16,8 +16,8 @@ def load_earth_relief(
     resolution="01d",
     region=None,
     registration=None,
-    use_srtm=False,
     data_source="igpp",
+    use_srtm=False,
 ):
     r"""
     Load Earth relief grids (topography and bathymetry) in various resolutions.


### PR DESCRIPTION
This moves `use_srtm` below `data_source` in the `load_earth_relief` docstring


Addresses #2225 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
