### PR TITLE
Use plural for the unit of the resolution of datasets (higher 1 arc-xy)

### DIFF
--- a/examples/gallery/images/grdclip.py
+++ b/examples/gallery/images/grdclip.py
@@ -14,7 +14,7 @@ fig = pygmt.Figure()
 # Define region of interest around Iceland
 region = [-28, -10, 62, 68]
 
-# Load sample grid (3 arc minute global relief) in target area
+# Load sample grid (3 arc-minutes global relief) in target area
 grid = pygmt.datasets.load_earth_relief(resolution="03m", region=region)
 
 # Plot original grid

--- a/examples/gallery/images/grdgradient.py
+++ b/examples/gallery/images/grdgradient.py
@@ -15,7 +15,7 @@ import pygmt
 # Define region of interest around Yosemite valley
 region = [-119.825, -119.4, 37.6, 37.825]
 
-# Load sample grid (3 arc second global relief) in target area
+# Load sample grid (3-arc cseconds global relief) in target area
 grid = pygmt.datasets.load_earth_relief(resolution="03s", region=region)
 
 # calculate the reflection of a light source projecting from west to east

--- a/examples/gallery/images/grdgradient.py
+++ b/examples/gallery/images/grdgradient.py
@@ -15,7 +15,7 @@ import pygmt
 # Define region of interest around Yosemite valley
 region = [-119.825, -119.4, 37.6, 37.825]
 
-# Load sample grid (3-arc cseconds global relief) in target area
+# Load sample grid (3 arc-seconds global relief) in target area
 grid = pygmt.datasets.load_earth_relief(resolution="03s", region=region)
 
 # calculate the reflection of a light source projecting from west to east

--- a/examples/gallery/images/grdlandmask.py
+++ b/examples/gallery/images/grdlandmask.py
@@ -16,7 +16,7 @@ region = [-65, -40, -40, -20]
 # Assign a value of 0 for all water masses and a value of 1 for all land
 # masses.
 # Use shoreline data with (l)ow resolution and set the grid spacing to
-# 5 ar-minutes in x and y direction.
+# 5 arc-minutes in x and y direction.
 grid = pygmt.grdlandmask(region=region, spacing="5m", maskvalues=[0, 1], resolution="l")
 
 # Plot clipped grid

--- a/examples/gallery/images/grdlandmask.py
+++ b/examples/gallery/images/grdlandmask.py
@@ -16,7 +16,7 @@ region = [-65, -40, -40, -20]
 # Assign a value of 0 for all water masses and a value of 1 for all land
 # masses.
 # Use shoreline data with (l)ow resolution and set the grid spacing to
-# 5-arc minutes in x and y direction.
+# 5 ar-minutes in x and y direction.
 grid = pygmt.grdlandmask(region=region, spacing="5m", maskvalues=[0, 1], resolution="l")
 
 # Plot clipped grid

--- a/examples/gallery/images/grdlandmask.py
+++ b/examples/gallery/images/grdlandmask.py
@@ -16,7 +16,7 @@ region = [-65, -40, -40, -20]
 # Assign a value of 0 for all water masses and a value of 1 for all land
 # masses.
 # Use shoreline data with (l)ow resolution and set the grid spacing to
-# 5 arc minute in x and y direction.
+# 5-arc minutes in x and y direction.
 grid = pygmt.grdlandmask(region=region, spacing="5m", maskvalues=[0, 1], resolution="l")
 
 # Plot clipped grid

--- a/examples/tutorials/advanced/earth_relief.py
+++ b/examples/tutorials/advanced/earth_relief.py
@@ -11,8 +11,8 @@ plotted using the :meth:`pygmt.Figure.grdimage` method.
 import pygmt
 
 ###############################################################################
-# Load sample Earth relief data for the entire globe at a resolution of 1 arc
-# degree. The other available resolutions are show
+# Load sample Earth relief data for the entire globe at a resolution of
+# 1 arc-degree. The other available resolutions are show
 # at :gmt-datasets:`earth-relief.html`.
 grid = pygmt.datasets.load_earth_relief(resolution="01d")
 
@@ -87,12 +87,12 @@ fig.show()
 #
 # In addition to providing global data, the ``region`` parameter for
 # :func:`pygmt.datasets.load_earth_relief` can be used to provide data for a
