### PR TITLE
Fix typos in syntax of the projection documentation

### DIFF
--- a/examples/projections/conic/polyconic.py
+++ b/examples/projections/conic/polyconic.py
@@ -18,7 +18,7 @@ scale as well, but the meridians are not as they get further away from the
 central meridian. As a consequence, no parallel is standard because conformity
 is lost with the lengthening of the meridians.
 
-**poly**\ */scale* or **Poly**\ */width*
+**poly**\ /[*lon0*\/[*lat0*\/]]\ *scale* or **Poly**\ /[*lon0*\/[*lat0*\/]]\ *width*
 
 The projection is set with **poly** or **Poly**. The figure size is set
 with *scale* or *width*.

--- a/examples/projections/conic/polyconic.py
+++ b/examples/projections/conic/polyconic.py
@@ -18,7 +18,8 @@ scale as well, but the meridians are not as they get further away from the
 central meridian. As a consequence, no parallel is standard because conformity
 is lost with the lengthening of the meridians.
 
-**poly**\ /[*lon0*\/[*lat0*\/]]\ *scale* or **Poly**\ /[*lon0*\/[*lat0*\/]]\ *width*
+**poly**/\ [*lon0*/\ [*lat0*/]]\ *scale* or
+**Poly**/\ [*lon0*/\ [*lat0*/]]\ *width*
 
 The projection is set with **poly** or **Poly**. The figure size is set
 with *scale* or *width*.

--- a/examples/projections/cyl/cyl_equidistant.py
+++ b/examples/projections/cyl/cyl_equidistant.py
@@ -7,7 +7,7 @@ latitudes. The most common form is the Plate Carrée projection, where the
 scaling of longitudes and latitudes is the same. All meridians and parallels
 are straight lines.
 
-**q**\ *scale* or **Q**\ *width*
+**q**\ [*lon0*\/[*lat0*\/]]\ *scale* or **Q**\ [*lon0*\/[*lat0*\/]]\ *width*
 
 The projection is set with **q** or **Q**, and the figure size is set with
 *scale* or *width*.

--- a/examples/projections/cyl/cyl_equidistant.py
+++ b/examples/projections/cyl/cyl_equidistant.py
@@ -10,7 +10,10 @@ are straight lines.
 **q**\ [*lon0*/\ [*lat0*/]]\ *scale* or **Q**\ [*lon0*/\ [*lat0*/]]\ *width*
 
 The projection is set with **q** or **Q**, and the figure size is set with
