### PR TITLE
Use consistently 1-D, 2-D, or 3-D in 'session.py' and 'conversion.py' (with hyphen and capitalized)

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -10,7 +10,7 @@ from pygmt.exceptions import GMTInvalidInput
 
 def dataarray_to_matrix(grid):
     """
-    Transform an xarray.DataArray into a data 2D array and metadata.
+    Transform an xarray.DataArray into a data 2-D array and metadata.
 
     Use this to extract the underlying numpy array of data and the region and
     increment for the grid.
@@ -31,8 +31,8 @@ def dataarray_to_matrix(grid):
 
     Returns
     -------
-    matrix : 2d-array
-        The 2D array of data from the grid.
+    matrix : 2-D array
+        The 2-D array of data from the grid.
     region : list
         The West, East, South, North boundaries of the grid.
     inc : list
@@ -127,24 +127,24 @@ def dataarray_to_matrix(grid):
 
 def vectors_to_arrays(vectors):
     """
-    Convert 1d vectors (lists, arrays or pandas.Series) to C contiguous 1d
+    Convert 1-D vectors (lists, arrays or pandas.Series) to C contiguous 1-D
     arrays.
 
     Arrays must be in C contiguous order for us to pass their memory pointers
     to GMT. If any are not, convert them to C order (which requires copying the
-    memory). This usually happens when vectors are columns of a 2d array or
+    memory). This usually happens when vectors are columns of a 2-D array or
     have been sliced.
 
     If a vector is a list or pandas.Series, get the underlying numpy array.
 
     Parameters
     ----------
-    vectors : list of lists, 1d arrays or pandas.Series
+    vectors : list of lists, 1-D arrays or pandas.Series
         The vectors that must be converted.
 
     Returns
     -------
-    arrays : list of 1d arrays
+    arrays : list of 1-D arrays
         The converted numpy arrays
 
     Examples
@@ -179,12 +179,12 @@ def as_c_contiguous(array):
 
     Parameters
     ----------
-    array : 1d array
+    array : 1-D array
         The numpy array
 
     Returns
     -------
-    array : 1d array
+    array : 1-D array
         Array is C contiguous order.
 
     Examples
@@ -252,7 +252,7 @@ def kwargs_to_ctypes_array(argument, kwargs, dtype):
 
 def array_to_datetime(array):
     """
-    Convert an 1d datetime array from various types into pandas.DatetimeIndex
+    Convert an 1-D datetime array from various types into pandas.DatetimeIndex
     (i.e., numpy.datetime64).
 
     If the input array is not in legal datetime formats, raise a "ParseError"
@@ -260,7 +260,7 @@ def array_to_datetime(array):
 
     Parameters
     ----------
-    array : list or 1d array
+    array : list or 1-D array
         The input datetime array in various formats.
 
         Supported types:
@@ -272,7 +272,7 @@ def array_to_datetime(array):
 
     Returns
     -------
-    array : 1d datetime array in pandas.DatetimeIndex (i.e., numpy.datetime64)
+    array : 1-D datetime array in pandas.DatetimeIndex (i.e., numpy.datetime64)
 
     Examples
     --------

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -127,7 +127,7 @@ def dataarray_to_matrix(grid):
 
 def vectors_to_arrays(vectors):
     """
-    Convert 1-D vectors (lists, arrays or pandas.Series) to C contiguous 1-D
+    Convert 1-D vectors (lists, arrays, or pandas.Series) to C contiguous 1-D
     arrays.
 
     Arrays must be in C contiguous order for us to pass their memory pointers
@@ -139,7 +139,7 @@ def vectors_to_arrays(vectors):
 
     Parameters
     ----------
-    vectors : list of lists, 1-D arrays or pandas.Series
+    vectors : list of lists, 1-D arrays, or pandas.Series
         The vectors that must be converted.
 
     Returns

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -741,7 +741,7 @@ class Session:
         first. Use ``family='GMT_IS_DATASET|GMT_VIA_VECTOR'``.
 
         Not all numpy dtypes are supported, only: int8, int16, int32, int64,
