### PR TITLE
Add Figure.tilemap to plot XYZ tile maps

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install dependencies
         run: |
           mamba install gmt=6.4.0 numpy pandas xarray netCDF4 packaging \
-                        build ipython make myst-parser contextily geopandas \
+                        build ipython make myst-parser contextily geopandas rioxarray \
                         sphinx sphinx-copybutton sphinx-design sphinx-gallery sphinx_rtd_theme
 
       # Show installed pkg information for postmortem diagnostic

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -47,7 +47,7 @@ jobs:
             optional-packages: ''
           - python-version: '3.11'
             numpy-version: '1.24'
-            optional-packages: 'contextily geopandas ipython'
+            optional-packages: 'contextily geopandas ipython rioxarray'
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -101,8 +101,9 @@ jobs:
                         geopandas ghostscript libnetcdf hdf5 zlib curl pcre make
           pip install --pre --prefer-binary \
                         numpy pandas xarray netCDF4 packaging \
-                        build contextily dvc ipython 'pytest>=6.0' pytest-cov \
-                        pytest-doctestplus pytest-mpl sphinx-gallery
+                        build contextily dvc ipython rioxarray \
+                        'pytest>=6.0' pytest-cov pytest-doctestplus pytest-mpl \
+                        sphinx-gallery
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -66,7 +66,7 @@ jobs:
         run: |
           mamba install gmt=${{ matrix.gmt_version }} numpy \
                         pandas xarray netCDF4 packaging \
-                        contextily geopandas ipython \
+                        contextily geopandas ipython rioxarray \
                         build dvc make 'pytest>=6.0' \
                         pytest-cov pytest-doctestplus pytest-mpl sphinx-gallery
 

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -14,6 +14,7 @@ dependencies:
     # Optional dependencies
     - contextily
     - geopandas
+    - rioxarray
     # Development dependencies (general)
     - build
     - ipython

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -62,6 +62,7 @@ Plotting raster data
     Figure.grdimage
     Figure.grdview
     Figure.image
+    Figure.tilemap
 
 Configuring layout
 ~~~~~~~~~~~~~~~~~~

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -60,6 +60,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "rasterio": ("https://rasterio.readthedocs.io/en/stable/", None),
+    "rioxarray": ("https://corteva.github.io/rioxarray/stable/", None),
     "xarray": ("https://docs.xarray.dev/en/stable/", None),
     "xyzservices": ("https://xyzservices.readthedocs.io/en/stable", None),
 }

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -108,6 +108,7 @@ The following are optional dependencies:
 * `IPython <https://ipython.org>`__: For embedding the figures in Jupyter notebooks (recommended).
 * `Contextily <https://contextily.readthedocs.io>`__: For retrieving tile maps from the internet.
 * `GeoPandas <https://geopandas.org>`__: For using and plotting GeoDataFrame objects.
+* `RioXarray <https://https://corteva.github.io/rioxarray>`__: For saving multi-band rasters to GeoTIFFs.
 
 Installing GMT and other dependencies
 -------------------------------------

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -108,7 +108,7 @@ The following are optional dependencies:
 * `IPython <https://ipython.org>`__: For embedding the figures in Jupyter notebooks (recommended).
 * `Contextily <https://contextily.readthedocs.io>`__: For retrieving tile maps from the internet.
 * `GeoPandas <https://geopandas.org>`__: For using and plotting GeoDataFrame objects.
-* `RioXarray <https://https://corteva.github.io/rioxarray>`__: For saving multi-band rasters to GeoTIFFs.
+* `RioXarray <https://corteva.github.io/rioxarray>`__: For saving multi-band rasters to GeoTIFFs.
 
 Installing GMT and other dependencies
 -------------------------------------

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
     - contextily
     - geopandas
     - ipython
