### PR TITLE
Improve formulations in API Reference table

### DIFF
--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -94,8 +94,10 @@ def print_clib_info():
 
 def show_versions():
     """
-    Prints various dependency versions useful when submitting bug reports. This
-    includes information about:
+    Print various dependency versions which is useful when submitting bug
+    reports.
+
+    This includes information about:
 
     - PyGMT itself
     - System information (Python version, Operating System)

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -94,7 +94,7 @@ def print_clib_info():
 
 def show_versions():
     """
-    Print various dependency versions which is useful when submitting bug
+    Print various dependency versions which are useful when submitting bug
     reports.
 
     This includes information about:

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -34,7 +34,7 @@ __doctest_skip__ = ["grdclip"]
 )
 def grdclip(grid, **kwargs):
     r"""
-    Sets values in a grid that meet certain criteria to a new value.
+    Set values in a grid that meet certain criteria to a new value.
 
     Produce a clipped ``outgrid`` or :class:`xarray.DataArray` version of the
     input ``grid`` file.

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -41,8 +41,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
 )
 def histogram(self, data, **kwargs):
     r"""
-    Plots a histogram, and can read data from a file or list, array, or
-    dataframe.
+    Plot Cartesian histograms.
 
     Full option list at :gmt-docs:`histogram.html`
 

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -1,5 +1,5 @@
 """
-surface - Grids table data using adjustable tension continuous curvature
+surface - Grid table data using adjustable tension continuous curvature
 splines.
 """
 from pygmt.clib import Session
@@ -34,7 +34,7 @@ __doctest_skip__ = ["surface"]
 @kwargs_to_strings(I="sequence", R="sequence")
 def surface(data=None, x=None, y=None, z=None, **kwargs):
     r"""
-    Grids table data using adjustable tension continuous curvature splines.
+    Grid table data using adjustable tension continuous curvature splines.
 
     Surface reads randomly-spaced (x, y, z) triplets and produces gridded
     values z(x,y) by solving:

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -25,6 +25,8 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def ternary(self, data, alabel=None, blabel=None, clabel=None, **kwargs):
     r"""
+	Plot ternary diagrams.
+
     Reads (*a*,\ *b*,\ *c*\ [,\ *z*]) records from *data* and plots symbols at
     those locations on a ternary diagram. If a symbol is selected and no symbol
     size given, then we will interpret the fourth column of the input data as

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -25,7 +25,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def ternary(self, data, alabel=None, blabel=None, clabel=None, **kwargs):
     r"""
-	Plot ternary diagrams.
+    Plot ternary diagrams.
 
     Reads (*a*,\ *b*,\ *c*\ [,\ *z*]) records from *data* and plots symbols at
     those locations on a ternary diagram. If a symbol is selected and no symbol


### PR DESCRIPTION
**Description of proposed changes**

In the [API Reference table](https://www.pygmt.org/dev/api/index.html), the verbs are mainly used without third person "s", with a few exceptions. This PR changes these cases. In case people feel the other version is "more correct" or better, I can change it in that way. The change for `surface.py` is consistent with the upstream GMT documentation. The API documentation for NumPy is not consistent, but mainly no third person "s" is used, e.g., https://numpy.org/doc/1.24/reference/arrays.ndarray.html#shape-manipulation.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
