### PR TITLE
WIP: pygmt.binstats: Add aliase "tiling" for "T"

### DIFF
--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -20,6 +20,7 @@ from pygmt.io import load_dataarray
     I="spacing",
     N="normalize",
     R="region",
+    T="tiling",
     S="search_radius",
     V="verbose",
     W="weight",

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -88,6 +88,20 @@ def binstats(data, **kwargs):
         Sets the *search_radius* that determines which data points are
         considered close to a node. Append the distance unit.
         Not compatible with ``tiling``.
+    tiling : str
+        **h**\|\ **r**.
+        Instead of circular, possibly overlapping areas, select
+        non-overlapping tiling. Choose between rectangular hexagonal
+        binning. For **r**, set bin sizes via ``spacing`` and we write
+        the computed statistics to the grid file named in ``outgrid``.
+        For **h**, we write a table with the centers of the hexagons and
+        the computed statistics to standard output (or to the file named
+        in ``outgrid``). Here, the ``spacing`` setting is expected to
+        set the y-increment only and we compute the x-increment given
+        the geometry. Because the horizontal spacing between hexagon
+        centers in x and y have a ratio of, we will automatically
+        adjust xmax in ``region`` to fit a whole number of hexagons.
+        Note: Hexagonal tiling requires Cartesian data.
     weight : str
         Input data have an extra column containing observation point weight.
         If weights are given then weighted statistical quantities will be


### PR DESCRIPTION
**Description of proposed changes**
This PR aims to add a alias for `pygmt.binstats`:

- [ ]  **T** -> `tiling`

The docstring is orientated on https://docs.generic-mapping-tools.org/latest/gmtbinstats.html#t.
Related to comment: https://github.com/GenericMappingTools/pygmt/pull/2376/files#r1131483527.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