-        uint8, uint16, uint32, uint64, float32, float64, str\_, and datetime64.
+        uint8, uint16, uint32, uint64, float32, float64, str, and datetime64.
 
         .. warning::
             The numpy array must be C contiguous in memory. If it comes from a

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1381,10 +1381,10 @@ class Session:
             path, a raster grid, a vector matrix/arrays, or other supported
             data input.
         x/y/z : 1-D arrays or None
-            x, y and z columns as numpy arrays.
+            x, y, and z columns as numpy arrays.
         extra_arrays : list of 1-D arrays
-            Optional. A list of numpy arrays in addition to x, y and z. All
-            of these arrays must be of the same size as the x/y/z arrays.
+            Optional. A list of numpy arrays in addition to x, y, and z.
+            All of these arrays must be of the same size as the x/y/z arrays.
         required_z : bool
             State whether the 'z' column is required.
 

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -717,7 +717,7 @@ class Session:
         """
         # check the array has the given dimension
         if array.ndim != ndim:
-            raise GMTInvalidInput(f"Expected a numpy 1d array, got {array.ndim}d.")
+            raise GMTInvalidInput(f"Expected a numpy 1-D array, got {array.ndim}-D.")
 
         # check the array has a valid/known data type
         if array.dtype.type not in DTYPES:
@@ -732,7 +732,7 @@ class Session:
 
     def put_vector(self, dataset, column, vector):
         r"""
-        Attach a numpy 1D array as a column on a GMT dataset.
+        Attach a numpy 1-D array as a column on a GMT dataset.
 
         Use this function to attach numpy array data to a GMT dataset and pass
         it to GMT modules. Wraps ``GMT_Put_Vector``.
@@ -741,11 +741,11 @@ class Session:
         first. Use ``family='GMT_IS_DATASET|GMT_VIA_VECTOR'``.
 
         Not all numpy dtypes are supported, only: int8, int16, int32, int64,
-        uint8, uint16, uint32, uint64, float32, float64, str\_ and datetime64.
+        uint8, uint16, uint32, uint64, float32, float64, str\_, and datetime64.
 
         .. warning::
             The numpy array must be C contiguous in memory. If it comes from a
