### PR TITLE
 Remove the deprecated load_hotspots function (deprecated since v0.6.0)

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -236,7 +236,6 @@ Use :func:`pygmt.datasets.load_sample_data` instead.
     :toctree: generated
 
     datasets.load_fractures_compilation
-    datasets.load_hotspots
     datasets.load_japan_quakes
     datasets.load_mars_shape
     datasets.load_ocean_ridge_points

--- a/pygmt/datasets/__init__.py
+++ b/pygmt/datasets/__init__.py
@@ -13,7 +13,6 @@ from pygmt.datasets.earth_vertical_gravity_gradient import (
 from pygmt.datasets.samples import (
     list_sample_data,
     load_fractures_compilation,
-    load_hotspots,
     load_japan_quakes,
     load_mars_shape,
     load_ocean_ridge_points,

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -79,8 +79,8 @@ def load_sample_data(name):
     # Dictionary of private load functions
     load_func = {
         "earth_relief_holes": _load_earth_relief_holes,
-        "hotspots": _load_hotspots,
         "fractures": _load_fractures_compilation,
+        "hotspots": _load_hotspots,
         "japan_quakes": _load_japan_quakes,
         "maunaloa_co2": _load_maunaloa_co2,
         "notre_dame_topography": _load_notre_dame_topography,

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -72,7 +72,6 @@ def load_sample_data(name):
     load_func_old = {
         "bathymetry": load_sample_bathymetry,
         "fractures": load_fractures_compilation,
-        "hotspots": load_hotspots,
         "japan_quakes": load_japan_quakes,
         "mars_shape": load_mars_shape,
         "ocean_ridge_points": load_ocean_ridge_points,
@@ -83,6 +82,7 @@ def load_sample_data(name):
     load_func = {
         "rock_compositions": _load_rock_sample_compositions,
         "earth_relief_holes": _load_earth_relief_holes,
+        "hotspots": _load_hotspots,
         "maunaloa_co2": _load_maunaloa_co2,
         "notre_dame_topography": _load_notre_dame_topography,
     }
@@ -285,23 +285,10 @@ def load_fractures_compilation(**kwargs):
     return data[["length", "azimuth"]]
 
 
-def load_hotspots(**kwargs):
+def _load_hotspots():
     """
-    (Deprecated) Load a table with the locations, names, and suggested symbol
+    Load a table with the locations, names, and suggested symbol
     sizes of hotspots.
-
-    .. warning:: Deprecated since v0.6.0. This function has been replaced with
-       ``load_sample_data(name="hotspots")`` and will be removed in
-       v0.9.0.
-
-    This is the ``@hotspots.txt`` dataset used in the GMT tutorials, with data
-    from Mueller, Royer, and Lawver, 1993, Geology, vol. 21, pp. 275-278. The
-    main 5 hotspots used by Doubrovine et al. [2012] have symbol sizes twice
-    the size of all other hotspots.
-
-    The data are downloaded to a cache directory (usually ``~/.gmt/cache``) the
-    first time you invoke this function. Afterwards, it will load the data from
-    the cache. So you'll need an internet connection the first time around.
 
     Returns
     -------
@@ -310,14 +297,6 @@ def load_hotspots(**kwargs):
         "placename".
     """
 
-    if "suppress_warning" not in kwargs:
-        warnings.warn(
-            "This function has been deprecated since v0.6.0 and will be "
-            "removed in v0.9.0. Please use "
-            "load_sample_data(name='hotspots') instead.",
-            category=FutureWarning,
-            stacklevel=2,
-        )
     fname = which("@hotspots.txt", download="c")
     columns = ["longitude", "latitude", "symbol_size", "place_name"]
     data = pd.read_table(filepath_or_buffer=fname, sep="\t", skiprows=3, names=columns)

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -269,7 +269,12 @@ def _load_hotspots():
     """
 
     fname = which("@hotspots.txt", download="c")
-    return pd.read_csv(fname, sep="\t", skiprows=3, names=["longitude", "latitude", "symbol_size", "place_name"])
+    return pd.read_csv(
+        fname,
+        sep="\t",
+        skiprows=3,
+        names=["longitude", "latitude", "symbol_size", "place_name"],
+    )
 
 
 def load_mars_shape(**kwargs):

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -256,7 +256,7 @@ def _load_hotspots():
     """
     Load a table with the locations, names, and suggested symbol sizes of
     hotspots as a pandas.DataFrame.
-    
+
     The data is from Mueller, Royer, and Lawver, 1993, Geology, vol. 21,
     pp. 275-278. The main 5 hotspots used by Doubrovine et al. [2012]
     have symbol sizes twice the size of all other hotspots.

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -288,7 +288,7 @@ def load_fractures_compilation(**kwargs):
 def _load_hotspots():
     """
     Load a table with the locations, names, and suggested symbol sizes of
-    hotspots.
+    hotspots as a pandas.DataFrame.
 
     Returns
     -------

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -294,7 +294,7 @@ def _load_hotspots():
     -------
     data : pandas.DataFrame
         The data table with columns "longitude", "latitude", "symbol_size", and
-        "placename".
+        "place_name".
     """
 
     fname = which("@hotspots.txt", download="c")

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -298,7 +298,7 @@ def _load_hotspots():
     -------
     data : pandas.DataFrame
         The data table. The column names are "longitude", "latitude",
-        "symbol_size", and "palce_name".
+        "symbol_size", and "place_name".
         "place_name".
     """
 

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -257,7 +257,7 @@ def _load_hotspots():
     Load a table with the locations, names, and suggested symbol sizes of
     hotspots as a pandas.DataFrame.
 
-    The data is from Mueller, Royer, and Lawver, 1993, Geology, vol. 21,
+    The data are from Mueller, Royer, and Lawver, 1993, Geology, vol. 21,
     pp. 275-278. The main 5 hotspots used by Doubrovine et al. [2012]
     have symbol sizes twice the size of all other hotspots.
 
@@ -266,7 +266,6 @@ def _load_hotspots():
     data : pandas.DataFrame
         The data table. The column names are "longitude", "latitude",
         "symbol_size", and "place_name".
-        "place_name".
     """
 
     fname = which("@hotspots.txt", download="c")

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -287,8 +287,8 @@ def load_fractures_compilation(**kwargs):
 
 def _load_hotspots():
     """
-    Load a table with the locations, names, and suggested symbol
-    sizes of hotspots.
+    Load a table with the locations, names, and suggested symbol sizes of
+    hotspots.
 
     Returns
     -------

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -289,11 +289,16 @@ def _load_hotspots():
     """
     Load a table with the locations, names, and suggested symbol sizes of
     hotspots as a pandas.DataFrame.
+    
+    The data is from Mueller, Royer, and Lawver, 1993, Geology, vol. 21,
+    pp. 275-278. The main 5 hotspots used by Doubrovine et al. [2012]
+    have symbol sizes twice the size of all other hotspots.
 
     Returns
     -------
     data : pandas.DataFrame
-        The data table with columns "longitude", "latitude", "symbol_size", and
+        The data table. The column names are "longitude", "latitude",
+        "symbol_size", and "palce_name".
         "place_name".
     """
 

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -270,7 +270,7 @@ def _load_hotspots():
 
     fname = which("@hotspots.txt", download="c")
     columns = ["longitude", "latitude", "symbol_size", "place_name"]
-    data = pd.read_table(filepath_or_buffer=fname, sep="\t", skiprows=3, names=columns)
+    data = pd.read_csv(fname, delim_whitespace=True, skiprows=3, names=columns)
     return data
 
 

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -269,9 +269,7 @@ def _load_hotspots():
     """
 
     fname = which("@hotspots.txt", download="c")
-    columns = ["longitude", "latitude", "symbol_size", "place_name"]
-    data = pd.read_csv(fname, delim_whitespace=True, skiprows=3, names=columns)
-    return data
+    return pd.read_csv(fname, sep="\t", skiprows=3, names=["longitude", "latitude", "symbol_size", "place_name"])
 
 
 def load_mars_shape(**kwargs):

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -4,11 +4,7 @@ Test basic functionality for loading sample datasets.
 import numpy.testing as npt
 import pandas as pd
 import pytest
-from pygmt.datasets import (
-    load_mars_shape,
-    load_sample_data,
-    load_usgs_quakes,
-)
+from pygmt.datasets import load_mars_shape, load_sample_data, load_usgs_quakes
 from pygmt.exceptions import GMTInvalidInput
 
 

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -6,7 +6,6 @@ import pandas as pd
 import pytest
 from pygmt.datasets import (
     load_fractures_compilation,
-    load_hotspots,
     load_japan_quakes,
     load_mars_shape,
     load_ocean_ridge_points,
@@ -129,9 +128,7 @@ def test_hotspots():
     """
     Check that the @hotspots.txt dataset loads without errors.
     """
-    with pytest.warns(expected_warning=FutureWarning) as record:
-        data = load_hotspots()
-        assert len(record) == 1
+    data = load_sample_data(name="hotspots")
     assert data.shape == (55, 4)
     assert list(data.columns) == [
         "longitude",

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -117,6 +117,12 @@ def test_hotspots():
         "place_name",
     ]
     assert isinstance(data, pd.DataFrame)
+    assert data["longitude"].min() == -169.6
+    assert data["longitude"].max() == 167
+    assert data["latitude"].min() == -78
+    assert data["latitude"].max() == 64
+    assert data["symbol_size"].min() == 0.25
+    assert data["symbol_size"].max() == 0.5
 
 
 def test_load_notre_dame_topography():


### PR DESCRIPTION
**Description of proposed changes**

Related to #2302 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
