### PR TITLE
Revise the notes about registration and gtype of remote datasets

### DIFF
--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -60,7 +60,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
     However, these properties may be lost after specific grid operations and
     need to be set manually before further passed to PyGMT functions.
-    Refer to :class:pygmt.GMTDataArrayAccessor for detailed explanations and
+    Refer to :class:`pygmt.GMTDataArrayAccessor` for detailed explanations and
     workarounds.
 
     Examples

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -58,9 +58,10 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     The registration and coordinate system type of the returned
     :class:`xarray.DataArray` grids can be accessed via the GMT accessors
     (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
-    However, these properties may be lost after specific grid operations and
-    need to be set manually before passing the grid further to PyGMT functions.
-    Refer to :class:`pygmt.GMTDataArrayAccessor` for detailed explanations and
+    However, these properties may be lost after specific grid operations (such
+    as slicing) and will need to be manually set before passing the grid to any
+    PyGMT data processing or plotting functions. Refer to
+    :class:`pygmt.GMTDataArrayAccessor` for detailed explanations and
     workarounds.
 
     Examples

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -55,7 +55,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     Note
     ----
     The registration and coordinate system type of the returned
-    :class:`xarray.DataArray` grids can be accessed via the GMT accessors
+    :class:`xarray.DataArray` grid can be accessed via the GMT accessors
     (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
     However, these properties may be lost after specific grid operations (such
     as slicing) and will need to be manually set before passing the grid to any

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -56,7 +56,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     ----
 
     The registration and coordinate system type of the returned
-    :class:`xarray.DataArray` grids can be accessed by the GMT accessors
+    :class:`xarray.DataArray` grids can be accessed via the GMT accessors
     (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
     However, these properties may be lost after specific grid operations and
     need to be set manually before passing the grid further to PyGMT functions.

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -59,7 +59,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     :class:`xarray.DataArray` grids can be accessed by the GMT accessors
     (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
     However, these properties may be lost after specific grid operations and
-    need to be set manually before being passed further to PyGMT functions.
+    need to be set manually before passing the grid further to PyGMT functions.
     Refer to :class:`pygmt.GMTDataArrayAccessor` for detailed explanations and
     workarounds.
 

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -54,9 +54,14 @@ def load_earth_age(resolution="01d", region=None, registration=None):
 
     Note
     ----
-    The :class:`xarray.DataArray` grid doesn't support slice operation, for
-    Earth seafloor crustal age with resolutions of 5 arc-minutes or higher,
-    which are stored as smaller tiles.
+
+    The registration and coordinate system type of the returned
+    :class:`xarray.DataArray` grids can be accessed by the GMT accessors
+    (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
+    However, these properties may be lost after specific grid operations and
+    need to be set manually before further passed to PyGMT functions.
+    Refer to :class:pygmt.GMTDataArrayAccessor for detailed explanations and
+    workarounds.
 
     Examples
     --------

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -54,7 +54,6 @@ def load_earth_age(resolution="01d", region=None, registration=None):
 
     Note
     ----
-
     The registration and coordinate system type of the returned
     :class:`xarray.DataArray` grids can be accessed via the GMT accessors
     (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -59,7 +59,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     :class:`xarray.DataArray` grids can be accessed by the GMT accessors
     (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
     However, these properties may be lost after specific grid operations and
-    need to be set manually before further passed to PyGMT functions.
+    need to be set manually before being passed further to PyGMT functions.
     Refer to :class:`pygmt.GMTDataArrayAccessor` for detailed explanations and
     workarounds.
 

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -55,9 +55,14 @@ def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None
 
     Note
     ----
-    The :class:`xarray.DataArray` grid doesn't support slice operation, for
-    Earth free-air anomaly with resolutions of 5 arc-minutes or higher,
-    which are stored as smaller tiles.
+    The registration and coordinate system type of the returned
+    :class:`xarray.DataArray` grid can be accessed via the GMT accessors
+    (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
+    However, these properties may be lost after specific grid operations (such
+    as slicing) and will need to be manually set before passing the grid to any
+    PyGMT data processing or plotting functions. Refer to
+    :class:`pygmt.GMTDataArrayAccessor` for detailed explanations and
+    workarounds.
 
     Examples
     --------

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -54,9 +54,14 @@ def load_earth_geoid(resolution="01d", region=None, registration=None):
 
     Note
     ----
-    The :class:`xarray.DataArray` grid doesn't support slice operation, for
-    Earth geoid grids with resolutions of 5 arc-minutes or higher,
-    which are stored as smaller tiles.
+    The registration and coordinate system type of the returned
+    :class:`xarray.DataArray` grid can be accessed via the GMT accessors
+    (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
+    However, these properties may be lost after specific grid operations (such
+    as slicing) and will need to be manually set before passing the grid to any
+    PyGMT data processing or plotting functions. Refer to
+    :class:`pygmt.GMTDataArrayAccessor` for detailed explanations and
+    workarounds.
 
     Examples
     --------

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -79,9 +79,14 @@ def load_earth_magnetic_anomaly(
 
     Note
     ----
-    The :class:`xarray.DataArray` grid doesn't support slice operation, for
-    Earth magnetic anomaly with resolutions of 5 arc-minutes or higher,
-    which are stored as smaller tiles.
+    The registration and coordinate system type of the returned
+    :class:`xarray.DataArray` grid can be accessed via the GMT accessors
+    (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
+    However, these properties may be lost after specific grid operations (such
+    as slicing) and will need to be manually set before passing the grid to any
+    PyGMT data processing or plotting functions. Refer to
+    :class:`pygmt.GMTDataArrayAccessor` for detailed explanations and
+    workarounds.
 
     Examples
     --------

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -58,6 +58,17 @@ def load_earth_mask(resolution="01d", region=None, registration=None):
         - 4: Smaller lakes in islands that are found within lakes
           inside the land area
 
+    Note
+    ----
+    The registration and coordinate system type of the returned
+    :class:`xarray.DataArray` grid can be accessed via the GMT accessors
+    (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
+    However, these properties may be lost after specific grid operations (such
+    as slicing) and will need to be manually set before passing the grid to any
+    PyGMT data processing or plotting functions. Refer to
+    :class:`pygmt.GMTDataArrayAccessor` for detailed explanations and
+    workarounds.
+
     Examples
     --------
 

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -92,9 +92,14 @@ def load_earth_relief(
 
     Note
     ----
-    The :class:`xarray.DataArray` grid doesn't support slice operation, for
-    Earth relief data with resolutions of 5 arc-minutes or higher, which are
-    stored as smaller tiles.
+    The registration and coordinate system type of the returned
+    :class:`xarray.DataArray` grid can be accessed via the GMT accessors
+    (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
+    However, these properties may be lost after specific grid operations (such
+    as slicing) and will need to be manually set before passing the grid to any
+    PyGMT data processing or plotting functions. Refer to
+    :class:`pygmt.GMTDataArrayAccessor` for detailed explanations and
+    workarounds.
 
     Examples
     --------

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -56,9 +56,14 @@ def load_earth_vertical_gravity_gradient(
 
     Note
     ----
-    The :class:`xarray.DataArray` grid doesn't support slice operation, for
-    Earth vertical gravity gradient grids with resolutions of 5 arc-minutes or
-    higher, which are stored as smaller tiles.
+    The registration and coordinate system type of the returned
+    :class:`xarray.DataArray` grid can be accessed via the GMT accessors
+    (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
+    However, these properties may be lost after specific grid operations (such
+    as slicing) and will need to be manually set before passing the grid to any
+    PyGMT data processing or plotting functions. Refer to
+    :class:`pygmt.GMTDataArrayAccessor` for detailed explanations and
+    workarounds.
 
     Examples
     --------


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/GenericMappingTools/pygmt/issues/2378 for context.

**Preview**: https://pygmt-dev--2384.org.readthedocs.build/en/2384/api/generated/pygmt.datasets.load_earth_age.html


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #2378


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
