### PR TITLE
Fix ci_tests.yaml to actually run full tests on Wednesday

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -130,12 +130,12 @@ jobs:
 
       # Run the regular tests
       - name: Run tests
-        if: github.event.schedule != '0 0 * * 3'
+        if: ${{ !endsWith(github.event.schedule, '3') }}
         run: make test PYTEST_EXTRA="-r P"
 
       # Run full tests including doctests on Wednesday
       - name: Run full tests
-        if: github.event_name == 'schedule' && github.event.schedule == '0 0 * * 3'
+        if: github.event_name == 'schedule' && endsWith(github.event.schedule, '3')
         run: make fulltest PYTEST_EXTRA="-r P"
 
       # Upload diff images on test failure


### PR DESCRIPTION
**Description of proposed changes**

Previous expression was matching too strictly on the crontab, so using endsWith instead. xref https://docs.github.com/en/actions/learn-github-actions/expressions#endswith. Inspired by https://github.com/orgs/community/discussions/25662#discussioncomment-3248648.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Cherry-picked from 0bf561fd707da85aa7a1f4e4108cc2b1042f3b72 and 21cfbff31885370e91416f3efb3821d7cf037e68 in #2283

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Patches #1833.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