+    - rioxarray
     # Development dependencies (general)
     - build
     - dvc

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -113,7 +113,7 @@ def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_ret
         raise ModuleNotFoundError(
             "Package `contextily` is required to be installed to use this function. "
             "Please use `pip install contextily` or "
-            "`conda install -c conda-forge contextily` "
+            "`mamba install -c conda-forge contextily` "
             "to install the package."
         )
 

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -103,9 +103,10 @@ def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_ret
     Frozen({'band': 3, 'y': 256, 'x': 512})
     >>> raster.coords
     Coordinates:
-      * band     (band) uint8 0 1 2
-      * y        (y) float64 -7.081e-10 -7.858e+04 ... -1.996e+07 -2.004e+07
-      * x        (x) float64 -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
+      * band         (band) uint8 0 1 2
+      * y            (y) float64 -7.081e-10 -7.858e+04 ... -1.996e+07 ...
+      * x            (x) float64 -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
+        spatial_ref  int64 0
     """
     # pylint: disable=too-many-locals
     if contextily is None:

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -106,7 +106,6 @@ def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_ret
       * band         (band) uint8 0 1 2
       * y            (y) float64 -7.081e-10 -7.858e+04 ... -1.996e+07 ...
       * x            (x) float64 -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
-        spatial_ref  int64 0
     """
     # pylint: disable=too-many-locals
     if contextily is None:
@@ -148,6 +147,6 @@ def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_ret
 
     # If rioxarray is installed, set the coordinate reference system
     if hasattr(dataarray, "rio"):
-        dataarray = dataarray.rio.write_crs(input_crs="EPSG:3857")
+        dataarray = dataarray.rio.set_crs(input_crs="EPSG:3857")
 
     return dataarray

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -518,6 +518,7 @@ class Figure:
         subplot,
         ternary,
         text,
+        tilemap,
         timestamp,
         velo,
         wiggle,

--- a/pygmt/src/__init__.py
+++ b/pygmt/src/__init__.py
@@ -51,6 +51,7 @@ from pygmt.src.subplot import set_panel, subplot
 from pygmt.src.surface import surface
 from pygmt.src.ternary import ternary
 from pygmt.src.text import text_ as text  # "text" is an argument within "text_"
+from pygmt.src.tilemap import tilemap
 from pygmt.src.timestamp import timestamp
 from pygmt.src.triangulate import triangulate
 from pygmt.src.velo import velo

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -120,17 +120,16 @@ def tilemap(
             "to install the package."
         )
 
+    raster = load_tile_map(
+        region=region,
+        zoom=zoom,
+        source=source,
+        lonlat=lonlat,
+        wait=wait,
+        max_retries=max_retries,
+    )
     with GMTTempFile(suffix=".tif") as tmpfile:
-        raster = load_tile_map(
-            region=region,
-            zoom=zoom,
-            source=source,
-            lonlat=lonlat,
-            wait=wait,
-            max_retries=max_retries,
-        )
         raster.rio.to_raster(raster_path=tmpfile.name)
