### PR TITLE
GMTDataArrayAccessor: Add inline examples for setting GMT specific properties (#2370)Co-authored-by: Michael Grund <23025878+michaelgrund@users.noreply.github.com>

### DIFF
--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -34,7 +34,7 @@ class GMTDataArrayAccessor:
     >>> import numpy as np
     >>> import pygmt
     >>> import xarray as xr
-    >>> # creata a DataArray in gridline coordinates of sin(lon) * cos(lat)
+    >>> # create a DataArray in gridline coordinates of sin(lon) * cos(lat)
     >>> interval = 2.5
     >>> lat = np.arange(90, -90 - interval, -interval)
     >>> lon = np.arange(0, 360 + interval, interval)

--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -9,20 +9,43 @@ from pygmt.src.grdinfo import grdinfo
 @xr.register_dataarray_accessor("gmt")
 class GMTDataArrayAccessor:
     """
-    This is the GMT extension for :class:`xarray.DataArray`.
+    GMT extension for :class:`xarray.DataArray`.
 
-    You can access various GMT specific metadata about your grid as follows:
+    The extension provides easy ways to access and change the GMT specific
+    properties about grids. Currently, two properties are available:
+
+    - ``registration``: Gridline (0) or Pixel (1) registration
+    - ``gtype``: Cartesian (0) or Geographic (1) coordinate system
+
+    You can access these GMT specific properties about your grid as follows:
 
     >>> from pygmt.datasets import load_earth_relief
     >>> # Use the global Earth relief grid with 1 degree spacing
     >>> grid = load_earth_relief(resolution="01d", registration="pixel")
-
     >>> # See if grid uses Gridline (0) or Pixel (1) registration
     >>> grid.gmt.registration
     1
     >>> # See if grid uses Cartesian (0) or Geographic (1) coordinate system
     >>> grid.gmt.gtype
     1
+
+    You can also set the GMT specific properties for grids created by yourself:
+
+    >>> import numpy as np
+    >>> import pygmt
+    >>> import xarray as xr
+    >>> # creata a DataArray in gridline coordinates of sin(lon) * cos(lat)
+    >>> interval = 2.5
+    >>> lat = np.arange(90, -90 - interval, -interval)
+    >>> lon = np.arange(0, 360 + interval, interval)
+    >>> longrid, latgrid = np.meshgrid(lon, lat)
+    >>> data = np.sin(np.deg2rad(longrid)) * np.cos(np.deg2rad(latgrid))
+    >>> grid = xr.DataArray(
+    ...     data, coords=[("latitude", lat), ("longitude", lon)]
+    ... )
+    >>> # set it to a gridline-registered geographic grid
+    >>> grid.gmt.registration = 0
+    >>> grid.gmt.gtype = 1
     """
 
     def __init__(self, xarray_obj):
@@ -51,8 +74,8 @@ class GMTDataArrayAccessor:
             self._registration = value
         else:
             raise GMTInvalidInput(
-                f"Invalid grid registration value: {value}, should be a boolean of "
-                "either 0 for Gridline registration or 1 for Pixel registration"
+                f"Invalid grid registration value: {value}, should be either "
+                "0 for Gridline registration or 1 for Pixel registration."
             )
 
     @property
@@ -69,6 +92,6 @@ class GMTDataArrayAccessor:
             self._gtype = value
         else:
             raise GMTInvalidInput(
-                f"Invalid coordinate system type: {value}, should be a boolean of "
-                "either 0 for Cartesian or 1 for Geographic"
+                f"Invalid coordinate system type: {value}, should be "
+                "either 0 for Cartesian or 1 for Geographic."
             )


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
