### PR TITLE
Fix the test for the default registration of earth_mag4km_02m dataset (#2341

### DIFF
--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -189,6 +189,7 @@ def download_test_data():
         "@earth_mag_01d_g",
         "@S30W060.earth_mag_02m_p.nc",  # Specific grid for 02m test
         "@earth_mag4km_01d_g",
+        "@S30W120.earth_mag4km_02m_p.nc",  # Specific grid for 02m test
         # Earth mask grid
         "@earth_mask_01d_g",
         # Earth free-air anomaly grids

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -80,6 +80,22 @@ def test_earth_mag_incorrect_resolution_registration():
         )
 
 
+def test_earth_mag_02m_default_registration():
+    """
+    Test that the grid returned by default for the 2 arc-minute resolution has
+    a "pixel" registration.
+    """
+    data = load_earth_magnetic_anomaly(resolution="02m", region=[-10, -9, 3, 5])
+    assert data.shape == (60, 30)
+    assert data.gmt.registration == 1
+    npt.assert_allclose(data.coords["lat"].data.min(), 3.016666667)
+    npt.assert_allclose(data.coords["lat"].data.max(), 4.983333333)
+    npt.assert_allclose(data.coords["lon"].data.min(), -9.98333333)
+    npt.assert_allclose(data.coords["lon"].data.max(), -9.01666667)
+    npt.assert_allclose(data.min(), -231)
+    npt.assert_allclose(data.max(), 131.79999)
+
+
 def test_earth_mag4km_01d():
     """
     Test some properties of the magnetic anomaly 4km 01d data.
@@ -112,22 +128,6 @@ def test_earth_mag4km_01d_with_region():
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -153.19995)
     npt.assert_allclose(data.max(), 113.59985)
-
-
-def test_earth_mag_02m_default_registration():
-    """
-    Test that the grid returned by default for the 2 arc-minute resolution has
-    a "pixel" registration.
-    """
-    data = load_earth_magnetic_anomaly(resolution="02m", region=[-10, -9, 3, 5])
-    assert data.shape == (60, 30)
-    assert data.gmt.registration == 1
-    npt.assert_allclose(data.coords["lat"].data.min(), 3.016666667)
-    npt.assert_allclose(data.coords["lat"].data.max(), 4.983333333)
-    npt.assert_allclose(data.coords["lon"].data.min(), -9.98333333)
-    npt.assert_allclose(data.coords["lon"].data.max(), -9.01666667)
-    npt.assert_allclose(data.min(), -231)
-    npt.assert_allclose(data.max(), 131.79999)
 
 
 def test_earth_mag4km_02m_default_registration():

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -146,8 +146,8 @@ def test_earth_mag4km_02m_default_registration():
     npt.assert_allclose(data.coords["lat"].data.max(), 5.98333333)
     npt.assert_allclose(data.coords["lon"].data.min(), -114.98333333)
     npt.assert_allclose(data.coords["lon"].data.max(), -112.01666667)
-    npt.assert_allclose(data.min(), -132.80003)
-    npt.assert_allclose(data.max(), 79.59996)
+    npt.assert_allclose(data.min(), -132.80005)
+    npt.assert_allclose(data.max(), 79.59985)
 
 
 def test_earth_mag_01d_wdmam():

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -130,18 +130,17 @@ def test_earth_mag_02m_default_registration():
     npt.assert_allclose(data.max(), 131.79999)
 
     data = load_earth_magnetic_anomaly(
-        resolution="05m",
+        resolution="02m",
         region=[-115, -112, 4, 6],
-        registration="gridline",
         data_source="emag2_4km",
     )
-    assert data.shape == (25, 37)
-    assert data.lat.min() == 4
-    assert data.lat.max() == 6
-    assert data.lon.min() == -115
-    assert data.lon.max() == -112
-    npt.assert_allclose(data.min(), -128.40015)
-    npt.assert_allclose(data.max(), 76.80005)
+    assert data.shape == (60, 90)
+    assert data.lat.min() == 4.01666667
+    assert data.lat.max() == 5.98333333
+    assert data.lon.min() == -114.98333333
+    assert data.lon.max() == -112.01666667
+    npt.assert_allclose(data.min(), -132.80003)
+    npt.assert_allclose(data.max(), 79.59996)
 
 
 def test_earth_mag_01d_wdmam():
@@ -196,13 +195,13 @@ def test_earth_mag_03m_wdmam_with_region():
     npt.assert_allclose(data.max(), 629.6)
 
 
-def test_earth_mag_05m_wdmam_without_region():
+def test_earth_mag_03m_wdmam_without_region():
     """
     Test loading a high-resolution WDMAM grid without passing 'region'.
     """
     with pytest.raises(GMTInvalidInput):
         load_earth_magnetic_anomaly(
-            resolution="05m", registration="gridline", data_source="wdmam"
+            resolution="03m", registration="gridline", data_source="wdmam"
         )
 
 

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -129,16 +129,23 @@ def test_earth_mag_02m_default_registration():
     npt.assert_allclose(data.min(), -231)
     npt.assert_allclose(data.max(), 131.79999)
 
+
+def test_earth_mag4km_02m_default_registration():
+    """
+    Test that the grid returned by default for the 2 arc-minute resolution has
+    a "pixel" registration.
+    """
     data = load_earth_magnetic_anomaly(
         resolution="02m",
         region=[-115, -112, 4, 6],
         data_source="emag2_4km",
     )
     assert data.shape == (60, 90)
-    assert data.lat.min() == 4.01666667
-    assert data.lat.max() == 5.98333333
-    assert data.lon.min() == -114.98333333
-    assert data.lon.max() == -112.01666667
+    assert data.gmt.registration == 1
+    npt.assert_allclose(data.coords["lat"].data.min(), 4.01666667)
+    npt.assert_allclose(data.coords["lat"].data.max(), 5.98333333)
+    npt.assert_allclose(data.coords["lon"].data.min(), -114.98333333)
+    npt.assert_allclose(data.coords["lon"].data.max(), -112.01666667)
     npt.assert_allclose(data.min(), -132.80003)
     npt.assert_allclose(data.max(), 79.59996)
 


### PR DESCRIPTION
**Description of proposed changes**

The test `test_earth_mag_02m_default_registration` should test the "02m" dataset, but it actually tests the "05m" earth_mag4km dataset. This PR fixes the issue and also caches the tile.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
