### PR TITLE
Figure.ternary: Fix the crash for pd.DataFrame input with GMT 6.3-6.4

### DIFF
--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -1,6 +1,8 @@
 """
 ternary - Plot data on ternary diagrams.
 """
+import pandas as pd
+from packaging.version import Version
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -79,6 +81,12 @@ def ternary(self, data, alabel=None, blabel=None, clabel=None, **kwargs):
         kwargs["L"] = "/".join([alabel, blabel, clabel])
 
     with Session() as lib:
+        # Patch for GMT < 6.5.0.
+        # See https://github.com/GenericMappingTools/pygmt/pull/2138
+        if Version(lib.info["version"]) < Version("6.5.0") and isinstance(
+            data, pd.DataFrame
+        ):
+            data = data.to_numpy()
         file_context = lib.virtualfile_from_data(check_kind="vector", data=data)
         with file_context as infile:
             lib.call_module(


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/GenericMappingTools/pygmt/pull/2138 for the related issue. 

`Figure.ternary` crashes for a pd.DataFrame input with GMT 6.3-6.4. This PR fixes the crash by converting pd.DataFrame to NumPy array as mentioned in https://github.com/GenericMappingTools/pygmt/pull/2138#issuecomment-1356284659.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
