### PR TITLE
Add the missing mpl_image_compare mark to test_plot_dataframe_incols

### DIFF
--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -515,6 +515,7 @@ def test_plot_shapefile():
     return fig
 
 
+@pytest.mark.mpl_image_compare
 def test_plot_dataframe_incols():
     """
     Make sure that the incols parameter works for pandas.DataFrame.


### PR DESCRIPTION
**Description of proposed changes**

Fix the following error shown in the CI runs:
```
pygmt/tests/test_plot.py::test_plot_dataframe_incols
  /usr/share/miniconda3/envs/pygmt/lib/python3.8/site-packages/_pytest/python.py:199: PytestReturnNotNoneWarning: Expected None, but pygmt/tests/test_plot.py::test_plot_dataframe_incols returned <pygmt.figure.Figure object at 0x7fb2c5134520>, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    warnings.warn(
```

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
