### PR TITLE
Do not show the 'Improve this page' button on sphinx-gallery execution time pages

### DIFF
--- a/doc/_templates/breadcrumbs.html
+++ b/doc/_templates/breadcrumbs.html
@@ -18,8 +18,10 @@
                 {% else %}
                     {% set example_script = example_script + ".py" %}
                 {% endif %}
-                <a href="https://github.com/{{ github_repo }}/edit/{{ github_version }}/{{ doc_path }}/{{ example_script }}"
-                   class="fa fa-github"> Improve this page</a>
+                {% if pagename.split("/")[-1] != "sg_execution_times" %}
+                    <a href="https://github.com/{{ github_repo }}/edit/{{ github_version }}/{{ doc_path }}/{{ example_script }}"
+                       class="fa fa-github"> Improve this page</a>
+                {% endif %}
             {% else %}
                 <a href="https://github.com/{{ github_repo }}/edit/{{ github_version }}/{{ doc_path }}/{{ pagename }}{{ page_source_suffix }}"
                    class="fa fa-github"> Improve this page</a>


### PR DESCRIPTION
**Description of proposed changes**

Sphinx-gallery generates summary pages for script execution times, e.g., https://www.pygmt.org/dev/gallery/histograms/sg_execution_times.html. The "Improve this page" button makes no sense on these pages, and results in broken links (e.g., https://github.com/GenericMappingTools/pygmt/issues/2255).

This PR fixes the issue by disable the "Improve this page" button on these pages.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #2255.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
