### PR TITLE
NEP29: Test PyGMT on NumPy 1.24

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -39,14 +39,14 @@ jobs:
             isDraft: true
           - os: windows-latest
             isDraft: true
-        # Pair Python 3.8 with NumPy 1.21 and Python 3.10 with NumPy 1.23
-        # Only install optional packages on Python 3.10/NumPy 1.23
+        # Pair Python 3.8 with NumPy 1.21 and Python 3.10 with NumPy 1.24
+        # Only install optional packages on Python 3.10/NumPy 1.24
         include:
           - python-version: '3.8'
             numpy-version: '1.21'
             optional-packages: ''
           - python-version: '3.10'
-            numpy-version: '1.23'
+            numpy-version: '1.24'
             optional-packages: 'geopandas ipython'
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
**Description of proposed changes**

Bumps NumPy to [1.24.0](https://github.com/numpy/numpy/releases/tag/v1.24.0) released on 19 December 2022.

- [Release notes](https://github.com/numpy/numpy/releases)
- [Changelog](https://github.com/numpy/numpy/blob/8cec82012694571156e8d7696307c848a7603b4e/doc/changelog/1.24.0-changelog.rst)

This is in line with PyGMT's policy on [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) at [pygmt.org/v0.7.0/maintenance.html#dependencies-policy](https://www.pygmt.org/v0.7.0/maintenance.html#dependencies-policy), xref https://github.com/GenericMappingTools/pygmt/pull/1074.

Note that the branch protection rules at [GenericMappingTools/pygmt/settings/branches](https://github.com/GenericMappingTools/pygmt/settings/branches) will need to be changed to use Python 3.10/Numpy 1.24 instead of Python 3.10/Numpy 1.23 before this Pull Request is merged.

Supersedes https://github.com/GenericMappingTools/pygmt/pull/1701

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