-*scale* or *width*.
+*scale* or *width*. Optionally, the central meridian can be set with *lon0*
+[Default is the middle of the map]. Optionally, the standard parallel can
+be set with *lat0* [Default is the equator]. When supplied, the central
+meridian must be supplied as well.
 """
 import pygmt
 

--- a/examples/projections/cyl/cyl_equidistant.py
+++ b/examples/projections/cyl/cyl_equidistant.py
@@ -7,7 +7,7 @@ latitudes. The most common form is the Plate Carrée projection, where the
 scaling of longitudes and latitudes is the same. All meridians and parallels
 are straight lines.
 
-**q**\ [*lon0*\/[*lat0*\/]]\ *scale* or **Q**\ [*lon0*\/[*lat0*\/]]\ *width*
+**q**\ [*lon0*/\ [*lat0*/]]\ *scale* or **Q**\ [*lon0*/\ [*lat0*/]]\ *width*
 
 The projection is set with **q** or **Q**, and the figure size is set with
 *scale* or *width*.

--- a/examples/projections/cyl/cyl_mercator.py
+++ b/examples/projections/cyl/cyl_mercator.py
@@ -13,7 +13,7 @@ course for the entire voyage. The Mercator projection has been used extensively
 for world maps in which the distortion towards the polar regions grows
 rather large.
 
-**m**\ [*lon0*\/[*lat0*\/]]\ *scale* or **M**\ [*lon0*\/[*lat0*\/]]\ *width*
+**m**\ [*lon0*/\ [*lat0*/]]\ *scale* or **M**\ [*lon0*/\ [*lat0*/]]\ *width*
 
 The projection is set with **m** or **M**. The central meridian is set with the
 optional *lon0* and the standard parallel is set with the optional *lat0*.

--- a/examples/projections/cyl/cyl_mercator.py
+++ b/examples/projections/cyl/cyl_mercator.py
@@ -13,7 +13,7 @@ course for the entire voyage. The Mercator projection has been used extensively
 for world maps in which the distortion towards the polar regions grows
 rather large.
 
-**m**\ [*lon0[/lat0]*]\ */scale* or **M**\ [*lon0*][*/lat0*]\ */width*
+**m**\ [*lon0*\/[*lat0*\/]]\ *scale* or **M**\ [*lon0*\/[*lat0*\/]]\ *width*
 
 The projection is set with **m** or **M**. The central meridian is set with the
 optional *lon0* and the standard parallel is set with the optional *lat0*.

--- a/examples/projections/cyl/cyl_stereographic.py
+++ b/examples/projections/cyl/cyl_stereographic.py
@@ -11,8 +11,8 @@ onto a cylinder in the direction of the antipodal point on the equator. The
 cylinder crosses the sphere at two standard parallels, equidistant from the
 equator.
 
-**cyl_stere/**\ [*lon0/*]\ [*lat0/*]\ *scale*
-or **Cyl_stere/**\ [*lon0/*]\ [*lat0/*]\ *width*
+**cyl_stere**\ /[*lon0*\ /[*lat0*\/]]\ *scale*
+or **Cyl_stere**\ /[*lon0*\ /[*lat0*\/]]\ *width*
 
 The projection is set with **cyl_stere** or **Cyl_stere**. The central meridian
 is set by the optional *lon0*, and the figure size is set with *scale* or

--- a/examples/projections/cyl/cyl_stereographic.py
+++ b/examples/projections/cyl/cyl_stereographic.py
@@ -11,8 +11,8 @@ onto a cylinder in the direction of the antipodal point on the equator. The
 cylinder crosses the sphere at two standard parallels, equidistant from the
 equator.
 
-**cyl_stere**\ /[*lon0*\ /[*lat0*\/]]\ *scale*
-or **Cyl_stere**\ /[*lon0*\ /[*lat0*\/]]\ *width*
+**cyl_stere**/\ [*lon0*/\ [*lat0*/]]\ *scale* or
+**Cyl_stere**/\ [*lon0*/\ [*lat0*/]]\ *width*
 
 The projection is set with **cyl_stere** or **Cyl_stere**. The central meridian
 is set by the optional *lon0*, and the figure size is set with *scale* or

--- a/examples/projections/cyl/cyl_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_transverse_mercator.py
@@ -9,7 +9,7 @@ infinity at 90° from center. The central meridian, each meridian 90° away from
 the center, and equator are straight lines; other parallels and meridians are
 complex curves.
 
-**t**\ *lon0/*\ [*lat0/*\ ]\ *scale* or **T**\ *lon0/*\ [*lat0/*\ ]\ *width*
+**t**\ *lon0*/\ [*lat0*/\ ]\ *scale* or **T**\ *lon0*/\ [*lat0*/\ ]\ *width*
 
 The projection is set with **t** or **T**. The central meridian is set
 by  *lon0*, the latitude of the origin is set by the optional *lat0*, and the

--- a/examples/projections/cyl/cyl_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_transverse_mercator.py
@@ -9,7 +9,7 @@ infinity at 90° from center. The central meridian, each meridian 90° away from
 the center, and equator are straight lines; other parallels and meridians are
 complex curves.
 
-**t**\ *lon0*/\ [*lat0*/\ ]\ *scale* or **T**\ *lon0*/\ [*lat0*/\ ]\ *width*
+**t**\ *lon0*/\ [*lat0*/]\ *scale* or **T**\ *lon0*/\ [*lat0*/]\ *width*
 
 The projection is set with **t** or **T**. The central meridian is set
 by  *lon0*, the latitude of the origin is set by the optional *lat0*, and the

--- a/examples/projections/cyl/cyl_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_transverse_mercator.py
@@ -9,7 +9,7 @@ infinity at 90° from center. The central meridian, each meridian 90° away from
 the center, and equator are straight lines; other parallels and meridians are
 complex curves.
 
-**t**\ *lon0*/\ [*lat0*/]\ *scale* or **T**\ *lon0*/\ [*lat0*/]\ *width*
+**t**\ *lon0*\ [/\ *lat0*]/\ *scale* or **T**\ *lon0*\ [/\ *lat0*]/\ *width*
 
 The projection is set with **t** or **T**. The central meridian is set
 by  *lon0*, the latitude of the origin is set by the optional *lat0*, and the

--- a/examples/projections/table/README.txt
+++ b/examples/projections/table/README.txt
@@ -72,7 +72,7 @@ The below table shows the projection codes for the 31 GMT projections.
    * - **S**\ |lon0|/|lat0|\ [/\ *horizon*]/\ *width*
      - :doc:`General stereographic
        </projections/azim/azim_general_stereographic>`
-   * - **T**\ |lon0|/\ [/|lat0|/]\ *width*
+   * - **T**\ |lon0|\ [/\ |lat0|]/\ *width*
      - :doc:`Transverse Mercator </projections/cyl/cyl_transverse_mercator>`
    * - **U**\ *zone*/*width*
      - :doc:`Universal Transverse Mercator (UTM)

--- a/examples/projections/table/README.txt
+++ b/examples/projections/table/README.txt
@@ -24,7 +24,7 @@ The below table shows the projection codes for the 31 GMT projections.
      - :doc:`Albers conic equal area </projections/conic/conic_albers>`
    * - **C**\ |lon0|/|lat0|/\ *width*
      - :doc:`Cassini cylindrical </projections/cyl/cyl_cassini>`
-   * - **Cyl_stere/**\ [|lon0|\ [/|lat0|/]]\ *width*
+   * - **Cyl_stere**\ /[|lon0|\/[|lat0|/]]\ *width*
      - :doc:`Cylindrical stereographic </projections/cyl/cyl_stereographic>`
    * - **D**\ |lon0|/|lat0|/|lat1|/|lat2|/\ *width*
      - :doc:`Equidistant conic </projections/conic/conic_equidistant>`
@@ -49,11 +49,11 @@ The below table shows the projection codes for the 31 GMT projections.
      - :doc:`Eckert VI equal area </projections/misc/misc_eckertVI>`
    * - **L**\ |lon0|/|lat0|/|lat1|/|lat2|/\ *width*
      - :doc:`Lambert conic conformal </projections/conic/conic_lambert>`
-   * - **M**\ [|lon0|\ [/|lat0|]/]\ *width*
+   * - **M**\ [|lon0|\ /[|lat0|/]]\ *width*
      - :doc:`Mercator cylindrical </projections/cyl/cyl_mercator>`
    * - **N**\ [|lon0|/]\ *width*
      - :doc:`Robinson </projections/misc/misc_robinson>`
-   * - **Oa**\ |lon0|/|lat0|/\ *azim*/*width*\ [**+v**]
+   * - **Oa**\ |lon0|/|lat0|/\ *azimuth*/*width*\ [**+v**]
      - :doc:`Oblique Mercator, 1: origin and azimuth </projections/cyl/cyl_oblique_mercator_1>`
    * - **Ob**\ |lon0|/|lat0|/|lon1|/|lat1|/\ *width*\ [**+v**]
      - :doc:`Oblique Mercator, 2: two points </projections/cyl/cyl_oblique_mercator_2>`
@@ -63,16 +63,16 @@ The below table shows the projection codes for the 31 GMT projections.
        [**+r**\ *offset*][**+t**\ *origin*][**+z**\ [**p**\|\ *radius*]]
      - :doc:`Polar </projections/nongeo/polar>` [azimuthal]
        (:math:`\theta, r`) (or cylindrical)
-   * - **Poly**\ [|lon0|\ [/|lat0|]/]\ *width*
+   * - **Poly**\ /[|lon0|\ /[|lat0|/]]\ *width*
      - :doc:`Polyconic </projections/conic/polyconic>`
-   * - **Q**\ [|lon0|\ [/|lat0|/]]\ *width*
+   * - **Q**\ [|lon0|\ /[|lat0|/]]\ *width*
      - :doc:`Equidistant cylindrical </projections/cyl/cyl_equidistant>`
    * - **R**\ [|lon0|/]\ *width*
      - :doc:`Winkel Tripel </projections/misc/misc_winkel_tripel>`
    * - **S**\ |lon0|/|lat0|\ [/\ *horizon*]/\ *width*
      - :doc:`General stereographic
        </projections/azim/azim_general_stereographic>`
-   * - **T**\ [|lon0|\ [/|lat0|]/]\ *width*
+   * - **T**\ |lon0|\ [/|lat0|]/\ *width*
      - :doc:`Transverse Mercator </projections/cyl/cyl_transverse_mercator>`
    * - **U**\ *zone*/*width*
      - :doc:`Universal Transverse Mercator (UTM)

--- a/examples/projections/table/README.txt
+++ b/examples/projections/table/README.txt
@@ -24,7 +24,7 @@ The below table shows the projection codes for the 31 GMT projections.
      - :doc:`Albers conic equal area </projections/conic/conic_albers>`
    * - **C**\ |lon0|/|lat0|/\ *width*
      - :doc:`Cassini cylindrical </projections/cyl/cyl_cassini>`
-   * - **Cyl_stere**\ /[|lon0|\/[|lat0|/]]\ *width*
+   * - **Cyl_stere**/\ [|lon0|/\ [|lat0|/]]\ *width*
      - :doc:`Cylindrical stereographic </projections/cyl/cyl_stereographic>`
    * - **D**\ |lon0|/|lat0|/|lat1|/|lat2|/\ *width*
      - :doc:`Equidistant conic </projections/conic/conic_equidistant>`
@@ -34,8 +34,8 @@ The below table shows the projection codes for the 31 GMT projections.
      - :doc:`Azimuthal gnomonic </projections/azim/azim_gnomonic>`
    * - **G**\ |lon0|/|lat0|\ [/\ *horizon*]/\ *width*
      - :doc:`Azimuthal orthographic </projections/azim/azim_orthographic>`
-   * - **G**\ |lon0|/|lat0|\ */width*\[**+a**\ *azimuth*]\ [**+t**\ *tilt*]\
-       [**+v**\ *vwidth/vheight*]\ [**+w**\ *twist*]\ [**+z**\ *altitude*]
+   * - **G**\ |lon0|/|lat0|/\ *width*\ [**+a**\ *azimuth*]\ [**+t**\ *tilt*]\
+       [**+v**\ *vwidth*/*vheight*]\ [**+w**\ *twist*]\ [**+z**\ *altitude*]
      - :doc:`General perspective </projections/azim/azim_general_perspective>`
    * - **H**\ [|lon0|/]\ *width*
      - :doc:`Hammer equal area </projections/misc/misc_hammer>`
@@ -49,7 +49,7 @@ The below table shows the projection codes for the 31 GMT projections.
      - :doc:`Eckert VI equal area </projections/misc/misc_eckertVI>`
    * - **L**\ |lon0|/|lat0|/|lat1|/|lat2|/\ *width*
      - :doc:`Lambert conic conformal </projections/conic/conic_lambert>`
-   * - **M**\ [|lon0|\ /[|lat0|/]]\ *width*
+   * - **M**\ [|lon0|/\ [|lat0|/]]\ *width*
      - :doc:`Mercator cylindrical </projections/cyl/cyl_mercator>`
    * - **N**\ [|lon0|/]\ *width*
      - :doc:`Robinson </projections/misc/misc_robinson>`
@@ -63,16 +63,16 @@ The below table shows the projection codes for the 31 GMT projections.
        [**+r**\ *offset*][**+t**\ *origin*][**+z**\ [**p**\|\ *radius*]]
      - :doc:`Polar </projections/nongeo/polar>` [azimuthal]
        (:math:`\theta, r`) (or cylindrical)
-   * - **Poly**\ /[|lon0|\ /[|lat0|/]]\ *width*
+   * - **Poly**/\ [|lon0|/\ [|lat0|/]]\ *width*
      - :doc:`Polyconic </projections/conic/polyconic>`
-   * - **Q**\ [|lon0|\ /[|lat0|/]]\ *width*
+   * - **Q**\ [|lon0|/\ [|lat0|/]]\ *width*
      - :doc:`Equidistant cylindrical </projections/cyl/cyl_equidistant>`
    * - **R**\ [|lon0|/]\ *width*
      - :doc:`Winkel Tripel </projections/misc/misc_winkel_tripel>`
    * - **S**\ |lon0|/|lat0|\ [/\ *horizon*]/\ *width*
      - :doc:`General stereographic
        </projections/azim/azim_general_stereographic>`
-   * - **T**\ |lon0|\ [/|lat0|]/\ *width*
+   * - **T**\ |lon0|/\ [/|lat0|/]\ *width*
      - :doc:`Transverse Mercator </projections/cyl/cyl_transverse_mercator>`
    * - **U**\ *zone*/*width*
      - :doc:`Universal Transverse Mercator (UTM)


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix some typos in the syntax of the projections, including both the overview table and the separate documentation pages.

Start in #2253
Fixes #2059


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
