### PR TITLE
Fix bug with different band dtype from load_tile_map by casting to uint8

### DIFF
--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -94,17 +94,18 @@ def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_ret
     >>> import contextily
     >>> from pygmt.datasets import load_tile_map
     >>> raster = load_tile_map(
-    ...     region=[103.60, 104.06, 1.22, 1.49],  # West, East, South, North
+    ...     region=[-180.0, 180.0, -90.0, 0.0],  # West, East, South, North
+    ...     zoom=1,  # less detailed zoom level
     ...     source=contextily.providers.Stamen.TerrainBackground,
     ...     lonlat=True,  # bounding box coordinates are longitude/latitude
     ... )
     >>> raster.sizes
-    Frozen({'band': 3, 'y': 1024, 'x': 1536})
+    Frozen({'band': 3, 'y': 256, 'x': 512})
     >>> raster.coords
     Coordinates:
       * band     (band) uint8 0 1 2
-      * y        (y) float64 1.663e+05 1.663e+05 1.663e+05 ... 1.272e+05 ...
-      * x        (x) float64 1.153e+07 1.153e+07 1.153e+07 ... 1.158e+07 ...
+      * y        (y) float64 -7.081e-10 -7.858e+04 ... -1.996e+07 -2.004e+07
+      * x        (x) float64 -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
     """
     # pylint: disable=too-many-locals
     if contextily is None:

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -102,7 +102,7 @@ def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_ret
     Frozen({'band': 3, 'y': 1024, 'x': 1536})
     >>> raster.coords
     Coordinates:
-      * band     (band) int64 0 1 2
+      * band     (band) uint8 0 1 2
       * y        (y) float64 1.663e+05 1.663e+05 1.663e+05 ... 1.272e+05 ...
       * x        (x) float64 1.153e+07 1.153e+07 1.153e+07 ... 1.158e+07 ...
     """
@@ -137,7 +137,7 @@ def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_ret
     dataarray = xr.DataArray(
         data=rgb_image,
         coords={
-            "band": [0, 1, 2],  # Red, Green, Blue
+            "band": np.uint8([0, 1, 2]),  # Red, Green, Blue
             "y": np.linspace(start=top, stop=bottom, num=rgb_image.shape[1]),
             "x": np.linspace(start=left, stop=right, num=rgb_image.shape[2]),
         },


### PR DESCRIPTION
**Description of proposed changes**

The band list `[0, 1, 2]` was being converted to int32 on Windows + NumPy 1.24, but is int64 on other platforms. Casting the band coordinate explicitly to `uint8` for consistency.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Patches bug in #2125 as reported in https://github.com/GenericMappingTools/pygmt/pull/2125#issuecomment-1453006453


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
