### PR TITLE
Convert comments to module docstrings and fix the missing-docstring pylint issues

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -205,7 +205,6 @@ Miscellaneous
     print_clib_info
     show_versions
 
-
 .. currentmodule:: pygmt
 
 Datasets

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -206,8 +206,6 @@ Miscellaneous
     show_versions
 
 
-.. automodule:: pygmt.datasets
-
 .. currentmodule:: pygmt
 
 Datasets
@@ -241,8 +239,6 @@ Use :func:`pygmt.datasets.load_sample_data` instead.
     datasets.load_sample_bathymetry
     datasets.load_usgs_quakes
 
-.. automodule:: pygmt.exceptions
-
 .. currentmodule:: pygmt
 
 Exceptions
@@ -261,8 +257,6 @@ All custom exceptions are derived from :class:`pygmt.exceptions.GMTError`.
     exceptions.GMTCLibNoSessionError
     exceptions.GMTCLibNotFoundError
 
-
-.. automodule:: pygmt.clib
 
 .. currentmodule:: pygmt
 

--- a/pygmt/clib/__init__.py
+++ b/pygmt/clib/__init__.py
@@ -1,8 +1,8 @@
-# pylint: disable=missing-docstring
-#
-# Low-level wrapper for the GMT C API.
-#
-# The pygmt.clib.Session class wraps the GMT C shared library (libgmt) with a
-# pythonic interface. Access to the C library is done through ctypes.
+"""
+Low-level wrapper for the GMT C API.
+
+The pygmt.clib.Session class wraps the GMT C shared library (libgmt) with a
+pythonic interface. Access to the C library is done through ctypes.
+"""
 
 from pygmt.clib.session import Session

--- a/pygmt/clib/__init__.py
+++ b/pygmt/clib/__init__.py
@@ -2,7 +2,7 @@
 Low-level wrapper for the GMT C API.
 
 The pygmt.clib.Session class wraps the GMT C shared library (libgmt) with a
-pythonic interface. Access to the C library is done through ctypes.
+Pythonic interface. Access to the C library is done through ctypes.
 """
 
 from pygmt.clib.session import Session

--- a/pygmt/datasets/__init__.py
+++ b/pygmt/datasets/__init__.py
@@ -1,6 +1,8 @@
-# pylint: disable=missing-docstring
-#
-# Load sample data included with GMT (downloaded from the GMT cache server).
+"""
+Functions to load GMT remote data and sample data.
+
+Data are downloaded from the GMT data server.
+"""
 
 from pygmt.datasets.earth_age import load_earth_age
 from pygmt.datasets.earth_free_air_anomaly import load_earth_free_air_anomaly

--- a/pygmt/exceptions.py
+++ b/pygmt/exceptions.py
@@ -1,7 +1,8 @@
-# pylint: disable=missing-docstring
-#
-# Custom exception types used throughout the library. All exceptions derive
-# from GMTError.
+"""
+Custom exception types used throughout the library.
+
+All exceptions derive from GMTError.
+"""
 
 
 class GMTError(Exception):


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
