### PR TITLE
Fix Transverse Mercator documentation typo

### DIFF
--- a/examples/projections/table/README.txt
+++ b/examples/projections/table/README.txt
@@ -49,7 +49,7 @@ The below table shows the projection codes for the 31 GMT projections.
      - :doc:`Eckert VI equal area </projections/misc/misc_eckertVI>`
    * - **L**\ |lon0|/|lat0|/|lat1|/|lat2|/\ *width*
      - :doc:`Lambert conic conformal </projections/conic/conic_lambert>`
-   * - **M**\ |lon0|\ [/|lat0|]/]\ *width*
+   * - **M**\ [|lon0|\ [/|lat0|]/]\ *width*
      - :doc:`Mercator cylindrical </projections/cyl/cyl_mercator>`
    * - **N**\ [|lon0|/]\ *width*
      - :doc:`Robinson </projections/misc/misc_robinson>`

--- a/examples/projections/table/README.txt
+++ b/examples/projections/table/README.txt
@@ -49,7 +49,7 @@ The below table shows the projection codes for the 31 GMT projections.
      - :doc:`Eckert VI equal area </projections/misc/misc_eckertVI>`
    * - **L**\ |lon0|/|lat0|/|lat1|/|lat2|/\ *width*
      - :doc:`Lambert conic conformal </projections/conic/conic_lambert>`
-   * - **M**\ [|lon0|\ [/|lat0|]/]\ *width*
+   * - **M**\ |lon0|\ [/|lat0|]/]\ *width*
      - :doc:`Mercator cylindrical </projections/cyl/cyl_mercator>`
    * - **N**\ [|lon0|/]\ *width*
      - :doc:`Robinson </projections/misc/misc_robinson>`
@@ -72,7 +72,7 @@ The below table shows the projection codes for the 31 GMT projections.
    * - **S**\ |lon0|/|lat0|\ [/\ *horizon*]/\ *width*
      - :doc:`General stereographic
        </projections/azim/azim_general_stereographic>`
-   * - **T**\ [|lon0|\ [/|lat0|]/]\ *width*
+   * - **T**\ |lon0|\ [/|lat0|]/]\ *width*
      - :doc:`Transverse Mercator </projections/cyl/cyl_transverse_mercator>`
    * - **U**\ *zone*/*width*
      - :doc:`Universal Transverse Mercator (UTM)


### PR DESCRIPTION
Fixes the Transverse Mercator syntax issues in #2059.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #2059


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
