### PR TITLE
Use "general" verb form in docstrings

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -273,21 +273,21 @@ class Figure:
             The desired figure file name, including the extension. See the list
             of supported formats and their extensions above.
         transparent : bool
-            If True, will use a transparent background for the figure. Only
-            valid for PNG format.
+            If ``True``, will use a transparent background for the figure.
+            Only valid for PNG format.
         crop : bool
-            If True, will crop the figure canvas (page) to the plot area.
+            If ``True``, will crop the figure canvas (page) to the plot area.
         anti_alias: bool
-            If True, will use anti aliasing when creating raster images (PNG,
-            JPG, TIFF). More specifically, it passes arguments ``t2``
+            If ``True``, will use anti aliasing when creating raster images
+            (PNG, JPG, TIFF). More specifically, it passes arguments ``t2``
             and ``g2`` to the ``anti_aliasing`` parameter of
             :meth:`pygmt.Figure.psconvert`. Ignored if creating vector
             graphics.
         show: bool
-            If True, will open the figure in an external viewer.
+            If ``True``, will open the figure in an external viewer.
         dpi : int
-            Set raster resolution in dpi. Default is 720 for PDF, 300 for
-            others.
+            Set raster resolution in dpi [Default is ``720`` for PDF, ``300``
+            for others].
         **kwargs : dict
             Additional keyword arguments passed to
             :meth:`pygmt.Figure.psconvert`. Valid parameters are ``gs_path``,

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -209,8 +209,8 @@ class Figure:
         anti_aliasing : str
             [**g**\|\ **p**\|\ **t**\][**1**\|\ **2**\|\ **4**].
             Set the anti-aliasing options for **g**\ raphics or **t**\ ext.
-            Append the size of the subsample box (1, 2, or 4) [4]. [Default is
-            no anti-aliasing (same as bits = 1)].
+            Append the size of the subsample box (1, 2, or 4) [Default is
+            ``"4"``]. [Default is no anti-aliasing (same as bits = 1).]
         fmt : str
             Set the output format, where **b** means BMP, **e** means EPS,
             **E** means EPS with PageSize command, **f** means PDF, **F** means

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -212,7 +212,7 @@ class Figure:
             Append the size of the subsample box (1, 2, or 4) [4]. [Default is
             no anti-aliasing (same as bits = 1)].
         fmt : str
-            Sets the output format, where **b** means BMP, **e** means EPS,
+            Set the output format, where **b** means BMP, **e** means EPS,
             **E** means EPS with PageSize command, **f** means PDF, **F** means
             multi-page PDF, **j** means JPEG, **g** means PNG, **G** means
             transparent PNG (untouched regions are transparent), **m** means

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -278,7 +278,7 @@ class Figure:
         crop : bool
             If ``True``, will crop the figure canvas (page) to the plot area.
         anti_alias: bool
-            If ``True``, will use anti aliasing when creating raster images
+            If ``True``, will use anti-aliasing when creating raster images
             (PNG, JPG, TIFF). More specifically, it passes arguments ``t2``
             and ``g2`` to the ``anti_aliasing`` parameter of
             :meth:`pygmt.Figure.psconvert`. Ignored if creating vector

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -29,7 +29,7 @@ COMMON_DOCSTRINGS = {
             [**s**\|\ **S**]][**+l**\|\ **r**][**+p**\ *percent*].
             Features with an area smaller than *min_area* in km\ :sup:`2` or of
             hierarchical level that is lower than *min_level* or higher than
