### PR TITLE
Figure.psconvert: Remove the deprecated parameter 'icc_gray' (deprecated since v0.6.0)

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -141,7 +141,7 @@ class Figure:
         V="verbose",
     )
     @kwargs_to_strings()
-    def psconvert(self, icc_gray=False, **kwargs):
+    def psconvert(self, **kwargs):
         r"""
         Convert [E]PS file(s) to other formats.
 
@@ -230,18 +230,6 @@ class Figure:
         # Default cropping the figure to True
         if kwargs.get("A") is None:
             kwargs["A"] = ""
-
-        if icc_gray:
-            msg = (
-                "The 'icc_gray' parameter has been deprecated since v0.6.0"
-                " and will be removed in v0.8.0."
-            )
-            warnings.warn(msg, category=FutureWarning, stacklevel=2)
-            if kwargs.get("N") is None:
-                kwargs["N"] = "+i"
-            else:
-                kwargs["N"] += "+i"
-
         # Manually handle prefix -F argument so spaces aren't converted to \040
         # by build_arg_string function. For more information, see
         # https://github.com/GenericMappingTools/pygmt/pull/1487

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -3,7 +3,6 @@ Define the Figure class that handles all plotting.
 """
 import base64
 import os
-import warnings
 from pathlib import Path
 from tempfile import TemporaryDirectory
 

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -266,17 +266,6 @@ def test_figure_set_display_invalid():
         set_display(method="invalid")
 
 
-def test_figure_icc_gray():
-    """
-    Check if icc_gray parameter works correctly if used.
-    """
-    fig = Figure()
-    fig.basemap(region=[0, 1, 0, 1], projection="X1c/1c", frame=True)
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        fig.psconvert(icc_gray=True, prefix="Test")
-        assert len(record) == 1  # check that only one warning was raised
-
-
 def test_figure_deprecated_xshift_yshift():
     """
     Check if deprecation of parameters X/Y/xshift/yshift work correctly if


### PR DESCRIPTION
**Description of proposed changes**

Related to https://github.com/GenericMappingTools/pygmt/pull/1673.



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
