### PR TITLE
Update the documentation template to show class attributes

### DIFF
--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -4,6 +4,11 @@
 
 .. autoclass:: {{ objname }}
 
+{% for item in attributes %}
+.. autoproperty::
+    {{ objname }}.{{ item }}
+{% endfor %}
+
 {% if methods != ["__init__"] %}
 .. rubric:: Methods Summary
 


### PR DESCRIPTION
**Description of proposed changes**

Currently, PyGMT provides 6 classes. Class attributes/properties are useful but not documented. This PR fixes the issue by updating the doc template of classes.

List of PyGMT classes:

- `pygmt.Figure`: https://www.pygmt.org/dev/api/generated/pygmt.Figure.html
- `pygmt.triangulate`: https://www.pygmt.org/dev/api/generated/pygmt.triangulate.html
- `pygmt.grdhisteq`: https://www.pygmt.org/dev/api/generated/pygmt.grdhisteq.html
- `pygmt.config`: https://www.pygmt.org/dev/api/generated/pygmt.config.html
- `pygmt.GMTDataArrayAccessor`: https://www.pygmt.org/dev/api/generated/pygmt.GMTDataArrayAccessor.html
- `pygmt.clib.Session`: https://www.pygmt.org/dev/api/generated/pygmt.clib.Session.html

Currently, only `pygmt.Figure` and `pygmt.GMTDataArrayAccessor` have attributes/properties. So the changes only affect these two classes:

**Preview**:

- https://pygmt-dev--2374.org.readthedocs.build/en/2374/api/generated/pygmt.Figure.html#pygmt.Figure
- https://pygmt-dev--2374.org.readthedocs.build/en/2374/api/generated/pygmt.GMTDataArrayAccessor.html#pygmt.GMTDataArrayAccessor

<img width="945" alt="image" src="https://user-images.githubusercontent.com/3974108/219706794-69114f85-95e6-40f4-b9c5-f415b07a00ae.png">

<img width="956" alt="image" src="https://user-images.githubusercontent.com/3974108/219706856-70b19848-1e8a-477f-a7fa-ff492daf07db.png">
