### PR TITLE
pygmt.config: Correctly resetting to default values that contain whitespaces

### DIFF
--- a/pygmt/src/config.py
+++ b/pygmt/src/config.py
@@ -207,7 +207,7 @@ class config:  # pylint: disable=invalid-name
     def __exit__(self, exc_type, exc_value, traceback):
         # revert to initial values
         arg_str = " ".join(
-            [f"{key}={value}" for key, value in self.old_defaults.items()]
+            [f'{key}="{value}"' for key, value in self.old_defaults.items()]
         )
         with Session() as lib:
             lib.call_module(module="set", args=arg_str)

--- a/pygmt/tests/test_config.py
+++ b/pygmt/tests/test_config.py
@@ -72,8 +72,13 @@ def test_config_format_date_map():
 
     Note the space in 'o dd', this acts as a regression test for
     https://github.com/GenericMappingTools/pygmt/issues/247.
+
+    Setting FORMAT_DATE_MAP="yyyy mm dd" as a regression test for
+    https://github.com/GenericMappingTools/pygmt/issues/2298.
     """
     fig = Figure()
+    # Set the FORMAT_DATE_MAP to "yyyy mm dd" that contains whitespaces.
+    config(FORMAT_DATE_MAP="yyyy mm dd")
     with config(FORMAT_DATE_MAP="o dd"):
         fig.basemap(
             region=["1969-7-21T", "1969-7-23T", 0, 1],

--- a/pygmt/tests/test_config.py
+++ b/pygmt/tests/test_config.py
@@ -77,7 +77,7 @@ def test_config_format_date_map():
     https://github.com/GenericMappingTools/pygmt/issues/2298.
     """
     fig = Figure()
-    # Set the FORMAT_DATE_MAP to "yyyy mm dd" that contains whitespaces.
+    # Set FORMAT_DATE_MAP to "yyyy mm dd" which contains whitespaces.
     config(FORMAT_DATE_MAP="yyyy mm dd")
     with config(FORMAT_DATE_MAP="o dd"):
         fig.basemap(


### PR DESCRIPTION
**Description of proposed changes**

Fixes https://github.com/GenericMappingTools/pygmt/issues/2298


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
