### PR TITLE
Do not raise a KeyError exception if attribute actual_range doesn't exist

### DIFF
--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -322,7 +322,7 @@ def _load_remote_dataset(
     # Remove the actual range because it gets outdated when indexing the grid,
     # which causes problems when exporting it to netCDF for usage on the
     # command-line.
-    grid.attrs.pop("actual_range")
+    grid.attrs.pop("actual_range", None)
     for coord in grid.coords:
-        grid[coord].attrs.pop("actual_range")
+        grid[coord].attrs.pop("actual_range", None)
     return grid


### PR DESCRIPTION
**Description of proposed changes**

`grid.attrs.pop("actual_range")` raises a KeyError exception if the `actual_range` attribute doesn't exist. This PR fixes the issue by setting the default return value to None.

Address my comment https://github.com/GenericMappingTools/pygmt/pull/2398#issuecomment-1455335417.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
