### PR TITLE
Update parameter 'uncertaintycolor' to 'uncertaintyfill' in example 'velo_arrow_ellipse.py'

### DIFF
--- a/examples/gallery/seismology/velo_arrow_ellipse.py
+++ b/examples/gallery/seismology/velo_arrow_ellipse.py
@@ -30,7 +30,7 @@ fig.velo(
     data=df,
     region=[-10, 8, -10, 6],
     pen="0.6p,red",
-    uncertaintycolor="lightblue1",
+    uncertaintyfill="lightblue1",
     line=True,
     spec="e0.2/0.39/18",
     frame=["WSne", "2g2f"],


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to rename 'uncertaintycolor' to 'uncertaintyfill' in the gallery example [Velocity arrows and confidence ellipses](https://www.pygmt.org/dev/gallery/seismology/velo_arrow_ellipse.html).

**Related to**: https://github.com/GenericMappingTools/pygmt/pull/2206 and https://github.com/GenericMappingTools/pygmt/pull/2201#issuecomment-1325286845

**Adresses**: https://github.com/GenericMappingTools/pygmt/issues/1617

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