-            column slice of a 2d array, for example, you will have to make a
+            column slice of a 2-D array, for example, you will have to make a
             copy. Use :func:`numpy.ascontiguousarray` to make sure your vector
             is contiguous (it won't copy if it already is).
 
@@ -756,8 +756,8 @@ class Session:
             :meth:`pygmt.clib.Session.create_data`.
         column : int
             The column number of this vector in the dataset (starting from 0).
-        vector : numpy 1d-array
-            The array that will be attached to the dataset. Must be a 1d C
+        vector : numpy 1-D array
+            The array that will be attached to the dataset. Must be a 1-D C
             contiguous array.
 
         Raises
@@ -796,7 +796,7 @@ class Session:
 
     def put_strings(self, dataset, family, strings):
         """
-        Attach a numpy 1D array of dtype str as a column on a GMT dataset.
+        Attach a numpy 1-D array of dtype str as a column on a GMT dataset.
 
         Use this function to attach string type numpy array data to a GMT
         dataset and pass it to GMT modules. Wraps ``GMT_Put_Strings``.
@@ -806,7 +806,7 @@ class Session:
 
         .. warning::
             The numpy array must be C contiguous in memory. If it comes from a
-            column slice of a 2d array, for example, you will have to make a
+            column slice of a 2-D array, for example, you will have to make a
             copy. Use :func:`numpy.ascontiguousarray` to make sure your vector
             is contiguous (it won't copy if it already is).
 
@@ -818,8 +818,8 @@ class Session:
         family : str
             The family type of the dataset. Can be either ``GMT_IS_VECTOR`` or
             ``GMT_IS_MATRIX``.
-        strings : numpy 1d-array
-            The array that will be attached to the dataset. Must be a 1d C
+        strings : numpy 1-D array
+            The array that will be attached to the dataset. Must be a 1-D C
             contiguous array.
 
         Raises
@@ -856,7 +856,7 @@ class Session:
 
     def put_matrix(self, dataset, matrix, pad=0):
         """
-        Attach a numpy 2D array to a GMT dataset.
+        Attach a numpy 2-D array to a GMT dataset.
 
         Use this function to attach numpy array data to a GMT dataset and pass
         it to GMT modules. Wraps ``GMT_Put_Matrix``.
@@ -865,7 +865,7 @@ class Session:
         first. Use ``|GMT_VIA_MATRIX'`` in the family.
 
         Not all numpy dtypes are supported, only: int8, int16, int32, int64,
-        uint8, uint16, uint32, uint64, float32 and float64.
+        uint8, uint16, uint32, uint64, float32, and float64.
 
         .. warning::
             The numpy array must be C contiguous in memory. Use
@@ -877,8 +877,8 @@ class Session:
         dataset : :class:`ctypes.c_void_p`
             The ctypes void pointer to a ``GMT_Dataset``. Create it with
             :meth:`pygmt.clib.Session.create_data`.
-        matrix : numpy 2d-array
-            The array that will be attached to the dataset. Must be a 2d C
+        matrix : numpy 2-D array
+            The array that will be attached to the dataset. Must be a 2-D C
             contiguous array.
         pad : int
             The amount of padding that should be added to the matrix. Use when
@@ -1085,7 +1085,7 @@ class Session:
     @contextmanager
     def virtualfile_from_vectors(self, *vectors):
         """
-        Store 1d arrays as columns of a table inside a virtual file.
+        Store 1-D arrays as columns of a table inside a virtual file.
 
         Use the virtual file name to pass in the data in your vectors to a GMT
         module.
@@ -1100,12 +1100,12 @@ class Session:
         :meth:`pygmt.clib.Session.open_virtual_file`.
 
         If the arrays are C contiguous blocks of memory, they will be passed
-        without copying to GMT. If they are not (e.g., they are columns of a 2D
-        array), they will need to be copied to a contiguous block.
+        without copying to GMT. If they are not (e.g., they are columns of a
+        2-D array), they will need to be copied to a contiguous block.
 
         Parameters
         ----------
-        vectors : 1d arrays
+        vectors : 1-D arrays
             The vectors that will be included in the array. All must be of the
             same size.
 
@@ -1189,7 +1189,7 @@ class Session:
     @contextmanager
     def virtualfile_from_matrix(self, matrix):
         """
-        Store a 2d array as a table inside a virtual file.
+        Store a 2-D array as a table inside a virtual file.
 
         Use the virtual file name to pass in the data in your matrix to a GMT
         module.
@@ -1215,7 +1215,7 @@ class Session:
 
         Parameters
         ----------
-        matrix : 2d array
+        matrix : 2-D array
             The matrix that will be included in the GMT data container.
 
         Yields
@@ -1380,9 +1380,9 @@ class Session:
             Any raster or vector data format. This could be a file name or
             path, a raster grid, a vector matrix/arrays, or other supported
             data input.
-        x/y/z : 1d arrays or None
+        x/y/z : 1-D arrays or None
             x, y and z columns as numpy arrays.
-        extra_arrays : list of 1d arrays
+        extra_arrays : list of 1-D arrays
             Optional. A list of numpy arrays in addition to x, y and z. All
             of these arrays must be of the same size as the x/y/z arrays.
         required_z : bool
@@ -1453,22 +1453,22 @@ class Session:
                 _data.append(np.atleast_1d(z))
             if extra_arrays:
                 _data.extend(extra_arrays)
-        elif kind == "matrix":  # turn 2D arrays into list of vectors
+        elif kind == "matrix":  # turn 2-D arrays into list of vectors
             try:
-                # pandas.Series will be handled below like a 1d numpy ndarray
+                # pandas.Series will be handled below like a 1-D numpy.ndarray
                 assert not hasattr(data, "to_frame")
                 # pandas.DataFrame and xarray.Dataset types
                 _data = [array for _, array in data.items()]
             except (AttributeError, AssertionError):
                 try:
-                    # Just use virtualfile_from_matrix for 2D numpy.ndarray
+                    # Just use virtualfile_from_matrix for 2-D numpy.ndarray
                     # which are signed integer (i), unsigned integer (u) or
                     # floating point (f) types
                     assert data.ndim == 2 and data.dtype.kind in "iuf"
                     _virtualfile_from = self.virtualfile_from_matrix
                     _data = (data,)
                 except (AssertionError, AttributeError):
-                    # Python list, tuple, numpy ndarray and pandas.Series types
+                    # Python list, tuple, numpy.ndarray, and pandas.Series types
                     _data = np.atleast_2d(np.asanyarray(data).T)
 
         # Finally create the virtualfile from the data, to be passed into GMT
@@ -1485,8 +1485,8 @@ class Session:
 
         Returns
         -------
-        * wesn : 1d array
-            A 1D numpy array with the west, east, south, and north dimensions
+        * wesn : 1-D array
+            A numpy 1-D array with the west, east, south, and north dimensions
             of the current figure.
 
         Examples

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -763,8 +763,8 @@ class Session:
         Raises
         ------
         GMTCLibError
-            If given invalid input or ``GMT_Put_Vector`` exits with status !=
-            0.
+            If given invalid input or ``GMT_Put_Vector`` exits with
+            status != 0.
         """
         c_put_vector = self.get_libgmt_func(
             "GMT_Put_Vector",
@@ -1468,7 +1468,8 @@ class Session:
                     _virtualfile_from = self.virtualfile_from_matrix
                     _data = (data,)
                 except (AssertionError, AttributeError):
-                    # Python list, tuple, numpy.ndarray, and pandas.Series types
+                    # Python list, tuple, numpy.ndarray, and pandas.Series
+                    # types
                     _data = np.atleast_2d(np.asanyarray(data).T)
 
         # Finally create the virtualfile from the data, to be passed into GMT

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -825,8 +825,8 @@ class Session:
         Raises
         ------
         GMTCLibError
-            If given invalid input or ``GMT_Put_Strings`` exits with status !=
-            0.
+            If given invalid input or ``GMT_Put_Strings`` exits with
+            status != 0.
         """
         c_put_strings = self.get_libgmt_func(
             "GMT_Put_Strings",
@@ -887,8 +887,8 @@ class Session:
         Raises
         ------
         GMTCLibError
-            If given invalid input or ``GMT_Put_Matrix`` exits with status !=
-            0.
+            If given invalid input or ``GMT_Put_Matrix`` exits with
+            status != 0.
         """
         c_put_matrix = self.get_libgmt_func(
             "GMT_Put_Matrix",
@@ -1375,7 +1375,7 @@ class Session:
         ----------
         check_kind : str
             Used to validate the type of data that can be passed in. Choose
-            from 'raster', 'vector' or None. Default is None (no validation).
+            from 'raster', 'vector', or None. Default is None (no validation).
         data : str or pathlib.Path or xarray.DataArray or {table-like} or None
             Any raster or vector data format. This could be a file name or
             path, a raster grid, a vector matrix/arrays, or other supported

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -741,7 +741,7 @@ class Session:
         first. Use ``family='GMT_IS_DATASET|GMT_VIA_VECTOR'``.
 
         Not all numpy dtypes are supported, only: int8, int16, int32, int64,
-        uint8, uint16, uint32, uint64, float32, float64, str, and datetime64.
+        uint8, uint16, uint32, uint64, float32, float64, str\_, and datetime64.
 
         .. warning::
             The numpy array must be C contiguous in memory. If it comes from a


### PR DESCRIPTION
**Description of proposed changes**

This PR is similar to PR #2252, aiming to use consistently 1-D, 2-D, or 3-D (with hyphen and capitalized).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
