### PR TITLE
Fix typo in documentation of dataset functions

### DIFF
--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -37,7 +37,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
         ``"03m"``, ``"02m"``, or ``"01m"``.
 
     region : str or list
-        The subregion of the grid to load, in the forms of a list
+        The subregion of the grid to load, in the form of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
         Required for grids with resolutions higher than 5
         arc-minutes (i.e., ``"05m"``).

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -37,7 +37,7 @@ def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None
         ``"03m"``, ``"02m"``, or ``"01m"``.
 
     region : str or list
-        The subregion of the grid to load, in the forms of a list
+        The subregion of the grid to load, in the form of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
         Required for grids with resolutions higher than 5
         arc-minutes (i.e., ``"05m"``).

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -37,7 +37,7 @@ def load_earth_geoid(resolution="01d", region=None, registration=None):
         ``"03m"``, ``"02m"``, or ``"01m"``.
 
     region : str or list
-        The subregion of the grid to load, in the forms of a list
+        The subregion of the grid to load, in the form of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
         Required for grids with resolutions higher than 5
         arc-minutes (i.e., ``"05m"``).

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -42,7 +42,7 @@ def load_earth_magnetic_anomaly(
         ``"03m"``, or ``"02m"``.
 
     region : str or list
-        The subregion of the grid to load, in the forms of a list
+        The subregion of the grid to load, in the form of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
         Required for grids with resolutions higher than 5
         arc-minutes (i.e., ``"05m"``).

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -50,7 +50,7 @@ def load_earth_relief(
         ``"03s"``, or ``"01s"``.
 
     region : str or list
-        The subregion of the grid to load, in the forms of a list
+        The subregion of the grid to load, in the form of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
         Required for Earth relief grids with resolutions higher than 5
         arc-minutes (i.e., ``"05m"``).

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -190,7 +190,7 @@ def _load_remote_dataset(
         arc-degrees, arc-minutes, and arc-seconds, respectively.
 
     region : str or list
-        The subregion of the grid to load, in the forms of a list
+        The subregion of the grid to load, in the form of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
         Required for tiled grids.
 


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix the typo mentioned in https://github.com/GenericMappingTools/pygmt/pull/2240#discussion_r1055344334 and https://github.com/GenericMappingTools/pygmt/pull/2241#discussion_r1055410607 in the documentation of the other dataset functions.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
