### PR TITLE
Remove the deprecated load_japan_quakes function (deprecated since v0.6.0)

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -237,7 +237,6 @@ Use :func:`pygmt.datasets.load_sample_data` instead.
 
     datasets.load_fractures_compilation
     datasets.load_hotspots
-    datasets.load_japan_quakes
     datasets.load_mars_shape
     datasets.load_ocean_ridge_points
     datasets.load_sample_bathymetry

--- a/pygmt/datasets/__init__.py
+++ b/pygmt/datasets/__init__.py
@@ -14,7 +14,6 @@ from pygmt.datasets.samples import (
     list_sample_data,
     load_fractures_compilation,
     load_hotspots,
-    load_japan_quakes,
     load_mars_shape,
     load_ocean_ridge_points,
     load_sample_bathymetry,

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -73,7 +73,6 @@ def load_sample_data(name):
         "bathymetry": load_sample_bathymetry,
         "fractures": load_fractures_compilation,
         "hotspots": load_hotspots,
-        "japan_quakes": load_japan_quakes,
         "mars_shape": load_mars_shape,
         "ocean_ridge_points": load_ocean_ridge_points,
         "usgs_quakes": load_usgs_quakes,
@@ -81,10 +80,11 @@ def load_sample_data(name):
 
     # Dictionary of private load functions
     load_func = {
-        "rock_compositions": _load_rock_sample_compositions,
         "earth_relief_holes": _load_earth_relief_holes,
+        "japan_quakes": _load_japan_quakes,
         "maunaloa_co2": _load_maunaloa_co2,
         "notre_dame_topography": _load_notre_dame_topography,
+        "rock_compositions": _load_rock_sample_compositions,
     }
 
     if name in load_func_old:
@@ -95,21 +95,9 @@ def load_sample_data(name):
     return data
 
 
-def load_japan_quakes(**kwargs):
+def _load_japan_quakes():
     """
-    (Deprecated) Load a table of earthquakes around Japan as a
-    pandas.DataFrame.
-
-    .. warning:: Deprecated since v0.6.0. This function has been replaced with
-       ``load_sample_data(name="japan_quakes")`` and will be removed in
-       v0.9.0.
-
-    Data is from the NOAA NGDC database. This is the ``@tut_quakes.ngdc``
-    dataset used in the GMT tutorials.
-
-    The data are downloaded to a cache directory (usually ``~/.gmt/cache``) the
-    first time you invoke this function. Afterwards, it will load the data from
-    the cache. So you'll need an internet connection the first time around.
+    Load a table of earthquakes around Japan as a pandas.DataFrame.
 
     Returns
     -------
@@ -117,29 +105,21 @@ def load_japan_quakes(**kwargs):
         The data table. Columns are year, month, day, latitude, longitude,
         depth (in km), and magnitude of the earthquakes.
     """
-
-    if "suppress_warning" not in kwargs:
-        warnings.warn(
-            "This function has been deprecated since v0.6.0 and will be "
-            "removed in v0.9.0. Please use "
-            "load_sample_data(name='japan_quakes') instead.",
-            category=FutureWarning,
-            stacklevel=2,
-        )
-
     fname = which("@tut_quakes.ngdc", download="c")
-    data = pd.read_csv(fname, header=1, sep=r"\s+")
-    data.columns = [
-        "year",
-        "month",
-        "day",
-        "latitude",
-        "longitude",
-        "depth_km",
-        "magnitude",
-    ]
-
-    return data
+    return pd.read_csv(
+        fname,
+        header=1,
+        delim_whitespace=True,
+        names=[
+            "year",
+            "month",
+            "day",
+            "latitude",
+            "longitude",
+            "depth_km",
+            "magnitude",
+        ],
+    )
 
 
 def load_ocean_ridge_points(**kwargs):

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -102,8 +102,9 @@ def _load_japan_quakes():
     Returns
     -------
     data : pandas.DataFrame
-        The data table. Columns are year, month, day, latitude, longitude,
-        depth (in km), and magnitude of the earthquakes.
+        The data table. The column names are "year", "month", "day",
+        "latitude", "longitude", "depth_km", and "magnitude" of the
+        earthquakes.
     """
     fname = which("@tut_quakes.ngdc", download="c")
     return pd.read_csv(

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -99,6 +99,8 @@ def _load_japan_quakes():
     """
     Load a table of earthquakes around Japan as a pandas.DataFrame.
 
+    Data is from the NOAA NGDC database.
+
     Returns
     -------
     data : pandas.DataFrame

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -38,20 +38,6 @@ def test_japan_quakes():
     assert data["day"].max() == 31
 
 
-def test_load_sample_data():
-    """
-    Check that the dataset loads without errors.
-    """
-    data = load_sample_data(name="japan_quakes")
-    assert data.shape == (115, 7)
-    assert data["year"].min() == 1987
-    assert data["year"].max() == 1988
-    assert data["month"].min() == 1
-    assert data["month"].max() == 12
-    assert data["day"].min() == 1
-    assert data["day"].max() == 31
-
-
 def test_ocean_ridge_points():
     """
     Check that the @ridge.txt dataset loads without errors.

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -7,7 +7,6 @@ import pytest
 from pygmt.datasets import (
     load_fractures_compilation,
     load_hotspots,
-    load_japan_quakes,
     load_mars_shape,
     load_ocean_ridge_points,
     load_sample_bathymetry,
@@ -29,9 +28,7 @@ def test_japan_quakes():
     """
     Check that the dataset loads without errors.
     """
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        data = load_japan_quakes()
-        assert len(record) == 1
+    data = load_sample_data(name="japan_quakes")
     assert data.shape == (115, 7)
     assert data["year"].min() == 1987
     assert data["year"].max() == 1988


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
