### PR TITLE
pygmt.grdfilter: Add the missing grid registration to suppress warnings

### DIFF
--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -127,7 +127,7 @@ def grdfilter(grid, **kwargs):
     >>> # Apply a filter of 600km (full width) to the @earth_relief_30m file
     >>> # and return a filtered field (saved as netcdf)
     >>> pygmt.grdfilter(
-    ...     grid="@earth_relief_30m",
+    ...     grid="@earth_relief_30m_g",
     ...     filter="m600",
     ...     distance="4",
     ...     region=[150, 250, 10, 40],


### PR DESCRIPTION
**Description of proposed changes**

Suppress the following warning:
```
----------------------------- Captured stderr call -----------------------------
Warning: sion [WARNING]: Remote dataset given to a data processing module but no registration was specified - default to gridline registration (if available)
```

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
