### PR TITLE
Consistently use delim_whitespace=True instead of sep=r'\s+' in pd.read_csv calls

### DIFF
--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -289,7 +289,7 @@ def _load_notre_dame_topography():
         The data table with columns "x", "y", and "z".
     """
     fname = which("@Table_5_11.txt", download="c")
-    return pd.read_csv(fname, sep=r"\s+", header=None, names=["x", "y", "z"])
+    return pd.read_csv(fname, delim_whitespace=True, header=None, names=["x", "y", "z"])
 
 
 def _load_maunaloa_co2():
@@ -303,7 +303,7 @@ def _load_maunaloa_co2():
     """
     fname = which("@MaunaLoa_CO2.txt", download="c")
     return pd.read_csv(
-        fname, header=None, skiprows=1, sep=r"\s+", names=["date", "co2_ppm"]
+        fname, header=None, skiprows=1, delim_whitespace=True, names=["date", "co2_ppm"]
     )
 
 

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -19,7 +19,7 @@ def fixture_data():
     """
     Load the point data from the test file.
     """
-    return pd.read_table(POINTS_DATA, header=None, sep=r"\s+")
+    return pd.read_table(POINTS_DATA, header=None, delim_whitespace=True)
 
 
 @pytest.fixture(scope="module", name="region")

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -51,7 +51,7 @@ def fixture_dataframe():
     Load a pandas DataFrame with points.
     """
     return pd.read_csv(
-        POINTS_DATA, sep=r"\s+", header=None, names=["longitude", "latitude"]
+        POINTS_DATA, delim_whitespace=True, header=None, names=["longitude", "latitude"]
     )
 
 

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -18,7 +18,7 @@ def fixture_data():
     """
     fname = which("@Table_5_11_mean.xyz", download="c")
     return pd.read_csv(
-        fname, sep=r"\s+", header=None, names=["x", "y", "z"], skiprows=1
+        fname, delim_whitespace=True, header=None, names=["x", "y", "z"], skiprows=1
     )
 
 

--- a/pygmt/tests/test_triangulate.py
+++ b/pygmt/tests/test_triangulate.py
@@ -19,7 +19,7 @@ def fixture_dataframe():
     """
     fname = which("@Table_5_11_mean.xyz", download="c")
     return pd.read_csv(
-        fname, sep=r"\s+", header=None, names=["x", "y", "z"], skiprows=1
+        fname, delim_whitespace=True, header=None, names=["x", "y", "z"], skiprows=1
     )[:10]
 
 


### PR DESCRIPTION
**Description of proposed changes**

As mentioned in the [`read_csv`](https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html`) API documentation, `delim_whitespace=True` is equivalent to `sep='\s+'`:

> **delim_whitespace** : bool, default False
>     Specifies whether or not whitespace (e.g. ' ' or '    ') will be used as the sep. Equivalent to setting sep='\s+'. If this option is set to True, nothing should be passed in for the delimiter parameter.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
