### PR TITLE
Remove the deprecated load_sample_bathymetry function (deprecated since v0.6.0)

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -240,7 +240,6 @@ Use :func:`pygmt.datasets.load_sample_data` instead.
     datasets.load_japan_quakes
     datasets.load_mars_shape
     datasets.load_ocean_ridge_points
-    datasets.load_sample_bathymetry
     datasets.load_usgs_quakes
 
 .. automodule:: pygmt.exceptions

--- a/pygmt/datasets/__init__.py
+++ b/pygmt/datasets/__init__.py
@@ -17,7 +17,6 @@ from pygmt.datasets.samples import (
     load_japan_quakes,
     load_mars_shape,
     load_ocean_ridge_points,
-    load_sample_bathymetry,
     load_sample_data,
     load_usgs_quakes,
 )

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -79,7 +79,6 @@ def load_sample_data(name):
     # Dictionary of private load functions
     load_func = {
         "bathymetry": _load_sample_bathymetry,
-        "rock_compositions": _load_rock_sample_compositions,
         "earth_relief_holes": _load_earth_relief_holes,
         "fractures": _load_fractures_compilation,
         "japan_quakes": _load_japan_quakes,

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -181,8 +181,8 @@ def load_ocean_ridge_points(**kwargs):
 
 def _load_sample_bathymetry(**kwargs):
     """
-    Load a table of ship observations of bathymetry off Baja
-    California as a pandas.DataFrame.
+    Load a table of ship observations of bathymetry off Baja California as a
+    pandas.DataFrame.
 
     Returns
     -------

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -179,7 +179,7 @@ def load_ocean_ridge_points(**kwargs):
     return data
 
 
-def _load_sample_bathymetry(**kwargs):
+def _load_sample_bathymetry():
     """
     Load a table of ship observations of bathymetry off Baja California as a
     pandas.DataFrame.

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -78,7 +78,7 @@ def load_sample_data(name):
 
     # Dictionary of private load functions
     load_func = {
-        "bathymetry": _load_sample_bathymetry,
+        "bathymetry": _load_baja_california_bathymetry,
         "earth_relief_holes": _load_earth_relief_holes,
         "fractures": _load_fractures_compilation,
         "japan_quakes": _load_japan_quakes,
@@ -162,7 +162,7 @@ def load_ocean_ridge_points(**kwargs):
     return data
 
 
-def _load_sample_bathymetry():
+def _load_baja_california_bathymetry():
     """
     Load a table of ship observations of bathymetry off Baja California as a
     pandas.DataFrame.

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -70,7 +70,6 @@ def load_sample_data(name):
 
     # Dictionary of public load functions for backwards compatibility
     load_func_old = {
-        "bathymetry": load_sample_bathymetry,
         "fractures": load_fractures_compilation,
         "hotspots": load_hotspots,
         "japan_quakes": load_japan_quakes,
@@ -81,6 +80,7 @@ def load_sample_data(name):
 
     # Dictionary of private load functions
     load_func = {
+        "bathymetry": _load_sample_bathymetry,
         "rock_compositions": _load_rock_sample_compositions,
         "earth_relief_holes": _load_earth_relief_holes,
         "maunaloa_co2": _load_maunaloa_co2,
@@ -179,20 +179,10 @@ def load_ocean_ridge_points(**kwargs):
     return data
 
 
-def load_sample_bathymetry(**kwargs):
+def _load_sample_bathymetry(**kwargs):
     """
-    (Deprecated) Load a table of ship observations of bathymetry off Baja
+    Load a table of ship observations of bathymetry off Baja
     California as a pandas.DataFrame.
-
-    .. warning:: Deprecated since v0.6.0. This function has been replaced with
-       ``load_sample_data(name="bathymetry")`` and will be removed in
-       v0.9.0.
-
-    This is the ``@tut_ship.xyz`` dataset used in the GMT tutorials.
-
-    The data are downloaded to a cache directory (usually ``~/.gmt/cache``) the
-    first time you invoke this function. Afterwards, it will load the data from
-    the cache. So you'll need an internet connection the first time around.
 
     Returns
     -------
@@ -200,14 +190,6 @@ def load_sample_bathymetry(**kwargs):
         The data table. Columns are longitude, latitude, and bathymetry.
     """
 
-    if "suppress_warning" not in kwargs:
-        warnings.warn(
-            "This function has been deprecated since v0.6.0 and will be "
-            "removed in v0.9.0. Please use "
-            "load_sample_data(name='bathymetry') instead.",
-            category=FutureWarning,
-            stacklevel=2,
-        )
     fname = which("@tut_ship.xyz", download="c")
     data = pd.read_csv(
         fname, sep="\t", header=None, names=["longitude", "latitude", "bathymetry"]

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -187,7 +187,8 @@ def _load_sample_bathymetry():
     Returns
     -------
     data : pandas.DataFrame
-        The data table. Columns are longitude, latitude, and bathymetry.
+        The data table. The column names are "longitude", "latitude",
+        and "bathymetry".
     """
 
     fname = which("@tut_ship.xyz", download="c")

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -158,10 +158,9 @@ def _load_baja_california_bathymetry():
     """
 
     fname = which("@tut_ship.xyz", download="c")
-    data = pd.read_csv(
+    return pd.read_csv(
         fname, sep="\t", header=None, names=["longitude", "latitude", "bathymetry"]
     )
-    return data
 
 
 def load_usgs_quakes(**kwargs):

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -10,7 +10,6 @@ from pygmt.datasets import (
     load_japan_quakes,
     load_mars_shape,
     load_ocean_ridge_points,
-    load_sample_bathymetry,
     load_sample_data,
     load_usgs_quakes,
 )
@@ -73,9 +72,7 @@ def test_sample_bathymetry():
     """
     Check that the @tut_ship.xyz dataset loads without errors.
     """
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        data = load_sample_bathymetry()
-        assert len(record) == 1
+    data = load_sample_data(name="bathymetry")
     assert data.shape == (82970, 3)
     assert data["longitude"].min() == 245.0
     assert data["longitude"].max() == 254.705


### PR DESCRIPTION
**Description of proposed changes**

Related to #2302


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
