### PR TITLE
NEP29: Set minimum required version to NumPy 1.21+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -261,7 +261,7 @@ Compatibility with GMT/Python/NumPy versions
       - `Dev Documentation <https://www.pygmt.org/dev>`_ (reflects `main branch <https://github.com/GenericMappingTools/pygmt>`_)
       - >=6.3.0
       - >=3.8
-      - >=1.20
+      - >=1.21
     * - `v0.8.0 <https://github.com/GenericMappingTools/pygmt/releases/tag/v0.8.0>`_ (latest release)
       - `v0.8.0 Documentation <https://www.pygmt.org/v0.8.0>`_
       - >=6.3.0

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -6,7 +6,7 @@ dependencies:
     # Required dependencies
     - pip
     - gmt=6.4.0
-    - numpy>=1.20
+    - numpy>=1.21
     - pandas
     - xarray
     - netCDF4

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -97,7 +97,7 @@ Dependencies
 
 PyGMT requires the following libraries to be installed:
 
-* `numpy <https://numpy.org>`__ (>= 1.20)
+* `numpy <https://numpy.org>`__ (>= 1.21)
 * `pandas <https://pandas.pydata.org>`__
 * `xarray <https://xarray.dev/>`__
 * `netCDF4 <https://unidata.github.io/netcdf4-python>`__

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
     # Required dependencies
     - pip
     - gmt=6.4.0
-    - numpy>=1.20
+    - numpy>=1.21
     - pandas
     - xarray
     - netCDF4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
 ]
 dependencies = [
-    "numpy>=1.20",
+    "numpy>=1.21",
     "pandas",
     "xarray",
     "netCDF4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Required packages
-numpy>=1.20
+numpy>=1.21
 pandas
 xarray
 netCDF4


### PR DESCRIPTION
**Description of proposed changes**

Following NEP29 policy where NumPy 1.20 is to be dropped on or after 31 January 2023 (in a minor version increment, i.e. for PyGMT v0.9.0). Bumps minimum supported NumPy version to 1.21 in the pyproject.toml, requirements.txt and environment.yml files. Also update installation documentation to mention NumPy 1.21+ requirement.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This is in line with PyGMT's policy on [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule) at https://www.pygmt.org/v0.8.0/maintenance.html#dependencies-policy, xref https://github.com/GenericMappingTools/pygmt/pull/1074.

Note that CI tests already run on NumPy 1.21 since #2057.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Supersedes #1985.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
