### PR TITLE
Remove the deprecated load_usgs_quakes function (deprecated since v0.6.0)

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -241,7 +241,6 @@ Use :func:`pygmt.datasets.load_sample_data` instead.
     datasets.load_mars_shape
     datasets.load_ocean_ridge_points
     datasets.load_sample_bathymetry
-    datasets.load_usgs_quakes
 
 .. automodule:: pygmt.exceptions
 

--- a/pygmt/datasets/__init__.py
+++ b/pygmt/datasets/__init__.py
@@ -10,8 +10,4 @@ from pygmt.datasets.earth_relief import load_earth_relief
 from pygmt.datasets.earth_vertical_gravity_gradient import (
     load_earth_vertical_gravity_gradient,
 )
-from pygmt.datasets.samples import (
-    list_sample_data,
-    load_mars_shape,
-    load_sample_data,
-)
+from pygmt.datasets.samples import list_sample_data, load_mars_shape, load_sample_data

--- a/pygmt/datasets/__init__.py
+++ b/pygmt/datasets/__init__.py
@@ -19,5 +19,4 @@ from pygmt.datasets.samples import (
     load_ocean_ridge_points,
     load_sample_bathymetry,
     load_sample_data,
-    load_usgs_quakes,
 )

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -219,8 +219,6 @@ def _load_usgs_quakes():
     """
     Load a table of global earthquakes from the USGS as a pandas.DataFrame.
 
-    This is the ``@usgs_quakes_22.txt`` dataset used in the GMT tutorials.
-
     Returns
     -------
     data : pandas.DataFrame

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -72,7 +72,6 @@ def load_sample_data(name):
     load_func_old = {
         "hotspots": load_hotspots,
         "mars_shape": load_mars_shape,
-        "usgs_quakes": load_usgs_quakes,
     }
 
     # Dictionary of private load functions

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -76,7 +76,6 @@ def load_sample_data(name):
         "japan_quakes": load_japan_quakes,
         "mars_shape": load_mars_shape,
         "ocean_ridge_points": load_ocean_ridge_points,
-        "usgs_quakes": load_usgs_quakes,
     }
 
     # Dictionary of private load functions
@@ -85,6 +84,7 @@ def load_sample_data(name):
         "earth_relief_holes": _load_earth_relief_holes,
         "maunaloa_co2": _load_maunaloa_co2,
         "notre_dame_topography": _load_notre_dame_topography,
+        "usgs_quakes": _load_usgs_quakes,
     }
 
     if name in load_func_old:
@@ -215,20 +215,11 @@ def load_sample_bathymetry(**kwargs):
     return data
 
 
-def load_usgs_quakes(**kwargs):
+def _load_usgs_quakes():
     """
-    (Deprecated) Load a table of global earthquakes from the USGS as a
-    pandas.DataFrame.
-
-    .. warning:: Deprecated since v0.6.0. This function has been replaced with
-       ``load_sample_data(name="usgs_quakes")`` and will be removed in
-       v0.9.0.
+    Load a table of global earthquakes from the USGS as a pandas.DataFrame.
 
     This is the ``@usgs_quakes_22.txt`` dataset used in the GMT tutorials.
-
-    The data are downloaded to a cache directory (usually ``~/.gmt/cache``) the
-    first time you invoke this function. Afterwards, it will load the data from
-    the cache. So you'll need an internet connection the first time around.
 
     Returns
     -------
@@ -236,15 +227,6 @@ def load_usgs_quakes(**kwargs):
         The data table. Use ``print(data.describe())`` to see the available
         columns.
     """
-
-    if "suppress_warning" not in kwargs:
-        warnings.warn(
-            "This function has been deprecated since v0.6.0 and will be "
-            "removed in v0.9.0. Please use "
-            "load_sample_data(name='usgs_quakes') instead.",
-            category=FutureWarning,
-            stacklevel=2,
-        )
     fname = which("@usgs_quakes_22.txt", download="c")
     data = pd.read_csv(fname)
     return data

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -73,7 +73,6 @@ def load_sample_data(name):
         "bathymetry": load_sample_bathymetry,
         "hotspots": load_hotspots,
         "mars_shape": load_mars_shape,
-        "ocean_ridge_points": load_ocean_ridge_points,
         "usgs_quakes": load_usgs_quakes,
     }
 

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -194,8 +194,7 @@ def _load_usgs_quakes():
         columns.
     """
     fname = which("@usgs_quakes_22.txt", download="c")
