### PR TITLE
Fix the failing plot3d_projection test

### DIFF
--- a/pygmt/tests/baseline/test_plot3d_projection.png.dvc
+++ b/pygmt/tests/baseline/test_plot3d_projection.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 9db4a08f03a39f5ea3106df0c870b0b4
-  size: 37904
+- md5: 3e2050baf59fa2ec7dbe7e3340eea32f
+  size: 34774
   path: test_plot3d_projection.png

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -104,7 +104,7 @@ def test_plot3d_projection(data, region):
         zscale=5,
         perspective=[225, 30],
         region=region,
-        projection="R270/10c",
+        projection="R40/10c",
         style="s1c",
         fill="green",
         frame=["ag", "zag"],


### PR DESCRIPTION
**Description of proposed changes**

The `test_plot3d_projection` test fails for the GMT master branch. The error messages are:
```
----------------------------- Captured stderr call -----------------------------
Error: [ERROR]: Western boundary is > 180 degrees from specified central meridian and thus your region is invalid
Error: [ERROR]: General map projection error
```
Based on the comments in https://github.com/GenericMappingTools/gmt/pull/7295#issuecomment-1455698274, I think the central meridian is incorrectly given in this test.

This PR changed the central meridian to be the center of the specified region.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
