### PR TITLE
load_earth_relief: Add earth_relief_type explanation to docstrings

### DIFF
--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -30,7 +30,7 @@ def load_earth_relief(
     This module downloads the grids that can also be accessed by
     passing in the file name **@**\ *earth_relief_type*\_\ *res*\[_\ *reg*] to
     any grid plotting/processing function. *earth_relief_type* is the GMT name
-    for the dataset; the available options of **earth_relief**\,
+    for the dataset. The available options are **earth_relief**\,
     **earth_gebco**\, **earth_gebcosi**\, and **earth_synbath**\. *res* is the
     grid resolution (see below), and *reg* is grid registration type
     (**p** for pixel registration or **g** for gridline registration).

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -29,9 +29,11 @@ def load_earth_relief(
 
     This module downloads the grids that can also be accessed by
     passing in the file name **@**\ *earth_relief_type*\_\ *res*\[_\ *reg*] to
-    any grid plotting/processing function. *res* is the grid resolution
-    (see below), and *reg* is grid registration type (**p** for pixel
-    registration or **g** for gridline registration).
+    any grid plotting/processing function. *earth_relief_type* is the GMT name
+    for the dataset; the available options of **earth_relief**\,
+    **earth_gebco**\, **earth_gebcosi**\, and **earth_synbath**\. *res* is the
+    grid resolution (see below), and *reg* is grid registration type
+    (**p** for pixel registration or **g** for gridline registration).
 
     Refer to :gmt-datasets:`earth-relief.html` for more details about available
     datasets, including version information and references.


### PR DESCRIPTION
Add an explanation of `earth_relief_type` to `load_earth_relief` docstring.


Addresses #2225 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
