### PR TITLE
Remove the deprecated load_ocean_ridge_points function (deprecated since v0.6.0) 

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -239,7 +239,6 @@ Use :func:`pygmt.datasets.load_sample_data` instead.
     datasets.load_hotspots
     datasets.load_japan_quakes
     datasets.load_mars_shape
-    datasets.load_ocean_ridge_points
     datasets.load_sample_bathymetry
     datasets.load_usgs_quakes
 

--- a/pygmt/datasets/__init__.py
+++ b/pygmt/datasets/__init__.py
@@ -16,7 +16,6 @@ from pygmt.datasets.samples import (
     load_hotspots,
     load_japan_quakes,
     load_mars_shape,
-    load_ocean_ridge_points,
     load_sample_bathymetry,
     load_sample_data,
     load_usgs_quakes,

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -75,7 +75,6 @@ def load_sample_data(name):
         "hotspots": load_hotspots,
         "japan_quakes": load_japan_quakes,
         "mars_shape": load_mars_shape,
-        "ocean_ridge_points": load_ocean_ridge_points,
         "usgs_quakes": load_usgs_quakes,
     }
 
@@ -85,6 +84,7 @@ def load_sample_data(name):
         "earth_relief_holes": _load_earth_relief_holes,
         "maunaloa_co2": _load_maunaloa_co2,
         "notre_dame_topography": _load_notre_dame_topography,
+        "ocean_ridge_points": _load_ocean_ridge_points,
     }
 
     if name in load_func_old:
@@ -142,39 +142,25 @@ def load_japan_quakes(**kwargs):
     return data
 
 
-def load_ocean_ridge_points(**kwargs):
+def _load_ocean_ridge_points():
     """
-    (Deprecated) Load a table of ocean ridge points for the entire world as a
+    Load a table of ocean ridge points for the entire world as a
     pandas.DataFrame.
 
-    .. warning:: Deprecated since v0.6.0. This function has been replaced with
-       ``load_sample_data(name="ocean_ridge_points")`` and will be removed in
-       v0.9.0.
-
     This is the ``@ridge.txt`` dataset used in the GMT tutorials.
-
-    The data are downloaded to a cache directory (usually ``~/.gmt/cache``) the
-    first time you invoke this function. Afterwards, it will load the data from
-    the cache. So you'll need an internet connection the first time around.
 
     Returns
     -------
     data : pandas.DataFrame
-        The data table. Columns are longitude and latitude.
+        The data table. The column names are longitude and latitude.
     """
-
-    if "suppress_warning" not in kwargs:
-        warnings.warn(
-            "This function has been deprecated since v0.6.0 and will be removed "
-            "in v0.9.0. Please use load_sample_data(name='ocean_ridge_points') "
-            "instead.",
-            category=FutureWarning,
-            stacklevel=2,
-        )
-
     fname = which("@ridge.txt", download="c")
     data = pd.read_csv(
-        fname, sep=r"\s+", names=["longitude", "latitude"], skiprows=1, comment=">"
+        fname,
+        delim_whitespace=True,
+        names=["longitude", "latitude"],
+        skiprows=1,
+        comment=">",
     )
     return data
 

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -147,12 +147,10 @@ def _load_ocean_ridge_points():
     Load a table of ocean ridge points for the entire world as a
     pandas.DataFrame.
 
-    This is the ``@ridge.txt`` dataset used in the GMT tutorials.
-
     Returns
     -------
     data : pandas.DataFrame
-        The data table. The column names are longitude and latitude.
+        The data table. The column names are "longitude" and "latitude".
     """
     fname = which("@ridge.txt", download="c")
     data = pd.read_csv(

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -136,14 +136,13 @@ def _load_ocean_ridge_points():
         The data table. The column names are "longitude" and "latitude".
     """
     fname = which("@ridge.txt", download="c")
-    data = pd.read_csv(
+    return pd.read_csv(
         fname,
         delim_whitespace=True,
         names=["longitude", "latitude"],
         skiprows=1,
         comment=">",
     )
-    return data
 
 
 def load_sample_bathymetry(**kwargs):

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -9,7 +9,6 @@ from pygmt.datasets import (
     load_hotspots,
     load_japan_quakes,
     load_mars_shape,
-    load_ocean_ridge_points,
     load_sample_bathymetry,
     load_sample_data,
     load_usgs_quakes,
@@ -59,9 +58,7 @@ def test_ocean_ridge_points():
     """
     Check that the @ridge.txt dataset loads without errors.
     """
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        data = load_ocean_ridge_points()
-        assert len(record) == 1
+    data = load_sample_data(name="ocean_ridge_points")
     assert data.shape == (4146, 2)
     assert data["longitude"].min() == -179.9401
     assert data["longitude"].max() == 179.935


### PR DESCRIPTION
This replaces `load_ocean_ridge_points` with `_load_ocean_ridge_points`.

It also changes the argument `sep=r"\s+"` to `delim_whitespace=True`.

Addresses: #2302


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
