### PR TITLE
Use consistently 1-D, 2-D, or 3-D (with hyphen and capitalized)

### DIFF
--- a/examples/gallery/3d_plots/scatter3d.py
+++ b/examples/gallery/3d_plots/scatter3d.py
@@ -1,6 +1,6 @@
 """
 3-D Scatter plots
-----------------
+-----------------
 
 The :meth:`pygmt.Figure.plot3d` method can be used to plot symbols in 3-D.
 In the example below, we show how the

--- a/examples/gallery/3d_plots/scatter3d.py
+++ b/examples/gallery/3d_plots/scatter3d.py
@@ -1,11 +1,11 @@
 """
-3D Scatter plots
+3-D Scatter plots
 ----------------
 
-The :meth:`pygmt.Figure.plot3d` method can be used to plot symbols in 3D.
+The :meth:`pygmt.Figure.plot3d` method can be used to plot symbols in 3-D.
 In the example below, we show how the
 `Iris flower dataset <https://en.wikipedia.org/wiki/Iris_flower_data_set>`__
-can be visualized using a perspective 3D plot. The ``region``
+can be visualized using a perspective 3-D plot. The ``region``
 parameter has to include the :math:`x`, :math:`y`, :math:`z` axis limits in the
 form of (xmin, xmax, ymin, ymax, zmin, zmax), which can be done automatically
 using :func:`pygmt.info`. To plot the z-axis frame, set ``frame`` as a
@@ -42,7 +42,7 @@ region = pygmt.info(
     spacing=(1, 2, 0.5),
 )
 
-# Make a 3D scatter plot, coloring each of the 3 species differently
+# Make a 3-D scatter plot, coloring each of the 3 species differently
 fig = pygmt.Figure()
 
 # Define a colormap to be used for three categories, define the range of the
