### PR TITLE
pygmt.grdtrack: Remove the warning about the incorrect parameter order of 'points, grid' (warned since v0.7.0)

### DIFF
--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -1,10 +1,7 @@
 """
 grdtrack - Sample grids at specified (x,y) locations.
 """
-import warnings
-
 import pandas as pd
-import xarray as xr
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -14,7 +11,6 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.src.which import which
 
 __doctest_skip__ = ["grdtrack"]
 
@@ -296,29 +292,6 @@ def grdtrack(grid, points=None, newcolname=None, outfile=None, **kwargs):
 
     if hasattr(points, "columns") and newcolname is None:
         raise GMTInvalidInput("Please pass in a str to 'newcolname'")
-
-    # Backward compatibility with old parameter order "points, grid".
-    # deprecated_version="0.7.0", remove_version="v0.9.0"
-    is_a_grid = True
-    if not isinstance(grid, (xr.DataArray, str)):
-        is_a_grid = False
-    elif isinstance(grid, str):
-        try:
-            xr.open_dataarray(which(grid, download="a"), engine="netcdf4").close()
-            is_a_grid = True
-        except (ValueError, OSError):
-            is_a_grid = False
-    if not is_a_grid:
-        msg = (
-            "Positional parameters 'points, grid' of pygmt.grdtrack() has changed "
-            "to 'grid, points=None' since v0.7.0. It's likely that you're NOT "
-            "passing a valid grid as the first positional argument or "
-            "are passing an invalid grid to the 'grid' parameter. "
-            "Please check the order of arguments with the latest documentation. "
-            "This warning will be removed in v0.9.0."
-        )
-        grid, points = points, grid
-        warnings.warn(msg, category=FutureWarning, stacklevel=1)
 
     with GMTTempFile(suffix=".csv") as tmpfile:
         with Session() as lib:

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -177,18 +177,3 @@ def test_grdtrack_set_points_and_profile(dataarray, dataframe):
     """
     with pytest.raises(GMTInvalidInput):
         grdtrack(grid=dataarray, points=dataframe, profile="BL/TR")
-
-
-def test_grdtrack_old_parameter_order(dataframe, dataarray, expected_array):
-    """
-    Run grdtrack with the old parameter order 'points, grid'.
-
-    This test should be removed in v0.9.0.
-    """
-    for points in (POINTS_DATA, dataframe):
-        for grid in ("@static_earth_relief.nc", dataarray):
-            with pytest.warns(expected_warning=FutureWarning) as record:
-                output = grdtrack(points, grid)
-                assert len(record) == 1
-                assert isinstance(output, pd.DataFrame)
-                npt.assert_allclose(np.array(output), expected_array)


### PR DESCRIPTION
**Description of proposed changes**

In PR #1867, we changed the parameter order from "points, grid" to "grid, points", and raises a warning about incorrect parameter order. The PR first appeared in v0.7.0 and is expected to be removed in v0.9.0.

This PR removes the warning.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