-            *max_level* will not be plotted [Default is 0/0/4 (all
+            *max_level* will not be plotted [Default is ``"0/0/4"`` (all
             features)].""",
     "frame": r"""
         frame : bool or str or list
@@ -305,13 +305,13 @@ COMMON_DOCSTRINGS = {
             [**x**\|\ **y**\|\ **z**]\ *azim*\[/*elev*\[/*zlevel*]]\
             [**+w**\ *lon0*/*lat0*\[/*z0*]][**+v**\ *x0*/*y0*].
             Select perspective view and set the azimuth and elevation angle of
-            the viewpoint. Default is [180, 90]. Full documentation is at
+            the viewpoint [Default is ``[180, 90]``]. Full documentation is at
             :gmt-docs:`gmt.html#perspective-full`.
         """,
     "registration": r"""
         registration : str
             **g**\|\ **p**.
-            Force gridline (**g**) or pixel (**p**) node registration.
+            Force gridline (**g**) or pixel (**p**) node registration
             [Default is **g**\ (ridline)].
         """,
     "skiprows": r"""
@@ -333,7 +333,7 @@ COMMON_DOCSTRINGS = {
     "transparency": r"""
         transparency : int or float
             Set transparency level, in [0-100] percent range
-            [Default is 0, i.e., opaque].
+            [Default is ``0``, i.e., opaque].
             Only visible when PDF or raster format output is selected.
             Only the PNG format selection adds a transparency layer
             in the image (for further processing). """,

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -71,8 +71,8 @@ def basemap(self, **kwargs):
         radius. You can override this radius by appending another value.
         Finally, append **+s** to draw an offset background shaded region.
         Here, *dx/dy* indicates the shift relative to the foreground frame
-        [Default is 4p/-4p] and shade sets the fill style to use for shading
-        [Default is gray50].
+        [Default is ``"4p/-4p"``] and shade sets the fill style to use for
+        shading [Default is ``"gray50"``].
     rose : str
         Draw a map directional rose on the map at the location defined by
         the reference and anchor points.

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -58,7 +58,7 @@ def basemap(self, **kwargs):
     box : bool or str
         [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]]\
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
-        If set to ``True``, draws a rectangular border around the
+        If set to ``True``, draw a rectangular border around the
         map scale or rose. Alternatively, specify a different pen with
         **+p**\ *pen*. Add **+g**\ *fill* to fill the scale panel [Default is
         no fill]. Append **+c**\ *clearance* where *clearance* is either gap,

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -55,7 +55,7 @@ def basemap(self, **kwargs):
     map_scale : str
         [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\
         **+w**\ *length*.
-        Draws a simple map scale centered on the reference point specified.
+        Draw a simple map scale centered on the reference point specified.
     box : bool or str
         [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]]\
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
@@ -75,11 +75,11 @@ def basemap(self, **kwargs):
         [Default is 4p/-4p] and shade sets the fill style to use for shading
         [Default is gray50].
     rose : str
-        Draws a map directional rose on the map at the location defined by
+        Draw a map directional rose on the map at the location defined by
         the reference and anchor points.
     compass : str
-        Draws a map magnetic rose on the map at the location defined by the
-        reference and anchor points
+        Draw a map magnetic rose on the map at the location defined by the
+        reference and anchor points.
     {timestamp}
     {verbose}
     {panel}

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -84,7 +84,7 @@ def binstats(data, **kwargs):
         Normalize the resulting grid values by the area represented by the
         search *radius* [no normalization].
     search_radius : float or str
-        Sets the *search_radius* that determines which data points are
+        Set the *search_radius* that determines which data points are
         considered close to a node. Append the distance unit.
         Not compatible with ``tiling``.
     weight : str

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -77,7 +77,7 @@ def coast(self, **kwargs):
         strings in a list.
     resolution : str
         **f**\|\ **h**\|\ **i**\|\ **l**\|\ **c**.
-        Selects the resolution of the data set to: (**f**\ )ull,
+        Select the resolution of the data set to: (**f**\ )ull,
         (**h**\ )igh, (**i**\ )ntermediate, (**l**\ )ow,
         and (**c**\ )rude.
     land : str
@@ -128,7 +128,7 @@ def coast(self, **kwargs):
     map_scale : str
         [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\
         **+w**\ *length*.
-        Draws a simple map scale centered on the reference point specified.
+        Draw a simple map scale centered on the reference point specified.
     borders : int or str or list
         *border*\ [/*pen*].
         Draw political boundaries. Specify the type of boundary and

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -71,7 +71,7 @@ def colorbar(self, **kwargs):
     box : bool or str
         [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]]\
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
-        If set to ``True``, draws a rectangular border around the color scale.
+        If set to ``True``, draw a rectangular border around the color scale.
         Alternatively, specify a different pen with **+p**\ *pen*. Add
         **+g**\ *fill* to fill the scale panel [Default is no fill]. Append
         **+c**\ *clearance* where *clearance* is either gap, xgap/ygap, or

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -52,7 +52,7 @@ def colorbar(self, **kwargs):
         [**+h**\|\ **v**][**+j**\ *justify*]\
         [**+m**\ [**a**\|\ **c**\|\ **l**\|\ **u**]]\
         [**+n**\ [*txt*]][**+o**\ *dx*\ [/*dy*]].
-        Defines the reference point on the map for the color scale using one of
+        Define the reference point on the map for the color scale using one of
         four coordinate systems: (1) Use **g** for map (user) coordinates, (2)
         use **j** or **J** for setting *refpoint* via a 2-character
         justification code that refers to the (invisible) map domain rectangle,

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -83,13 +83,13 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
     I : bool
         Color the triangles using CPT.
     triangular_mesh_pen : str
-        Pen to draw the underlying triangulation [Default is None].
+        Pen to draw the underlying triangulation [Default is ``None``].
     no_clip : bool
-        Do NOT clip contours or image at the boundaries [Default will clip
-        to fit inside region].
+        Do **not** clip contours or image at the frame boundaries
+        [Default is ``False`` to fit inside ``region``].
     Q : float or str
         [*cut*][**+z**].
-        Do not draw contours with less than cut number of points.
+        Do not draw contours with less than *cut* number of points.
     skip : bool or str
         [**p**\|\ **t**].
         Skip input points outside region.

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -108,7 +108,7 @@ def dimfilter(grid, **kwargs):
           value. Append **+l** or **+h** to the sectors if you rather want to
           return the smallest or largest of the modal values.
     spacing : str or list
-        *x_inc* [and optionally *y_inc*] is the output Increment. Append
+        *x_inc* [and optionally *y_inc*] is the output increment. Append
         **m** to indicate minutes, or **c** to indicate seconds. If the new
         *x_inc*, *y_inc* are NOT integer multiples of the old ones (in the
         input data), filtering will be considerably slower. [Default is same

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -111,11 +111,11 @@ def dimfilter(grid, **kwargs):
         *x_inc* [and optionally *y_inc*] is the output Increment. Append
         **m** to indicate minutes, or **c** to indicate seconds. If the new
         *x_inc*, *y_inc* are NOT integer multiples of the old ones (in the
-        input data), filtering will be considerably slower. [Default: Same
+        input data), filtering will be considerably slower. [Default is same
         as input.]
     region : str or list
         [*xmin*, *xmax*, *ymin*, *ymax*].
-        Define the region of the output points. [Default: Same as input.]
+        Define the region of the output points [Default is same as input].
     {verbose}
 
     Returns

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -77,7 +77,7 @@ def dimfilter(grid, **kwargs):
           calculation.
     filter : str
         **x**\ *width*\ [**+l**\|\ **u**].
-        Sets the primary filter type. Choose among convolution and
+        Set the primary filter type. Choose among convolution and
         non-convolution filters. Use the filter code **x** followed by
         the full diameter *width*. Available convolution filters are:
 
@@ -94,7 +94,7 @@ def dimfilter(grid, **kwargs):
           to return the smallest or largest of each sector's modal values.
     sectors : str
         **x**\ *sectors*\ [**+l**\|\ **u**]
-        Sets the secondary filter type **x** and the number of bow-tie sectors.
+        Set the secondary filter type **x** and the number of bow-tie sectors.
         *sectors* must be integer and larger than 0. When *sectors* is
         set to 1, the secondary filter is not effective. Available secondary
         filters **x** are:
@@ -115,7 +115,7 @@ def dimfilter(grid, **kwargs):
         as input.]
     region : str or list
         [*xmin*, *xmax*, *ymin*, *ymax*].
-        Defines the region of the output points. [Default: Same as input.]
+        Define the region of the output points. [Default: Same as input.]
     {verbose}
 
     Returns

--- a/pygmt/src/filter1d.py
+++ b/pygmt/src/filter1d.py
@@ -35,7 +35,7 @@ def filter1d(data, output_type="pandas", outfile=None, **kwargs):
     ----------
     filter_type : str
         **type**\ *width*\ [**+h**].
-        Sets the filter **type**. Choose among convolution and non-convolution
+        Set the filter **type**. Choose among convolution and non-convolution
         filters. Append the filter code followed by the full filter
         *width* in same units as time column. By default, this
         performs a low-pass filtering; append **+h** to select high-pass
@@ -82,7 +82,7 @@ def filter1d(data, output_type="pandas", outfile=None, **kwargs):
         half the filter-width of data at each end.
 
     time_col : int
-        Indicates which column contains the independent variable (time). The
+        Indicate which column contains the independent variable (time). The
         left-most column is 0, while the right-most is (*n_cols* - 1)
         [Default is 0].
 

--- a/pygmt/src/filter1d.py
+++ b/pygmt/src/filter1d.py
@@ -84,7 +84,7 @@ def filter1d(data, output_type="pandas", outfile=None, **kwargs):
     time_col : int
         Indicate which column contains the independent variable (time). The
         left-most column is 0, while the right-most is (*n_cols* - 1)
-        [Default is 0].
+        [Default is ``0``].
 
     output_type : str
         Determine the format the xyz data will be returned in [Default is

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -80,7 +80,7 @@ def grd2cpt(grid, **kwargs):
     transparency : int or float or str
         Set a constant level of transparency (0-100) for all color slices.
         Append **+a** to also affect the foreground, background, and NaN
-        colors [Default is no transparency, i.e., 0 (opaque)].
+        colors [Default is no transparency, i.e., ``0`` (opaque)].
     cmap : str
         Select the master color palette table (CPT) to use in the
         interpolation. Full list of built-in color palette tables can be found

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -114,7 +114,7 @@ def grd2cpt(grid, **kwargs):
         Define the range of the new CPT by giving the lowest and highest
         z-value (and optionally an interval). If this is not given, the
         existing range in the master CPT will be used intact. The values
-        produced defines the color slice boundaries.  If **+n** is used it
+        produced defines the color slice boundaries. If **+n** is used it
         refers to the number of such boundaries and not the number of slices.
         For details on array creation, see
         :gmt-docs:`makecpt.html#generate-1d-array`.

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -78,11 +78,11 @@ def grd2cpt(grid, **kwargs):
     grid : str or xarray.DataArray
         The file name of the input grid or the grid loaded as a DataArray.
     transparency : int or float or str
-        Sets a constant level of transparency (0-100) for all color slices.
+        Set a constant level of transparency (0-100) for all color slices.
         Append **+a** to also affect the foreground, background, and NaN
         colors [Default is no transparency, i.e., 0 (opaque)].
     cmap : str
-        Selects the master color palette table (CPT) to use in the
+        Select the master color palette table (CPT) to use in the
         interpolation. Full list of built-in color palette tables can be found
         at :gmt-docs:`cookbook/cpts.html#built-in-color-palette-tables-cpt`.
     background : bool or str
@@ -111,7 +111,7 @@ def grd2cpt(grid, **kwargs):
         to resample the color table into *nlevels* equidistant slices.
     series : list or str
         [*min/max/inc*\ [**+b**\|\ **l**\|\ **n**\]|\ *file*\|\ *list*\].
-        Defines the range of the new CPT by giving the lowest and highest
+        Define the range of the new CPT by giving the lowest and highest
         z-value (and optionally an interval). If this is not given, the
         existing range in the master CPT will be used intact. The values
         produced defines the color slice boundaries.  If **+n** is used it

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -126,14 +126,14 @@ def grdgradient(grid, **kwargs):
     tiles : str
         **c**\|\ **r**\|\ **R**.
         Control how normalization via ``normalize`` is carried out. When
-        multiple  grids should be normalized the same way (i.e., with the same
-        *offset*  and/or *sigma*),
-        we must pass these values via ``normalize``.  However, this is
+        multiple grids should be normalized the same way (i.e., with the same
+        *offset* and/or *sigma*),
+        we must pass these values via ``normalize``. However, this is
         inconvenient if we compute these values from a grid. Use **c** to
-        save  the results  of *offset* and *sigma* to a statistics file; if
-        grid output is not  needed for this run then do not specify
-        ``outgrid``. For  subsequent runs,  just use **r** to read these
-        values.  Using **R**  will read then delete the statistics file.
+        save the results of *offset* and *sigma* to a statistics file; if
+        grid output is not needed for this run then do not specify
+        ``outgrid``. For subsequent runs, just use **r** to read these
+        values. Using **R** will read then delete the statistics file.
     {region}
     slope_file : str
         Name of output grid file with scalar magnitudes of gradient vectors.

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -125,11 +125,11 @@ def grdgradient(grid, **kwargs):
         all nodes after gradient calculations are completed.
     tiles : str
         **c**\|\ **r**\|\ **R**.
-        Control how normalization via ``normalize`` is carried out.  When
+        Control how normalization via ``normalize`` is carried out. When
         multiple  grids should be normalized the same way (i.e., with the same
         *offset*  and/or *sigma*),
         we must pass these values via ``normalize``.  However, this is
-        inconvenient if we compute these values from a grid.  Use **c** to
+        inconvenient if we compute these values from a grid. Use **c** to
         save  the results  of *offset* and *sigma* to a statistics file; if
         grid output is not  needed for this run then do not specify
         ``outgrid``. For  subsequent runs,  just use **r** to read these

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -125,7 +125,7 @@ def grdgradient(grid, **kwargs):
         all nodes after gradient calculations are completed.
     tiles : str
         **c**\|\ **r**\|\ **R**.
-        Controls how normalization via ``normalize`` is carried out.  When
+        Control how normalization via ``normalize`` is carried out.  When
         multiple  grids should be normalized the same way (i.e., with the same
         *offset*  and/or *sigma*),
         we must pass these values via ``normalize``.  However, this is

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -84,7 +84,7 @@ class grdhisteq:  # pylint: disable=invalid-name
             The name of the output ASCII file to store the results of the
             histogram equalization in.
         output_type: str
-            Determines the output type. Use "file", "xarray", "pandas", or
+            Determine the output type. Use "file", "xarray", "pandas", or
             "numpy".
         divisions : int
             Set the number of divisions of the data range [Default is 16].

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -87,7 +87,7 @@ class grdhisteq:  # pylint: disable=invalid-name
             Determine the output type. Use "file", "xarray", "pandas", or
             "numpy".
         divisions : int
-            Set the number of divisions of the data range [Default is 16].
+            Set the number of divisions of the data range [Default is ``16``].
 
         {region}
         {verbose}

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -146,8 +146,8 @@ def grdimage(self, grid, **kwargs):
         Force conversion to monochrome image using the (television) YIQ
         transformation. Cannot be used with ``nan_transparent``.
     no_clip : bool
-        Do not clip the image at the map boundary (only relevant for
-        non-rectangular maps).
+        Do **not** clip the image at the frame boundaries (only relevant
+        for non-rectangular maps) [Default is ``False``].
     nan_transparent : bool
         Make grid nodes with z = NaN transparent, using the color-masking
         feature in PostScript Level 3 (the PS device must support PS Level

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -113,7 +113,7 @@ def grdimage(self, grid, **kwargs):
         to project a raw image (an image without referencing coordinates).
     dpi : int
         [**i**\|\ *dpi*].
-        Sets the resolution of the projected grid that will be created if a
+        Set the resolution of the projected grid that will be created if a
         map projection other than Linear or Mercator was selected [100]. By
         default, the projected grid will be of the same size (rows and
         columns) as the input file. Specify **i** to use the PostScript

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -113,10 +113,11 @@ def grdimage(self, grid, **kwargs):
     dpi : int
         [**i**\|\ *dpi*].
         Set the resolution of the projected grid that will be created if a
-        map projection other than Linear or Mercator was selected [100]. By
-        default, the projected grid will be of the same size (rows and
-        columns) as the input file. Specify **i** to use the PostScript
-        image operator to interpolate the image at the device resolution.
+        map projection other than Linear or Mercator was selected [Default
+        is ``100`` dpi]. By default, the projected grid will be of the
+        same size (rows and columns) as the input file. Specify **i** to
+        use the PostScript image operator to interpolate the image at the
+        device resolution.
     bit_color : str
         *color*\ [**+b**\|\ **f**\].
         This parameter only applies when a resulting 1-bit image otherwise

--- a/pygmt/src/grdinfo.py
+++ b/pygmt/src/grdinfo.py
@@ -43,7 +43,7 @@ def grdinfo(grid, **kwargs):
     {region}
     per_column : str or bool
         **n**\|\ **t**.
-        Formats the report using tab-separated fields on a single line. The
+        Format the report using tab-separated fields on a single line. The
         output is name *w e s n z0 z1 dx dy nx ny* [ *x0 y0 x1 y1* ]
         [ *med scale* ] [ *mean std rms* ] [ *n_nan* ] *registration gtype*.
         The data in brackets are outputted depending on the ``force_scan``

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -52,7 +52,7 @@ def grdlandmask(**kwargs):
     {region}
     {area_thresh}
     resolution : str
-        *res*\[\ **+f**\]. Selects the resolution of the data set to use
+        *res*\[\ **+f**\]. Select the resolution of the data set to use
         ((**f**)ull, (**h**)igh, (**i**)ntermediate, (**l**)ow, or
         (**c**)rude). The resolution drops off by ~80% between data sets.
         [Default is **l**]. Append **+f** to automatically select a lower

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -77,7 +77,7 @@ def grdlandmask(**kwargs):
         ponds-in-islands-in-lakes outlines [Default is no line tracing].
     maskvalues : str or list
         [*wet*, *dry*] or [*ocean*, *land*, *lake*, *island*, *pond*].
-        Sets the values that will be assigned to nodes. Values can
+        Set the values that will be assigned to nodes. Values can
         be any number, including the textstring NaN
         [Default is [0, 1, 0, 1, 0] (i.e., [0, 1])]. Also select
         ``bordervalues`` to let nodes exactly on feature boundaries be

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -81,7 +81,7 @@ def grdview(self, grid, **kwargs):
         via the **+g** modifier, and the projection is not oblique, the frontal
         facade between the plane and the data perimeter is colored.
     surftype : str
-        Specifies cover type of the grid.
+        Specify cover type of the grid.
         Select one of following settings:
 
         - **m** - mesh plot [Default].

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -77,7 +77,7 @@ def grdview(self, grid, **kwargs):
         (if drapegrid is a grid) will be looked-up via the CPT (see ``cmap``).
     plane : float or str
         *level*\ [**+g**\ *fill*].
-        Draws a plane at this z-level. If the optional color is provided
+        Draw a plane at this z-level. If the optional color is provided
         via the **+g** modifier, and the projection is not oblique, the frontal
         facade between the plane and the data perimeter is colored.
     surftype : str
@@ -97,10 +97,10 @@ def grdview(self, grid, **kwargs):
         Draw contour lines on top of surface or mesh (not image). Append
         pen attributes used for the contours.
     meshpen : str
-        Sets the pen attributes used for the mesh. You must also select
+        Set the pen attributes used for the mesh. You must also select
         ``surftype`` of **m** or **sm** for meshlines to be drawn.
     facadepen :str
-        Sets the pen attributes used for the facade. You must also select
+        Set the pen attributes used for the facade. You must also select
         ``plane`` for the facade outline to be drawn.
     shading : str
         Provide the name of a grid file with intensities in the (-1,+1)

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -101,7 +101,7 @@ def histogram(self, data, **kwargs):
         bin, use **l**, and to only include extreme values above the last bin
         into that last bin, use **h**.
     stairs : bool
-        Draws a stairs-step diagram which does not include the internal bars
+        Draw a stairs-step diagram which does not include the internal bars
         of the default histogram.
     horizontal : bool
         Plot the histogram using horizontal bars instead of the

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -43,7 +43,7 @@ def image(self, imagefile, **kwargs):
         [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\ **+r**\ *dpi*\
         **+w**\ [**-**]\ *width*\ [/*height*]\ [**+j**\ *justify*]\
         [**+n**\ *nx*\ [/*ny*] ]\ [**+o**\ *dx*\ [/*dy*]].
-        Sets reference point on the map for the image.
+        Set reference point on the map for the image.
     box : bool or str
         [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]]\
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -47,7 +47,7 @@ def image(self, imagefile, **kwargs):
     box : bool or str
         [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]]\
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
-        Without further arguments, draws a rectangular border around the image
+        If set to ``True``, draws a rectangular border around the image
         using :gmt-term:`MAP_FRAME_PEN`.
     monochrome : bool
         Convert color image to monochrome grayshades using the (television)

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -47,7 +47,7 @@ def image(self, imagefile, **kwargs):
     box : bool or str
         [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]]\
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
-        If set to ``True``, draws a rectangular border around the image
+        If set to ``True``, draw a rectangular border around the image
         using :gmt-term:`MAP_FRAME_PEN`.
     monochrome : bool
         Convert color image to monochrome grayshades using the (television)

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -103,8 +103,8 @@ def inset(self, **kwargs):
         a string with the values separated by forward
         slashes [Default is no margins].
     no_clip : bool
-        Do NOT clip features extruding outside map inset boundaries [Default
-        is clip].
+        Do **not** clip features extruding outside the inset frame
+        boundaries [Default is ``False``].
     {region}
     {projection}
     {verbose}

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -76,7 +76,7 @@ def inset(self, **kwargs):
         [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\
         *pen*]][**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\
         [[*dx*/*dy*/][*shade*]]].
-        If set to ``True``, draws a rectangular box around the map
+        If set to ``True``, draw a rectangular box around the map
         inset using the default pen; specify a different pen
         with **+p**\ *pen*. Add **+g**\ *fill* to fill the logo box
         [Default is no fill].

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -77,7 +77,7 @@ def inset(self, **kwargs):
         *pen*]][**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\
         [[*dx*/*dy*/][*shade*]]].
 
-        If passed ``True``, this draws a rectangular box around the map
+        If set to ``True``, draws a rectangular box around the map
         inset using the default pen; specify a different pen
         with **+p**\ *pen*. Add **+g**\ *fill* to fill the logo box
         [Default is no fill].

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -76,7 +76,6 @@ def inset(self, **kwargs):
         [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\
         *pen*]][**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\
         [[*dx*/*dy*/][*shade*]]].