-# specific area. The ``region`` parameter is required for resolutions at 5 arc
-# minutes or higher, and accepts a list (as in the example below) or a string.
-# The geographic ranges are passed as *xmin*/*xmax*/*ymin*/*ymax*.
+# specific area. The ``region`` parameter is required for resolutions at
+# 5 arc-minutes or higher, and accepts a list (as in the example below) or a
+# string. The geographic ranges are passed as *xmin*/*xmax*/*ymin*/*ymax*.
 #
-# The example below uses data with a 10 arc minute resolution, and plots it on
-# a 15 centimeter figure with a Mercator projection and a CPT set to *geo*.
+# The example below uses data with a 10 arc-minutes resolution, and plots it on
+# a 15 centimeters figure with a Mercator projection and a CPT set to *geo*.
 # ``frame="a"`` is used to add a frame to the figure.
 
 grid = pygmt.datasets.load_earth_relief(resolution="10m", region=[-14, 30, 35, 60])

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -32,7 +32,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     ----------
     resolution : str
         The grid resolution. The suffix ``d`` and ``m`` stand for
-        arc-degree and arc-minute. It can be ``"01d"``, ``"30m"``,
+        arc-degrees and arc-minutes. It can be ``"01d"``, ``"30m"``,
         ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``,
         ``"03m"``, ``"02m"``, or ``"01m"``.
 

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -40,7 +40,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
         The subregion of the grid to load, in the forms of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
         Required for grids with resolutions higher than 5
-        arc-minute (i.e., ``"05m"``).
+        arc-minutes (i.e., ``"05m"``).
 
     registration : str
         Grid registration type. Either ``"pixel"`` for pixel registration or
@@ -66,9 +66,9 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     >>> from pygmt.datasets import load_earth_age
     >>> # load the default grid (gridline-registered 1 arc-degree grid)
     >>> grid = load_earth_age()
-    >>> # load the 30 arc-minute grid with "gridline" registration
+    >>> # load the 30 arc-minutes grid with "gridline" registration
     >>> grid = load_earth_age(resolution="30m", registration="gridline")
