### PR TITLE
CI: Fix the comment format of the dvc-diff workflow

### DIFF
--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -87,12 +87,10 @@ jobs:
         # Mention git commit SHA in the report
         echo -e "Report last updated at commit ${{ github.event.pull_request.head.sha }}" >> report.md
 
-        # Format report to escape newlines before publishing as GitHub comment
-        report=$(cat report.md)
-        report="${report//'%'/'%25'}"
-        report="${report//$'\n'/'%0A'}"
-        report="${report//$'\r'/'%0D'}"
-        echo "report=$report" >> $GITHUB_OUTPUT
+        # Save the report content to the output parameter 'report'
+        echo 'report<<EOF' >> $GITHUB_OUTPUT
+        cat report.md >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
 
     - name: Find comment with image diff report
       uses: peter-evans/find-comment@v2.2.1


### PR DESCRIPTION
**Description of proposed changes**

First found in https://github.com/GenericMappingTools/pygmt/pull/2208#issuecomment-1410312490 and reported in https://github.com/GenericMappingTools/pygmt/issues/2340.

The comment posted by the dvc-diff workflow is badly formatted, likely due to unknown github changes:
![image](https://user-images.githubusercontent.com/3974108/218297528-a219b9cd-c153-4186-969c-bf8f5f7a3f27.png)

This PR fixes the issue by saving the report content into the `report` output parameter using the **multiline string syntax**.

References: 

1. https://github.com/github/docs/issues/21529
2. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string


Changes in this PR were tested in PR #2340. Please see the revision history of the comment https://github.com/GenericMappingTools/pygmt/pull/2208#issuecomment-1410312490.