-
         If set to ``True``, draws a rectangular box around the map
         inset using the default pen; specify a different pen
         with **+p**\ *pen*. Add **+g**\ *fill* to fill the logo box
@@ -91,9 +90,9 @@ def inset(self, **kwargs):
         rectangular borders instead, with a 6p corner radius. You
         can override this radius by appending another value. Append
         **+s** to draw an offset background shaded region. Here, *dx*/*dy*
-        indicates the shift relative to the foreground frame
-        [4p/-4p] and ``shade`` sets the fill style to use for
-        shading [Default is gray50].
+        indicates the shift relative to the foreground frame [Default is
+        ``"4p/-4p"``] and ``shade`` sets the fill style to use for
+        shading [Default is ``"gray50"``].
     margin : int or str or list
         This is clearance that is added around the inside of the inset.
         Plotting will take place within the inner region only. The margins

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -52,7 +52,7 @@ def legend(self, spec=None, position="JTR+jTR+o0.2c", box="+gwhite+p1p", **kwarg
         [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\
         **+w**\ *width*\ [/*height*]\ [**+j**\ *justify*]\ [**+l**\ *spacing*]\
         [**+o**\ *dx*\ [/*dy*]].
-        Defines the reference point on the map for the
+        Define the reference point on the map for the
         legend. By default, uses **JTR**\ **+jTR**\ **+o**\ 0.2c which
         places the legend at the top-right corner inside the map frame, with a
         0.2 cm offset.

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -58,7 +58,7 @@ def legend(self, spec=None, position="JTR+jTR+o0.2c", box="+gwhite+p1p", **kwarg
     box : bool or str
         [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]]\
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
-        Without further arguments, draws a rectangular border around the legend
+        If set to ``True``, draws a rectangular border around the legend
         using :gmt-term:`MAP_FRAME_PEN`. By default, uses
         **+g**\ white\ **+p**\ 1p which draws a box around the legend using a
         1p black pen and adds a white background.

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -58,7 +58,7 @@ def legend(self, spec=None, position="JTR+jTR+o0.2c", box="+gwhite+p1p", **kwarg
     box : bool or str
         [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]]\
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
-        If set to ``True``, draws a rectangular border around the legend
+        If set to ``True``, draw a rectangular border around the legend
         using :gmt-term:`MAP_FRAME_PEN`. By default, uses
         **+g**\ white\ **+p**\ 1p which draws a box around the legend using a
         1p black pen and adds a white background.

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -39,7 +39,7 @@ def logo(self, **kwargs):
     position : str
         [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\
         **+w**\ *width*\ [**+j**\ *justify*]\ [**+o**\ *dx*\ [/*dy*]].
-        Sets reference point on the map for the image.
+        Set reference point on the map for the image.
     box : bool or str
         Without further arguments, draws a rectangular border around the
         GMT logo.

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -40,7 +40,7 @@ def logo(self, **kwargs):
         **+w**\ *width*\ [**+j**\ *justify*]\ [**+o**\ *dx*\ [/*dy*]].
         Set reference point on the map for the image.
     box : bool or str
-        Without further arguments, draws a rectangular border around the
+        If set to ``True``, draws a rectangular border around the
         GMT logo.
     style : str
         [**l**\|\ **n**\|\ **u**].

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -40,7 +40,7 @@ def logo(self, **kwargs):
         **+w**\ *width*\ [**+j**\ *justify*]\ [**+o**\ *dx*\ [/*dy*]].
         Set reference point on the map for the image.
     box : bool or str
-        If set to ``True``, draws a rectangular border around the
+        If set to ``True``, draw a rectangular border around the
         GMT logo.
     style : str
         [**l**\|\ **n**\|\ **u**].

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -67,7 +67,7 @@ def makecpt(**kwargs):
     transparency : str
         Set a constant level of transparency (0-100) for all color slices.
         Append **+a** to also affect the foreground, background, and NaN
-        colors [Default is no transparency, i.e., 0 (opaque)].
+        colors [Default is no transparency, i.e., ``0`` (opaque)].
     cmap : str
         Select the master color palette table (CPT) to use in the
         interpolation. Full list of built-in color palette tables can be found

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -65,11 +65,11 @@ def makecpt(**kwargs):
     Parameters
     ----------
     transparency : str
-        Sets a constant level of transparency (0-100) for all color slices.
+        Set a constant level of transparency (0-100) for all color slices.
         Append **+a** to also affect the foreground, background, and NaN
         colors [Default is no transparency, i.e., 0 (opaque)].
     cmap : str
-        Selects the master color palette table (CPT) to use in the
+        Select the master color palette table (CPT) to use in the
         interpolation. Full list of built-in color palette tables can be found
         at :gmt-docs:`cookbook/cpts.html#built-in-color-palette-tables-cpt`.
     background : bool or str
@@ -94,7 +94,7 @@ def makecpt(**kwargs):
         build ranges *start*-*start+1* instead.
     series : list or str
         [*min/max/inc*\[**+b**\|\ **l**\|\ **n**]\|\ *file*\|\ *list*].
-        Defines the range of the new CPT by giving the lowest and highest
+        Define the range of the new CPT by giving the lowest and highest
         z-value (and optionally an interval). If this is not given, the
         existing range in the master CPT will be used intact. The values
         produced defines the color slice boundaries.  If **+n** is used it

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -217,10 +217,10 @@ def meca(
         attributes [Default is ``"0.25p"``].
     compressionfill : str
         Set color or pattern for filling compressive quadrants
-        [Default is black].
+        [Default is ``"black"``].
     extensionfill : str
         Set color or pattern for filling extensive quadrants
-        [Default is white].
+        [Default is ``"white"``].
     pen : str
         Set pen attributes for outline of beachball
         [Default is ``"0.25p,black,solid"``].

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -157,7 +157,7 @@ def meca(
           ``convention`` is not needed and is ignored if specified.
 
     scale : str
-        Adjusts the scaling of the radius of the beachball, which is
+        Adjust the scaling of the radius of the beachball, which is
         proportional to the magnitude. *scale* defines the size for
         magnitude = 5 (i.e. scalar seismic moment M0 = 4.0E23 dynes-cm).
     convention : str
@@ -204,7 +204,7 @@ def meca(
         or pd.DataFrame.
     offset : bool or str
         [**+p**\ *pen*][**+s**\ *size*].
-        Offsets beachball(s) to longitude(s) and latitude(s) specified in the
+        Offset beachball(s) to longitude(s) and latitude(s) specified in the
         the last two columns of the input file or array, or by
         ``plot_longitude`` and ``plot_latitude`` if provided. A small circle
         is plotted at the initial location and a line connects the beachball
@@ -212,7 +212,7 @@ def meca(
         [Default is no circle]. Use **+p**\ *pen* to set the line pen
         attributes [Default is 0.25p].
     no_clip : bool
-        Does NOT skip symbols that fall outside frame boundary specified by
+        Do NOT skip symbols that fall outside frame boundary specified by
         ``region`` [Default is False, i.e. plot symbols inside map frame only].
     {projection}
     {region}

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -231,9 +231,9 @@ def meca(
         determined by the z-value (i.e., event depth or the third column for
         an input file).
     no_clip : bool
-        Do NOT skip symbols that fall outside frame boundary specified by
-        ``region`` [Default is ``False``, i.e., plot symbols inside map
-        frame only].
+        Do **not** skip symbols that fall outside the frame boundaries
+        [Default is ``False``, i.e., plot symbols inside the frame
+        boundaries only].
     {projection}
     {region}
     {frame}

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -214,7 +214,7 @@ def meca(
         is plotted at the initial location and a line connects the beachball
         to the circle. Use **+s**\ *size* to set the diameter of the circle
         [Default is no circle]. Use **+p**\ *pen* to set the line pen
-        attributes [Default is 0.25p].
+        attributes [Default is ``"0.25p"``].
     compressionfill : str
         Set color or pattern for filling compressive quadrants
         [Default is black].
@@ -232,7 +232,8 @@ def meca(
         an input file).
     no_clip : bool
         Do NOT skip symbols that fall outside frame boundary specified by
-        ``region`` [Default is False, i.e. plot symbols inside map frame only].
+        ``region`` [Default is ``False``, i.e., plot symbols inside map
+        frame only].
     {projection}
     {region}
     {frame}

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -89,7 +89,7 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
     {region}
 
     search_radius : str
-        Sets the search radius that determines which data points are considered
+        Set the search radius that determines which data points are considered
         close to a node.
 
     outgrid : str

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -168,8 +168,9 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
         :gmt-docs:`plot.html#l`.
     no_clip : bool or str
         [**c**\|\ **r**].
-        Do NOT clip symbols that fall outside map border [Default plots
-        points whose coordinates are strictly inside the map border only].
+        Do **not** clip symbols that fall outside the frame boundaries
+        [Default plots points whose coordinates are strictly inside the
+        frame boundaries only].
         The parameter does not apply to lines and polygons which are always
         clipped to the map region. For periodic (360-longitude) maps we
         must plot all symbols twice in case they are clipped by the

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -139,7 +139,7 @@ def plot3d(
         [Default plots points whose coordinates are strictly inside the
         frame boundaries only].
         This parameter does not apply to lines and polygons which are always
-        clipped to the map region. For periodic (360-longitude) maps we
+        clipped to the map region. For periodic (360° longitude) maps we
         must plot all symbols twice in case they are clipped by the
         repeating boundary. ``no_clip=True`` will turn off clipping and not
         plot repeating symbols. Use ``no_clip="r"`` to turn off clipping

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -135,8 +135,9 @@ def plot3d(
         :gmt-docs:`plot3d.html#l`.
     no_clip : bool or str
         [**c**\|\ **r**].
-        Do NOT clip symbols that fall outside map border [Default plots
-        points whose coordinates are strictly inside the map border only].
+        Do **not** clip symbols that fall outside the frame boundaries
+        [Default plots points whose coordinates are strictly inside the
+        frame boundaries only].
         This parameter does not apply to lines and polygons which are always
         clipped to the map region. For periodic (360-longitude) maps we
         must plot all symbols twice in case they are clipped by the

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -86,7 +86,7 @@ def plot3d(
         z, fill, and size, respectively.
     x/y/z : float or 1-D arrays
         The x, y, and z coordinates, or arrays of x, y and z coordinates of
-        the data points
+        the data points.
     size : 1-D array
         The size of the data points in units specified in ``style``.
         Only valid if using ``x``/``y``/``z``.

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -79,7 +79,7 @@ def rose(self, data=None, length=None, azimuth=None, **kwargs):
         values
 
     orientation : bool
-        Specifies that the input data are orientation data (i.e., have a
+        Specify that the input data are orientation data (i.e., have a
         180 degree ambiguity) instead of true 0-360 degree directions
         [Default is 0-360 degrees]. We compensate by counting each record
         twice: First as azimuth and second as azimuth +180. Ignored if
@@ -94,11 +94,11 @@ def rose(self, data=None, length=None, azimuth=None, **kwargs):
         half circle plot or (0, 360) for full circle.
 
     diameter : str
-         Sets the diameter of the rose diagram. If not given,
+         Set the diameter of the rose diagram. If not given,
          then we default to a diameter of 7.5 cm.
 
     sector : float or str
-         Gives the sector width in degrees for sector and rose diagram.
+         Give the sector width in degrees for sector and rose diagram.
          Default ``0`` means windrose diagram. Append **+r** to draw rose
          diagram instead of sector diagram (e.g. ``"10+r"``).
 
@@ -176,7 +176,7 @@ def rose(self, data=None, length=None, azimuth=None, **kwargs):
         individual directions using the supplied attributes.
 
     alpha : float or str
-        Sets the confidence level used to determine if the mean
+        Set the confidence level used to determine if the mean
         resultant is significant (i.e., Lord Rayleigh test for
         uniformity) [Default is ``alpha=0.05``]. **Note**: The
         critical values are approximated [Berens, 2009] and requires

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -75,7 +75,7 @@ def rose(self, data=None, length=None, azimuth=None, **kwargs):
 
     length/azimuth : float or 1-D arrays
         Length and azimuth values, or arrays of length and azimuth
-        values
+        values.
 
     orientation : bool
         Specify that the input data are orientation data (i.e., have a
@@ -87,7 +87,7 @@ def rose(self, data=None, length=None, azimuth=None, **kwargs):
     region : str or list
         *r0/r1/az0/az1* or [*r0*, *r1*, *az0*, *az1*].
         *Required if this is the first plot command*.
-        Specifies the ``region`` of interest in (*r*, *azimuth*) space.
+        Specify the ``region`` of interest in (*r*, *azimuth*) space.
         Here, *r0* is 0 and *r1* is the maximal length in units.
         For *az0* and *az1*, specify either (-90, 90) or (0, 180) for
         half circle plot or (0, 360) for full circle.

--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -84,7 +84,7 @@ def select(data=None, outfile=None, **kwargs):
         *gridmask*. Nodes that are outside are either NaN or zero.
     reverse : str
         [**cflrsz**].
-        Reverses the sense of the test for each of the criteria specified:
+        Reverse the sense of the test for each of the criteria specified:
 
         - **c** select records NOT inside any point's circle of influence.
         - **f** select records NOT inside any of the polygons.

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -146,7 +146,8 @@ def text_(
         Set the pen used to draw a rectangle around the text string
         (see ``clearance``) [Default is ``"0.25p,black,solid"``].
     no_clip : bool
-        Do NOT clip text at map boundaries [Default is with clip].
+        Do **not** clip text at the frame boundaries [Default is
+        ``False``].
     {verbose}
     {aspatial}
     {panel}

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -81,7 +81,7 @@ def text_(
         The x and y coordinates, or an array of x and y coordinates to plot
         the text.
     position : str
-        Sets reference point on the map for the text by using x, y
+        Set reference point on the map for the text by using x, y
         coordinates extracted from ``region`` instead of providing them
         through ``x``/``y``. Specify with a two-letter (order independent)
         code, chosen from:
@@ -134,7 +134,7 @@ def text_(
         Set color for filling text boxes [Default is no fill].
     offset : str
         [**j**\|\ **J**]\ *dx*\[/*dy*][**+v**\[*pen*]].
-        Offsets the text from the projected (x, y) point by *dx*/\ *dy*
+        Offset the text from the projected (x, y) point by *dx*/\ *dy*
         [Default is ``"0/0"``].
         If *dy* is not specified then it is set equal to *dx*. Use **j** to
         offset the text away from the point instead (i.e., the text
@@ -144,7 +144,7 @@ def text_(
         point to the shifted point; append a pen to change the attributes
         for this line.
     pen : str
-        Sets the pen used to draw a rectangle around the text string
+        Set the pen used to draw a rectangle around the text string
         (see ``clearance``) [Default is ``"0.25p,black,solid"``].
     no_clip : bool
         Do NOT clip text at map boundaries [Default is with clip].

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -100,7 +100,7 @@ class triangulate:  # pylint: disable=invalid-name
             The name of the output ASCII file to store the results of the
             histogram equalization in.
         output_type: str
-            Determines the output type. Use "file", "xarray", "pandas", or
+            Determine the output type. Use "file", "xarray", "pandas", or
             "numpy".
         {verbose}
         {binary}

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -212,9 +212,10 @@ def velo(self, data=None, **kwargs):
         ``cmap``). If instead modifier **+cf** is appended then the color from
         the cpt file is applied to error fill only [Default]. Use just **+c**
         to set both pen and fill color.
-    no_clip: bool or str
-        Do NOT skip symbols that fall outside the frame boundary specified
-        by ``region`` [Default plots symbols inside frame only].
+    no_clip: bool
+        Do **not** skip symbols that fall outside the frame boundaries
+        [Default is ``False``, i.e., plot symbols inside the frame
+        boundaries only].
     {verbose}
     pen : str
         [*pen*][**+c**\ [**f**\|\ **l**]].

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -72,7 +72,7 @@ def velo(self, data=None, **kwargs):
         :class:`pandas.DataFrame` inputs.
 
     spec: str
-        Selects the meaning of the columns in the data file and the figure to
+        Select the meaning of the columns in the data file and the figure to
         be plotted. In all cases, the scales are in data units per length unit
         and sizes are in length units (default length unit is controlled by
         :gmt-term:`PROJ_LENGTH_UNIT` unless **c**, **i**, or **p** is
@@ -172,7 +172,7 @@ def velo(self, data=None, **kwargs):
     {frame}
     {cmap}
     rescale : str
-        can be used to rescale the uncertainties of velocities (``spec="e"``
+        Can be used to rescale the uncertainties of velocities (``spec="e"``
         and ``spec="r"``) and rotations (``spec="w"``). Can be combined with
         the ``confidence`` variable.
     uncertaintyfill : str

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -67,7 +67,7 @@ def wiggle(
     {projection}
     {region}
     scale : str or float
-        Gives anomaly scale in data-units/distance-unit. Append **c**, **i**,
+        Give anomaly scale in data-units/distance-unit. Append **c**, **i**,
         or **p** to indicate the distance unit (centimeters, inches, or
         points); if no unit is given we use the default unit that is
         controlled by :gmt-term:`PROJ_LENGTH_UNIT`.
@@ -76,7 +76,7 @@ def wiggle(
         [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\
         **+w**\ *length*\ [**+j**\ *justify*]\ [**+al**\|\ **r**]\
         [**+o**\ *dx*\ [/*dy*]][**+l**\ [*label*]].
-        Defines the reference point on the map for the vertical scale bar.
+        Define the reference point on the map for the vertical scale bar.
     fillpositive : str
         Set color or pattern for filling positive wiggles
         [Default is no fill].

--- a/pygmt/src/x2sys_init.py
+++ b/pygmt/src/x2sys_init.py
@@ -60,13 +60,13 @@ def x2sys_init(tag, **kwargs):
         - **geoz** (same, with one z-column).
 
     suffix : str
-        Specifies the file extension (suffix) for these data files. If not
+        Specify the file extension (suffix) for these data files. If not
         given we use the format definition file prefix as the suffix (see
         ``fmtfile``).
 
     discontinuity : str
         **d**\|\ **g**.
-        Selects geographical coordinates. Append **d** for discontinuity at the
+        Select geographical coordinates. Append **d** for discontinuity at the
         Dateline (makes longitude go from -180 to +180) or **g** for
         discontinuity at Greenwich (makes longitude go from 0 to 360
         [Default]). If not given we assume the data are Cartesian.
@@ -80,7 +80,7 @@ def x2sys_init(tag, **kwargs):
 
     units : str or list
         **d**\|\ **s**\ *unit*.
-        Sets the units used for distance and speed when requested by other
+        Set the units used for distance and speed when requested by other
         programs. Append **d** for distance or **s** for speed, then give the
         desired *unit* as:
 

--- a/pygmt/src/x2sys_init.py
+++ b/pygmt/src/x2sys_init.py
@@ -67,8 +67,8 @@ def x2sys_init(tag, **kwargs):
     discontinuity : str
         **d**\|\ **g**.
         Select geographical coordinates. Append **d** for discontinuity at the
-        Dateline (makes longitude go from -180 to +180) or **g** for
-        discontinuity at Greenwich (makes longitude go from 0 to 360
+        Dateline (makes longitude go from -180° to +180°) or **g** for
+        discontinuity at Greenwich (makes longitude go from 0° to 360°
         [Default]). If not given we assume the data are Cartesian.
 
     spacing : str or list


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to use more consistently the "general" verb form in the docstrings.

Fixes: https://github.com/GenericMappingTools/pygmt/pull/2345#discussion_r1110977228
Related to GMT upstream documentation: https://github.com/GenericMappingTools/gmt/commit/a57fd6c2f5b16c7fcaaaaa4b806233d19f0cd75b, https://github.com/GenericMappingTools/gmt/commit/8256073836925692451f5ece92e2cb81ec7fad26

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
