### PR TITLE
Expand Colorbar gallery example for categorical data

### DIFF
--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -8,10 +8,10 @@ placement via the ``position`` parameter. The full list of color palette tables
 can be found at :gmt-docs:`cookbook/cpts.html`. You can set the ``position`` of
 the colorbar using the following options:
 
-- **j/J**: justified inside/outside the figure frame using any 2-character
+- **j/J**: placed inside/outside the figure frame using a 2-character
   combination of vertical (**T**\ op, **M**\ iddle, **B**\ ottom) and
   horizontal (**L**\ eft, **C**\ enter, **R**\ ight) alignment codes, e.g.
-  ``position="jTR"`` for top right.
+  ``position="jTR"`` for Top Right.
 - **g**: using map coordinates, e.g. ``position="g170/-45"`` for longitude
   170E, latitude 45S.
 - **x**: using paper coordinates, e.g. ``position="x5c/7c"`` for 5 cm, 7 cm
@@ -48,10 +48,9 @@ fig.colorbar(
 # Create a colorbar suitable for surface topography - oleron
 fig.colorbar(
     cmap="oleron",
-    # Colorbar position justified outside figure frame (J) at Middle Right
-    # (MR), offset (+o) by 1 cm horizontally and 0 cm vertically from anchor
-    # point, with a length/width (+w) of 7 cm by 0.5 cm and a box for NaN
-    # values (+n)
+    # Colorbar placed outside figure frame (J) at Middle Right (MR),
+    # offset (+o) by 1 cm horizontally and 0 cm vertically from anchor point,
+    # with a length/width (+w) of 7 cm by 0.5 cm and a box for NaN values (+n)
     position="JMR+o1c/0c+w7c/0.5c+n+mc",
     # Note that the label 'Elevation' is moved to the opposite side and plotted
     # vertically as a column of text using '+mc' in the position parameter
@@ -72,9 +71,9 @@ pygmt.makecpt(
 # Plot the colorbar
 fig.colorbar(
     cmap=True,  # Use colormap set up above
-    # Colorbar position justified inside figure frame (j) at Bottom Left (BL),
-    # offset (+o) by 0.5 cm horizontally and 0.8 cm vertically from anchor
-    # point, and plotted horizontally (+h)
+    # Colorbar placed inside figure frame (j) at Bottom Left (BL),
+    # offset (+o) by 0.5 cm horizontally and 0.8 cm vertically from anchor point,
+    # and plotted horizontally (+h)
     position="jBL+o0.5c/0.8c+h",
     box=True,
     # Divide colorbar into equal-sized rectangles

--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -8,7 +8,7 @@ placement via the ``position`` parameter. The full list of color palette tables
 can be found at :gmt-docs:`cookbook/cpts.html`. You can set the ``position`` of
 the colorbar using the following options:
 
-- **j/J**: placed inside/outside the figure frame using any 2-character
+- **j/J**: placed inside/outside the map frame using any 2-character
   combination of vertical (**T**\ op, **M**\ iddle, **B**\ ottom) and
   horizontal (**L**\ eft, **C**\ enter, **R**\ ight) alignment codes, e.g.
   ``position="jTR"`` for Top Right.
@@ -48,7 +48,7 @@ fig.colorbar(
 # Create a colorbar suitable for surface topography - oleron
 fig.colorbar(
     cmap="oleron",
-    # Colorbar placed outside figure frame (J) at Middle Right (MR),
+    # Colorbar placed outside map frame (J) at Middle Right (MR),
     # offset (+o) by 1 cm horizontally and 0 cm vertically from anchor point,
     # with a length/width (+w) of 7 cm by 0.5 cm and a box for NaN values (+n)
     position="JMR+o1c/0c+w7c/0.5c+n+mc",
@@ -71,7 +71,7 @@ pygmt.makecpt(
 # Plot the colorbar
 fig.colorbar(
     cmap=True,  # Use colormap set up above
-    # Colorbar placed inside figure frame (j) at Bottom Left (BL),
+    # Colorbar placed inside map frame (j) at Bottom Left (BL),
     # offset (+o) by 0.5 cm horizontally and 0.8 cm vertically from anchor
     # point, and plotted horizontally (+h)
     position="jBL+o0.5c/0.8c+h",

--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -21,6 +21,7 @@ the colorbar using the following options:
 Note that the anchor point defaults to the bottom left (**BL**). Append ``+h``
 to ``position`` to get a horizontal colorbar instead of a vertical one.
 """
+
 import pygmt
 
 fig = pygmt.Figure()

--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -58,4 +58,25 @@ fig.colorbar(
     scale=10,
 )
 
+# ============
+# Create a colorbar suitable for categorical data - hawaii
+# Set up the colormap
+pygmt.makecpt(
+    cmap="hawaii",
+    series=[0, 3, 1],
+    # comma-spearted string later used as annotations of the colorbar
+    color_model="+cclass A,class B,class C,class D",
+)
+# Plot the colorbar
+fig.colorbar(
+    cmap=True,  # use colormap set up above
+    # Colorbar position justified inside map frame (j) at Bottom Left (BL),
+    # offset (+o) by 0.5 cm horizontally and 0.8 cm vertically from anchor
+    # point, and plotted horizontally (+h)
+    position="jBL+o0.5c/0.8c+h",
+    box=True,
+    # Separate colorbar into equal-sized rectangles
+    equalsize=0.5,
+)
+
 fig.show()

--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -48,9 +48,10 @@ fig.colorbar(
 # Create a colorbar suitable for surface topography - oleron
 fig.colorbar(
     cmap="oleron",
-    # Colorbar position justified outside figure frame (J) at Middle Right (MR),
-    # offset (+o) by 1 cm horizontally and 0 cm vertically from anchor point,
-    # with a length/width (+w) of 7 cm by 0.5 cm and a box for NaN values (+n)
+    # Colorbar position justified outside figure frame (J) at Middle Right
+    # (MR), offset (+o) by 1 cm horizontally and 0 cm vertically from anchor
+    # point, with a length/width (+w) of 7 cm by 0.5 cm and a box for NaN
+    # values (+n)
     position="JMR+o1c/0c+w7c/0.5c+n+mc",
     # Note that the label 'Elevation' is moved to the opposite side and plotted
     # vertically as a column of text using '+mc' in the position parameter

--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -72,8 +72,8 @@ pygmt.makecpt(
 fig.colorbar(
     cmap=True,  # Use colormap set up above
     # Colorbar placed inside figure frame (j) at Bottom Left (BL),
-    # offset (+o) by 0.5 cm horizontally and 0.8 cm vertically from anchor point,
-    # and plotted horizontally (+h)
+    # offset (+o) by 0.5 cm horizontally and 0.8 cm vertically from anchor
+    # point, and plotted horizontally (+h)
     position="jBL+o0.5c/0.8c+h",
     box=True,
     # Divide colorbar into equal-sized rectangles

--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -8,7 +8,7 @@ placement via the ``position`` parameter. The full list of color palette tables
 can be found at :gmt-docs:`cookbook/cpts.html`. You can set the ``position`` of
 the colorbar using the following options:
 
-- **j/J**: justified inside/outside the map frame using any 2-character
+- **j/J**: justified inside/outside the figure frame using any 2-character
   combination of vertical (**T**\ op, **M**\ iddle, **B**\ ottom) and
   horizontal (**L**\ eft, **C**\ enter, **R**\ ight) alignment codes, e.g.
   ``position="jTR"`` for top right.
@@ -48,7 +48,7 @@ fig.colorbar(
 # Create a colorbar suitable for surface topography - oleron
 fig.colorbar(
     cmap="oleron",
-    # Colorbar position justified outside map frame (J) at Middle Right (MR),
+    # Colorbar position justified outside figure frame (J) at Middle Right (MR),
     # offset (+o) by 1 cm horizontally and 0 cm vertically from anchor point,
     # with a length/width (+w) of 7 cm by 0.5 cm and a box for NaN values (+n)
     position="JMR+o1c/0c+w7c/0.5c+n+mc",
@@ -71,7 +71,7 @@ pygmt.makecpt(
 # Plot the colorbar
 fig.colorbar(
     cmap=True,  # Use colormap set up above
-    # Colorbar position justified inside map frame (j) at Bottom Left (BL),
+    # Colorbar position justified inside figure frame (j) at Bottom Left (BL),
     # offset (+o) by 0.5 cm horizontally and 0.8 cm vertically from anchor
     # point, and plotted horizontally (+h)
     position="jBL+o0.5c/0.8c+h",

--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -8,7 +8,7 @@ placement via the ``position`` parameter. The full list of color palette tables
 can be found at :gmt-docs:`cookbook/cpts.html`. You can set the ``position`` of
 the colorbar using the following options:
 
-- **j/J**: placed inside/outside the figure frame using a 2-character
+- **j/J**: placed inside/outside the figure frame using any 2-character
   combination of vertical (**T**\ op, **M**\ iddle, **B**\ ottom) and
   horizontal (**L**\ eft, **C**\ enter, **R**\ ight) alignment codes, e.g.
   ``position="jTR"`` for Top Right.

--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -64,12 +64,12 @@ fig.colorbar(
 pygmt.makecpt(
     cmap="hawaii",
     series=[0, 3, 1],
-    # comma-spearted string later used as annotations of the colorbar
+    # Comma-separated string for the annotations of the colorbar
     color_model="+cclass A,class B,class C,class D",
 )
 # Plot the colorbar
 fig.colorbar(
-    cmap=True,  # use colormap set up above
+    cmap=True,  # Use colormap set up above
     # Colorbar position justified inside map frame (j) at Bottom Left (BL),
     # offset (+o) by 0.5 cm horizontally and 0.8 cm vertically from anchor
     # point, and plotted horizontally (+h)

--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -26,10 +26,12 @@ import pygmt
 fig = pygmt.Figure()
 fig.basemap(region=[0, 3, 6, 9], projection="x3c", frame=["af", "WSne+tColorbars"])
 
+# ============
 # Create a colorbar designed for seismic tomography - roma
 # Colorbar is placed at bottom center (BC) by default if no position is given
 fig.colorbar(cmap="roma", frame=["x+lVelocity", "y+lm/s"])
 
+# ============
 # Create a colorbar showing the scientific rainbow - batlow
 fig.colorbar(
     cmap="batlow",
@@ -41,6 +43,7 @@ fig.colorbar(
     scale=100,
 )
 
+# ============
 # Create a colorbar suitable for surface topography - oleron
 fig.colorbar(
     cmap="oleron",

--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -76,7 +76,7 @@ fig.colorbar(
     # point, and plotted horizontally (+h)
     position="jBL+o0.5c/0.8c+h",
     box=True,
-    # Separate colorbar into equal-sized rectangles
+    # Divide colorbar into equal-sized rectangles
     equalsize=0.5,
 )
 

--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -66,7 +66,7 @@ pygmt.makecpt(
     cmap="hawaii",
     series=[0, 3, 1],
     # Comma-separated string for the annotations of the colorbar
-    color_model="+cclass A,class B,class C,class D",
+    color_model="+cA,B,C,D",
 )
 # Plot the colorbar
 fig.colorbar(


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to extend the [Colorbar gallery example](https://www.pygmt.org/dev/gallery/embellishments/colorbar.html) to show a colorbar suitable for categorical data.

Related to: https://github.com/GenericMappingTools/pygmt/pull/2357#issuecomment-1432407386

Currently the modified output figure looks like:
![colorbar_gallery_equalsize](https://user-images.githubusercontent.com/94163266/224074101-d4f4cf2e-378a-4ffa-b759-75268acead83.png)

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
