### PR TITLE
Remove the deprecated load_fractures_compilation function (deprecated since v0.6.0)

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -235,7 +235,6 @@ Use :func:`pygmt.datasets.load_sample_data` instead.
 .. autosummary::
     :toctree: generated
 
-    datasets.load_fractures_compilation
     datasets.load_hotspots
     datasets.load_japan_quakes
     datasets.load_mars_shape

--- a/pygmt/datasets/__init__.py
+++ b/pygmt/datasets/__init__.py
@@ -12,7 +12,6 @@ from pygmt.datasets.earth_vertical_gravity_gradient import (
 )
 from pygmt.datasets.samples import (
     list_sample_data,
-    load_fractures_compilation,
     load_hotspots,
     load_japan_quakes,
     load_mars_shape,

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -243,7 +243,6 @@ def _load_fractures_compilation():
     data : pandas.DataFrame
         The data table. The column names are "length" and
         "azimuth" of the fractures.
-
     """
 
     fname = which("@fractures_06.txt", download="c")

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -25,6 +25,7 @@ def list_sample_data():
     names = {
         "bathymetry": "Table of ship bathymetric observations off Baja California",
         "earth_relief_holes": "Regional 20 arc-minutes Earth relief grid with holes",
+        "fractures": "Table of hypothetical fracture lengths and azimuths",
         "hotspots": "Table of locations, names, and symbol sizes of hotpots from "
         " Mueller et al., 1993",
         "japan_quakes": "Table of earthquakes around Japan from NOAA NGDC database",

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -263,7 +263,7 @@ def _load_fractures_compilation():
     """
 
     fname = which("@fractures_06.txt", download="c")
-    data = pd.read_csv(fname, header=None, sep=r"\s+", names=["azimuth", "length"])
+    data = pd.read_csv(fname, header=None, delim_whitespace=True, names=["azimuth", "length"])
     return data[["length", "azimuth"]]
 
 

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -25,7 +25,6 @@ def list_sample_data():
     names = {
         "bathymetry": "Table of ship bathymetric observations off Baja California",
         "earth_relief_holes": "Regional 20 arc-minutes Earth relief grid with holes",
-        "fractures": "Table of hypothetical fracture lengths and azimuths",
         "hotspots": "Table of locations, names, and symbol sizes of hotpots from "
         " Mueller et al., 1993",
         "japan_quakes": "Table of earthquakes around Japan from NOAA NGDC database",
@@ -71,7 +70,6 @@ def load_sample_data(name):
     # Dictionary of public load functions for backwards compatibility
     load_func_old = {
         "bathymetry": load_sample_bathymetry,
-        "fractures": load_fractures_compilation,
         "hotspots": load_hotspots,
         "japan_quakes": load_japan_quakes,
         "mars_shape": load_mars_shape,
@@ -83,6 +81,7 @@ def load_sample_data(name):
     load_func = {
         "rock_compositions": _load_rock_sample_compositions,
         "earth_relief_holes": _load_earth_relief_holes,
+        "fractures": _load_fractures_compilation,
         "maunaloa_co2": _load_maunaloa_co2,
         "notre_dame_topography": _load_notre_dame_topography,
     }
@@ -250,20 +249,10 @@ def load_usgs_quakes(**kwargs):
     return data
 
 
-def load_fractures_compilation(**kwargs):
+def _load_fractures_compilation():
     """
-    (Deprecated) Load a table of fracture lengths and azimuths as
-    hypothetically digitized from geological maps as a pandas.DataFrame.
-
-    .. warning:: Deprecated since v0.6.0. This function has been replaced with
-       ``load_sample_data(name="fractures")`` and will be removed in
-       v0.9.0.
-
-    This is the ``@fractures_06.txt`` dataset used in the GMT tutorials.
-
-    The data are downloaded to a cache directory (usually ``~/.gmt/cache``) the
-    first time you invoke this function. Afterwards, it will load the data from
-    the cache. So you'll need an internet connection the first time around.
+    Load a table of fracture lengths and azimuths as hypothetically 
+    digitized from geological maps as a pandas.DataFrame.
 
     Returns
     -------
@@ -272,14 +261,6 @@ def load_fractures_compilation(**kwargs):
         columns.
     """
 
-    if "suppress_warning" not in kwargs:
-        warnings.warn(
-            "This function has been deprecated since v0.6.0 and will be "
-            "removed in v0.9.0. Please use "
-            "load_sample_data(name='fractures') instead.",
-            category=FutureWarning,
-            stacklevel=2,
-        )
     fname = which("@fractures_06.txt", download="c")
     data = pd.read_csv(fname, header=None, sep=r"\s+", names=["azimuth", "length"])
     return data[["length", "azimuth"]]

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -241,8 +241,9 @@ def _load_fractures_compilation():
     Returns
     -------
     data : pandas.DataFrame
-        The data table. Use ``print(data.describe())`` to see the available
-        columns.
+        The data table. The column names are "length" and
+        "azimuth" of the fractures.
+
     """
 
     fname = which("@fractures_06.txt", download="c")

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -252,8 +252,8 @@ def load_usgs_quakes(**kwargs):
 
 def _load_fractures_compilation():
     """
-    Load a table of fracture lengths and azimuths as hypothetically 
-    digitized from geological maps as a pandas.DataFrame.
+    Load a table of fracture lengths and azimuths as hypothetically digitized
+    from geological maps as a pandas.DataFrame.
 
     Returns
     -------

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -246,7 +246,9 @@ def _load_fractures_compilation():
     """
 
     fname = which("@fractures_06.txt", download="c")
-    data = pd.read_csv(fname, header=None, delim_whitespace=True, names=["azimuth", "length"])
+    data = pd.read_csv(
+        fname, header=None, delim_whitespace=True, names=["azimuth", "length"]
+    )
     return data[["length", "azimuth"]]
 
 

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -5,7 +5,6 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from pygmt.datasets import (
-    load_fractures_compilation,
     load_hotspots,
     load_japan_quakes,
     load_mars_shape,
@@ -99,9 +98,7 @@ def test_fractures_compilation():
     """
     Check that the @fractures_06.txt dataset loads without errors.
     """
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        data = load_fractures_compilation()
-        assert len(record) == 1
+    data = load_sample_data(name="fractures_compilation")
     assert data.shape == (361, 2)
     assert data["length"].min() == 98.6561
     assert data["length"].max() == 984.652

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -98,7 +98,7 @@ def test_fractures_compilation():
     """
     Check that the @fractures_06.txt dataset loads without errors.
     """
-    data = load_sample_data(name="fractures_compilation")
+    data = load_sample_data(name="fractures")
     assert data.shape == (361, 2)
     assert data["length"].min() == 98.6561
     assert data["length"].max() == 984.652


### PR DESCRIPTION
**Description of proposed changes**

Related to #2302

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
