### PR TITLE
Remove the deprecated load_mars_shape function (deprecated since v0.6.0)

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -238,7 +238,6 @@ Use :func:`pygmt.datasets.load_sample_data` instead.
     datasets.load_fractures_compilation
     datasets.load_hotspots
     datasets.load_japan_quakes
-    datasets.load_mars_shape
     datasets.load_ocean_ridge_points
     datasets.load_sample_bathymetry
     datasets.load_usgs_quakes

--- a/pygmt/datasets/__init__.py
+++ b/pygmt/datasets/__init__.py
@@ -15,7 +15,6 @@ from pygmt.datasets.samples import (
     load_fractures_compilation,
     load_hotspots,
     load_japan_quakes,
-    load_mars_shape,
     load_ocean_ridge_points,
     load_sample_bathymetry,
     load_sample_data,

--- a/pygmt/datasets/__init__.py
+++ b/pygmt/datasets/__init__.py
@@ -10,8 +10,4 @@ from pygmt.datasets.earth_relief import load_earth_relief
 from pygmt.datasets.earth_vertical_gravity_gradient import (
     load_earth_vertical_gravity_gradient,
 )
-from pygmt.datasets.samples import (
-    list_sample_data,
-    load_sample_data,
-    load_usgs_quakes,
-)
+from pygmt.datasets.samples import list_sample_data, load_sample_data, load_usgs_quakes

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -1,8 +1,6 @@
 """
 Functions to load sample data.
 """
-import warnings
-
 import pandas as pd
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.io import load_dataarray
@@ -68,9 +66,6 @@ def load_sample_data(name):
     if name not in names:
         raise GMTInvalidInput(f"Invalid dataset name '{name}'.")
 
-    # Dictionary of public load functions for backwards compatibility
-    load_func_old = {}
-
     # Dictionary of private load functions
     load_func = {
         "bathymetry": _load_baja_california_bathymetry,
@@ -86,9 +81,7 @@ def load_sample_data(name):
         "usgs_quakes": _load_usgs_quakes,
     }
 
-    if name in load_func_old:
-        data = load_func_old[name](suppress_warning=True)
-    elif name in load_func:
+    if name in load_func:
         data = load_func[name]()
 
     return data

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -327,7 +327,7 @@ def load_hotspots(**kwargs):
 def _load_mars_shape():
     """
     Load a table of data for the shape of Mars as a pandas.DataFrame.
-    
+
     Data and information are from Smith, D. E., and M. T. Zuber (1996),
     The shape of Mars and the topographic signature of the hemispheric
     dichotomy.
@@ -335,11 +335,12 @@ def _load_mars_shape():
     Returns
     -------
     data : pandas.DataFrame
-        The data table with column names "longitude", "latitude", and "radius_m".
+        The data table with column names "longitude", "latitude", and
+        "radius_m".
     """
     fname = which("@mars370d.txt", download="c")
     data = pd.read_csv(
-        fname, sep="\t", header=None, names=["longitude", "latitude", "radius(m)"]
+        fname, sep="\t", header=None, names=["longitude", "latitude", "radius_m"]
     )
     return data
 

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -327,6 +327,10 @@ def load_hotspots(**kwargs):
 def _load_mars_shape():
     """
     Load a table of data for the shape of Mars as a pandas.DataFrame.
+    
+    Data and information are from Smith, D. E., and M. T. Zuber (1996),
+    The shape of Mars and the topographic signature of the hemispheric
+    dichotomy.
 
     Returns
     -------

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -80,11 +80,7 @@ def load_sample_data(name):
         "rock_compositions": _load_rock_sample_compositions,
         "usgs_quakes": _load_usgs_quakes,
     }
-
-    if name in load_func:
-        data = load_func[name]()
-
-    return data
+    return load_func[name]()
 
 
 def _load_japan_quakes():

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -70,10 +70,10 @@ def load_sample_data(name):
     load_func = {
         "bathymetry": _load_baja_california_bathymetry,
         "earth_relief_holes": _load_earth_relief_holes,
-        "mars_shape": _load_mars_shape,
         "fractures": _load_fractures_compilation,
         "hotspots": _load_hotspots,
         "japan_quakes": _load_japan_quakes,
+        "mars_shape": _load_mars_shape,
         "maunaloa_co2": _load_maunaloa_co2,
         "notre_dame_topography": _load_notre_dame_topography,
         "ocean_ridge_points": _load_ocean_ridge_points,

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -335,7 +335,7 @@ def _load_mars_shape():
     Returns
     -------
     data : pandas.DataFrame
-        The data table with columns "longitude", "latitude", and "radius(m)".
+        The data table with column names "longitude", "latitude", and "radius_m".
     """
     fname = which("@mars370d.txt", download="c")
     data = pd.read_csv(

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -324,7 +324,7 @@ def load_hotspots(**kwargs):
     return data
 
 
-def _load_mars_shape(**kwargs):
+def _load_mars_shape():
     """
     Load a table of data for the shape of Mars as a pandas.DataFrame.
 

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -74,7 +74,6 @@ def load_sample_data(name):
         "fractures": load_fractures_compilation,
         "hotspots": load_hotspots,
         "japan_quakes": load_japan_quakes,
-        "mars_shape": load_mars_shape,
         "ocean_ridge_points": load_ocean_ridge_points,
         "usgs_quakes": load_usgs_quakes,
     }
@@ -83,6 +82,7 @@ def load_sample_data(name):
     load_func = {
         "rock_compositions": _load_rock_sample_compositions,
         "earth_relief_holes": _load_earth_relief_holes,
+        "mars_shape": _load_mars_shape,
         "maunaloa_co2": _load_maunaloa_co2,
         "notre_dame_topography": _load_notre_dame_topography,
     }
@@ -324,37 +324,15 @@ def load_hotspots(**kwargs):
     return data
 
 
-def load_mars_shape(**kwargs):
+def _load_mars_shape(**kwargs):
     """
-    (Deprecated) Load a table of data for the shape of Mars.
-
-    .. warning:: Deprecated since v0.6.0. This function has been replaced with
-       ``load_sample_data(name="mars_shape")`` and will be removed in
-       v0.9.0.
-
-    This is the ``@mars370d.txt`` dataset used in GMT examples, with data and
-    information from Smith, D. E., and M. T. Zuber (1996), The shape of Mars
-    and the topographic signature of the hemispheric dichotomy. Data columns
-    are "longitude," "latitude", and "radius (meters)."
-
-    The data are downloaded to a cache directory (usually ``~/.gmt/cache``) the
-    first time you invoke this function. Afterwards, it will load the data from
-    the cache. So you'll need an internet connection the first time around.
+    Load a table of data for the shape of Mars as a pandas.DataFrame.
 
     Returns
     -------
     data : pandas.DataFrame
         The data table with columns "longitude", "latitude", and "radius(m)".
     """
-
-    if "suppress_warning" not in kwargs:
-        warnings.warn(
-            "This function has been deprecated since v0.6.0 and will be "
-            "removed in v0.9.0. Please use "
-            "load_sample_data(name='mars_shape') instead.",
-            category=FutureWarning,
-            stacklevel=2,
-        )
     fname = which("@mars370d.txt", download="c")
     data = pd.read_csv(
         fname, sep="\t", header=None, names=["longitude", "latitude", "radius(m)"]

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -8,7 +8,6 @@ from pygmt.datasets import (
     load_fractures_compilation,
     load_hotspots,
     load_japan_quakes,
-    load_mars_shape,
     load_ocean_ridge_points,
     load_sample_bathymetry,
     load_sample_data,
@@ -113,9 +112,7 @@ def test_mars_shape():
     """
     Check that the @mars370d.txt dataset loads without errors.
     """
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        data = load_mars_shape()
-        assert len(record) == 1
+    data = load_sample_data(name="mars_shape")
     assert data.shape == (370, 3)
     assert data["longitude"].min() == 0.008
     assert data["longitude"].max() == 359.983

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -118,8 +118,8 @@ def test_mars_shape():
     assert data["longitude"].max() == 359.983
     assert data["latitude"].min() == -79.715
     assert data["latitude"].max() == 85.887
-    assert data["radius(m)"].min() == -6930
-    assert data["radius(m)"].max() == 15001
+    assert data["radius_m"].min() == -6930
+    assert data["radius_m"].max() == 15001
 
 
 def test_hotspots():


### PR DESCRIPTION
Removes the deprecated function `load_mars_shape` and replaces it with `_load_mars_shape`.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses: #2302 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
