### PR TITLE
Wrap GMT's standard data type GMT_GRID for grids

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -292,6 +292,7 @@ Python objects to and from GMT virtual files:
     clib.Session.virtualfile_in
     clib.Session.virtualfile_out
     clib.Session.virtualfile_to_dataset
+    clib.Session.virtualfile_to_grid
 
 Low level access (these are mostly used by the :mod:`pygmt.clib` package):
 

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -292,7 +292,7 @@ Python objects to and from GMT virtual files:
     clib.Session.virtualfile_in
     clib.Session.virtualfile_out
     clib.Session.virtualfile_to_dataset
-    clib.Session.virtualfile_to_grid
+    clib.Session.virtualfile_to_raster
 
 Low level access (these are mostly used by the :mod:`pygmt.clib` package):
 

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1958,7 +1958,7 @@ class Session:
         outgrid: str | None = None,
     ) -> xr.DataArray | None:
         """
-        Output a raster data stored in a virtual file to an :class:`xarray.DataArray`
+        Output raster data stored in a virtual file to an :class:`xarray.DataArray`
         object.
 
         The raster data can be a grid, an image or a cube.
@@ -1966,7 +1966,7 @@ class Session:
         Parameters
         ----------
         vfname
-            The virtual file name that stores the result grid.
+            The virtual file name that stores the result grid/image/cube.
         kind
             Type of the raster data. Valid values are ``"grid"``, ``"image"``,
             ``"cube"`` or ``None``. If ``None``, will inquire the data type from the

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1954,7 +1954,7 @@ class Session:
     def virtualfile_to_raster(
         self,
         vfname: str,
-        kind: Literal["grid", "image", "cube", None] = None,
+        kind: Literal["grid", "image", "cube", None] = "grid",
         outgrid: str | None = None,
     ) -> xr.DataArray | None:
         """

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1740,7 +1740,9 @@ class Session:
         return c_inquire_virtualfile(self.session_pointer, vfname.encode())
 
     def read_virtualfile(
-        self, vfname: str, kind: Literal["dataset", "grid", None] = None
+        self,
+        vfname: str,
+        kind: Literal["dataset", "grid", "image", "cube", None] = None,
     ):
         """
         Read data from a virtual file and optionally cast into a GMT data container.
@@ -1799,6 +1801,8 @@ class Session:
         # _GMT_DATASET).
         if kind is None:  # Return the ctypes void pointer
             return pointer
+        if kind in ["image", "cube"]:
+            raise NotImplementedError(f"kind={kind} is not supported yet.")
         dtype = {"dataset": _GMT_DATASET, "grid": _GMT_GRID}[kind]
         return ctp.cast(pointer, ctp.POINTER(dtype))
 
@@ -2004,7 +2008,7 @@ class Session:
             return None
         if kind is None:  # Inquire the data family from the virtualfile
             family = self.inquire_virtualfile(vfname)
-            kind = {
+            kind = {  # type: ignore[assignment]
                 self["GMT_IS_GRID"]: "grid",
                 self["GMT_IS_IMAGE"]: "image",
                 self["GMT_IS_CUBE"]: "cube",

--- a/pygmt/datatypes/grid.py
+++ b/pygmt/datatypes/grid.py
@@ -14,7 +14,7 @@ class _GMT_GRID(ctp.Structure):  # noqa: N801
     """
     GMT grid structure for holding a grid and its header.
 
-    The class is only meant for internal use and is not exposed to users. See the GMT
+    This class is only meant for internal use and is not exposed to users. See the GMT
     source code gmt_resources.h for the original C structure definitions.
 
     Examples
@@ -192,8 +192,8 @@ class _GMT_GRID(ctp.Structure):  # noqa: N801
             if grid[dim][0] > grid[dim][1]:
                 grid = grid.isel({dim: slice(None, None, -1)})
 
-        # Set the gmt accessor.
-        # Must put at the end. The information get lost after specific grid operation.
+        # Set GMT accessors.
+        # Must put at the end, otherwise info gets lost after certain grid operations.
         grid.gmt.registration = header.registration
         grid.gmt.gtype = header.gtype
         return grid

