### PR TITLE
Document limitations of GMT xarray accessors

### DIFF
--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -31,7 +31,7 @@ class GMTDataArrayAccessor:
 
     Due to the limitations of xarray accessors, the GMT accessors are created
     once per :class:`xarray.DataArray` instance. You may lose these
-    GMT-specific properties when manipulating grids (e.g., arithmetic, slice
+    GMT-specific properties when manipulating grids (e.g., arithmetic and slice
     operations) or when accessing a :class:`xarray.DataArray` from a
     :class:`xarray.Dataset`. In these cases, you need to manually set these
     properties beforing passing it to PyGMT.
@@ -39,7 +39,8 @@ class GMTDataArrayAccessor:
     Examples
     --------
 
-    You can access these GMT specific properties about your grid as follows:
+    For GMT's built-in remote datasets, these GMT-specific properties are
+    automatically determined and you can access them as follows:
 
     >>> from pygmt.datasets import load_earth_relief
     >>> # Use the global Earth relief grid with 1 degree spacing
@@ -51,7 +52,10 @@ class GMTDataArrayAccessor:
     >>> grid.gmt.gtype
     1
 
-    You can also set the GMT specific properties for grids created by yourself:
+    For :class:`xarray.DataArray` grids created by yourself, grid properties
+    ``registration`` and ``gtype`` default to 0 (i.e., a Cartesian
+    gridline-registrated grid). You need to set the correct properties before
+    passing it to PyGMT functions:
 
     >>> import numpy as np
     >>> import pygmt

--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -116,6 +116,7 @@ class GMTDataArrayAccessor:
     >>> ds.zval.gmt.registration, ds.zval.gmt.gtype
     (0, 0)
     >>> # the workaround is to assign the DataArray into a variable
+    >>> zval = ds.zval
     >>> zval.gmt.registration, zval.gmt.gtype
     (0, 0)
     >>> zval.gmt.registration, zval.gmt.gtype = 0, 1

--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -82,8 +82,7 @@ class GMTDataArrayAccessor:
     instance, so you may lose these GMT-specific properties after manipulating
     your grid.
 
-
-    Inplace assignment operators like ``*=* don't create new instances, so the
+    Inplace assignment operators like ``*=`` don't create new instances, so the
     properties are still kept:
 
     >>> grid *= 2.0
@@ -105,17 +104,17 @@ class GMTDataArrayAccessor:
     (0, 1)
 
     Accesing a :class:`xarray.DataArray` from a :class:`xarray.Dataset` always
-    creates new instances, so these properties are always lost:
+    creates new instances, so these properties are always lost. The workaround
+    is to assign the :class:`xarray.DataArray` into a variable:
 
     >>> ds = xr.Dataset({"zval": grid})
     >>> ds.zval.gmt.registration, ds.zval.gmt.gtype
     (0, 0)
     >>> # manually set these properties won't work as expected
-    >>> ds.zval.gmt.registration = 0
-    >>> ds.zval.gmt.gtype = 1
+    >>> ds.zval.gmt.registration, ds.zval.gmt.gtype = 0, 1
     >>> ds.zval.gmt.registration, ds.zval.gmt.gtype
     (0, 0)
-    >>> # the workaround is to assign the DataArray into a variable
+    >>> # workaround: assign the DataArray into a variable
     >>> zval = ds.zval
     >>> zval.gmt.registration, zval.gmt.gtype
     (0, 0)

--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -34,7 +34,7 @@ class GMTDataArrayAccessor:
     GMT-specific properties when manipulating grids (e.g., arithmetic and slice
     operations) or when accessing a :class:`xarray.DataArray` from a
     :class:`xarray.Dataset`. In these cases, you need to manually set these
-    properties beforing passing it to PyGMT.
+    properties before passing the grid to PyGMT.
 
     Examples
     --------
@@ -53,8 +53,8 @@ class GMTDataArrayAccessor:
     1
 
     For :class:`xarray.DataArray` grids created by yourself, grid properties
-    ``registration`` and ``gtype`` default to 0 (i.e., a Cartesian
-    gridline-registrated grid). You need to set the correct properties before
+    ``registration`` and ``gtype`` default to 0 (i.e., a gridline-registered,
+    Cartesian grid). You need to set the correct properties before
     passing it to PyGMT functions:
 
     >>> import numpy as np

--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -1,5 +1,5 @@
 """
-GMT accessor methods.
+GMT accessor for :class:`xarray.DataArray`.
 """
 import xarray as xr
 from pygmt.exceptions import GMTInvalidInput
@@ -9,13 +9,33 @@ from pygmt.src.grdinfo import grdinfo
 @xr.register_dataarray_accessor("gmt")
 class GMTDataArrayAccessor:
     """
-    GMT extension for :class:`xarray.DataArray`.
+    GMT accessor for :class:`xarray.DataArray`.
 
-    The extension provides easy ways to access and change the GMT specific
-    properties about grids. Currently, two properties are available:
+    The accessor extends :class:`xarray.DataArray` to store GMT-specific
+    properties about grids, which are important for PyGMT to correctly process
+    and plot the grids.
 
-    - ``registration``: Gridline (0) or Pixel (1) registration
-    - ``gtype``: Cartesian (0) or Geographic (1) coordinate system
+    Attributes
+    ----------
+
+    registration : int
+        Registration type of the grid, either 0 (Gridline) or 1 (Pixel).
+    gtype : int
+        Coordinate system type of the grid, either 0 (Cartesian) or 1
+        (Geographic).
+
+    Notes
+    -----
+
+    Due to the limitations of xarray accessors, the GMT accessors are created
+    once per :class:`xarray.DataArray` instance. You may lose these
+    GMT-specific properties when manipulating grids (e.g., arithmetic, slice
+    operations) or when accessing a :class:`xarray.DataArray` from a
+    :class:`xarray.Dataset`. In these cases, you need to manually set these
+    properties beforing passing it to PyGMT.
+
+    Examples
+    --------
 
     You can access these GMT specific properties about your grid as follows:
 
@@ -43,9 +63,34 @@ class GMTDataArrayAccessor:
     >>> grid = xr.DataArray(
     ...     data, coords=[("latitude", lat), ("longitude", lon)]
     ... )
+    >>> # default to a gridline-registrated Cartesian grid
+    >>> grid.gmt.registration, grid.gmt.gtype
+    (0, 0)
     >>> # set it to a gridline-registered geographic grid
     >>> grid.gmt.registration = 0
     >>> grid.gmt.gtype = 1
+    >>> grid.gmt.registration, grid.gmt.gtype
+    (0, 1)
+
+    Note that the accessors are created once per :class:`xarray.DataArray`
+    instance, so you may lose these GMT-specific properties after manipulating
+    grids:
+
+    >>> grid *= 2.0
+    >>> # no new instance is created. The properties are kept
+    >>> grid.gmt.registration, grid.gmt.gtype
+    (0, 1)
+
+    >>> # grid2 is a slice of the original grid
+    >>> grid2 = grid[0:30, 50:80]
+    >>> # properties are reset to the default values for new instance
+    >>> grid2.gmt.registration, grid2.gmt.gtype
+    (0, 0)
+    >>> # need to set these properties before passing the grid to PyGMT
+    >>> grid2.gmt.registration = grid.gmt.registration
+    >>> grid2.gmt.gtype = grid.gmt.gtype
+    >>> grid2.gmt.registration, grid2.gmt.gtype
+    (0, 1)
     """
 
     def __init__(self, xarray_obj):
@@ -64,34 +109,32 @@ class GMTDataArrayAccessor:
     @property
     def registration(self):
         """
-        Registration type of the grid, either Gridline (0) or Pixel (1).
+        Registration type of the grid, either 0 (Gridline) or 1 (Pixel).
         """
         return self._registration
 
     @registration.setter
     def registration(self, value):
-        if value in (0, 1):
-            self._registration = value
-        else:
+        if value not in (0, 1):
             raise GMTInvalidInput(
                 f"Invalid grid registration value: {value}, should be either "
                 "0 for Gridline registration or 1 for Pixel registration."
             )
+        self._registration = value
 
     @property
     def gtype(self):
         """
-        Coordinate system type of the grid, either Cartesian (0) or Geographic
-        (1).
+        Coordinate system type of the grid, either 0 (Cartesian) or 1
+        (Geographic).
         """
         return self._gtype
 
     @gtype.setter
     def gtype(self, value):
-        if value in (0, 1):
-            self._gtype = value
-        else:
+        if value not in (0, 1):
             raise GMTInvalidInput(
                 f"Invalid coordinate system type: {value}, should be "
                 "either 0 for Cartesian or 1 for Geographic."
             )
+        self._gtype = value

--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -80,12 +80,18 @@ class GMTDataArrayAccessor:
 
     Note that the accessors are created once per :class:`xarray.DataArray`
     instance, so you may lose these GMT-specific properties after manipulating
-    grids:
+    your grid.
+
+
+    Inplace assignment operators like ``*=* don't create new instances, so the
+    properties are still kept:
 
     >>> grid *= 2.0
-    >>> # no new instance is created. The properties are kept
     >>> grid.gmt.registration, grid.gmt.gtype
     (0, 1)
+
+    Other grid operations (e.g., arithmetic or slice operations) create new
+    instances, so the properties will be lost:
 
     >>> # grid2 is a slice of the original grid
     >>> grid2 = grid[0:30, 50:80]
@@ -96,6 +102,24 @@ class GMTDataArrayAccessor:
     >>> grid2.gmt.registration = grid.gmt.registration
     >>> grid2.gmt.gtype = grid.gmt.gtype
     >>> grid2.gmt.registration, grid2.gmt.gtype
+    (0, 1)
+
+    Accesing a :class:`xarray.DataArray` from a :class:`xarray.Dataset` always
+    creates new instances, so these properties are always lost:
+
+    >>> ds = xr.Dataset({"zval": grid})
+    >>> ds.zval.gmt.registration, ds.zval.gmt.gtype
+    (0, 0)
+    >>> # manually set these properties won't work as expected
+    >>> ds.zval.gmt.registration = 0
+    >>> ds.zval.gmt.gtype = 1
+    >>> ds.zval.gmt.registration, ds.zval.gmt.gtype
+    (0, 0)
+    >>> # the workaround is to assign the DataArray into a variable
+    >>> zval.gmt.registration, zval.gmt.gtype
+    (0, 0)
+    >>> zval.gmt.registration, zval.gmt.gtype = 0, 1
+    >>> zval.gmt.registration, zval.gmt.gtype
     (0, 1)
     """
 


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/GenericMappingTools/pygmt/issues/499 for context.

**Preview**: https://pygmt-dev--2375.org.readthedocs.build/en/2375/api/generated/pygmt.GMTDataArrayAccessor.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