-    >>> # load high-resolution (5 arc-minute) grid for a specific region
+    >>> # load high-resolution (5 arc-minutes) grid for a specific region
     >>> grid = load_earth_age(
     ...     resolution="05m",
     ...     region=[120, 160, 30, 60],

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -30,7 +30,7 @@ def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None
     ----------
     resolution : str
         The grid resolution. The suffix ``d`` and ``m`` stand for
-        arc-degree and arc-minute. It can be ``"01d"``, ``"30m"``,
+        arc-degrees and arc-minutes. It can be ``"01d"``, ``"30m"``,
         ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``,
         ``"03m"``, ``"02m"``, or ``"01m"``.
 

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -30,7 +30,7 @@ def load_earth_geoid(resolution="01d", region=None, registration=None):
     ----------
     resolution : str
         The grid resolution. The suffix ``d`` and ``m`` stand for
-        arc-degree and arc-minute. It can be ``"01d"``, ``"30m"``,
+        arc-degrees and arc-minutes. It can be ``"01d"``, ``"30m"``,
         ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``,
         ``"03m"``, ``"02m"``, or ``"01m"``.
 

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -38,7 +38,7 @@ def load_earth_geoid(resolution="01d", region=None, registration=None):
         The subregion of the grid to load, in the forms of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
         Required for grids with resolutions higher than 5
-        arc-minute (i.e., ``"05m"``).
+        arc-minutes (i.e., ``"05m"``).
 
     registration : str
         Grid registration type. Either ``"pixel"`` for pixel registration or

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -35,7 +35,7 @@ def load_earth_magnetic_anomaly(
     ----------
     resolution : str
         The grid resolution. The suffix ``d`` and ``m`` stand for
-        arc-degree and arc-minute. It can be ``"01d"``, ``"30m"``,
+        arc-degrees and arc-minutes. It can be ``"01d"``, ``"30m"``,
         ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``,
         ``"03m"``, or ``"02m"``.
 

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -43,7 +43,7 @@ def load_earth_magnetic_anomaly(
         The subregion of the grid to load, in the forms of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
         Required for grids with resolutions higher than 5
-        arc-minute (i.e., ``"05m"``).
+        arc-minutes (i.e., ``"05m"``).
 
     registration : str
         Grid registration type. Either ``"pixel"`` for pixel registration or

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -53,7 +53,7 @@ def load_earth_relief(
         The subregion of the grid to load, in the forms of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
         Required for Earth relief grids with resolutions higher than 5
-        arc-minute (i.e., ``"05m"``).
+        arc-minutes (i.e., ``"05m"``).
 
     registration : str
         Grid registration type. Either ``"pixel"`` for pixel registration or
@@ -87,7 +87,7 @@ def load_earth_relief(
         By default, the land-only SRTM tiles from NASA are used to generate the
         ``"03s"`` and ``"01s"`` grids, and the missing ocean values are filled
         by up-sampling the SRTM15 tiles which have a resolution of 15
-        arc-second (i.e., ``"15s"``). If True, will only load the original
+        arc-seconds (i.e., ``"15s"``). If True, will only load the original
         land-only SRTM tiles. Only works when ``data_source="igpp"``.
 
     Returns
@@ -108,15 +108,15 @@ def load_earth_relief(
     >>> from pygmt.datasets import load_earth_relief
     >>> # load the default grid (gridline-registered 1 arc-degree grid)
     >>> grid = load_earth_relief()
-    >>> # load the 30 arc-minute grid with "gridline" registration
+    >>> # load the 30 arc-minutes grid with "gridline" registration
     >>> grid = load_earth_relief(resolution="30m", registration="gridline")
-    >>> # load high-resolution (5 arc-minute) grid for a specific region
+    >>> # load high-resolution (5 arc-minutes) grid for a specific region
     >>> grid = load_earth_relief(
     ...     resolution="05m",
     ...     region=[120, 160, 30, 60],
     ...     registration="gridline",
     ... )
-    >>> # load the original 3 arc-second land-only SRTM tiles from NASA
+    >>> # load the original 3 arc-seconds land-only SRTM tiles from NASA
     >>> grid = load_earth_relief(
     ...     resolution="03s",
     ...     region=[135, 136, 35, 36],

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -44,10 +44,10 @@ def load_earth_relief(
     ----------
     resolution : str
         The grid resolution. The suffix ``d``, ``m`` and ``s`` stand for
-        arc-degree, arc-minute and arc-second. It can be ``"01d"``, ``"30m"``,
-        ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``,
-        ``"03m"``, ``"02m"``, ``"01m"``, ``"30s"``, ``"15s"``, ``"03s"``,
-        or ``"01s"``.
+        arc-degrees, arc-minutes, and arc-seconds. It can be ``"01d"``,
+        ``"30m"``, ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``,
+        ``"04m"``, ``"03m"``, ``"02m"``, ``"01m"``, ``"30s"``, ``"15s"``,
+        ``"03s"``, or ``"01s"``.
 
     region : str or list
         The subregion of the grid to load, in the forms of a list

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -187,7 +187,7 @@ def _load_remote_dataset(
 
     resolution : str
         The grid resolution. The suffix ``d``, ``m``, and ``s`` stand for
-        arc-degree, arc-minute, and arc-second respectively.
+        arc-degrees, arc-minutes, and arc-seconds, respectively.
 
     region : str or list
         The subregion of the grid to load, in the forms of a list

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -24,7 +24,7 @@ def list_sample_data():
     """
     names = {
         "bathymetry": "Table of ship bathymetric observations off Baja California",
-        "earth_relief_holes": "Regional 20 arc-minute Earth relief grid with holes",
+        "earth_relief_holes": "Regional 20 arc-minutes Earth relief grid with holes",
         "fractures": "Table of hypothetical fracture lengths and azimuths",
         "hotspots": "Table of locations, names, and symbol sizes of hotpots from "
         " Mueller et al., 1993",

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -57,8 +57,8 @@ COMMON_DOCSTRINGS = {
             *x_inc* [and optionally *y_inc*] is the grid spacing.
 
             - **Geographical (degrees) coordinates**: Optionally, append an
-              increment unit. Choose among **m** to indicate arc minutes or
-              **s** to indicate arc seconds. If one of the units **e**, **f**,
+              increment unit. Choose among **m** to indicate arc-minutes or
+              **s** to indicate arc-seconds. If one of the units **e**, **f**,
               **k**, **M**, **n** or **u** is appended instead, the increment
               is assumed to be given in meter, foot, km, mile, nautical mile or
               US survey foot, respectively, and will be converted to the
@@ -188,12 +188,12 @@ COMMON_DOCSTRINGS = {
             A unit **u** may be appended to the specified *gap*:
 
                 - For geographic data (**x**\|\ **y**\|\ **d**), the unit may
-                  be arc **d**\ (egree), **m**\ (inute), and **s**\ (econd), or
-                  (m)\ **e**\ (ter), **f**\ (eet), **k**\ (ilometer),
+                  be arc- **d**\ (egrees), **m**\ (inutes), and **s**\ (econds)
+                  , or (m)\ **e**\ (ters), **f**\ (eet), **k**\ (ilometers),
                   **M**\ (iles), or **n**\ (autical miles) [Default is
-                  (m)\ **e**\ (ter)].
+                  (m)\ **e**\ (ters)].
                 - For projected data (**X**\|\ **Y**\|\ **D**), the unit may be
-                  **i**\ (nch), **c**\ (entimeter), or **p**\ (oint).
+                  **i**\ (nches), **c**\ (entimeters), or **p**\ (oints).
 
             Append modifier **+a** to specify that *all* the criteria must be
             met [default imposes breaks if any one criterion is met].

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -165,7 +165,7 @@ def grd2cpt(grid, **kwargs):
     Example
     -------
     >>> import pygmt
-    >>> # load the 30 arc minute grid with "gridline" registration
+    >>> # load the 30 arc-minutes grid with "gridline" registration
     >>> grid = pygmt.datasets.load_earth_relief("30m", registration="gridline")
     >>> # create a plot
     >>> fig = pygmt.Figure()

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -98,7 +98,7 @@ def grdcontour(self, grid, **kwargs):
     Example
     -------
     >>> import pygmt
-    >>> # load the 15 arc minute grid with "gridline" registration
+    >>> # load the 15 arc-minutes grid with "gridline" registration
     >>> # in a specified region
     >>> grid = pygmt.datasets.load_earth_relief(
     ...     resolution="15m",

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -164,7 +164,7 @@ def grdimage(self, grid, **kwargs):
     Example
     -------
     >>> import pygmt
-    >>> # load the 30 arc minute grid with "gridline" registration
+    >>> # load the 30 arc-minutes grid with "gridline" registration
     >>> grid = pygmt.datasets.load_earth_relief("30m", registration="gridline")
     >>> # create a new plot with pygmt.Figure()
     >>> fig = pygmt.Figure()

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -138,8 +138,8 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
     >>> import pygmt
     >>> # Load a sample dataset of bathymetric x, y, and z values
     >>> data = pygmt.datasets.load_sample_data(name="bathymetry")
-    >>> # Create a new grid with 5 arc-minute spacing in the designated region
-    >>> # Set search_radius to only consider points within 10 arc-minute of a node
+    >>> # Create a new grid with 5 arc-minutes spacing in the designated region
+    >>> # Set search_radius to only consider points within 10 arc-minutes of a node
     >>> output = pygmt.nearneighbor(
     ...     data=data,
     ...     spacing="5m",

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -123,7 +123,7 @@ def test_earth_relief_05m_with_region():
 
 def test_earth_gebcosi_15m_with_region():
     """
-    Test loading a subregion of 15 arc-minute resolution earth_gebcosi grid.
+    Test loading a subregion of 15 arc-minutes resolution earth_gebcosi grid.
     """
     data = load_earth_relief(
         resolution="15m",
@@ -163,7 +163,7 @@ def test_earth_relief_05m_without_region():
 
 def test_earth_relief_03s_landonly_srtm():
     """
-    Test loading original 3 arc-second land-only SRTM tiles.
+    Test loading original 3 arc-seconds land-only SRTM tiles.
     """
     data = load_earth_relief(
         "03s", region=[135, 136, 35, 36], registration="gridline", use_srtm=True


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to use plural for the unit of the resolution of the datasets for resolutions higher than 1 arc-xy:
- [x] datasets
- [x] src (documentation)
- [x] tests
- [x] helpers
- [x] examples/gallery
- [x] examples/tutorials 

Related to: https://github.com/GenericMappingTools/pygmt/pull/2238#discussion_r1049360200, https://github.com/GenericMappingTools/pygmt/pull/2238#discussion_r1049502707

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
