### PR TITLE
Fix the formatting of docstrings in load_earth_relief and load_earth_magnetic_anomaly

### DIFF
--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -60,15 +60,15 @@ def load_earth_magnetic_anomaly(
     data_source : str
         Select the source of the magnetic anomaly data. Available options are:
 
-        - ``"emag2"`` : EMAG2 Global Earth Magnetic Anomaly Model [Default
-          option]. Only includes data observed at sea level over
+        - ``"emag2"``: EMAG2 Global Earth Magnetic Anomaly Model [Default
+          option]. It only includes data observed at sea level over
           oceanic regions. See :gmt-datasets:`earth-mag.html`.
 
-        - ``"emag2_4km"`` : Use a version of EMAG2 where all observations
+        - ``"emag2_4km"``: Use a version of EMAG2 where all observations
           are relative to an altitude of 4 km above the geoid and include
           data over land.
 
-        - ``"wdmam"`` : World Digital Magnetic Anomaly Map (WDMAM).
+        - ``"wdmam"``: World Digital Magnetic Anomaly Map (WDMAM).
           See :gmt-datasets:`earth-wdmam.html`.
 
     Returns

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -58,20 +58,18 @@ def load_earth_magnetic_anomaly(
         ``data_source="emag2_4km"``, which are ``"pixel"`` only.
 
     data_source : str
-        Select the source of the magnetic anomaly data.
+        Select the source of the magnetic anomaly data. Available options are:
 
-        Available options:
-
-        - **emag2** : EMAG2 Global Earth Magnetic Anomaly Model [Default
+        - ``"emag2"`` : EMAG2 Global Earth Magnetic Anomaly Model [Default
           option]. Only includes data observed at sea level over
           oceanic regions. See :gmt-datasets:`earth-mag.html`.
 
-        - **emag2_4km** : Use a version of EMAG2 where all observations
+        - ``"emag2_4km"`` : Use a version of EMAG2 where all observations
           are relative to an altitude of 4 km above the geoid and include
           data over land.
 
-        - **wdmam** : World Digital Magnetic Anomaly Map (WDMAM).
-          See :gmt-datasets:`earth-wdmam.html`
+        - ``"wdmam"`` : World Digital Magnetic Anomaly Map (WDMAM).
+          See :gmt-datasets:`earth-wdmam.html`.
 
     Returns
     -------

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -75,7 +75,7 @@ def load_earth_magnetic_anomaly(
     -------
     grid : :class:`xarray.DataArray`
         The Earth magnetic anomaly grid. Coordinates are latitude and
-        longitude in degrees. Units are in nano Teslas (nT).
+        longitude in degrees. Units are in nano Tesla (nT).
 
     Note
     ----

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -23,7 +23,9 @@ def load_earth_relief(
     Load Earth relief grids (topography and bathymetry) in various resolutions.
 
     The grids are downloaded to a user data directory
-    (usually a subdirectory under ~/.gmt/server/earth/) the first time you
+    (usually ``~/.gmt/server/earth/earth_relief``,
+    ``~/.gmt/server/earth/earth_gebco``, ``~/.gmt/server/earth/earth_gebcosi``,
+    or ``~/.gmt/server/earth/earth_synbath``) the first time you
     invoke this function. Afterwards, it will load the grid from the data
     directory. So you'll need an internet connection the first time around.
 

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -61,18 +61,18 @@ def load_earth_relief(
     data_source : str
         Select the source for the Earth relief data. Available options are:
 
-        - ``"igpp"`` : IGPP Global Earth Relief [Default option]. See
+        - ``"igpp"``: IGPP Global Earth Relief [Default option]. See
           :gmt-datasets:`earth-relief.html`.
 
-        - ``"synbath"`` : IGPP Global Earth Relief dataset that uses
-          stastical properties of young seafloor to provide more realistic
+        - ``"synbath"``: IGPP Global Earth Relief dataset that uses
+          stastical properties of young seafloor to provide a more realistic
           relief of young areas with small seamounts.
 
-        - ``"gebco"`` : GEBCO Global Earth Relief with only observed relief and
+        - ``"gebco"``: GEBCO Global Earth Relief with only observed relief and
           inferred relief via altimetric gravity. See
           :gmt-datasets:`earth-gebco.html`.
 
-        - ``"gebcosi"`` : GEBCO Global Earth Relief that gives sub-ice (si)
+        - ``"gebcosi"``: GEBCO Global Earth Relief that gives sub-ice (si)
           elevations.
 
     use_srtm : bool

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -59,22 +59,20 @@ def load_earth_relief(
         for all resolutions except ``"15s"`` which is ``"pixel"`` only.
 
     data_source : str
-        Select the source for the Earth relief data.
+        Select the source for the Earth relief data. Available options are:
 
-        Available options:
-
-        - **igpp** : IGPP Global Earth Relief [Default option]. See
+        - ``"igpp"`` : IGPP Global Earth Relief [Default option]. See
           :gmt-datasets:`earth-relief.html`.
 
-        - **synbath** : IGPP Global Earth Relief dataset that uses
+        - ``"synbath"`` : IGPP Global Earth Relief dataset that uses
           stastical properties of young seafloor to provide more realistic
           relief of young areas with small seamounts.
 
-        - **gebco** : GEBCO Global Earth Relief with only observed relief and
+        - ``"gebco"`` : GEBCO Global Earth Relief with only observed relief and
           inferred relief via altimetric gravity. See
           :gmt-datasets:`earth-gebco.html`.
 
-        - **gebcosi** : GEBCO Global Earth Relief that gives sub-ice (si)
+        - ``"gebcosi"`` : GEBCO Global Earth Relief that gives sub-ice (si)
           elevations.
 
     use_srtm : bool


### PR DESCRIPTION
**Description of proposed changes**

In the current documentation, the available `data_source` options are formatted in **bold**.
<img width="844" alt="image" src="https://user-images.githubusercontent.com/3974108/213385594-ccb10b9e-d666-42f5-bcf4-5cae9da63f82.png">

Since these options are strings that should be passed to `data_source` (e.g., `data_source="emga2"`), so they should be formatted like ``"emag2"`` instead.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