--- a/pygmt/datatypes/grid.py
+++ b/pygmt/datatypes/grid.py
@@ -3,7 +3,197 @@ Wrapper for the GMT_GRID data type.
 """
 
 import ctypes as ctp
+from typing import ClassVar
+
+import numpy as np
+import xarray as xr
+from pygmt.datatypes.header import _GMT_GRID_HEADER, gmt_grdfloat
 
 
 class _GMT_GRID(ctp.Structure):  # noqa: N801
-    pass
+    """
+    GMT grid structure for holding a grid and its header.
+
+    The class is only meant for internal use and is not exposed to users. See the GMT
+    source code gmt_resources.h for the original C structure definitions.
+
+    Examples
+    --------
+    >>> from pygmt.clib import Session
+    >>> with Session() as lib:
+    ...     with lib.virtualfile_out(kind="grid") as voutgrd:
+    ...         lib.call_module("read", f"@static_earth_relief.nc {voutgrd} -Tg")
+    ...         # Read the grid from the virtual file
+    ...         grid = lib.read_virtualfile(voutgrd, kind="grid").contents
+    ...         # The grid header
+    ...         header = grid.header.contents
+    ...         # Access the header properties
+    ...         print(header.n_rows, header.n_columns, header.registration)
+    ...         print(header.wesn[:], header.z_min, header.z_max, header.inc[:])
+    ...         print(header.z_scale_factor, header.z_add_offset)
+    ...         print(header.x_units, header.y_units, header.z_units)
+    ...         print(header.title)
+    ...         print(header.command)
+    ...         print(header.remark)
+    ...         print(header.nm, header.size, header.complex_mode)
+    ...         print(header.type, header.n_bands, header.mx, header.my)
+    ...         print(header.pad[:])
+    ...         print(header.mem_layout, header.nan_value, header.xy_off)
+    ...         # The x and y coordinates
+    ...         print(grid.x[: header.n_columns])
+    ...         print(grid.y[: header.n_rows])
+    ...         # The data array (with paddings)
+    ...         data = np.reshape(
+    ...             grid.data[: header.mx * header.my], (header.my, header.mx)
+    ...         )
+    ...         # The data array (without paddings)
+    ...         pad = header.pad[:]
+    ...         data = data[pad[2] : header.my - pad[3], pad[0] : header.mx - pad[1]]
+    ...         print(data)
+    14 8 1
+    [-55.0, -47.0, -24.0, -10.0] 190.0 981.0 [1.0, 1.0]
+    1.0 0.0
+    b'longitude [degrees_east]' b'latitude [degrees_north]' b'elevation (m)'
+    b'Produced by grdcut'
+    b'grdcut @earth_relief_01d_p -R-55/-47/-24/-10 -Gstatic_earth_relief.nc'
+    b'Reduced by Gaussian Cartesian filtering (111.2 km fullwidth) from ...'
+    112 216 0
+    18 1 12 18
+    [2, 2, 2, 2]
+    b'' nan 0.5
+    [-54.5, -53.5, -52.5, -51.5, -50.5, -49.5, -48.5, -47.5]
+    [-10.5, -11.5, -12.5, -13.5, -14.5, -15.5, ..., -22.5, -23.5]
+    [[347.5 331.5 309.  282.  190.  208.  299.5 348. ]
+    [349.  313.  325.5 247.  191.  225.  260.  452.5]
+    [345.5 320.  335.  292.  207.5 247.  325.  346.5]
+    [450.5 395.5 366.  248.  250.  354.5 550.  797.5]
+    [494.5 488.5 357.  254.5 286.  484.5 653.5 930. ]
+    [601.  526.5 535.  299.  398.5 645.  797.5 964. ]
+    [308.  595.5 555.5 556.  580.  770.  927.  920. ]
+    [521.5 682.5 796.  886.  571.5 638.5 739.5 881.5]
+    [310.  521.5 757.  570.5 538.5 524.  686.5 794. ]
+    [561.5 539.  446.5 481.5 439.5 553.  726.5 981. ]
+    [557.  435.  385.5 345.5 413.5 496.  519.5 833.5]
+    [373.  367.5 349.  352.5 419.5 428.  570.  667.5]
+    [383.  284.5 344.5 394.  491.  556.5 578.5 618.5]
+    [347.5 344.5 386.  640.5 617.  579.  646.5 671. ]]
+    """
+
+    _fields_: ClassVar = [
+        # Pointer to full GMT header for grid
+        ("header", ctp.POINTER(_GMT_GRID_HEADER)),
+        # Pointer to grid data
+        ("data", ctp.POINTER(gmt_grdfloat)),
+        # Pointer to x coordinate vector
+        ("x", ctp.POINTER(ctp.c_double)),
+        # Pointer to y coordinate vector
+        ("y", ctp.POINTER(ctp.c_double)),
+        # Low-level information for GMT use only
+        ("hidden", ctp.c_void_p),
+    ]
+
+    def to_dataarray(self) -> xr.DataArray:
+        """
+        Convert a _GMT_GRID object to a :class:`xarray.DataArray` object.
+
+        Returns
+        -------
+        dataarray
+            A :class:`xr.DataArray` object.
+
+        Examples
+        --------
+        >>> from pygmt.clib import Session
+        >>> with Session() as lib:
+        ...     with lib.virtualfile_out(kind="grid") as voutgrd:
+        ...         lib.call_module("read", f"@static_earth_relief.nc {voutgrd} -Tg")
+        ...         # Read the grid from the virtual file
+        ...         grid = lib.read_virtualfile(voutgrd, kind="grid")
+        ...         # Convert to xarray.DataArray and use it later
+        ...         da = grid.contents.to_dataarray()
+        >>> da  # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+        <xarray.DataArray 'z' (lat: 14, lon: 8)>...
+        array([[347.5, 344.5, 386. , 640.5, 617. , 579. , 646.5, 671. ],
+               [383. , 284.5, 344.5, 394. , 491. , 556.5, 578.5, 618.5],
+               [373. , 367.5, 349. , 352.5, 419.5, 428. , 570. , 667.5],
+               [557. , 435. , 385.5, 345.5, 413.5, 496. , 519.5, 833.5],
+               [561.5, 539. , 446.5, 481.5, 439.5, 553. , 726.5, 981. ],
+               [310. , 521.5, 757. , 570.5, 538.5, 524. , 686.5, 794. ],
+               [521.5, 682.5, 796. , 886. , 571.5, 638.5, 739.5, 881.5],
+               [308. , 595.5, 555.5, 556. , 580. , 770. , 927. , 920. ],
+               [601. , 526.5, 535. , 299. , 398.5, 645. , 797.5, 964. ],
+               [494.5, 488.5, 357. , 254.5, 286. , 484.5, 653.5, 930. ],
+               [450.5, 395.5, 366. , 248. , 250. , 354.5, 550. , 797.5],
+               [345.5, 320. , 335. , 292. , 207.5, 247. , 325. , 346.5],
+               [349. , 313. , 325.5, 247. , 191. , 225. , 260. , 452.5],
+               [347.5, 331.5, 309. , 282. , 190. , 208. , 299.5, 348. ]])
+        Coordinates:
+          * lat      (lat) float64... -23.5 -22.5 -21.5 -20.5 ... -12.5 -11.5 -10.5
+          * lon      (lon) float64... -54.5 -53.5 -52.5 -51.5 -50.5 -49.5 -48.5 -47.5
+        Attributes:
+            Conventions:   CF-1.7
+            title:         Produced by grdcut
+            history:       grdcut @earth_relief_01d_p -R-55/-47/-24/-10 -Gstatic_ea...
+            description:   Reduced by Gaussian Cartesian filtering (111.2 km fullwi...
+            long_name:     elevation (m)
+            actual_range:  [190. 981.]
+        >>> da.coords["lon"]  # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+        <xarray.DataArray 'lon' (lon: 8)>...
+        array([-54.5, -53.5, -52.5, -51.5, -50.5, -49.5, -48.5, -47.5])
+        Coordinates:
+          * lon      (lon) float64... -54.5 -53.5 -52.5 -51.5 -50.5 -49.5 -48.5 -47.5
+        Attributes:
+            long_name:      longitude
+            units:          degrees_east
+            standard_name:  longitude
+            axis:           X
+            actual_range:   [-55. -47.]
+        >>> da.coords["lat"]  # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+        <xarray.DataArray 'lat' (lat: 14)>...
+        array([-23.5, -22.5, -21.5, -20.5, -19.5, -18.5, -17.5, -16.5, -15.5, -14.5,
+            -13.5, -12.5, -11.5, -10.5])
+        Coordinates:
+          * lat      (lat) float64... -23.5 -22.5 -21.5 -20.5 ... -12.5 -11.5 -10.5
+        Attributes:
+            long_name:      latitude
+            units:          degrees_north
+            standard_name:  latitude
+            axis:           Y
+            actual_range:   [-24. -10.]
+        >>> da.gmt.registration, da.gmt.gtype
+        (1, 1)
+        """
+        # The grid header
+        header = self.header.contents
+
+        # Get dimensions and their attributes from the header.
+        dims, dim_attrs = header.dims, header.dim_attrs
+        # The coordinates, given as a tuple of the form (dims, data, attrs)
+        coords = [
+            (dims[0], self.y[: header.n_rows], dim_attrs[0]),
+            (dims[1], self.x[: header.n_columns], dim_attrs[1]),
+        ]
+
+        # The data array without paddings
+        pad = header.pad[:]
+        data = np.reshape(self.data[: header.mx * header.my], (header.my, header.mx))[
+            pad[2] : header.my - pad[3], pad[0] : header.mx - pad[1]
+        ]
+
+        # Create the xarray.DataArray object
+        grid = xr.DataArray(
+            data, coords=coords, name=header.name, attrs=header.data_attrs
+        )
+
+        # Flip the coordinates and data if necessary so that coordinates are ascending.
+        # `grid.sortby(list(grid.dims))` sometimes causes crashes.
+        # The solution comes from https://github.com/pydata/xarray/discussions/6695.
+        for dim in grid.dims:
+            if grid[dim][0] > grid[dim][1]:
+                grid = grid.isel({dim: slice(None, None, -1)})
+
+        # Set the gmt accesssor.
+        # Must put at the end. The information get lost after specific grid operation.
+        grid.gmt.registration = header.registration
+        grid.gmt.gtype = header.gtype
+        return grid

--- a/pygmt/datatypes/grid.py
+++ b/pygmt/datatypes/grid.py
@@ -192,7 +192,7 @@ class _GMT_GRID(ctp.Structure):  # noqa: N801
             if grid[dim][0] > grid[dim][1]:
                 grid = grid.isel({dim: slice(None, None, -1)})
 
-        # Set the gmt accesssor.
+        # Set the gmt accessor.
         # Must put at the end. The information get lost after specific grid operation.
         grid.gmt.registration = header.registration
         grid.gmt.gtype = header.gtype

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -267,10 +267,12 @@ COMMON_DOCSTRINGS = {
             - ``file`` will save the result to the file specified by the ``outfile``
               parameter.""",
     "outgrid": """
-        outgrid : str or None
-            Name of the output netCDF grid file. For writing a specific grid
-            file format or applying basic data operations to the output grid,
-            see :gmt-docs:`gmt.html#grd-inout-full` for the available modifiers.""",
+        outgrid
+            Name of the output netCDF grid file. If not specified, will return an
+            :class:`xarray.DataArray` object. For writing a specific grid file format or
+            applying basic data operations to the output grid, see
+            :gmt-docs:`gmt.html#grd-inout-full` for the available modifiers.
+        """,
     "panel": r"""
         panel : bool, int, or list
             [*row,col*\|\ *index*].

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -111,4 +111,6 @@ def binstats(data, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="binstats", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -111,4 +111,4 @@ def binstats(data, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="binstats", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -111,6 +111,4 @@ def binstats(data, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="binstats", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -3,21 +3,13 @@ binstats - Bin spatial data and determine statistics per bin
 """
 
 from pygmt.clib import Session
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
-from pygmt.io import load_dataarray
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 
 @fmt_docstring
 @use_alias(
     C="statistic",
     E="empty",
-    G="outgrid",
     I="spacing",
     N="normalize",
     R="region",
@@ -31,7 +23,7 @@ from pygmt.io import load_dataarray
     r="registration",
 )
 @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma")
-def binstats(data, **kwargs):
+def binstats(data, outgrid: str | None = None, **kwargs):
     r"""
     Bin spatial data and determine statistics per bin.
 
@@ -110,13 +102,13 @@ def binstats(data, **kwargs):
         - None if ``outgrid`` is set (grid output will be stored in file set by
           ``outgrid``)
     """
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
-                if (outgrid := kwargs.get("G")) is None:
-                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                lib.call_module(
-                    module="binstats", args=build_arg_string(kwargs, infile=vintbl)
-                )
-
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(check_kind="vector", data=data) as vintbl,
+            lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+        ):
+            kwargs["G"] = voutgrd
+            lib.call_module(
+                module="binstats", args=build_arg_string(kwargs, infile=vintbl)
+            )
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -150,6 +150,4 @@ def dimfilter(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="dimfilter", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -150,4 +150,4 @@ def dimfilter(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="dimfilter", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -4,14 +4,7 @@ dimfilter - Directional filtering of grids in the space domain.
 
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
-from pygmt.io import load_dataarray
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["dimfilter"]
 
@@ -20,14 +13,13 @@ __doctest_skip__ = ["dimfilter"]
 @use_alias(
     D="distance",
     F="filter",
-    G="outgrid",
     I="spacing",
     N="sectors",
     R="region",
     V="verbose",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def dimfilter(grid, **kwargs):
+def dimfilter(grid, outgrid: str | None = None, **kwargs):
     r"""
     Filter a grid by dividing the filter circle.
 
@@ -149,13 +141,13 @@ def dimfilter(grid, **kwargs):
             distance, filters, or sectors."""
         )
 
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
-                if (outgrid := kwargs.get("G")) is None:
-                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                lib.call_module(
-                    module="dimfilter", args=build_arg_string(kwargs, infile=vingrd)
-                )
-
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
+            lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+        ):
+            kwargs["G"] = voutgrd
+            lib.call_module(
+                module="dimfilter", args=build_arg_string(kwargs, infile=vingrd)
+            )
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -150,4 +150,6 @@ def dimfilter(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="dimfilter", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -3,21 +3,13 @@ grdclip - Change the range and extremes of grid values.
 """
 
 from pygmt.clib import Session
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
-from pygmt.io import load_dataarray
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["grdclip"]
 
 
 @fmt_docstring
 @use_alias(
-    G="outgrid",
     R="region",
     Sa="above",
     Sb="below",
@@ -32,7 +24,7 @@ __doctest_skip__ = ["grdclip"]
     Si="sequence",
     Sr="sequence",
 )
-def grdclip(grid, **kwargs):
+def grdclip(grid, outgrid: str | None = None, **kwargs):
     r"""
     Set values in a grid that meet certain criteria to a new value.
 
@@ -95,13 +87,13 @@ def grdclip(grid, **kwargs):
     >>> [new_grid.data.min(), new_grid.data.max()]
     [0.0, 10000.0]
     """
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
-                if (outgrid := kwargs.get("G")) is None:
-                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                lib.call_module(
-                    module="grdclip", args=build_arg_string(kwargs, infile=vingrd)
-                )
-
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
+            lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+        ):
+            kwargs["G"] = voutgrd
+            lib.call_module(
+                module="grdclip", args=build_arg_string(kwargs, infile=vingrd)
+            )
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -96,6 +96,4 @@ def grdclip(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdclip", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -96,4 +96,6 @@ def grdclip(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdclip", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -96,4 +96,4 @@ def grdclip(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdclip", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -79,4 +79,6 @@ def grdfill(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdfill", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -79,6 +79,4 @@ def grdfill(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdfill", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -79,4 +79,4 @@ def grdfill(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdfill", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -4,14 +4,7 @@ grdfill - Fill blank areas from a grid.
 
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
-from pygmt.io import load_dataarray
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["grdfill"]
 
@@ -19,13 +12,12 @@ __doctest_skip__ = ["grdfill"]
 @fmt_docstring
 @use_alias(
     A="mode",
-    G="outgrid",
     N="no_data",
     R="region",
     V="verbose",
 )
 @kwargs_to_strings(R="sequence")
-def grdfill(grid, **kwargs):
+def grdfill(grid, outgrid: str | None = None, **kwargs):
     r"""
     Fill blank areas from a grid file.
 
@@ -77,13 +69,14 @@ def grdfill(grid, **kwargs):
     """
     if kwargs.get("A") is None and kwargs.get("L") is None:
         raise GMTInvalidInput("At least parameter 'mode' or 'L' must be specified.")
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
-                if (outgrid := kwargs.get("G")) is None:
-                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                lib.call_module(
-                    module="grdfill", args=build_arg_string(kwargs, infile=vingrd)
-                )
 
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
+            lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+        ):
+            kwargs["G"] = voutgrd
+            lib.call_module(
+                module="grdfill", args=build_arg_string(kwargs, infile=vingrd)
+            )
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -133,6 +133,4 @@ def grdfilter(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdfilter", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -133,4 +133,6 @@ def grdfilter(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdfilter", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -3,21 +3,13 @@ grdfilter - Filter a grid in the space (or time) domain.
 """
 
 from pygmt.clib import Session
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
-from pygmt.io import load_dataarray
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 
 @fmt_docstring
 @use_alias(
     D="distance",
     F="filter",
-    G="outgrid",
     I="spacing",
     N="nans",
     R="region",
@@ -28,7 +20,7 @@ from pygmt.io import load_dataarray
     x="cores",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def grdfilter(grid, **kwargs):
+def grdfilter(grid, outgrid: str | None = None, **kwargs):
     r"""
     Filter a grid in the space (or time) domain.
 
@@ -132,13 +124,13 @@ def grdfilter(grid, **kwargs):
     >>> grid = pygmt.datasets.load_earth_relief()
     >>> smooth_field = pygmt.grdfilter(grid=grid, filter="g600", distance="4")
     """
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
-                if (outgrid := kwargs.get("G")) is None:
-                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                lib.call_module(
-                    module="grdfilter", args=build_arg_string(kwargs, infile=vingrd)
-                )
-
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
+            lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+        ):
+            kwargs["G"] = voutgrd
+            lib.call_module(
+                module="grdfilter", args=build_arg_string(kwargs, infile=vingrd)
+            )
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -133,4 +133,4 @@ def grdfilter(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdfilter", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -173,4 +173,4 @@ def grdgradient(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdgradient", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -173,6 +173,4 @@ def grdgradient(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdgradient", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -173,4 +173,6 @@ def grdgradient(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdgradient", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -5,14 +5,12 @@ grdgradient - Compute directional gradients from a grid.
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
-    GMTTempFile,
     args_in_kwargs,
     build_arg_string,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.io import load_dataarray
 
 __doctest_skip__ = ["grdgradient"]
 
@@ -22,7 +20,6 @@ __doctest_skip__ = ["grdgradient"]
     A="azimuth",
     D="direction",
     E="radiance",
-    G="outgrid",
     N="normalize",
     Q="tiles",
     R="region",
@@ -32,7 +29,7 @@ __doctest_skip__ = ["grdgradient"]
     n="interpolation",
 )
 @kwargs_to_strings(A="sequence", E="sequence", R="sequence")
-def grdgradient(grid, **kwargs):
+def grdgradient(grid, outgrid: str | None = None, **kwargs):
     r"""
     Compute the directional derivative of the vector gradient of the data.
 
@@ -160,20 +157,20 @@ def grdgradient(grid, **kwargs):
     >>> # Create a new grid from an input grid, set the azimuth to 10 degrees,
     >>> new_grid = pygmt.grdgradient(grid=grid, azimuth=10)
     """
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        if kwargs.get("Q") is not None and kwargs.get("N") is None:
-            raise GMTInvalidInput("""Must specify normalize if tiles is specified.""")
-        if not args_in_kwargs(args=["A", "D", "E"], kwargs=kwargs):
-            raise GMTInvalidInput(
-                """At least one of the following parameters must be specified:
-                azimuth, direction, or radiance"""
+    if kwargs.get("Q") is not None and kwargs.get("N") is None:
+        raise GMTInvalidInput("""Must specify normalize if tiles is specified.""")
+    if not args_in_kwargs(args=["A", "D", "E"], kwargs=kwargs):
+        raise GMTInvalidInput(
+            "At least one of the following parameters must be specified: "
+            "azimuth, direction, or radiance."
+        )
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
+            lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+        ):
+            kwargs["G"] = voutgrd
+            lib.call_module(
+                module="grdgradient", args=build_arg_string(kwargs, infile=vingrd)
             )
-        with Session() as lib:
-            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
-                if (outgrid := kwargs.get("G")) is None:
-                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                lib.call_module(
-                    module="grdgradient", args=build_arg_string(kwargs, infile=vingrd)
-                )
-
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -129,7 +129,7 @@ class grdhisteq:  # noqa: N801
                 lib.call_module(
                     module="grdhisteq", args=build_arg_string(kwargs, infile=vingrd)
                 )
-                return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+                return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
 
     @staticmethod
     @fmt_docstring

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -9,14 +9,12 @@ import pandas as pd
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
-    GMTTempFile,
     build_arg_string,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
     validate_output_table_type,
 )
-from pygmt.io import load_dataarray
 
 __doctest_skip__ = ["grdhisteq.*"]
 
@@ -56,7 +54,6 @@ class grdhisteq:  # noqa: N801
     @fmt_docstring
     @use_alias(
         C="divisions",
-        G="outgrid",
         R="region",
         N="gaussian",
         Q="quadratic",
@@ -64,7 +61,7 @@ class grdhisteq:  # noqa: N801
         h="header",
     )
     @kwargs_to_strings(R="sequence")
-    def equalize_grid(grid, **kwargs):
+    def equalize_grid(grid, outgrid: str | None = None, **kwargs):
         r"""
         Perform histogram equalization for a grid.
 
@@ -123,15 +120,16 @@ class grdhisteq:  # noqa: N801
         This method does a weighted histogram equalization for geographic
         grids to account for node area varying with latitude.
         """
-        with GMTTempFile(suffix=".nc") as tmpfile:
-            with Session() as lib:
-                with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
-                    if (outgrid := kwargs.get("G")) is None:
-                        kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                    lib.call_module(
-                        module="grdhisteq", args=build_arg_string(kwargs, infile=vingrd)
-                    )
-            return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+        with Session() as lib:
+            with (
+                lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
+                lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+            ):
+                kwargs["G"] = voutgrd
+                lib.call_module(
+                    module="grdhisteq", args=build_arg_string(kwargs, infile=vingrd)
+                )
+                return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
 
     @staticmethod
     @fmt_docstring

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -129,9 +129,7 @@ class grdhisteq:  # noqa: N801
                 lib.call_module(
                     module="grdhisteq", args=build_arg_string(kwargs, infile=vingrd)
                 )
-                return lib.virtualfile_to_raster(
-                    vfname=voutgrd, kind="grid", outgrid=outgrid
-                )
+                return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
 
     @staticmethod
     @fmt_docstring

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -129,7 +129,9 @@ class grdhisteq:  # noqa: N801
                 lib.call_module(
                     module="grdhisteq", args=build_arg_string(kwargs, infile=vingrd)
                 )
-                return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+                return lib.virtualfile_to_raster(
+                    vfname=voutgrd, kind="grid", outgrid=outgrid
+                )
 
     @staticmethod
     @fmt_docstring

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -101,4 +101,4 @@ def grdlandmask(outgrid: str | None = None, **kwargs):
         with lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd:
             kwargs["G"] = voutgrd
             lib.call_module(module="grdlandmask", args=build_arg_string(kwargs))
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -101,6 +101,4 @@ def grdlandmask(outgrid: str | None = None, **kwargs):
         with lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd:
             kwargs["G"] = voutgrd
             lib.call_module(module="grdlandmask", args=build_arg_string(kwargs))
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -101,4 +101,6 @@ def grdlandmask(outgrid: str | None = None, **kwargs):
         with lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd:
             kwargs["G"] = voutgrd
             lib.call_module(module="grdlandmask", args=build_arg_string(kwargs))
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -4,14 +4,7 @@ grdlandmask - Create a "wet-dry" mask grid from shoreline data base
 
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
-from pygmt.io import load_dataarray
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["grdlandmask"]
 
@@ -21,7 +14,6 @@ __doctest_skip__ = ["grdlandmask"]
     A="area_thresh",
     D="resolution",
     E="bordervalues",
-    G="outgrid",
     I="spacing",
     N="maskvalues",
     R="region",
@@ -30,7 +22,7 @@ __doctest_skip__ = ["grdlandmask"]
     x="cores",
 )
 @kwargs_to_strings(I="sequence", R="sequence", N="sequence", E="sequence")
-def grdlandmask(**kwargs):
+def grdlandmask(outgrid: str | None = None, **kwargs):
     r"""
     Create a grid file with set values for land and water.
 
@@ -105,10 +97,8 @@ def grdlandmask(**kwargs):
     if kwargs.get("I") is None or kwargs.get("R") is None:
         raise GMTInvalidInput("Both 'region' and 'spacing' must be specified.")
 
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            if (outgrid := kwargs.get("G")) is None:
-                kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
+    with Session() as lib:
+        with lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd:
+            kwargs["G"] = voutgrd
             lib.call_module(module="grdlandmask", args=build_arg_string(kwargs))
-
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -113,6 +113,4 @@ def grdproject(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdproject", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -113,4 +113,6 @@ def grdproject(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdproject", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -4,14 +4,7 @@ grdproject - Forward and inverse map transformation of grids.
 
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
-from pygmt.io import load_dataarray
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["grdproject"]
 
@@ -22,7 +15,6 @@ __doctest_skip__ = ["grdproject"]
     D="spacing",
     E="dpi",
     F="scaling",
-    G="outgrid",
     J="projection",
     I="inverse",
     M="unit",
@@ -32,7 +24,7 @@ __doctest_skip__ = ["grdproject"]
     r="registration",
 )
 @kwargs_to_strings(C="sequence", D="sequence", R="sequence")
-def grdproject(grid, **kwargs):
+def grdproject(grid, outgrid: str | None = None, **kwargs):
     r"""
     Change projection of gridded data between geographical and rectangular.
 
@@ -111,13 +103,14 @@ def grdproject(grid, **kwargs):
     """
     if kwargs.get("J") is None:
         raise GMTInvalidInput("The projection must be specified.")
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
-                if (outgrid := kwargs.get("G")) is None:
-                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                lib.call_module(
-                    module="grdproject", args=build_arg_string(kwargs, infile=vingrd)
-                )
 
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
+            lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+        ):
+            kwargs["G"] = voutgrd
+            lib.call_module(
+                module="grdproject", args=build_arg_string(kwargs, infile=vingrd)
+            )
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -113,4 +113,4 @@ def grdproject(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdproject", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -88,4 +88,6 @@ def grdsample(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdsample", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -88,4 +88,4 @@ def grdsample(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdsample", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -88,6 +88,4 @@ def grdsample(grid, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="grdsample", args=build_arg_string(kwargs, infile=vingrd)
             )
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -3,21 +3,13 @@ grdsample - Resample a grid onto a new lattice
 """
 
 from pygmt.clib import Session
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
-from pygmt.io import load_dataarray
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["grdsample"]
 
 
 @fmt_docstring
 @use_alias(
-    G="outgrid",
     I="spacing",
     R="region",
     T="translate",
@@ -28,7 +20,7 @@ __doctest_skip__ = ["grdsample"]
     x="cores",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def grdsample(grid, **kwargs):
+def grdsample(grid, outgrid: str | None = None, **kwargs):
     r"""
     Change the registration, spacing, or nodes in a grid file.
 
@@ -87,13 +79,13 @@ def grdsample(grid, **kwargs):
     >>> # and set both x- and y-spacing to 0.5 arc-degrees
     >>> new_grid = pygmt.grdsample(grid=grid, translate=True, spacing=[0.5, 0.5])
     """
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
-                if (outgrid := kwargs.get("G")) is None:
-                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                lib.call_module(
-                    module="grdsample", args=build_arg_string(kwargs, infile=vingrd)
-                )
-
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
+            lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+        ):
+            kwargs["G"] = voutgrd
+            lib.call_module(
+                module="grdsample", args=build_arg_string(kwargs, infile=vingrd)
+            )
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -148,4 +148,6 @@ def nearneighbor(
             lib.call_module(
                 module="nearneighbor", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -3,14 +3,7 @@ nearneighbor - Grid table data using a "Nearest neighbor" algorithm.
 """
 
 from pygmt.clib import Session
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
-from pygmt.io import load_dataarray
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["nearneighbor"]
 
@@ -18,7 +11,6 @@ __doctest_skip__ = ["nearneighbor"]
 @fmt_docstring
 @use_alias(
     E="empty",
-    G="outgrid",
     I="spacing",
     N="sectors",
     R="region",
@@ -36,7 +28,9 @@ __doctest_skip__ = ["nearneighbor"]
     w="wrap",
 )
 @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma")
-def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
+def nearneighbor(
+    data=None, x=None, y=None, z=None, outgrid: str | None = None, **kwargs
+):
     r"""
     Grid table data using a "Nearest neighbor" algorithm.
 
@@ -143,15 +137,15 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
     ...     search_radius="10m",
     ... )
     """
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_in(
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
-            ) as vintbl:
-                if (outgrid := kwargs.get("G")) is None:
-                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                lib.call_module(
-                    module="nearneighbor", args=build_arg_string(kwargs, infile=vintbl)
-                )
-
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+            ) as vintbl,
+            lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+        ):
+            kwargs["G"] = voutgrd
+            lib.call_module(
+                module="nearneighbor", args=build_arg_string(kwargs, infile=vintbl)
+            )
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -148,6 +148,4 @@ def nearneighbor(
             lib.call_module(
                 module="nearneighbor", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -148,4 +148,4 @@ def nearneighbor(
             lib.call_module(
                 module="nearneighbor", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/sph2grd.py
+++ b/pygmt/src/sph2grd.py
@@ -73,4 +73,6 @@ def sph2grd(data, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="sph2grd", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/sph2grd.py
+++ b/pygmt/src/sph2grd.py
@@ -3,21 +3,13 @@ sph2grd - Compute grid from spherical harmonic coefficients
 """
 
 from pygmt.clib import Session
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
-from pygmt.io import load_dataarray
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["sph2grd"]
 
 
 @fmt_docstring
 @use_alias(
-    G="outgrid",
     I="spacing",
     R="region",
     V="verbose",
@@ -28,7 +20,7 @@ __doctest_skip__ = ["sph2grd"]
     x="cores",
 )
 @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma")
-def sph2grd(data, **kwargs):
+def sph2grd(data, outgrid: str | None = None, **kwargs):
     r"""
     Create spherical grid files in tension of data.
 
@@ -72,13 +64,13 @@ def sph2grd(data, **kwargs):
     >>> # set the grid spacing to 1 arc-degree, and the region to global ("g")
     >>> new_grid = pygmt.sph2grd(data="@EGM96_to_36.txt", spacing=1, region="g")
     """
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
-                if (outgrid := kwargs.get("G")) is None:
-                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                lib.call_module(
-                    module="sph2grd", args=build_arg_string(kwargs, infile=vintbl)
-                )
-
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(check_kind="vector", data=data) as vintbl,
+            lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+        ):
+            kwargs["G"] = voutgrd
+            lib.call_module(
+                module="sph2grd", args=build_arg_string(kwargs, infile=vintbl)
+            )
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/sph2grd.py
+++ b/pygmt/src/sph2grd.py
@@ -73,6 +73,4 @@ def sph2grd(data, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="sph2grd", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/sph2grd.py
+++ b/pygmt/src/sph2grd.py
@@ -73,4 +73,4 @@ def sph2grd(data, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="sph2grd", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -117,6 +117,4 @@ def sphdistance(data=None, x=None, y=None, outgrid: str | None = None, **kwargs)
             lib.call_module(
                 module="sphdistance", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -117,4 +117,4 @@ def sphdistance(data=None, x=None, y=None, outgrid: str | None = None, **kwargs)
             lib.call_module(
                 module="sphdistance", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -117,4 +117,6 @@ def sphdistance(data=None, x=None, y=None, outgrid: str | None = None, **kwargs)
             lib.call_module(
                 module="sphdistance", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -5,14 +5,7 @@ or natural nearest-neighbor grid on a sphere
 
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
-from pygmt.io import load_dataarray
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["sphdistance"]
 
@@ -22,7 +15,6 @@ __doctest_skip__ = ["sphdistance"]
     C="single_form",
     D="duplicate",
     E="quantity",
-    G="outgrid",
     I="spacing",
     L="unit",
     N="node_table",
@@ -31,7 +23,7 @@ __doctest_skip__ = ["sphdistance"]
     V="verbose",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def sphdistance(data=None, x=None, y=None, **kwargs):
+def sphdistance(data=None, x=None, y=None, outgrid: str | None = None, **kwargs):
     r"""
     Create Voronoi distance, node, or natural nearest-neighbor grid on a sphere.
 
@@ -116,13 +108,13 @@ def sphdistance(data=None, x=None, y=None, **kwargs):
     """
     if kwargs.get("I") is None or kwargs.get("R") is None:
         raise GMTInvalidInput("Both 'region' and 'spacing' must be specified.")
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_in(check_kind="vector", data=data, x=x, y=y) as vintbl:
-                if (outgrid := kwargs.get("G")) is None:
-                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                lib.call_module(
-                    module="sphdistance", args=build_arg_string(kwargs, infile=vintbl)
-                )
-
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(check_kind="vector", data=data, x=x, y=y) as vintbl,
+            lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+        ):
+            kwargs["G"] = voutgrd
+            lib.call_module(
+                module="sphdistance", args=build_arg_string(kwargs, infile=vintbl)
+            )
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/sphinterpolate.py
+++ b/pygmt/src/sphinterpolate.py
@@ -3,27 +3,19 @@ sphinterpolate - Spherical gridding in tension of data on a sphere
 """
 
 from pygmt.clib import Session
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
-from pygmt.io import load_dataarray
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["sphinterpolate"]
 
 
 @fmt_docstring
 @use_alias(
-    G="outgrid",
     I="spacing",
     R="region",
     V="verbose",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def sphinterpolate(data, **kwargs):
+def sphinterpolate(data, outgrid: str | None = None, **kwargs):
     r"""
     Create spherical grid files in tension of data.
 
@@ -66,14 +58,13 @@ def sphinterpolate(data, **kwargs):
     >>> # to produce a grid with a 1 arc-degree spacing
     >>> grid = pygmt.sphinterpolate(data=mars_shape, spacing=1, region="g")
     """
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
-                if (outgrid := kwargs.get("G")) is None:
-                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                lib.call_module(
-                    module="sphinterpolate",
-                    args=build_arg_string(kwargs, infile=vintbl),
-                )
-
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(check_kind="vector", data=data) as vintbl,
+            lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+        ):
+            kwargs["G"] = voutgrd
+            lib.call_module(
+                module="sphinterpolate", args=build_arg_string(kwargs, infile=vintbl)
+            )
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/sphinterpolate.py
+++ b/pygmt/src/sphinterpolate.py
@@ -67,4 +67,6 @@ def sphinterpolate(data, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="sphinterpolate", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/sphinterpolate.py
+++ b/pygmt/src/sphinterpolate.py
@@ -67,6 +67,4 @@ def sphinterpolate(data, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="sphinterpolate", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/sphinterpolate.py
+++ b/pygmt/src/sphinterpolate.py
@@ -67,4 +67,4 @@ def sphinterpolate(data, outgrid: str | None = None, **kwargs):
             lib.call_module(
                 module="sphinterpolate", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -161,4 +161,6 @@ def surface(data=None, x=None, y=None, z=None, outgrid: str | None = None, **kwa
             lib.call_module(
                 module="surface", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -161,4 +161,4 @@ def surface(data=None, x=None, y=None, z=None, outgrid: str | None = None, **kwa
             lib.call_module(
                 module="surface", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -161,6 +161,4 @@ def surface(data=None, x=None, y=None, z=None, outgrid: str | None = None, **kwa
             lib.call_module(
                 module="surface", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -4,14 +4,7 @@ splines.
 """
 
 from pygmt.clib import Session
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
-from pygmt.io import load_dataarray
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["surface"]
 
@@ -19,7 +12,6 @@ __doctest_skip__ = ["surface"]
 @fmt_docstring
 @use_alias(
     C="convergence",
-    G="outgrid",
     I="spacing",
     Ll="lower",
     Lu="upper",
@@ -38,7 +30,7 @@ __doctest_skip__ = ["surface"]
     w="wrap",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def surface(data=None, x=None, y=None, z=None, **kwargs):
+def surface(data=None, x=None, y=None, z=None, outgrid: str | None = None, **kwargs):
     r"""
     Grid table data using adjustable tension continuous curvature splines.
 
@@ -158,15 +150,15 @@ def surface(data=None, x=None, y=None, z=None, **kwargs):
     >>> # Perform gridding of topography data
     >>> grid = pygmt.surface(data=topography, spacing=1, region=[0, 4, 0, 8])
     """
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_in(
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
-            ) as vintbl:
-                if (outgrid := kwargs.get("G")) is None:
-                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                lib.call_module(
-                    module="surface", args=build_arg_string(kwargs, infile=vintbl)
-                )
-
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+            ) as vintbl,
+            lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+        ):
+            kwargs["G"] = voutgrd
+            lib.call_module(
+                module="surface", args=build_arg_string(kwargs, infile=vintbl)
+            )
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -146,7 +146,9 @@ class triangulate:  # noqa: N801
                 lib.call_module(
                     module="triangulate", args=build_arg_string(kwargs, infile=vintbl)
                 )
-                return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+                return lib.virtualfile_to_raster(
+                    vfname=voutgrd, kind="grid", outgrid=outgrid
+                )
 
     @staticmethod
     @fmt_docstring

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -146,9 +146,7 @@ class triangulate:  # noqa: N801
                 lib.call_module(
                     module="triangulate", args=build_arg_string(kwargs, infile=vintbl)
                 )
-                return lib.virtualfile_to_raster(
-                    vfname=voutgrd, kind="grid", outgrid=outgrid
-                )
+                return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
 
     @staticmethod
     @fmt_docstring

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -9,14 +9,12 @@ import numpy as np
 import pandas as pd
 from pygmt.clib import Session
 from pygmt.helpers import (
-    GMTTempFile,
     build_arg_string,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
     validate_output_table_type,
 )
-from pygmt.io import load_dataarray
 
 
 class triangulate:  # noqa: N801
@@ -50,7 +48,6 @@ class triangulate:  # noqa: N801
     @staticmethod
     @fmt_docstring
     @use_alias(
-        G="outgrid",
         I="spacing",
         J="projection",
         R="region",
@@ -66,7 +63,9 @@ class triangulate:  # noqa: N801
         w="wrap",
     )
     @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma")
-    def regular_grid(data=None, x=None, y=None, z=None, **kwargs):
+    def regular_grid(
+        data=None, x=None, y=None, z=None, outgrid: str | None = None, **kwargs
+    ):
         """
         Delaunay triangle based gridding of Cartesian data.
 
@@ -136,20 +135,18 @@ class triangulate:  # noqa: N801
         ``triangulate`` is a Cartesian or small-geographic area operator and is
         unaware of periodic or polar boundary conditions.
         """
-        # Return an xarray.DataArray if ``outgrid`` is not set
-        with GMTTempFile(suffix=".nc") as tmpfile:
-            with Session() as lib:
-                with lib.virtualfile_in(
+        with Session() as lib:
+            with (
+                lib.virtualfile_in(
                     check_kind="vector", data=data, x=x, y=y, z=z, required_z=False
-                ) as vintbl:
-                    if (outgrid := kwargs.get("G")) is None:
-                        kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                    lib.call_module(
-                        module="triangulate",
-                        args=build_arg_string(kwargs, infile=vintbl),
-                    )
-
-            return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+                ) as vintbl,
+                lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+            ):
+                kwargs["G"] = voutgrd
+                lib.call_module(
+                    module="triangulate", args=build_arg_string(kwargs, infile=vintbl)
+                )
+                return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
 
     @staticmethod
     @fmt_docstring

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -146,7 +146,7 @@ class triangulate:  # noqa: N801
                 lib.call_module(
                     module="triangulate", args=build_arg_string(kwargs, infile=vintbl)
                 )
-                return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+                return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
 
     @staticmethod
     @fmt_docstring

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -153,6 +153,4 @@ def xyz2grd(data=None, x=None, y=None, z=None, outgrid: str | None = None, **kwa
             lib.call_module(
                 module="xyz2grd", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_raster(
-                vfname=voutgrd, kind="grid", outgrid=outgrid
-            )
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -153,4 +153,4 @@ def xyz2grd(data=None, x=None, y=None, z=None, outgrid: str | None = None, **kwa
             lib.call_module(
                 module="xyz2grd", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -153,4 +153,6 @@ def xyz2grd(data=None, x=None, y=None, z=None, outgrid: str | None = None, **kwa
             lib.call_module(
                 module="xyz2grd", args=build_arg_string(kwargs, infile=vintbl)
             )
-            return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
+            return lib.virtualfile_to_raster(
+                vfname=voutgrd, kind="grid", outgrid=outgrid
+            )

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -4,14 +4,7 @@ xyz2grd - Convert data table to a grid.
 
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
-from pygmt.io import load_dataarray
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["xyz2grd"]
 
@@ -19,7 +12,6 @@ __doctest_skip__ = ["xyz2grd"]
 @fmt_docstring
 @use_alias(
     A="duplicate",
-    G="outgrid",
     I="spacing",
     J="projection",
     R="region",
@@ -35,7 +27,7 @@ __doctest_skip__ = ["xyz2grd"]
     w="wrap",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def xyz2grd(data=None, x=None, y=None, z=None, **kwargs):
+def xyz2grd(data=None, x=None, y=None, z=None, outgrid: str | None = None, **kwargs):
     r"""
     Create a grid file from table data.
 
@@ -150,15 +142,15 @@ def xyz2grd(data=None, x=None, y=None, z=None, **kwargs):
     if kwargs.get("I") is None or kwargs.get("R") is None:
         raise GMTInvalidInput("Both 'region' and 'spacing' must be specified.")
 
-    with GMTTempFile(suffix=".nc") as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_in(
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
-            ) as vintbl:
-                if (outgrid := kwargs.get("G")) is None:
-                    kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
-                lib.call_module(
-                    module="xyz2grd", args=build_arg_string(kwargs, infile=vintbl)
-                )
-
-        return load_dataarray(outgrid) if outgrid == tmpfile.name else None
+            ) as vintbl,
+            lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
+        ):
+            kwargs["G"] = voutgrd
+            lib.call_module(
+                module="xyz2grd", args=build_arg_string(kwargs, infile=vintbl)
+            )
+            return lib.virtualfile_to_grid(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/tests/test_datasets_load_remote_datasets.py
+++ b/pygmt/tests/test_datasets_load_remote_datasets.py
@@ -3,8 +3,6 @@ Test the _load_remote_dataset function.
 """
 
 import pytest
-from packaging.version import Version
-from pygmt.clib import __gmt_version__
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
 from pygmt.exceptions import GMTInvalidInput
 
@@ -35,8 +33,9 @@ def test_load_remote_dataset_benchmark_with_region():
     assert data.gmt.registration == 0
     assert data.shape == (11, 21)
     # The cpt attribute was added since GMT 6.4.0
-    if Version(__gmt_version__) >= Version("6.4.0"):
-        assert data.attrs["cpt"] == "@earth_age.cpt"
+    # Can't access the cpt attribute using virtual files
+    # if Version(__gmt_version__) >= Version("6.4.0"):
+    #    assert data.attrs["cpt"] == "@earth_age.cpt"
 
 
 def test_load_remote_dataset_invalid_resolutions():

--- a/pygmt/tests/test_sphinterpolate.py
+++ b/pygmt/tests/test_sphinterpolate.py
@@ -41,4 +41,4 @@ def test_sphinterpolate_no_outgrid(mars):
     npt.assert_allclose(temp_grid.max(), 14628.144)
     npt.assert_allclose(temp_grid.min(), -6908.1987)
     npt.assert_allclose(temp_grid.median(), 118.96849)
-    npt.assert_allclose(temp_grid.mean(), 272.60593)
+    npt.assert_allclose(temp_grid.mean(), 272.60578)


### PR DESCRIPTION
**Description of proposed changes**

This PR wraps GMT's standard data type `GMT_GRID` for grids, so that we can store the output grid in GMT virtual files and don't have to write the output grid into a temporary file and load it as xarray.DataArray.

## Expected enhancements/features

Here is a list of enhancements/features related to the `GMT_GRID` data type:

- [x] Wrap GMT's data structure `GMT_GRID_HEADER` for grid metadata [#3127]
- [x] Wrap GMT's standard data type `GMT_GRID` for grids 
- [x] Add the `Session.virtualfile_to_raster` method for handling output to an actual file or a virtual file [Similar to the `Session.virtualfile_to_dataset` in PR #3083] 
- [x] Refactor wrappers that write grids: (1) Simplify the codes; (2) Get rid of temporary files; (3) Improve performance 
- [ ] Passing `GMT_GRID` directly to GMT API. Currently, for an xarray.DataArray grid, we first convert it to a matrix, then pass the matrix with some metadata (like inc, registration and gtype) to GMT. This way has proven to cause troubles (e.g., #390), mainly due to grid paddings. It would be better if we could internally convert xarray.DataArray to GMT_GRID and then pass GMT_GRID to GMT API. It may help us fix many long-term issues. [Will do in future PRs]

## The `GMT_GRID`/`GMT_GRID_HEADER` data structure

The `GMT_GRID` data structure is defined at [gmt/src/gmt_resources.h](https://github.com/GenericMappingTools/gmt/blob/83f885ea4c2452e78a9d885a6c5840805781ed16/src/gmt_resources.h#L467):
```c
struct GMT_GRID {	/* To hold a GMT gmt_grdfloat grid and its header in one container */
	struct GMT_GRID_HEADER *header;	/* Pointer to full GMT header for the grid */
	gmt_grdfloat *data;             /* Pointer to the gmt_grdfloat grid */
	double *x, *y;                  /* Vector of coordinates */
	void *hidden;                   /* Row-by-row machinery information [NULL] */
};
```
it contains the x/y array, the data array and the grid header. The grid header `GMT_GRID_HEADER` is defined at [gmt/src/gmt_resources.h](https://github.com/GenericMappingTools/gmt/blob/83f885ea4c2452e78a9d885a6c5840805781ed16/src/gmt_resources.h#L402). It contains many important metadata information about the grid. Here are some important header variables:

- `n_columns`: Number of columns
- `n_rows`: Number of rows
- `registration`: 0 for gridline registration and 1 for pixel registration.
- `wesn`: min/max of x/y coordinates, i.e., [xmin, xmax, ymin, ymax]
- `z_min`/`z_max`: min/max of z values
- `inc`: x and y increment [should be equal to x[1] - x[0] and y[1] - y[0]]
- `z_scale_factor`/`z_add_offset`: Used for data compressing by storing floating-point data as smaller integers in a netCDF file. The relation between the actual data _z'_ and the data stored in netCDF file (_z_) is z' = z * scale_factor + offset (i.e., unpacking). Need to note that when reading a netCDF file, GMT already does the conversion, so `z_min`/`z_max` and the `data` array are already unpacked so we usually don't need to care about these two variables.
- `x_units`/`y_units`: x/y units in the form of `long_name [units]`. The `[units]` part is optional. Some examples are: `x`/`y`/`longitude [degrees_east]`/`latitude [degrees_north]`.
- `z_units`: Also in the form of `long_name [units]`.
- `pad`: Extra columns/rows on west/east/south/north sides. Paddings are mainly used for grid manipulations at grid boundary. Defaults are [2, 2, 2, 2].
- `mx`: actual columns in memory. Equal to n_columns + pad[0] + pad[1]
- `my`: actual rows in memory. Equal to n_rows + pad[2] + pad[3]

### Conversions between netCDF and `GMT_GRID`

Although netCDF is the default grid format for I/O, GMT uses the `GMT_GRID` data structure as its internal representation of grids. Thus, GMT needs to convert netCDF data/metadata to `GMT_GRID` for input and do the inverse for output. The conversions between netCDF and `GMT_GRID` are done by functions `gmt_nc_read_grd`/`gmt_nc_write_grd` in [`gmt/src/gmt_nc.c`](https://github.com/GenericMappingTools/gmt/blob/master/src/gmt_nc.c). Below Here are some technical notes:

- `x_units`/`y_units`/`z_units` has the form of `long_name [units]`, in which `[units]` is optional. `long_name` and `units` are netCDF attributes. [gmtnc_get_units](https://github.com/GenericMappingTools/gmt/blob/83f885ea4c2452e78a9d885a6c5840805781ed16/src/gmt_nc.c#L255)
- When reading, GMT reads the variable's `long_name` and `units` attributes and then sets the `x_units`/`y_units`/`z_units` string. If `long_name` is not defined, then use the variable's name instead. If `units` is not defined, then `[units]` is not appended. [gmtnc_get_units](https://github.com/GenericMappingTools/gmt/blob/83f885ea4c2452e78a9d885a6c5840805781ed16/src/gmt_nc.c#L255)
- For writing, GMT extracts the `long_name` and `units` attributes by parsing the `x_units`/`y_units`/`z_units` string, and setting the netCDF attributes if they're defined.  More attributes are added if it's a geographic coordinate. If `units="degrees_east"`, set attributes `standard_name` to `longitude` and `axis` to `X`; If `units="degrees_north"`, set attributes `standard_name` to `latitude` and `axis` to `Y`. [gmtnc_put_units](https://github.com/GenericMappingTools/gmt/blob/83f885ea4c2452e78a9d885a6c5840805781ed16/src/gmt_nc.c#L270)
- The default dimension names are `lon`/`time`/`x` for x axis and `lat`/`time`/`y` for y axis. [reference](https://github.com/GenericMappingTools/gmt/blob/83f885ea4c2452e78a9d885a6c5840805781ed16/src/gmt_nc.c#L566)
- The default name for the data is always `z` for 2-D grid or `cube` for 3-D cube, unless the variable name is given. The variable name is stored in the hidden structure `HH->varname`, but how is `HH->varname` determined?. [reference](https://github.com/GenericMappingTools/gmt/blob/83f885ea4c2452e78a9d885a6c5840805781ed16/src/gmt_nc.c#L591)
- When writing a netCDF file, GMT defines some global attributes, including `Conventions` (`CF-1.7`), `title`, `history`, `description`, `GMT_version`, `node_offset` (only for pixel grids). [reference](https://github.com/GenericMappingTools/gmt/blob/83f885ea4c2452e78a9d885a6c5840805781ed16/src/gmt_nc.c#L985)
- When writing x/y vectors, axis attributes `actual_range` (from `header-wesn`) and `axis` (`X` or `Y`) are also set. [reference](https://github.com/GenericMappingTools/gmt/blob/83f885ea4c2452e78a9d885a6c5840805781ed16/src/gmt_nc.c#L1044)
- When writing the data, some attributes are defined: `scale_factor` (if not 1.0), `add_offset` (if not 0.0), `cpt` (if defined by GMT), `_FillValue` (for NaN), `actual_range`.

## Benefits of current implementation

1. Simplify the codes of module wrappers
2. No longer to write output grid to temporary files
3. Performance improvements (https://github.com/GenericMappingTools/pygmt/pull/2398#issuecomment-1996219144)

## Limitations of current implementation

In addition to the metadata stored in the `GMT_GRID_HEADER` object, GMT also has some hidden metadata which is stored in a hidden data structure, for example, `grdtype` (Cartesian or Geographic grid?), `cpt` (the default CPT). The hidden data structure is private and may change between different GMT versions. So it's not a good practice to wrap and use the hidden data structure. But it also means we can't know the `grdtype`/`cpt` attributes when converting `GMT_GRID` to `xarray.DataArray`.

For `grdtype`, it's reasonable to say that the grid is geographic if x's unit is `degrees_east` and y's unit is `degrees_north` (see the note above and also [CF conventions](https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html)), but for `cpt`, we can't know if a grid has a default CPT or not.

Another limitation is that, `grdcut` now can't cut an image because we assume that the output is a grid. An initial fix is at #3115. But, as far as I can see, although many GMT modules can accept an image (e.g., `grdcut`, `grdimage`, `grdview`), only `grdcut` and `grdmix` can output an image. 

## References

- Function `gmtnc_put_units` in `gmt_nc.c`
- Function `gmtnc_get_units` in `gmt_nc.c`
- Function `gmtnc_grd_info` in `gmt_nc.c`
- Function `gmt_grd_init` in `gmt_grdio.c`