### PR TITLE
Correct docs for "wedge" (w) symbol in gallery example "Multi-parameter symbols"

### DIFF
--- a/examples/gallery/symbols/multi_parameter_symbols.py
+++ b/examples/gallery/symbols/multi_parameter_symbols.py
@@ -30,7 +30,7 @@ import pygmt
 # - **j**: rotated rectangle, ``direction/width/height``
 # - **r**: rectangle, ``width/height``
 # - **R**: rounded rectangle, ``width/height/radius``
-# - **w**: pie wedge, ``radius/startdir/stopdir``, the last two arguments are
+# - **w**: pie wedge, ``diameter/startdir/stopdir``, the last two arguments are
 #   directions given in degrees counter-clockwise from horizontal
 #
 # Upper-case versions **E**, **J**, and **W** are similar to **e**, **j** and
@@ -64,7 +64,7 @@ fig.show()
 # - **j**: rotated rectangle, ``[[lon, lat, direction, width, height]]``
 # - **r**: rectangle, ``[[lon, lat, width, height]]``
 # - **R**: rounded rectangle, ``[[lon, lat, width, height, radius]]``
-# - **w**: pie wedge, ``[[lon, lat, radius, startdir, stopdir]]``, the last two
+# - **w**: pie wedge, ``[[lon, lat, diameter, startdir, stopdir]]``, the last two
 #   arguments are directions given in degrees counter-clockwise from horizontal
 
 fig = pygmt.Figure()

--- a/examples/gallery/symbols/multi_parameter_symbols.py
+++ b/examples/gallery/symbols/multi_parameter_symbols.py
@@ -33,7 +33,7 @@ import pygmt
 # - **w**: pie wedge, ``diameter/startdir/stopdir``, the last two arguments are
 #   directions given in degrees counter-clockwise from horizontal
 #
-# Upper-case versions **E**, **J**, and **W** are similar to **e**, **j** and
+# Upper-case versions **E**, **J**, and **W** are similar to **e**, **j**, and
 # **w** but expect geographic azimuths and distances.
 
 fig = pygmt.Figure()

--- a/examples/gallery/symbols/multi_parameter_symbols.py
+++ b/examples/gallery/symbols/multi_parameter_symbols.py
@@ -64,8 +64,9 @@ fig.show()
 # - **j**: rotated rectangle, ``[[lon, lat, direction, width, height]]``
 # - **r**: rectangle, ``[[lon, lat, width, height]]``
 # - **R**: rounded rectangle, ``[[lon, lat, width, height, radius]]``
-# - **w**: pie wedge, ``[[lon, lat, diameter, startdir, stopdir]]``, the last two
-#   arguments are directions given in degrees counter-clockwise from horizontal
+# - **w**: pie wedge, ``[[lon, lat, diameter, startdir, stopdir]]``, the last
+#   two arguments are directions given in degrees counter-clockwise from
+#   horizontal
 
 fig = pygmt.Figure()
 fig.basemap(region=[0, 6, 0, 4], projection="x3c", frame=["xa1f0.2", "ya0.5f0.1"])


### PR DESCRIPTION
**Description of proposed changes**

For "pie wedges" (**w**)  users have to state the diameter not the radius. This PR corrects the corresponding gallery example [Multi-parameter symbols](https://www.pygmt.org/dev/gallery/symbols/multi_parameter_symbols.htm).

Please see also the upstream GMT documentation: https://docs.generic-mapping-tools.org/dev/plot.html#id2

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