-    data = pd.read_csv(fname)
-    return data
+    return pd.read_csv(fname)
 
 
 def _load_fractures_compilation():

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -12,7 +12,6 @@ from pygmt.datasets import (
     load_ocean_ridge_points,
     load_sample_bathymetry,
     load_sample_data,
-    load_usgs_quakes,
 )
 from pygmt.exceptions import GMTInvalidInput
 
@@ -89,9 +88,7 @@ def test_usgs_quakes():
     """
     Check that the dataset loads without errors.
     """
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        data = load_usgs_quakes()
-        assert len(record) == 1
+    data = load_sample_data(name="usgs_quakes")
     assert data.shape == (1197, 22)
 
 

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -4,11 +4,7 @@ Test basic functionality for loading sample datasets.
 import numpy.testing as npt
 import pandas as pd
 import pytest
-from pygmt.datasets import (
-    load_hotspots,
-    load_mars_shape,
-    load_sample_data,
-)
+from pygmt.datasets import load_hotspots, load_mars_shape, load_sample_data
 from pygmt.exceptions import GMTInvalidInput
 
 

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -65,7 +65,7 @@ def test_sample_bathymetry():
 
 def test_usgs_quakes():
     """
-    Check that the dataset loads without errors.
+    Check that the @usgs_quakes_22.txt dataset loads without errors.
     """
     data = load_sample_data(name="usgs_quakes")
     assert data.shape == (1197, 22)

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -90,6 +90,54 @@ def test_usgs_quakes():
     """
     data = load_sample_data(name="usgs_quakes")
     assert data.shape == (1197, 22)
+    assert list(data.columns) == [
+        "time",
+        "latitude",
+        "longitude",
+        "depth",
+        "mag",
+        "magType",
+        "nst",
+        "gap",
+        "dmin",
+        "rms",
+        "net",
+        "id",
+        "updated",
+        "place",
+        "type",
+        "horizontalError",
+        "depthError",
+        "magError",
+        "magNst",
+        "status",
+        "locationSource",
+        "magSource",
+    ]
+    npt.assert_allclose(data["latitude"].min(), -60.6819)
+    npt.assert_allclose(data["latitude"].max(), 72.6309)
+    npt.assert_allclose(data["longitude"].min(), -179.9953)
+    npt.assert_allclose(data["longitude"].max(), 179.9129)
+    npt.assert_allclose(data["depth"].min(), -0.21)
+    npt.assert_allclose(data["depth"].max(), 640.49)
+    npt.assert_allclose(data["mag"].min(), 3)
+    npt.assert_allclose(data["mag"].max(), 8.1)
+    npt.assert_allclose(data["nst"].min(), 3)
+    npt.assert_allclose(data["nst"].max(), 167)
+    npt.assert_allclose(data["gap"].min(), 10.0)
+    npt.assert_allclose(data["gap"].max(), 353.0)
+    npt.assert_allclose(data["dmin"].min(), 0.006421)
+    npt.assert_allclose(data["dmin"].max(), 39.455)
+    npt.assert_allclose(data["rms"].min(), 0.02)
+    npt.assert_allclose(data["rms"].max(), 1.76)
+    npt.assert_allclose(data["horizontalError"].min(), 0.09)
+    npt.assert_allclose(data["horizontalError"].max(), 36.8)
+    npt.assert_allclose(data["depthError"].min(), 0)
+    npt.assert_allclose(data["depthError"].max(), 65.06)
+    npt.assert_allclose(data["magError"].min(), 0.02)
+    npt.assert_allclose(data["magError"].max(), 0.524)
+    npt.assert_allclose(data["magNst"].min(), 1)
+    npt.assert_allclose(data["magNst"].max(), 944)
 
 
 def test_fractures_compilation():


### PR DESCRIPTION
This replaces `load_usgs_quakes` with the internal function `_load_usgs_quakes`. It also adds additional checks to `test_usgs_quakes`.


Addresses: #2302


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
