### PR TITLE
load_earth_magnatic_anomaly: Fix the description of resolution and registration

### DIFF
--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -55,7 +55,7 @@ def load_earth_magnetic_anomaly(
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``"gridline"``
         for all resolutions except ``"02m"`` for ``data_source="emag2"`` or
-        ``data_source="emag2_4km"`` which is ``"pixel"`` only.
+        ``data_source="emag2_4km"``, which are ``"pixel"`` only.
 
     data_source : str
         Select the source of the magnetic anomaly data.

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -42,7 +42,8 @@ def load_earth_magnetic_anomaly(
         The grid resolution. The suffix ``d`` and ``m`` stand for
         arc-degrees and arc-minutes. It can be ``"01d"``, ``"30m"``,
         ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``,
-        ``"03m"``, or ``"02m"``.
+        ``"03m"``, or ``"02m"``. The ``"02m"`` resolution is not available for
+        ``data_source="wdmam"``.
 
     region : str or list
         The subregion of the grid to load, in the form of a list
@@ -53,7 +54,8 @@ def load_earth_magnetic_anomaly(
     registration : str
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``"gridline"``
-        for all resolutions except ``"02m"`` which is ``"pixel"`` only.
+        for all resolutions except ``"02m"`` for ``data_source="emag2"`` or
+        ``data_source="emag2_4km"`` which is ``"pixel"`` only.
 
     data_source : str
         Select the source of the magnetic anomaly data.


### PR DESCRIPTION
**Description of proposed changes**

The `earth_wdmam` dataset doesn't provide the `02m` resolution. This PR updates the descriptions. 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