-
         with Session() as lib:
             lib.call_module(
                 module="grdimage", args=build_arg_string(kwargs, infile=tmpfile.name)

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -142,9 +142,9 @@ def tilemap(
         raster = raster.rio.reproject(dst_crs="OGC:CRS84")
         raster.gmt.gtype = 1  # set to geographic type
 
-    # Only set region if no_clip is False, so that plot is clipped to exact
-    # bounding box region
-    if not kwargs.get("N"):
+    # Only set region if no_clip is None or False, so that plot is clipped to
+    # exact bounding box region
+    if kwargs.get("N") in [None, False]:
         kwargs["R"] = "/".join(str(coordinate) for coordinate in region)
 
     with GMTTempFile(suffix=".tif") as tmpfile:

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -115,7 +115,7 @@ def tilemap(
         raise ModuleNotFoundError(
             "Package `rioxarray` is required to be installed to use this function. "
             "Please use `pip install rioxarray` or "
-            "`conda install -c conda-forge rioxarray` "
+            "`mamba install -c conda-forge rioxarray` "
             "to install the package."
         )
 

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -43,12 +43,12 @@ def tilemap(
     :func:`pygmt.datasets.load_tile_map` into a georeferenced form, and plots
     the tiles as a basemap or overlay using :meth:`pygmt.Figure.grdimage`.
 
-    **Note**: By default, standard web map tiles served in a Web Mercator
+    **Note**: By default, standard web map tiles served in a Spherical Mercator
     (EPSG:3857) Cartesian format will be reprojected to a geographic coordinate
     reference system (OGC:WGS84) and plotted with longitude/latitude bounds
     when ``lonlat=True``. If reprojection is not desired, please set
-    ``lonlat=False`` and provide Web Mercator (EPSG:3857) coordinates to the
-    ``region`` parameter.
+    ``lonlat=False`` and provide Spherical Mercator (EPSG:3857) coordinates to
+    the ``region`` parameter.
 
     {aliases}
 
@@ -136,8 +136,8 @@ def tilemap(
         max_retries=max_retries,
     )
 
-    # Reproject raster from Web Mercator (EPSG:3857) to lonlat (OGC:CRS84) if
-    # bounding box region was provided in lonlat
+    # Reproject raster from Spherical Mercator (EPSG:3857) to
+    # lonlat (OGC:CRS84) if bounding box region was provided in lonlat
     if lonlat and raster.rio.crs == "EPSG:3857":
         raster = raster.rio.reproject(dst_crs="OGC:CRS84")
         raster.gmt.gtype = 1  # set to geographic type

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -43,6 +43,13 @@ def tilemap(
     :func:`pygmt.datasets.load_tile_map` into a georeferenced form, and plots
     the tiles as a basemap or overlay using :meth:`pygmt.Figure.grdimage`.
 
+    **Note**: By default, standard web map tiles served in a Web Mercator
+    (EPSG:3857) Cartesian format will be reprojected to a geographic coordinate
+    reference system (OGC:WGS84) and plotted with longitude/latitude bounds
+    when ``lonlat=True``. If reprojection is not desired, please set
+    ``lonlat=False`` and provide Web Mercator (EPSG:3857) coordinates to the
+    ``region`` parameter.
+
     {aliases}
 
     Parameters
@@ -128,6 +135,13 @@ def tilemap(
         wait=wait,
         max_retries=max_retries,
     )
+
+    # Reproject raster from Web Mercator (EPSG:3857) to lonlat (OGC:CRS84) if
+    # bounding box region was provided in lonlat
+    if lonlat and raster.rio.crs == "EPSG:3857":
+        raster = raster.rio.reproject(dst_crs="OGC:CRS84")
+        raster.gmt.gtype = 1  # set to geographic type
+
     with GMTTempFile(suffix=".tif") as tmpfile:
         raster.rio.to_raster(raster_path=tmpfile.name)
         with Session() as lib:

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -1,8 +1,8 @@
 """
 tilemap - Plot XYZ tile maps.
 """
-
 from pygmt.clib import Session
+from pygmt.datasets.tile_map import load_tile_map
 from pygmt.helpers import (
     GMTTempFile,
     build_arg_string,
@@ -116,8 +116,6 @@ def tilemap(
         :doc:`install instructions for rioxarray <rioxarray:installation>`,
         (e.g. via ``pip install rioxarray``) before using this function.
     """
-    from pygmt.datasets import load_tile_map  # pylint: disable=import-outside-toplevel
-
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
 
     if rioxarray is None:

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -112,7 +112,7 @@ def tilemap(
 
     Raises
     ------
-    ModuleNotFoundError
+    ImportError
         If ``rioxarray`` is not installed. Follow
         :doc:`install instructions for rioxarray <rioxarray:installation>`,
         (e.g. via ``pip install rioxarray``) before using this function.
@@ -120,7 +120,7 @@ def tilemap(
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
 
     if rioxarray is None:
-        raise ModuleNotFoundError(
+        raise ImportError(
             "Package `rioxarray` is required to be installed to use this function. "
             "Please use `pip install rioxarray` or "
             "`mamba install -c conda-forge rioxarray` "

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -39,7 +39,7 @@ def tilemap(
     r"""
     Plots an XYZ tile map.
 
-    This function loads XYZ tile maps from a tile server or local file using
+    This method loads XYZ tile maps from a tile server or local file using
     :func:`pygmt.datasets.load_tile_map` into a georeferenced form, and plots
     the tiles as a basemap or overlay using :meth:`pygmt.Figure.grdimage`.
 

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -1,0 +1,145 @@
+"""
+tilemap - Plot XYZ tile maps.
+"""
+
+from pygmt.clib import Session
+from pygmt.helpers import (
+    GMTTempFile,
+    build_arg_string,
+    fmt_docstring,
+    kwargs_to_strings,
+    use_alias,
+)
+
+try:
+    import rioxarray
+except ImportError:
+    rioxarray = None
+
+
+@fmt_docstring
+@use_alias(
+    A="img_out",
+    B="frame",
+    C="cmap",
+    D="img_in",
+    E="dpi",
+    G="bit_color",
+    I="shading",
+    J="projection",
+    M="monochrome",
+    N="no_clip",
+    Q="nan_transparent",
+    # R="region",
+    V="verbose",
+    n="interpolation",
+    c="panel",
+    f="coltypes",
+    p="perspective",
+    t="transparency",
+    x="cores",
+)
+@kwargs_to_strings(c="sequence_comma", p="sequence")  # R="sequence",
+def tilemap(
+    self, region, zoom="auto", source=None, lonlat=True, wait=0, max_retries=2, **kwargs
+):
+    r"""
+    Plots an XYZ tile map.
+
+    This is a wrapper around :func:`pygmt.datasets.load_tile_map` and
+    :meth:`pygmt.Figure.grdimage`.
+
+    {aliases}
+
+    Parameters
+    ----------
+    region : list
+        The bounding box of the map in the form of a list [*xmin*, *xmax*,
+        *ymin*, *ymax*]. These coordinates should be in longitude/latitude if
+        ``lonlat=True`` or Spherical Mercator (EPSG:3857) if ``lonlat=False``.
+
+    zoom : int or str
+        Optional. Level of detail. Higher levels (e.g. ``22``) mean a zoom
+        level closer to the Earth's surface, with more tiles covering a smaller
+        geographical area and thus more detail. Lower levels (e.g. ``0``) mean
+        a zoom level further from the Earth's surface, with less tiles covering
+        a larger geographical area and thus less detail [Default is
+        ``"auto"`` to automatically determine the zoom level based on the
+        bounding box region extent].
+
+        **Note**: The maximum possible zoom level may be smaller than ``22``,
+        and depends on what is supported by the chosen web tile provider
+        source.
+
+    source : xyzservices.TileProvider or str
+        Optional. The tile source: web tile provider or path to a local file.
+        Provide either:
+
+        - A web tile provider in the form of a
+          :class:`xyzservices.TileProvider` object. See
+          :doc:`Contextily providers <contextily:providers_deepdive>` for a
+          list of tile providers [Default is
+          ``xyzservices.providers.Stamen.Terrain``, i.e. Stamen Terrain web
+          tiles].
+        - A web tile provider in the form of a URL. The placeholders for the
+          XYZ in the URL need to be {{x}}, {{y}}, {{z}}, respectively. E.g.
+          ``https://{{s}}.tile.openstreetmap.org/{{z}}/{{x}}/{{y}}.png``.
+        - A local file path. The file is read with
+          :doc:`rasterio <rasterio:index>` and all bands are loaded into the
+          basemap. See
+          :doc:`contextily:working_with_local_files`.
+
+        IMPORTANT: Tiles are assumed to be in the Spherical Mercator projection
+        (EPSG:3857).
+
+    lonlat : bool
+        Optional. If ``False``, coordinates in ``region`` are assumed to be
+        Spherical Mercator as opposed to longitude/latitude [Default is
+        ``True``].
+
+    wait : int
+        Optional. If the tile API is rate-limited, the number of seconds to
+        wait between a failed request and the next try [Default is ``0``].
+
+    max_retries : int
+        Optional. Total number of rejected requests allowed before contextily
+        will stop trying to fetch more tiles from a rate-limited API [Default
+        is ``2``].
+
+    kwargs : dict
+        Extra keyword arguments to pass to :meth:`pygmt.Figure.grdimage`.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If ``rioxarray`` is not installed. Follow
+        :doc:`install instructions for rioxarray <rioxarray:installation>`,
+        (e.g. via ``pip install rioxarray``) before using this function.
+    """
+    from pygmt.datasets import load_tile_map  # pylint: disable=import-outside-toplevel
+
+    kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
+
+    if rioxarray is None:
+        raise ModuleNotFoundError(
+            "Package `rioxarray` is required to be installed to use this function. "
+            "Please use `pip install rioxarray` or "
+            "`conda install -c conda-forge rioxarray` "
+            "to install the package."
+        )
+
+    with GMTTempFile(suffix=".tif") as tmpfile:
+        raster = load_tile_map(
+            region=region,
+            zoom=zoom,
+            source=source,
+            lonlat=lonlat,
+            wait=wait,
+            max_retries=max_retries,
+        )
+        raster.rio.to_raster(raster_path=tmpfile.name)
+
+        with Session() as lib:
+            lib.call_module(
+                module="grdimage", args=build_arg_string(kwargs, infile=tmpfile.name)
+            )

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -39,8 +39,9 @@ def tilemap(
     r"""
     Plots an XYZ tile map.
 
-    This is a wrapper around :func:`pygmt.datasets.load_tile_map` and
-    :meth:`pygmt.Figure.grdimage`.
+    This function loads XYZ tile maps from a tile server or local file using
+    :func:`pygmt.datasets.load_tile_map` into a georeferenced form, and plots
+    the tiles as a basemap or overlay using :meth:`pygmt.Figure.grdimage`.
 
     {aliases}
 

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -142,6 +142,11 @@ def tilemap(
         raster = raster.rio.reproject(dst_crs="OGC:CRS84")
         raster.gmt.gtype = 1  # set to geographic type
 
+    # Only set region if no_clip is False, so that plot is clipped to exact
+    # bounding box region
+    if not kwargs.get("N"):
+        kwargs["R"] = "/".join(str(coordinate) for coordinate in region)
+
     with GMTTempFile(suffix=".tif") as tmpfile:
         raster.rio.to_raster(raster_path=tmpfile.name)
         with Session() as lib:

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -19,12 +19,8 @@ except ImportError:
 
 @fmt_docstring
 @use_alias(
-    A="img_out",
     B="frame",
-    C="cmap",
-    D="img_in",
     E="dpi",
-    G="bit_color",
     I="shading",
     J="projection",
     M="monochrome",
@@ -32,12 +28,9 @@ except ImportError:
     Q="nan_transparent",
     # R="region",
     V="verbose",
-    n="interpolation",
     c="panel",
-    f="coltypes",
     p="perspective",
     t="transparency",
-    x="cores",
 )
 @kwargs_to_strings(c="sequence_comma", p="sequence")  # R="sequence",
 def tilemap(

--- a/pygmt/tests/baseline/test_tilemap.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: c07e5f703941bd60a84bc109074dfb50
-  size: 181869
+- md5: ea1fc9d829e8534aed7dac825ea0ddff
+  size: 123201
   path: test_tilemap.png

--- a/pygmt/tests/baseline/test_tilemap.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap.png.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: c07e5f703941bd60a84bc109074dfb50
+  size: 181869
+  path: test_tilemap.png

--- a/pygmt/tests/baseline/test_tilemap_no_clip_False.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_no_clip_False.png.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 9317080021b0ce6f3b9ea6d17feece00
+  size: 23275
+  path: test_tilemap_no_clip_False.png

--- a/pygmt/tests/baseline/test_tilemap_no_clip_True.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_no_clip_True.png.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 83e6119b2351f9d472ca7e3cc45388c3
+  size: 60984
+  path: test_tilemap_no_clip_True.png

--- a/pygmt/tests/baseline/test_tilemap_ogc_wgs84.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_ogc_wgs84.png.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: cc40d807da1218cd440dd8655f5f57fb
+  size: 56875
+  path: test_tilemap_ogc_wgs84.png

--- a/pygmt/tests/baseline/test_tilemap_ogc_wgs84.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_ogc_wgs84.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: cc40d807da1218cd440dd8655f5f57fb
-  size: 56875
+- md5: 3de0555d86aca49b92425c8d5272a934
+  size: 59286
   path: test_tilemap_ogc_wgs84.png

--- a/pygmt/tests/baseline/test_tilemap_web_mercator.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_web_mercator.png.dvc
@@ -1,4 +1,4 @@
 outs:
 - md5: ea1fc9d829e8534aed7dac825ea0ddff
   size: 123201
-  path: test_tilemap.png
+  path: test_tilemap_web_mercator.png

--- a/pygmt/tests/baseline/test_tilemap_web_mercator.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_web_mercator.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: ea1fc9d829e8534aed7dac825ea0ddff
-  size: 123201
+- md5: a76d9a9a1890d6b1345305eaea598bc3
+  size: 122195
   path: test_tilemap_web_mercator.png

--- a/pygmt/tests/test_tilemap.py
+++ b/pygmt/tests/test_tilemap.py
@@ -14,5 +14,5 @@ def test_tilemap():
     Create a simple tilemap plot.
     """
     fig = Figure()
-    fig.tilemap(region=[-157.6, -157.1, 1.68, 2.08], frame="afg")
+    fig.tilemap(region=[-180.0, 180.0, -90, 90], zoom=0, frame="afg")
     return fig

--- a/pygmt/tests/test_tilemap.py
+++ b/pygmt/tests/test_tilemap.py
@@ -9,10 +9,32 @@ rioxarray = pytest.importorskip("rioxarray")
 
 
 @pytest.mark.mpl_image_compare
-def test_tilemap():
+def test_tilemap_web_mercator():
     """
-    Create a simple tilemap plot.
+    Create a tilemap plot in Web Mercator projection (EPSG:3857).
     """
     fig = Figure()
-    fig.tilemap(region=[-180.0, 180.0, -90, 90], zoom=0, frame="afg")
+    fig.tilemap(
+        region=[-20000000.0, 20000000.0, -20000000.0, 20000000.0],
+        zoom=0,
+        lonlat=False,
+        frame="afg",
+    )
+    return fig
+
+
+@pytest.mark.mpl_image_compare
+def test_tilemap_ogc_wgs84():
+    """
+    Create a tilemap plot using longitude/latitude coordinates (OGC:WGS84),
+    centred on the international date line.
+    """
+    fig = Figure()
+    fig.tilemap(
+        region=[-180.0, 180.0, -90, 90],
+        zoom=0,
+        frame="afg",
+        projection="R180/5c",
+        verbose=True,
+    )
     return fig

--- a/pygmt/tests/test_tilemap.py
+++ b/pygmt/tests/test_tilemap.py
@@ -1,0 +1,18 @@
+"""
+Tests Figure.tilemap.
+"""
+import pytest
+from pygmt import Figure
+
+contextily = pytest.importorskip("contextily")
+rioxarray = pytest.importorskip("rioxarray")
+
+
+@pytest.mark.mpl_image_compare
+def test_tilemap():
+    """
+    Create a simple tilemap plot.
+    """
+    fig = Figure()
+    fig.tilemap(region=[-157.6, -157.1, 1.68, 2.08], frame="afg")
+    return fig

--- a/pygmt/tests/test_tilemap.py
+++ b/pygmt/tests/test_tilemap.py
@@ -38,3 +38,21 @@ def test_tilemap_ogc_wgs84():
         verbose=True,
     )
     return fig
+
+
+@pytest.mark.mpl_image_compare
+@pytest.mark.parametrize("no_clip", [False, True])
+def test_tilemap_no_clip(no_clip):
+    """
+    Create a tilemap plot clipped to the Southern Hemisphere when no_clip is
+    False, but for the whole globe when no_clip is True.
+    """
+    fig = Figure()
+    fig.tilemap(
+        region=[-180.0, 180.0, -90, 0.6886],
+        zoom=0,
+        frame="afg",
+        projection="H180/5c",
+        no_clip=no_clip,
+    )
+    return fig

--- a/pygmt/tests/test_tilemap.py
+++ b/pygmt/tests/test_tilemap.py
@@ -11,7 +11,7 @@ rioxarray = pytest.importorskip("rioxarray")
 @pytest.mark.mpl_image_compare
 def test_tilemap_web_mercator():
     """
-    Create a tilemap plot in Web Mercator projection (EPSG:3857).
+    Create a tilemap plot in Spherical Mercator projection (EPSG:3857).
     """
     fig = Figure()
     fig.tilemap(
@@ -31,11 +31,7 @@ def test_tilemap_ogc_wgs84():
     """
     fig = Figure()
     fig.tilemap(
-        region=[-180.0, 180.0, -90, 90],
-        zoom=0,
-        frame="afg",
-        projection="R180/5c",
-        verbose=True,
+        region=[-180.0, 180.0, -90, 90], zoom=0, frame="afg", projection="R180/5c"
     )
     return fig
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ dynamic = ["version"]
 all = [
     "contextily",
     "geopandas",
-    "ipython"
+    "ipython",
+    "rioxarray"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "geophysics",
     "geospatial",
     "oceanography",
-    "seismology"
+    "seismology",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -36,7 +36,7 @@ dependencies = [
     "pandas",
     "xarray",
     "netCDF4",
-    "packaging"
+    "packaging",
 ]
 dynamic = ["version"]
 
@@ -45,7 +45,7 @@ all = [
     "contextily",
     "geopandas",
     "ipython",
-    "rioxarray"
+    "rioxarray",
 ]
 
 [project.urls]


### PR DESCRIPTION
**Description of proposed changes**

New `tilemap` function for plotting XYZ tile maps! This is essentially a convenience wrapper around `pygmt.datasets.load_tile_map` and `pygmt.Figure.grdimage`.

**Preview** at https://pygmt-dev--2394.org.readthedocs.build/en/2394/api/generated/pygmt.Figure.tilemap.html

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This is the second part of #2115 that takes the output xarray.DataArray from `pygmt.datasets.load_tile_map` (added in #2125) and plots it using `fig.grdimage`.

Usage:

```python
import contextily
import pygmt

fig = pygmt.Figure()
fig.tilemap(
    region=[-157.6, -157.1, 1.68, 2.08],  # West, East, South, North
    source=contextily.providers.Stamen.Watercolor,
    frame=True,
)
fig.show()
```
produces this watercolor map of Kiribati:

![Kiribati_watercolor_map](https://user-images.githubusercontent.com/23487320/227151990-3113bc7d-6068-4dcb-bffd-8281543ee09b.png)

Notes:
- `rioxarray` will be added as an optional dependency, as it is used for the `xarray.DataArray` to GeoTIFF conversion
- ~The implementation of `tilemap` is a little tricky due to cyclic import issues, please suggest if there are better ways~ fixed with https://github.com/GenericMappingTools/pygmt/pull/2394#discussion_r1125417904
- By default, a given `region` with lonlat coordinates will produce a map with lonlat (OGC:WGS84) coordinates that are distorted from the original Spherical Mercator (EPSG:3857) tiles, see https://github.com/GenericMappingTools/pygmt/pull/2394#issuecomment-1475939603
- The `region` parameter only accepts a list like `[lonmin, lonmax, latmin, latmax]`, which is different from other GMT/PyGMT functions that accept more types of `region` values, see https://github.com/GenericMappingTools/pygmt/pull/2394#discussion_r1125203009

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #2115


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [x] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
