### PR TITLE
Use "data" consistently with plural

### DIFF
--- a/examples/projections/nongeo/polar.py
+++ b/examples/projections/nongeo/polar.py
@@ -20,7 +20,7 @@ The following customizing modifiers are available:
 
 - **+a**: by default, :math:`\theta` refers to the angle that is equivalent to
   a counterclockwise rotation with respect to the east direction (standard
-  definition); **+a** indicates that the input data is rotated clockwise
+  definition); **+a** indicates that the input data are rotated clockwise
   relative to the north direction (geographical azimuth angle).
 
 - **+r**\ *offset*: represents the offset of the r-axis. This modifier allows

--- a/examples/tutorials/advanced/date_time_charts.py
+++ b/examples/tutorials/advanced/date_time_charts.py
@@ -320,7 +320,7 @@ fig.show()
 ###############################################################################
 # The same concept shown above can be applied to smaller
 # as well as larger intervals. In this example,
-# data is plotted for different times throughout two days.
+# data are plotted for different times throughout two days.
 # Primary x-axis labels are modified to repeat every 6 hours
 # and secondary x-axis label repeats every day and shows
 # the day of the week.

--- a/examples/tutorials/basics/plot.py
+++ b/examples/tutorials/basics/plot.py
@@ -15,7 +15,7 @@ import pygmt
 ###############################################################################
 # For example, let's load the sample dataset of tsunami generating earthquakes
 # around Japan using :func:`pygmt.datasets.load_sample_data`.
-# The data is loaded as a :class:`pandas.DataFrame`.
+# The data are loaded as a :class:`pandas.DataFrame`.
 
 data = pygmt.datasets.load_sample_data(name="japan_quakes")
 

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -61,7 +61,7 @@ def load_earth_magnetic_anomaly(
         Available options:
 
         - **emag2** : EMAG2 Global Earth Magnetic Anomaly Model [Default
-          option]. Only includes data is observed from sea level over
+          option]. Only includes data observed at sea level over
           oceanic regions. See :gmt-datasets:`earth-mag.html`.
 
         - **emag2_4km** : Use a version of EMAG2 where all observations

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -99,7 +99,7 @@ def _load_japan_quakes():
     """
     Load a table of earthquakes around Japan as a pandas.DataFrame.
 
-    Data is from the NOAA NGDC database.
+    The data are from the NOAA NGDC database.
 
     Returns
     -------

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -45,7 +45,7 @@ def dimfilter(grid, **kwargs):
     do because it returns a minimum median out of *N* medians of *N*
     sectors. The output can be rough unless the input data are noise-free.
     Thus, an additional filtering (e.g., Gaussian via :func:`pygmt.grdfilter`)
-    of the DiM-filtered data are generally recommended.
+    of the DiM-filtered data is generally recommended.
 
     Full option list at :gmt-docs:`dimfilter.html`
 

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -43,9 +43,9 @@ def dimfilter(grid, **kwargs):
     may be less frequently sampled than the input. :func:`pygmt.dimfilter`
     will not produce a smooth output as other spatial filters
     do because it returns a minimum median out of *N* medians of *N*
-    sectors. The output can be rough unless the input data is noise-free.
+    sectors. The output can be rough unless the input data are noise-free.
     Thus, an additional filtering (e.g., Gaussian via :func:`pygmt.grdfilter`)
-    of the DiM-filtered data is generally recommended.
+    of the DiM-filtered data are generally recommended.
 
     Full option list at :gmt-docs:`dimfilter.html`
 


### PR DESCRIPTION
**Description of proposed changes**

It seems that "data" is  already plural and thus should be used with the plural form of the verb. This is mostly the case in the docs  with a few exceptions. This PR aims to use "data" consistently with plural. Happy to receive comments, whether these changes are meaningful and correct 🙂.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
