### PR TITLE
load_earth_relief now can load gebco, gebcosi and synbath datasets with GMT 6.3

### DIFF
--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -5,15 +5,15 @@ name: GMT Legacy Tests
 on:
   # push:
   #   branches: [ main ]
-  # pull_request:
-    # types: [ready_for_review]
-    # paths-ignore:
-    #  - 'doc/**'
-    #  - 'examples/**'
-    #  - '*.md'
-    #  - 'README.rst'
-    #  - 'LICENSE.txt'
-    #  - '.gitignore'
+  pull_request:
+    types: [ready_for_review]
+    paths-ignore:
+      - 'doc/**'
+      - 'examples/**'
+      - '*.md'
+      - 'README.rst'
+      - 'LICENSE.txt'
+      - '.gitignore'
   # Schedule tests on Tuesday
   schedule:
     - cron: '0 0 * * 2'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -5,15 +5,15 @@ name: GMT Legacy Tests
 on:
   # push:
   #   branches: [ main ]
-  pull_request:
-    types: [ready_for_review]
-    paths-ignore:
-      - 'doc/**'
-      - 'examples/**'
-      - '*.md'
-      - 'README.rst'
-      - 'LICENSE.txt'
-      - '.gitignore'
+  # pull_request:
+    # types: [ready_for_review]
+    # paths-ignore:
+    #  - 'doc/**'
+    #  - 'examples/**'
+    #  - '*.md'
+    #  - 'README.rst'
+    #  - 'LICENSE.txt'
+    #  - '.gitignore'
   # Schedule tests on Tuesday
   schedule:
     - cron: '0 0 * * 2'

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -4,10 +4,8 @@ load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
-from packaging.version import Version
-from pygmt.clib import Session
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
-from pygmt.exceptions import GMTInvalidInput, GMTVersionError
+from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import kwargs_to_strings
 
 __doctest_skip__ = ["load_earth_relief"]

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -134,13 +134,6 @@ def load_earth_relief(
             f"Invalid earth relief 'data_source' {data_source}, "
             "valid values are 'igpp', 'gebco', 'gebcosi' and 'synbath'."
         )
-    if data_source != "igpp":
-        with Session() as lib:
-            if Version(lib.info["version"]) < Version("6.4.0"):
-                raise GMTVersionError(
-                    f"The {data_source} option is not available for GMT"
-                    " versions before 6.4.0."
-                )
     # Choose earth relief data prefix
     if use_srtm and resolution in land_only_srtm_resolutions:
         if data_source == "igpp":


### PR DESCRIPTION
**Description of proposed changes**

As mentioned in https://github.com/GenericMappingTools/pygmt/issues/2225#issuecomment-1340896454, after PR #2266 is merged, gebco, gebcosi and synbath dataset should work with GMT 6.3. This PR remove the exception when gebco/gebcosi/synbath datasets are used with GMT 6.3.

Fixes https://github.com/GenericMappingTools/pygmt/issues/2225.

Notes that:

Some tests fail with GMT 6.3 in the GMT Legacy Tests workflow (https://github.com/GenericMappingTools/pygmt/actions/runs/3784213311). These tests should pass after the changes in this PR.

Let's see the workflow results trigged by this PR https://github.com/GenericMappingTools/pygmt/actions/runs/3795048765.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
