### PR TITLE
Do not show the 'Methods Summary' heading if a class only have the __init__ method

### DIFF
--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -4,6 +4,7 @@
 
 .. autoclass:: {{ objname }}
 
+{% if methods != ["__init__"] %}
 .. rubric:: Methods Summary
 
 .. autosummary::
@@ -12,6 +13,7 @@
     {{ objname }}.{{ item }}
     {% endif %}
     {% endfor %}
+{% endif %}
 
 .. include:: backreferences/{{ fullname }}.examples
 


### PR DESCRIPTION
**Description of proposed changes**

The `GMTDataArrayAccessor` class doesn't have public methods except `__init__`, but [its API documentation](https://www.pygmt.org/dev/api/generated/pygmt.GMTDataArrayAccessor.html#pygmt.GMTDataArrayAccessor) still show the "Methods Summary" heading.

In the updated template, classes that only have the `__init__` method won't show the "Methods Summary" heading.

| | |
|---|---|
| **Old** | <img width="940" alt="image" src="https://user-images.githubusercontent.com/3974108/219361778-01989a9c-a307-4191-9e03-7507376b0365.png"> |
|**New**|<img width="937" alt="image" src="https://user-images.githubusercontent.com/3974108/219365672-99482ba3-d783-4c68-9683-2059f14aa8c5.png">|

**Preview**: https://pygmt-dev--2371.org.readthedocs.build/en/2371/api/generated/pygmt.GMTDataArrayAccessor.html


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
