### PR TITLE
Allow printing show_versions() to in-memory buffer to enable testing

### DIFF
--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -17,8 +17,8 @@ Here are just a few of the things that PyGMT does well:
     lines, vectors, polygons, and symbols (pre-defined and customized).
   - Generating publication-quality illustrations and making animations.
 """
-
 import atexit as _atexit
+import sys
 from importlib.metadata import version
 
 from pygmt import clib
@@ -80,7 +80,7 @@ _begin()
 _atexit.register(_end)
 
 
-def print_clib_info():
+def print_clib_info(file=sys.stdout):
     """
     Print information about the GMT shared library that we can find.
 
@@ -93,10 +93,10 @@ def print_clib_info():
     with Session() as ses:
         for key in sorted(ses.info):
             lines.append(f"  {key}: {ses.info[key]}")
-    print("\n".join(lines))
+    print("\n".join(lines), file=file)
 
 
-def show_versions():
+def show_versions(file=sys.stdout):
     """
     Print various dependency versions which are useful when submitting bug
     reports.
@@ -168,19 +168,19 @@ def show_versions():
         "geopandas",
     ]
 
-    print("PyGMT information:")
-    print(f"  version: {__version__}")
+    print("PyGMT information:", file=file)
+    print(f"  version: {__version__}", file=file)
 
-    print("System information:")
+    print("System information:", file=file)
     for key, val in sys_info.items():
-        print(f"  {key}: {val}")
+        print(f"  {key}: {val}", file=file)
 
-    print("Dependency information:")
+    print("Dependency information:", file=file)
     for modname in deps:
-        print(f"  {modname}: {_get_module_version(modname)}")
-    print(f"  ghostscript: {_get_ghostscript_version()}")
+        print(f"  {modname}: {_get_module_version(modname)}", file=file)
+    print(f"  ghostscript: {_get_ghostscript_version()}", file=file)
 
-    print_clib_info()
+    print_clib_info(file=file)
 
 
 def test(doctest=True, verbose=True, coverage=False, figures=True):

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -112,7 +112,6 @@ def show_versions(file=sys.stdout):
     import importlib
     import platform
     import subprocess
-    import sys
 
     def _get_module_version(modname):
         """

--- a/pygmt/tests/test_init.py
+++ b/pygmt/tests/test_init.py
@@ -8,11 +8,12 @@ import pygmt
 
 def test_show_versions():
     """
-    Test pygmt.show_versions()
+    Check that pygmt.show_versions() reports version information from PyGMT,
+    the operating system, dependencies and the GMT library.
     """
-    f = io.StringIO()
-    pygmt.show_versions(file=f)
-    assert "PyGMT information:" in f.getvalue()
-    assert "System information:" in f.getvalue()
-    assert "Dependency information:" in f.getvalue()
-    assert "GMT library information:" in f.getvalue()
+    buf = io.StringIO()
+    pygmt.show_versions(file=buf)
+    assert "PyGMT information:" in buf.getvalue()
+    assert "System information:" in buf.getvalue()
+    assert "Dependency information:" in buf.getvalue()
+    assert "GMT library information:" in buf.getvalue()

--- a/pygmt/tests/test_init.py
+++ b/pygmt/tests/test_init.py
@@ -1,0 +1,18 @@
+"""
+Test functions in __init__.
+"""
+import io
+
+import pygmt
+
+
+def test_show_versions():
+    """
+    Test pygmt.show_versions()
+    """
+    f = io.StringIO()
+    pygmt.show_versions(file=f)
+    assert "PyGMT information:" in f.getvalue()
+    assert "System information:" in f.getvalue()
+    assert "Dependency information:" in f.getvalue()
+    assert "GMT library information:" in f.getvalue()


### PR DESCRIPTION
**Description of proposed changes**

To increase code coverage of `__init__.py`, check the output of `pygmt.show_versions()` that is printed to an in-memory string buffer instead of stdout.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Adapted from https://github.com/xarray-contrib/xbatcher/blob/v0.2.0/xbatcher/tests/test_print_versions.py. Was looking through some code in `xbatcher` and noticed the neat `print(..., file=io.StringIO)` trick. Thanks @maxrjones!

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Patches code coverage since #466


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
