### PR TITLE
Remove the setup.cfg file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-# An emtpy setup.cfg file for backward compatibility with pip<21.3.
-# See https://github.com/GenericMappingTools/pygmt/issues/2100 for the issue report.


### PR DESCRIPTION
**Description of proposed changes**

The setup.cfg file was removed in https://github.com/GenericMappingTools/pygmt/pull/1847 when we migrated configurations to pyproject.toml and was added back in https://github.com/GenericMappingTools/pygmt/pull/2109 for backward-compatibility with pip < 21.3.

The latest Anaconda/Miniconda now ships pip 22.2.2 by default, so it's time to remove the `setup.cfg` file again. 

Closes https://github.com/GenericMappingTools/pygmt/issues/2100.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
