### PR TITLE
Fix typos in docs of "pygmt.Figure.colorbar"

### DIFF
--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -89,7 +89,7 @@ def colorbar(self, **kwargs):
         to *zlo* and *zhi*. If one of these equal NaN then we leave that end of
         the CPT alone. The truncation takes place before the plotting.
     scale : float
-        Multiply all z-values in the CPT by the provided scale. By default
+        Multiply all z-values in the CPT by the provided scale. By default,
         the CPT is used as is.
     shading : str or list or bool
         Add illumination effects. Passing a single numerical value sets the

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -27,9 +27,9 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
 )
 def colorbar(self, **kwargs):
     r"""
-    Plot a gray or color scale-bar on maps.
+    Plot colormaps on figures.
 
-    Both horizontal and vertical scales are supported. For CPTs with
+    Both horizontal and vertical colorbars are supported. For CPTs with
     gradational colors (i.e., the lower and upper boundary of an interval
     have different colors) we will interpolate to give a continuous scale.
     Variations in intensity due to shading/illumination may be displayed by
@@ -44,7 +44,7 @@ def colorbar(self, **kwargs):
     Parameters
     ----------
     frame : str or list
-        Set color bar boundary frame, labels, and axes attributes.
+        Set colorbar boundary frame, labels, and axes attributes.
     {cmap}
     position : str
         [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\
@@ -59,7 +59,7 @@ def colorbar(self, **kwargs):
         (3) use **n** for normalized (0-1) coordinates, or (4) use **x** for
         plot coordinates (inches, cm, etc.). All but **x** requires both
         ``region`` and ``projection`` to be specified. Append **+w** followed
-        by the length and width of the color bar. If width is not specified
+        by the length and width of the colorbar. If width is not specified
         then it is set to 4% of the given length. Give a negative length to
         reverse the scale bar. Append **+h** to get a horizontal scale
         [Default is vertical (**+v**)]. By default, the anchor point on the

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -82,7 +82,7 @@ def colorbar(self, **kwargs):
         this radius by appending another value. Finally, append **+s** to draw
         an offset background shaded region. Here, *dx/dy* indicates the shift
         relative to the foreground frame [4p/-4p] and shade sets the fill
-        style to use for shading [Default is gray50].
+        style to use for shading [Default is ``"gray50"``].
     truncate : list or str
         *zlo*/*zhi*.
         Truncate the incoming CPT so that the lowest and highest z-levels are

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -71,7 +71,7 @@ def colorbar(self, **kwargs):
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
         If set to ``True``, draws a rectangular border around the color scale.
         Alternatively, specify a different pen with **+p**\ *pen*. Add
-        **+g**\ *fill* to fill the scale panel [default is no fill]. Append
+        **+g**\ *fill* to fill the scale panel [Default is no fill]. Append
         **+c**\ *clearance* where *clearance* is either gap, xgap/ygap, or
         lgap/rgap/bgap/tgap where these items are uniform, separate in x- and
         y-direction, or individual side spacings between scale and border.
@@ -82,7 +82,7 @@ def colorbar(self, **kwargs):
         this radius by appending another value. Finally, append **+s** to draw
         an offset background shaded region. Here, *dx/dy* indicates the shift
         relative to the foreground frame [4p/-4p] and shade sets the fill
-        style to use for shading [default is gray50].
+        style to use for shading [Default is gray50].
     truncate : list or str
         *zlo*/*zhi*.
         Truncate the incoming CPT so that the lowest and highest z-levels are

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -27,7 +27,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
 )
 def colorbar(self, **kwargs):
     r"""
-    Plot colormaps on figures.
+    Plot colorbars on figures.
 
     Both horizontal and vertical colorbars are supported. For CPTs with
     gradational colors (i.e., the lower and upper boundary of an interval


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a few typos in the documentation of `pygmt.Figure.colorbar`.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