@@ -69,7 +69,7 @@ fig.plot3d(
     # Vary each symbol size according to another feature (sepal width, scaled
     # by 0.1)
     size=0.1 * df.sepal_width,
-    # Use 3D cubes ("u") as symbols, with size in centimeter units ("c")
+    # Use 3-D cubes ("u") as symbols, with size in centimeter units ("c")
     style="uc",
     # Points colored by categorical number code
     fill=df.species.cat.codes.astype(int),

--- a/examples/gallery/images/contours.py
+++ b/examples/gallery/images/contours.py
@@ -5,8 +5,8 @@ The :meth:`pygmt.Figure.contour` method can plot contour lines from a table of
 points by direct triangulation. The data for the triangulation can be provided
 using one of three methods:
 
-#. ``x``, ``y``, ``z`` 1d :class:`numpy.ndarray` data columns.
-#. ``data`` 2d :class:`numpy.ndarray` data matrix with 3 columns corresponding
+#. ``x``, ``y``, ``z`` 1-D :class:`numpy.ndarray` data columns.
+#. ``data`` 2-D :class:`numpy.ndarray` data matrix with 3 columns corresponding
    to ``x``, ``y``, ``z``.
 #. ``data`` path string to a file containing the ``x``, ``y``, ``z`` in a
    tabular format.
@@ -14,7 +14,7 @@ using one of three methods:
 The parameters ``levels`` and ``annotation`` set the intervals of the contours
 and the annotation on the contours respectively.
 
-In this example we supply the data as  1d :class:`numpy.ndarray` with the
+In this example we supply the data as  1-D :class:`numpy.ndarray` with the
 ``x``, ``y``, and ``z`` parameters and draw the contours using a 0.5p pen with
 contours every 10 ``z`` values and annotations every 20 ``z`` values.
 """
@@ -35,7 +35,7 @@ fig.contour(
     projection="X10c/10c",
     frame="ag",
     pen="0.5p",
-    # pass the data as 3 1d data columns
+    # pass the data as 3 1-D data columns
     x=x,
     y=y,
     z=z,

--- a/examples/gallery/images/track_sampling.py
+++ b/examples/gallery/images/track_sampling.py
@@ -3,11 +3,12 @@ Sampling along tracks
 ---------------------
 
 The :func:`pygmt.grdtrack` function samples a raster grid's value along
-specified points. We will need to input a 2D raster to ``grid`` which can be an
-:class:`xarray.DataArray`. The argument passed to the ``points`` parameter can
-be a :class:`pandas.DataFrame` table where the first two columns are x and y
-(or longitude and latitude). Note also that there is a ``newcolname`` parameter
-that will be used to name the new column of values sampled from the grid.
+specified points. We will need to input a 2-D raster to ``grid`` which can be
+an :class:`xarray.DataArray`. The argument passed to the ``points`` parameter
+can be a :class:`pandas.DataFrame` table where the first two columns are
+x and y (or longitude and latitude). Note also that there is a ``newcolname``
+parameter that will be used to name the new column of values sampled from the
+grid.
 
 Alternatively, a NetCDF file path can be passed to ``grid``. An ASCII file path
 can also be accepted for ``points``. To save an output ASCII file, a file name

--- a/examples/gallery/lines/wiggle.py
+++ b/examples/gallery/lines/wiggle.py
@@ -3,10 +3,10 @@ Wiggle along tracks
 -------------------
 
 The :meth:`pygmt.Figure.wiggle` method can plot z = f(x,y) anomalies along
-tracks. ``x``, ``y``, ``z`` can be specified as 1-D arrays or within a specified
-file. The ``scale`` parameter can be used to set the scale of the anomaly in
-data/distance units. The positive and/or negative areas can be filled with
-color by setting the ``color`` parameter.
+tracks. ``x``, ``y``, ``z`` can be specified as 1-D arrays or within a
+specified file. The ``scale`` parameter can be used to set the scale of the
+anomaly in data/distance units. The positive and/or negative areas can be
+filled with color by setting the ``color`` parameter.
 """
 
 import numpy as np

--- a/examples/gallery/lines/wiggle.py
+++ b/examples/gallery/lines/wiggle.py
@@ -3,7 +3,7 @@ Wiggle along tracks
 -------------------
 
 The :meth:`pygmt.Figure.wiggle` method can plot z = f(x,y) anomalies along
-tracks. ``x``, ``y``, ``z`` can be specified as 1d arrays or within a specified
+tracks. ``x``, ``y``, ``z`` can be specified as 1-D arrays or within a specified
 file. The ``scale`` parameter can be used to set the scale of the anomaly in
 data/distance units. The positive and/or negative areas can be filled with
 color by setting the ``color`` parameter.

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -4,9 +4,9 @@ Focal mechanisms
 
 The :meth:`pygmt.Figure.meca` method can plot focal mechanisms or beachballs.
 We can specify the focal mechanism nodal planes or moment tensor components as
-a dictionary using the ``spec`` parameter (or they can be specified as a 1d or
-2d array, or within a specified file). The size of plotted beachballs can be
-specified using the ``scale`` parameter.
+a dictionary using the ``spec`` parameter (or they can be specified as a 1-D
+or 2-D array, or within a specified file). The size of plotted beachballs can
+be specified using the ``scale`` parameter.
 """
 
 import pygmt

--- a/examples/gallery/symbols/multi_parameter_symbols.py
+++ b/examples/gallery/symbols/multi_parameter_symbols.py
@@ -21,7 +21,7 @@ import pygmt
 ###############################################################################
 # We can plot multi-parameter symbols using the same symbol style. We need to
 # define locations (lon, lat) via the ``x`` and ``y`` parameters (scalar for
-# a single symbol or 1d list for several ones) and two or three symbol
+# a single symbol or 1-D list for several ones) and two or three symbol
 # parameters after those shortcuts via the ``style`` parameter.
 #
 # The multi-parameter symbols in the ``style`` parameter are defined as:
@@ -54,11 +54,11 @@ fig.show()
 
 ###############################################################################
 # We can also plot symbols with varying parameters via defining those values in
-# a 2d list or numpy array (``[[parameters]]`` for a single symbol or
+# a 2-D list or numpy array (``[[parameters]]`` for a single symbol or
 # ``[[parameters_1],[parameters_2],[parameters_i]]`` for several ones) or using
 # an appropriately formatted input file and passing it to ``data``.
 #
-# The symbol parameters in the 2d list or numpy array are defined as:
+# The symbol parameters in the 2-D list or numpy array are defined as:
 #
 # - **e**: ellipse, ``[[lon, lat, direction, major_axis, minor_axis]]``
 # - **j**: rotated rectangle, ``[[lon, lat, direction, width, height]]``

--- a/examples/gallery/symbols/points_categorical.py
+++ b/examples/gallery/symbols/points_categorical.py
@@ -39,7 +39,7 @@ region = pygmt.info(
     spacing=(3, 2),
 )
 
-# Make a 2D categorical scatter plot, coloring each of the 3 species
+# Make a 2-D categorical scatter plot, coloring each of the 3 species
 # differently
 fig = pygmt.Figure()
 

--- a/examples/tutorials/advanced/3d_perspective_image.py
+++ b/examples/tutorials/advanced/3d_perspective_image.py
@@ -1,6 +1,6 @@
 """
-Creating a 3D perspective image
-===============================
+Creating a 3-D perspective image
+================================
 
 Create 3-D perspective image or surface mesh from a grid
 using :meth:`pygmt.Figure.grdview`.

--- a/examples/tutorials/advanced/vectors.py
+++ b/examples/tutorials/advanced/vectors.py
@@ -18,7 +18,7 @@ import pygmt
 # On the shown figure, the plot is projected on a 10cm X 10cm region,
 # which is specified by the ``projection`` parameter.
 # The direction is specified
-# by a list of two 1d arrays structured as ``[[angle_in_degrees], [length]]``.
+# by a list of two 1-D arrays structured as ``[[angle_in_degrees], [length]]``.
 # The angle is measured in degrees and moves counter-clockwise from the
 # horizontal.
 # The length of the vector uses centimeters by default but
@@ -107,7 +107,7 @@ fig.show()
 ###############################################################################
 # Vectors can also be plotted by including all the information
 # about a vector in a single list. However, this requires creating
-# a 2D list or numpy array containing all vectors.
+# a 2-D list or numpy array containing all vectors.
 # Each vector list contains the information structured as:
 # ``[x_start, y_start, direction_degrees, length]``.
 #
@@ -132,7 +132,7 @@ fig.show()
 ###############################################################################
 # Using the functionality mentioned in the previous example,
 # multiple vectors can be plotted at the same time. Another
-# vector could be simply added to the 2D list or numpy
+# vector could be simply added to the 2-D list or numpy
 # array object and passed using ``data`` parameter.
 
 # Vector specifications structured as:
@@ -386,7 +386,7 @@ fig.show()
 # of one is the starting point of another. This can be done
 # by adding the coordinate lists together to create this structure:
 # ``[[start_latitude, start_longitude, end_latitude, end_longitude]]``.
-# Each list within the 2D list contains the start and end information
+# Each list within the 2-D list contains the start and end information
 # for each vector.
 
 # Coordinate pairs for all the locations used

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -44,7 +44,7 @@ COMMON_DOCSTRINGS = {
            (e.g., *color1*,\ *color2*,\ *color3*) to build a linear continuous
            CPT from those colors automatically.""",
     "color": """\
-        color : str or 1d array
+        color : str or 1-D array
             Select color or pattern for filling of symbols or polygons [Default
             is no fill].""",
     "fill": """\
@@ -227,13 +227,13 @@ COMMON_DOCSTRINGS = {
 
             Blank lines and lines starting with \# are always skipped.""",
     "incols": r"""
-        incols : str or 1d array
+        incols : str or 1-D array
             Specify data columns for primary input in arbitrary order. Columns
             can be repeated and columns not listed will be skipped [Default
             reads all columns in order, starting with the first (i.e., column
             0)].
 
-            - For *1d array*: specify individual columns in input order (e.g.,
+            - For *1-D array*: specify individual columns in input order (e.g.,
               ``incols=[1,0]`` for the 2nd column followed by the 1st column).
             - For :py:class:`str`: specify individual columns or column
               ranges in the format *start*\ [:*inc*]:*stop*, where *inc*
@@ -285,14 +285,14 @@ COMMON_DOCSTRINGS = {
             - **l** for bilinear
             - **n** for nearest-neighbor""",
     "outcols": r"""
-        outcols : str or 1d array
+        outcols : str or 1-D array
             *cols*\ [,...][,\ **t**\ [*word*]].
             Specify data columns for primary output in arbitrary order. Columns
             can be repeated and columns not listed will be skipped [Default
             writes all columns in order, starting with the first (i.e., column
             0)].
 
-            - For *1d array*: specify individual columns in output order (e.g.,
+            - For *1-D array*: specify individual columns in output order (e.g.,
               ``outcols=[1,0]`` for the 2nd column followed by the 1st column).
             - For :py:class:`str`: specify individual columns or column
               ranges in the format *start*\ [:*inc*]:*stop*, where *inc*
@@ -408,7 +408,7 @@ def fmt_docstring(module_func):
     ...     Parameters
     ...     ----------
     ...     data : str or {table-like}
-    ...         Pass in either a file name to an ASCII data table, a 2D
+    ...         Pass in either a file name to an ASCII data table, a 2-D
     ...         {table-classes}.
     ...     {region}
     ...     {projection}
@@ -424,9 +424,9 @@ def fmt_docstring(module_func):
     Parameters
     ----------
     data : str or numpy.ndarray or pandas.DataFrame or xarray.Dataset or geo...
-        Pass in either a file name to an ASCII data table, a 2D
+        Pass in either a file name to an ASCII data table, a 2-D
         :class:`numpy.ndarray`, a :class:`pandas.DataFrame`, an
-        :class:`xarray.Dataset` made up of 1D :class:`xarray.DataArray`
+        :class:`xarray.Dataset` made up of 1-D :class:`xarray.DataArray`
         data variables, or a :class:`geopandas.GeoDataFrame` containing the
         tabular data.
     region : str or list
@@ -461,7 +461,7 @@ def fmt_docstring(module_func):
     )
     filler_text["table-classes"] = (
         ":class:`numpy.ndarray`, a :class:`pandas.DataFrame`, an\n"
-        "    :class:`xarray.Dataset` made up of 1D :class:`xarray.DataArray`\n"
+        "    :class:`xarray.Dataset` made up of 1-D :class:`xarray.DataArray`\n"
         "    data variables, or a :class:`geopandas.GeoDataFrame` containing the\n"
         "    tabular data"
     )

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -25,7 +25,7 @@ def data_kind(data, x=None, y=None, z=None, required_z=False):
     * a pathlib.Path provided as 'data'
     * an xarray.DataArray provided as 'data'
     * a matrix provided as 'data'
-    * 1D arrays x and y (and z, optionally)
+    * 1-D arrays x and y (and z, optionally)
 
     Arguments should be ``None`` if not used. If doesn't fit any of these
     categories (or fits more than one), will raise an exception.
@@ -34,11 +34,11 @@ def data_kind(data, x=None, y=None, z=None, required_z=False):
     ----------
     data : str or pathlib.Path or xarray.DataArray or {table-like} or None
         Pass in either a file name or :class:`pathlib.Path` to an ASCII data
-        table, an :class:`xarray.DataArray`, a 1D/2D
+        table, an :class:`xarray.DataArray`, a 1-D/2-D
         {table-classes}.
-    x/y : 1d arrays or None
+    x/y : 1-D arrays or None
         x and y columns as numpy arrays.
-    z : 1d array or None
+    z : 1-D array or None
         z column as numpy array. To be used optionally when x and y are given.
     required_z : bool
         State whether the 'z' column is required.

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -49,7 +49,7 @@ def binstats(data, **kwargs):
     Parameters
     ----------
     data : str or {table-like}
-        A file name of an ASCII data table or a 2D
+        A file name of an ASCII data table or a 2-D
         {table-classes}.
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -108,9 +108,9 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     ----------
     data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
-        providing a file name to an ASCII data table, a 2D
+        providing a file name to an ASCII data table, a 2-D
         {table-classes}.
-    x/y/z : 1d arrays
+    x/y/z : 1-D arrays
         Arrays of x and y coordinates and values z of the data points.
 
     {spacing}
@@ -204,9 +204,9 @@ def blockmedian(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     ----------
     data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
-        providing a file name to an ASCII data table, a 2D
+        providing a file name to an ASCII data table, a 2-D
         {table-classes}.
-    x/y/z : 1d arrays
+    x/y/z : 1-D arrays
         Arrays of x and y coordinates and values z of the data points.
 
     {spacing}
@@ -291,9 +291,9 @@ def blockmode(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     ----------
     data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
-        providing a file name to an ASCII data table, a 2D
+        providing a file name to an ASCII data table, a 2-D
         {table-classes}.
-    x/y/z : 1d arrays
+    x/y/z : 1-D arrays
         Arrays of x and y coordinates and values z of the data points.
 
     {spacing}

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -49,9 +49,9 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
     ----------
     data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
-        providing a file name to an ASCII data table, a 2D
+        providing a file name to an ASCII data table, a 2-D
         {table-classes}.
-    x/y/z : 1d arrays
+    x/y/z : 1-D arrays
         Arrays of x and y coordinates and values z of the data points.
     {projection}
     {region}

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -76,7 +76,7 @@ def grdtrack(grid, points=None, newcolname=None, outfile=None, **kwargs):
         format).
 
     points : str or {table-like}
-        Pass in either a file name to an ASCII data table, a 2D
+        Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
 
     newcolname : str

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -51,7 +51,7 @@ def histogram(self, data, **kwargs):
     Parameters
     ----------
     data : str or list or {table-like}
-        Pass in either a file name to an ASCII data table, a Python list, a 2D
+        Pass in either a file name to an ASCII data table, a Python list, a 2-D
         {table-classes}.
     {projection}
     {region}

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -48,7 +48,7 @@ def info(data, **kwargs):
     Parameters
     ----------
     data : str or {table-like}
-        Pass in either a file name to an ASCII data table, a 1D/2D
+        Pass in either a file name to an ASCII data table, a 1-D/2-D
         {table-classes}.
     per_column : bool
         Report the min/max values per column in separate columns.

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -109,7 +109,7 @@ def meca(
 
     Parameters
     ----------
-    spec: str, 1D array, 2D array, dict, or pd.DataFrame
+    spec: str, 1-D array, 2-D array, dict, or pd.DataFrame
         Data that contains focal mechanism parameters.
 
         ``spec`` can be specified in either of the following types:
@@ -128,9 +128,9 @@ def meca(
             ``offset=True`` to take effect].
           - Text string to appear near the beachball [optional].
 
-        - *1D array*: focal mechanism parameters of a single event.
+        - *1-D array*: focal mechanism parameters of a single event.
           The meanings of columns are the same as above.
-        - *2D array*: focal mechanim parameters of multiple events.
+        - *2-D array*: focal mechanim parameters of multiple events.
           The meanings of columns are the same as above.
         - *dict or pd.DataFrame*: The dict keys or pd.DataFrame column names
           determine the focal mechanims convention. For different conventions,
@@ -151,7 +151,7 @@ def meca(
           ``latitude``, ``longitude``, ``depth``, ``plot_longitude``,
           ``plot_latitude``, and/or ``event_name``.
 
-          If ``spec`` is either a str, a 1D array or a 2D array, the
+          If ``spec`` is either a str, a 1-D array or a 2-D array, the
           ``convention`` parameter is required so we know how to interpret the
           columns. If ``spec`` is a dict or a pd.DataFrame, ``convention`` is
           not needed and is ignored if specified.
@@ -177,27 +177,27 @@ def meca(
         - ``"dc"``: the closest double couple defined from the moment tensor
           (zero trace and zero determinant)
         - ``"deviatoric"``: deviatoric part of the moment tensor (zero trace)
-    longitude: int, float, list, or 1d numpy array
+    longitude: int, float, list, or 1-D numpy array
         Longitude(s) of event location. Must be the same length as the
         number of events. Will override the ``longitude`` values
         in ``spec`` if ``spec`` is a dict or pd.DataFrame.
-    latitude: int, float, list, or 1d numpy array
+    latitude: int, float, list, or 1-D numpy array
         Latitude(s) of event location. Must be the same length as the
         number of events. Will override the ``latitude`` values
         in ``spec`` if ``spec`` is a dict or pd.DataFrame.
-    depth: int, float, list, or 1d numpy array
+    depth: int, float, list, or 1-D numpy array
         Depth(s) of event location in kilometers. Must be the same length as
         the number of events. Will override the ``depth`` values in ``spec``
         if ``spec`` is a dict or pd.DataFrame.
-    plot_longitude: int, float, str, list, or 1d numpy array
+    plot_longitude: int, float, str, list, or 1-D numpy array
         Longitude(s) at which to place beachball. Must be the same length as
         the number of events. Will override the ``plot_longitude`` values in
         ``spec`` if ``spec`` is a dict or pd.DataFrame.
-    plot_latitude: int, float, str, list, or 1d numpy array
+    plot_latitude: int, float, str, list, or 1-D numpy array
         Latitude(s) at which to place beachball. List must be the same length
         as the number of events. Will override the ``plot_latitude`` values in
         ``spec`` if ``spec`` is a dict or pd.DataFrame.
-    event_name : str or list of str, or 1d numpy array
+    event_name : str or list of str, or 1-D numpy array
         Text strings (e.g., event names) to appear near the beachball. List
         must be the same length as the number of events. Will override the
         ``event_name`` values in ``spec`` if ``spec`` is a dict or
@@ -303,7 +303,7 @@ def meca(
         # reorder columns in DataFrame
         spec = spec.reindex(newcols, axis=1)
     elif isinstance(spec, np.ndarray) and spec.ndim == 1:
-        # Convert 1d array into 2d array
+        # Convert 1-D array into 2-D array
         spec = np.atleast_2d(spec)
 
     # determine data_foramt from convection and component

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -79,9 +79,9 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
     ----------
     data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
-        providing a file name to an ASCII data table, a 2D
+        providing a file name to an ASCII data table, a 2-D
         {table-classes}.
-    x/y/z : 1d arrays
+    x/y/z : 1-D arrays
         Arrays of x and y coordinates and values z of the data points.
 
     {spacing}

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -59,7 +59,7 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
 
     Must provide either ``data`` or ``x``/``y``.
 
-    If providing data through ``x``/``y``, ``fill`` can be a 1d array that
+    If providing data through ``x``/``y``, ``fill`` can be a 1-D array that
     will be mapped to a colormap.
 
     If a symbol is selected and no symbol size given, then plot will
@@ -79,19 +79,19 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
     Parameters
     ----------
     data : str or {table-like}
-        Pass in either a file name to an ASCII data table, a 2D
+        Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
         Use parameter ``incols`` to choose which columns are x, y, fill, and
         size, respectively.
-    x/y : float or 1d arrays
+    x/y : float or 1-D arrays
         The x and y coordinates, or arrays of x and y coordinates of the
         data points
-    size : 1d array
+    size : 1-D array
         The size of the data points in units specified using ``style``.
         Only valid if using ``x``/``y``.
-    direction : list of two 1d arrays
+    direction : list of two 1-D arrays
         If plotting vectors (using ``style="V"`` or ``style="v"``), then
-        should be a list of two 1d arrays with the vector directions. These
+        should be a list of two 1-D arrays with the vector directions. These
         can be angle and length, azimuth and length, or x and y components,
         depending on the style options chosen.
     {projection}
@@ -153,15 +153,15 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
         the coordinates of a *refpoint* which will serve as a fixed external
         reference point for all groups.
     {fill}
-        *fill* can be a 1d array, but it is only valid if using ``x``/``y``
+        *fill* can be a 1-D array, but it is only valid if using ``x``/``y``
         and ``cmap=True`` is also required.
-    intensity : float or bool or 1d array
+    intensity : float or bool or 1-D array
         Provide an *intensity* value (nominally in the -1 to +1 range) to
         modulate the fill color by simulating illumination. If using
         ``intensity=True``, we will instead read *intensity* from the first
         data column after the symbol parameters (if given). *intensity* can
-        also be a 1d array to set varying intensity for symbols, but it is only
-        valid for ``x``/``y`` pairs.
+        also be a 1-D array to set varying intensity for symbols, but it is
+        only valid for ``x``/``y`` pairs.
     close : str
         [**+b**\|\ **d**\|\ **D**][**+xl**\|\ **r**\|\ *x0*]\
         [**+yl**\|\ **r**\|\ *y0*][**+p**\ *pen*].
@@ -206,7 +206,7 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
     {label}
     {perspective}
     {transparency}
-        ``transparency`` can also be a 1d array to set varying
+        ``transparency`` can also be a 1-D array to set varying
         transparency for symbols, but this option is only valid if using
         ``x``/``y``.
     {wrap}

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -62,7 +62,7 @@ def plot3d(
     Must provide either ``data`` or ``x``, ``y``, and ``z``.
 
     If providing data through ``x``, ``y``, and ``z``, ``fill`` can be a
-    1d array that will be mapped to a colormap.
+    1-D array that will be mapped to a colormap.
 
     If a symbol is selected and no symbol size given, then plot3d will
     interpret the fourth column of the input data as symbol size. Symbols
@@ -81,18 +81,18 @@ def plot3d(
     Parameters
     ----------
     data : str or {table-like}
-        Either a data file name, a 2d {table-classes}.
+        Either a data file name, a 2-D {table-classes}.
         Optionally, use parameter ``incols`` to specify which columns are x, y,
         z, fill, and size, respectively.
-    x/y/z : float or 1d arrays
+    x/y/z : float or 1-D arrays
         The x, y, and z coordinates, or arrays of x, y and z coordinates of
         the data points
-    size : 1d array
+    size : 1-D array
         The size of the data points in units specified in ``style``.
         Only valid if using ``x``/``y``/``z``.
-    direction : list of two 1d arrays
+    direction : list of two 1-D arrays
         If plotting vectors (using ``style="V"`` or ``style="v"``), then
-        should be a list of two 1d arrays with the vector directions. These
+        should be a list of two 1-D arrays with the vector directions. These
         can be angle and length, azimuth and length, or x and y components,
         depending on the style options chosen.
     {projection}
@@ -118,14 +118,14 @@ def plot3d(
         Offset the plot symbol or line locations by the given amounts
         *dx*/*dy*\ [/*dz*] [Default is no offset].
     {fill}
-        *fill* can be a 1d array, but it is only valid if using ``x``/``y``
+        *fill* can be a 1-D array, but it is only valid if using ``x``/``y``
         and ``cmap=True`` is also required.
-    intensity : float or bool or 1d array
+    intensity : float or bool or 1-D array
         Provide an *intensity* value (nominally in the -1 to +1 range) to
         modulate the fill color by simulating illumination. If using
         ``intensity=True``, we will instead read *intensity* from the first
         data column after the symbol parameters (if given). *intensity* can
-        also be a 1d array to set varying intensity for symbols, but it is only
+        also be a 1-D array to set varying intensity for symbols, but it is only
         valid for ``x``/``y``/``z``.
 
     close : str
@@ -175,7 +175,7 @@ def plot3d(
     {label}
     {perspective}
     {transparency}
-        ``transparency`` can also be a 1d array to set varying
+        ``transparency`` can also be a 1-D array to set varying
         transparency for symbols, but this option is only valid if using
         ``x``/``y``/``z``.
     {wrap}

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -125,8 +125,8 @@ def plot3d(
         modulate the fill color by simulating illumination. If using
         ``intensity=True``, we will instead read *intensity* from the first
         data column after the symbol parameters (if given). *intensity* can
-        also be a 1-D array to set varying intensity for symbols, but it is only
-        valid for ``x``/``y``/``z``.
+        also be a 1-D array to set varying intensity for symbols, but it is
+        only valid for ``x``/``y``/``z``.
 
     close : str
         [**+b**\|\ **d**\|\ **D**][**+xl**\|\ **r**\|\ *x0*]\

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -102,7 +102,7 @@ def project(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
     ----------
     data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
-        providing a file name to an ASCII data table, a 2D
+        providing a file name to an ASCII data table, a 2-D
         {table-classes}.
 
     center : str or list
@@ -189,7 +189,7 @@ def project(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
         a specific number of unique equidistant data via ``generate``. For
         degenerate ellipses you can just supply a single *diameter* instead.  A
         geographic diameter may be specified in any desired unit other than km
-        by appending the unit (e.g., 3d for degrees) [Default is km];
+        by appending the unit (e.g., 3-D for degrees) [Default is km];
         the increment is assumed to be in the same unit.  **Note**:
         For the Cartesian ellipse (which requires ``flat_earth``), the
         *direction* is counter-clockwise from the horizontal instead of an

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -66,7 +66,7 @@ def rose(self, data=None, length=None, azimuth=None, **kwargs):
     Parameters
     ----------
     data : str or {table-like}
-        Pass in either a file name to an ASCII data table, a 2D
+        Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
         Use parameter ``incols`` to choose which columns are length and
         azimuth, respectively. If a file with only azimuths is given, use
@@ -74,7 +74,7 @@ def rose(self, data=None, length=None, azimuth=None, **kwargs):
         lengths are set to unity (see ``scale="u"`` to set actual
         lengths to unity as well).
 
-    length/azimuth : float or 1d arrays
+    length/azimuth : float or 1-D arrays
         Length and azimuth values, or arrays of length and azimuth
         values
 

--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -64,7 +64,7 @@ def select(data=None, outfile=None, **kwargs):
     Parameters
     ----------
     data : str or {table-like}
-        Pass in either a file name to an ASCII data table, a 2D
+        Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
     outfile : str
         The file name for the output ASCII file.

--- a/pygmt/src/sph2grd.py
+++ b/pygmt/src/sph2grd.py
@@ -43,7 +43,7 @@ def sph2grd(data, **kwargs):
     ----------
     data : str or {table-like}
         Pass in data with L, M, C[L,M], S[L,M] values by
-        providing a file name to an ASCII data table, a 2D
+        providing a file name to an ASCII data table, a 2-D
         {table-classes}.
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -48,9 +48,9 @@ def sphdistance(data=None, x=None, y=None, **kwargs):
     ----------
     data : str or {table-like}
         Pass in (x, y) or (longitude, latitude) values by
-        providing a file name to an ASCII data table, a 2D
+        providing a file name to an ASCII data table, a 2-D
         {table-classes}.
-    x/y : 1d arrays
+    x/y : 1-D arrays
         Arrays of x and y coordinates.
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid

--- a/pygmt/src/sphinterpolate.py
+++ b/pygmt/src/sphinterpolate.py
@@ -40,7 +40,7 @@ def sphinterpolate(data, **kwargs):
     ----------
     data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
-        providing a file name to an ASCII data table, a 2D
+        providing a file name to an ASCII data table, a 2-D
         {table-classes}.
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -56,9 +56,9 @@ def surface(data=None, x=None, y=None, z=None, **kwargs):
     ----------
     data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
-        providing a file name to an ASCII data table, a 2D
+        providing a file name to an ASCII data table, a 2-D
         {table-classes}.
-    x/y/z : 1d arrays
+    x/y/z : 1-D arrays
         Arrays of x and y coordinates and values z of the data points.
 
     {spacing}

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -38,7 +38,7 @@ def ternary(self, data, alabel=None, blabel=None, clabel=None, **kwargs):
     Parameters
     ----------
     data : str or list or {table-like}
-        Pass in either a file name to an ASCII data table, a Python list, a 2D
+        Pass in either a file name to an ASCII data table, a Python list, a 2-D
         {table-classes}.
     width : str
         Set the width of the figure by passing a number, followed by

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -77,7 +77,7 @@ def text_(
     textfiles : str or list
         A text data file name, or a list of file names containing 1 or more
         records with (x, y[, angle, font, justify], text).
-    x/y : float or 1d arrays
+    x/y : float or 1-D arrays
         The x and y coordinates, or an array of x and y coordinates to plot
         the text.
     position : str
@@ -91,7 +91,7 @@ def text_(
 
         For example, ``position="TL"`` plots the text at the Top Left corner
         of the map.
-    text : str or 1d array
+    text : str or 1-D array
         The text string, or an array of strings to plot on the figure.
     angle: int, float, str or bool
         Set the angle measured in degrees counter-clockwise from
@@ -162,7 +162,7 @@ def text_(
         columns can be specified.
     {perspective}
     {transparency}
-        ``transparency`` can also be a 1d array to set varying
+        ``transparency`` can also be a 1-D array to set varying
         transparency for texts, but this option is only valid if using
         ``x``/``y`` and ``text``.
     {wrap}

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -84,7 +84,7 @@ class triangulate:  # pylint: disable=invalid-name
             Arrays of x and y coordinates and values z of the data points.
         data : str or {table-like}
             Pass in (x, y, z) or (longitude, latitude, elevation) values by
-            providing a file name to an ASCII data table, a 2D
+            providing a file name to an ASCII data table, a 2-D
             {table-classes}.
         {projection}
         {region}
@@ -200,7 +200,7 @@ class triangulate:  # pylint: disable=invalid-name
             Arrays of x and y coordinates and values z of the data points.
         data : str or {table-like}
             Pass in (x, y[, z]) or (longitude, latitude[, elevation]) values by
-            providing a file name to an ASCII data table, a 2D
+            providing a file name to an ASCII data table, a 2-D
             {table-classes}.
         {projection}
         {region}
@@ -317,7 +317,7 @@ class triangulate:  # pylint: disable=invalid-name
             Arrays of x and y coordinates and values z of the data points.
         data : str or {table-like}
             Pass in (x, y, z) or (longitude, latitude, elevation) values by
-            providing a file name to an ASCII data table, a 2D
+            providing a file name to an ASCII data table, a 2-D
             {table-classes}.
         {projection}
         {region}

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -66,7 +66,7 @@ def velo(self, data=None, **kwargs):
     Parameters
     ----------
     data : str or {table-like}
-        Pass in either a file name to an ASCII data table, a 2D
+        Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
         Note that text columns are only supported with file or
         :class:`pandas.DataFrame` inputs.

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -45,10 +45,10 @@ def wiggle(self, data=None, x=None, y=None, z=None, **kwargs):
 
     Parameters
     ----------
-    x/y/z : 1d arrays
+    x/y/z : 1-D arrays
         The arrays of x and y coordinates and z data points.
     data : str or {table-like}
-        Pass in either a file name to an ASCII data table, a 2D
+        Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
         Use parameter ``incols`` to choose which columns are x, y, z,
         respectively.

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -52,8 +52,8 @@ def xyz2grd(data=None, x=None, y=None, z=None, **kwargs):
     ----------
     data : str or {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
-        providing a file name to an ASCII data table, a 2D {table-classes}.
-    x/y/z : 1d arrays
+        providing a file name to an ASCII data table, a 2-D {table-classes}.
+    x/y/z : 1-D arrays
         The arrays of x and y coordinates and z data points.
     outgrid : str or None
         Optional. The name of the output netCDF file with extension .nc to

--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -86,7 +86,7 @@ def test_accessor_set_non_boolean():
 )
 def test_accessor_sliced_datacube():
     """
-    Check that a 2D grid which is sliced from an n-dimensional datacube works
+    Check that a 2-D grid which is sliced from an n-dimensional datacube works
     with accessor methods.
 
     This is a regression test for

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -799,7 +799,7 @@ def test_dataarray_to_matrix_dims_fails():
     """
     Check that it fails for > 2 dims.
     """
-    # Make a 3D regular grid
+    # Make a 3-D regular grid
     data = np.ones((10, 12, 11), dtype="float32")
     x = np.arange(11)
     y = np.arange(12)

--- a/pygmt/tests/test_clib_put_matrix.py
+++ b/pygmt/tests/test_clib_put_matrix.py
@@ -21,7 +21,7 @@ def fixture_dtypes():
 
 def test_put_matrix(dtypes):
     """
-    Check that assigning a numpy 2d array to a dataset works.
+    Check that assigning a numpy 2-D array to a dataset works.
     """
     shape = (3, 4)
     for dtype in dtypes:
@@ -66,7 +66,7 @@ def test_put_matrix_fails():
 
 def test_put_matrix_grid(dtypes):
     """
-    Check that assigning a numpy 2d array to an ASCII and NetCDF grid works.
+    Check that assigning a numpy 2-D array to an ASCII and NetCDF grid works.
     """
     wesn = [10, 15, 30, 40, 0, 0]
     inc = [1, 1]

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -126,7 +126,7 @@ def test_grdview_with_cmap_for_surface_monochrome_plot(xrgrid):
 def test_grdview_with_cmap_for_perspective_surface_plot(xrgrid):
     """
     Run grdview by passing in a grid and setting a colormap for producing a
-    surface plot with a 3D perspective viewpoint.
+    surface plot with a 3-D perspective viewpoint.
     """
     fig = Figure()
     fig.grdview(
@@ -139,7 +139,7 @@ def test_grdview_with_cmap_for_perspective_surface_plot(xrgrid):
 def test_grdview_on_a_plane(xrgrid):
     """
     Run grdview by passing in a grid and plotting it on a z-plane, while
-    setting a 3D perspective viewpoint.
+    setting a 3-D perspective viewpoint.
     """
     fig = Figure()
     fig.grdview(grid=xrgrid, plane=100, perspective=[225, 30], zscale=0.005)
@@ -150,7 +150,7 @@ def test_grdview_on_a_plane(xrgrid):
 def test_grdview_on_a_plane_with_colored_frontal_facade(xrgrid):
     """
     Run grdview by passing in a grid and plotting it on a z-plane whose frontal
-    facade is colored gray, while setting a 3D perspective viewpoint.
+    facade is colored gray, while setting a 3-D perspective viewpoint.
     """
     fig = Figure()
     fig.grdview(grid=xrgrid, plane="100+ggray", perspective=[225, 30], zscale=0.005)

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -67,7 +67,7 @@ def test_info_path(table):
 
 def test_info_2d_list():
     """
-    Make sure info works on a 2d list.
+    Make sure info works on a 2-D list.
     """
     output = info(data=[[0, 8], [3, 5], [6, 2]])
     expected_output = "<vector memory>: N = 3 <0/6> <2/8>\n"
@@ -126,7 +126,7 @@ def test_info_pandas_dataframe_time_column():
 
 def test_info_xarray_dataset_time_column():
     """
-    Make sure info works on xarray.Dataset 1D inputs with a time column.
+    Make sure info works on xarray.Dataset 1-D inputs with a time column.
     """
     table = xr.Dataset(
         coords={"index": [0, 1, 2, 3, 4]},
@@ -144,7 +144,7 @@ def test_info_xarray_dataset_time_column():
 
 def test_info_2d_array():
     """
-    Make sure info works on 2D numpy.ndarray inputs.
+    Make sure info works on 2-D numpy.ndarray inputs.
     """
     table = np.loadtxt(POINTS_DATA)
     output = info(data=table)
@@ -156,7 +156,7 @@ def test_info_2d_array():
 
 def test_info_1d_array():
     """
-    Make sure info works on 1D numpy.ndarray inputs.
+    Make sure info works on 1-D numpy.ndarray inputs.
     """
     output = info(data=np.arange(20))
     expected_output = "<vector memory>: N = 20 <0/19>\n"

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -84,11 +84,11 @@ def test_meca_spec_dataframe():
 @pytest.mark.mpl_image_compare
 def test_meca_spec_1d_array():
     """
-    Test supplying a 1D numpy array containing focal mechanisms and locations
+    Test supplying a 1-D numpy array containing focal mechanisms and locations
     to the spec parameter.
     """
     fig = Figure()
-    # supply focal mechanisms to meca as a 1D numpy array, here we are using
+    # supply focal mechanisms to meca as a 1-D numpy array, here we are using
     # the Harvard CMT zero trace convention but the focal mechanism
     # parameters may be specified any of the available conventions. Since we
     # are not using a dict or dataframe the convention and component should
@@ -122,11 +122,11 @@ def test_meca_spec_1d_array():
 @pytest.mark.mpl_image_compare
 def test_meca_spec_2d_array():
     """
-    Test supplying a 2D numpy array containing focal mechanisms and locations
+    Test supplying a 2-D numpy array containing focal mechanisms and locations
     to the spec parameter.
     """
     fig = Figure()
-    # supply focal mechanisms to meca as a 2D numpy array, here we are using
+    # supply focal mechanisms to meca as a 2-D numpy array, here we are using
     # the GCMT convention but the focal mechanism parameters may be
     # specified any of the available conventions. Since we are not using a
     # dict or dataframe the convention and component should be specified.
@@ -185,7 +185,7 @@ def test_meca_loc_array():
         strike=[327, 350], dip=[41, 50], rake=[68, 90], magnitude=[3, 2]
     )
     # longitude, latitude, and depth may be specified as an int, float,
-    # list, or 1d numpy array
+    # list, or 1-D numpy array
     longitude = np.array([-123.3, -124.4])
     latitude = np.array([48.4, 48.2])
     depth = [12.0, 11.0]  # to test mixed data types as inputs

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -35,7 +35,7 @@ def test_plot3d_red_circles_zscale(data, region):
     """
     Plot the 3-D data in red circles passing in vectors and setting
     zscale = 5
-	"""
+    """
     fig = Figure()
     fig.plot3d(
         x=data[:, 0],

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -54,7 +54,10 @@ def test_plot3d_red_circles_zscale(data, region):
 
 @pytest.mark.mpl_image_compare
 def test_plot3d_red_circles_zsize(data, region):
-    "Plot the 3-D data in red circles passing in vectors and setting zsize = 6c"
+    """
+    Plot the 3-D data in red circles passing in vectors and setting
+    zsize = "6c"
+    """
     fig = Figure()
     fig.plot3d(
         x=data[:, 0],

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -32,7 +32,7 @@ def fixture_region():
 
 @pytest.mark.mpl_image_compare
 def test_plot3d_red_circles_zscale(data, region):
-    "Plot the 3D data in red circles passing in vectors and setting zscale = 5"
+    "Plot the 3-D data in red circles passing in vectors and setting zscale = 5"
     fig = Figure()
     fig.plot3d(
         x=data[:, 0],
@@ -51,7 +51,7 @@ def test_plot3d_red_circles_zscale(data, region):
 
 @pytest.mark.mpl_image_compare
 def test_plot3d_red_circles_zsize(data, region):
-    "Plot the 3D data in red circles passing in vectors and setting zsize = 6c"
+    "Plot the 3-D data in red circles passing in vectors and setting zsize = 6c"
     fig = Figure()
     fig.plot3d(
         x=data[:, 0],

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -32,7 +32,10 @@ def fixture_region():
 
 @pytest.mark.mpl_image_compare
 def test_plot3d_red_circles_zscale(data, region):
-    "Plot the 3-D data in red circles passing in vectors and setting zscale = 5"
+    """
+    Plot the 3-D data in red circles passing in vectors and setting
+    zscale = 5
+	"""
     fig = Figure()
     fig.plot3d(
         x=data[:, 0],

--- a/pygmt/tests/test_rose.py
+++ b/pygmt/tests/test_rose.py
@@ -51,7 +51,7 @@ def test_rose_data_file(data_fractures_compilation):
 @pytest.mark.mpl_image_compare
 def test_rose_2d_array_single():
     """
-    Test supplying a 2D numpy array containing a single pair of lengths and
+    Test supplying a 2-D numpy array containing a single pair of lengths and
     directions.
     """
     data = np.array([[40, 60]])
@@ -73,7 +73,7 @@ def test_rose_2d_array_single():
 @pytest.mark.mpl_image_compare
 def test_rose_2d_array_multiple(data):
     """
-    Test supplying a 2D numpy array containing a list of lengths and
+    Test supplying a 2-D numpy array containing a list of lengths and
     directions.
     """
     fig = Figure()
@@ -94,7 +94,7 @@ def test_rose_2d_array_multiple(data):
 @pytest.mark.mpl_image_compare
 def test_rose_plot_data_using_cpt(data):
     """
-    Test supplying a 2D numpy array containing a list of lengths and
+    Test supplying a 2-D numpy array containing a list of lengths and
     directions.
 
     Use a cmap to color sectors.


### PR DESCRIPTION
**Description of proposed changes**

Corresponding to this upstream GMT PR https://github.com/GenericMappingTools/gmt/pull/7157, this PR aims to use consistently `x-D` (with hypen and capitalized, i.e., not `xd` or `xD`) for x=1,2,3.
- [x] src (documentation)
- [x] examples/gallery
- [x] examples/tutorials
- [x] datasets
- [x] helpers
- [x] tests

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
