### PR TITLE
doc: Update the intersphinx mapping and official site for xarray

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -58,7 +58,7 @@ intersphinx_mapping = {
     "geopandas": ("https://geopandas.org/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
-    "xarray": ("https://xarray.pydata.org/en/stable/", None),
+    "xarray": ("https://docs.xarray.dev/en/stable/", None),
 }
 
 # options for sphinx-copybutton

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -99,7 +99,7 @@ PyGMT requires the following libraries to be installed:
 
 * `numpy <https://numpy.org>`__ (>= 1.20)
 * `pandas <https://pandas.pydata.org>`__
-* `xarray <https://xarray.pydata.org>`__
+* `xarray <https://xarray.dev/>`__
 * `netCDF4 <https://unidata.github.io/netcdf4-python>`__
 * `packaging <https://packaging.pypa.io>`__
 


### PR DESCRIPTION
**Description of proposed changes**

New sites for xarray: https://xarray.dev/ and https://docs.xarray.dev/