### PR TITLE
Slight improvements of text and comments in gallery example "Line fronts"

### DIFF
--- a/examples/gallery/lines/linefronts.py
+++ b/examples/gallery/lines/linefronts.py
@@ -20,12 +20,12 @@ the left or right side of the front [Default is centered]. Append
 **f**\ ault [Default], **s**\ lip, or **t**\ riangle. Slip means left-lateral
 or right-lateral strike-slip arrows (centered is not an option). The **+s**
 modifier optionally accepts the angle used to draw the vector [Default is
-20]. Alternatively, use **+S** which draws arcuate arrow heads. Append
-**+o**\ *offset* to offset the first symbol from the beginning of the front
-by that amount [Default is 0]. The chosen symbol is drawn with the same pen
-as set for the line (i.e., via the ``pen`` parameter). To use an alternate
-pen, append **+p**\ *pen*. To skip the outline, just use **+p** with no
-argument. To make the main front line invisible, add **+i**.
+20 degrees]. Alternatively, use **+S** which draws arcuate arrow heads.
+Append **+o**\ *offset* to offset the first symbol from the beginning of
+the front by that amount [Default is 0]. The chosen symbol is drawn with
+the same pen as set for the line (i.e., via the ``pen`` parameter). To use
+an alternate pen, append **+p**\ *pen*. To skip the outline, just use
+**+p** with no argument. To make the main front line invisible, add **+i**.
 
 """
 
@@ -49,8 +49,8 @@ for frontstyle in [
     "f1c/0.25c+c",
     # line with triangle front style
     "f1c/0.3c+t",
-    # line with left-lateral ("+l") slip ("+s") front style, angle is set to 45
-    # and offset to 2.25 cm
+    # line with left-lateral ("+l") slip ("+s") front style, angle is set to
+    # 45 degrees and offset to 2.25 cm
     "f5c/1c+l+s45+o2.25c",
     # line with "faults" front style, symbols are plotted on the left side of
     # the front

--- a/examples/gallery/lines/linefronts.py
+++ b/examples/gallery/lines/linefronts.py
@@ -17,12 +17,12 @@ missing it is set to 30% of the *gap*, except when *gap* is negative
 and *size* is thus required. Append **+l** or **+r** to plot symbols on
 the left or right side of the front [Default is centered]. Append
 **+**\ *type* to specify which symbol to plot: **b**\ ox, **c**\ ircle,
-**f**\ ault (default), **s**\ lip, or **t**\ riangle. Slip means left-lateral
+**f**\ ault [Default], **s**\ lip, or **t**\ riangle. Slip means left-lateral
 or right-lateral strike-slip arrows (centered is not an option). The **+s**
-modifier optionally accepts the angle used to draw the vector (default is
-20). Alternatively, use **+S** which draws arcuate arrow heads. Append
+modifier optionally accepts the angle used to draw the vector [Default is
+20]. Alternatively, use **+S** which draws arcuate arrow heads. Append
 **+o**\ *offset* to offset the first symbol from the beginning of the front
-by that amount (default is 0). The chosen symbol is drawn with the same pen
+by that amount [Default is 0]. The chosen symbol is drawn with the same pen
 as set for the line (i.e., via the ``pen`` parameter). To use an alternate
 pen, append **+p**\ *pen*. To skip the outline, just use **+p** with no
 argument. To make the main front line invisible, add **+i**.
@@ -41,7 +41,7 @@ fig.basemap(region=[0, 10, 0, 20], projection="X15c/15c", frame="+tLine Fronts")
 
 # Plot the line using different front styles
 for frontstyle in [
-    # line with "faults" front style, same as +f (default)
+    # line with "faults" front style, same as +f [Default]
     "f1c/0.25c",
     # line with box front style
     "f1c/0.25c+b",

--- a/examples/gallery/lines/linefronts.py
+++ b/examples/gallery/lines/linefronts.py
@@ -26,7 +26,6 @@ the front by that amount [Default is 0]. The chosen symbol is drawn with
 the same pen as set for the line (i.e., via the ``pen`` parameter). To use
 an alternate pen, append **+p**\ *pen*. To skip the outline, just use
 **+p** with no argument. To make the main front line invisible, add **+i**.
-
 """
 
 import numpy as np


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to follow consistently the Default convention and to add a unit for the `+s` ("slip") modifier in the gallery example [Line fronts](https://www.pygmt.org/dev/gallery/lines/linefronts.html).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
