### PR TITLE
Fix setting "sharex", "sharey", and "frame" of Figure.subplot in combination with Figure.basemap

### DIFF
--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -33,7 +33,7 @@ def basemap(self, **kwargs):
     tick-mark intervals for boundary annotation, ticking, and [optionally]
     gridlines. A simple map scale or directional rose may also be plotted.
 
-    At least one of the parameters ``frame``, ``map_scale``, ``rose`` or
+    At least one of the parameters ``frame``, ``map_scale``, ``rose``, or
     ``compass`` must be specified if not in subplot mode.
 
     Full option list at :gmt-docs:`basemap.html`

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -92,7 +92,7 @@ def basemap(self, **kwargs):
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
     if not args_in_kwargs(args=["B", "L", "Td", "Tm", "c"], kwargs=kwargs):
         raise GMTInvalidInput(
-            "At least one of frame, map_scale, compass, rose, or panel must be specified."
+            "At least one of 'frame', 'map_scale', 'compass', 'rose', or 'panel' must be specified."
         )
     with Session() as lib:
         lib.call_module(module="basemap", args=build_arg_string(kwargs))

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -4,7 +4,6 @@ basemap - Plot base maps and frames for the figure.
 
 from pygmt.clib import Session
 from pygmt.helpers import (
-    args_in_kwargs,
     build_arg_string,
     fmt_docstring,
     kwargs_to_strings,

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -3,7 +3,6 @@ basemap - Plot base maps and frames for the figure.
 """
 
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     args_in_kwargs,
     build_arg_string,
@@ -90,9 +89,5 @@ def basemap(self, **kwargs):
     {transparency}
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
-    if not args_in_kwargs(args=["B", "L", "Td", "Tm", "c"], kwargs=kwargs):
-        raise GMTInvalidInput(
-            "At least one of 'frame', 'map_scale', 'compass', 'rose', or 'panel' must be specified."
-        )
     with Session() as lib:
         lib.call_module(module="basemap", args=build_arg_string(kwargs))

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -86,7 +86,5 @@ def basemap(self, **kwargs):
     {transparency}
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
-    if not args_in_kwargs(args=["B", "L", "Td", "Tm", "c"], kwargs=kwargs):
-        kwargs["B"] = True  # Plotting frames if required arguments not given
     with Session() as lib:
         lib.call_module(module="basemap", args=build_arg_string(kwargs))

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -3,7 +3,14 @@ basemap - Plot base maps and frames for the figure.
 """
 
 from pygmt.clib import Session
-from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import (
+    args_in_kwargs,
+    build_arg_string,
+    fmt_docstring,
+    kwargs_to_strings,
+    use_alias,
+)
 
 
 @fmt_docstring
@@ -32,6 +39,9 @@ def basemap(self, **kwargs):
     map projections are available, and the user may specify separate
     tick-mark intervals for boundary annotation, ticking, and [optionally]
     gridlines. A simple map scale or directional rose may also be plotted.
+
+    At least one of the parameters ``frame``, ``map_scale``, ``rose`` or
+    ``compass`` must be specified.
 
     Full option list at :gmt-docs:`basemap.html`
 
@@ -80,5 +90,9 @@ def basemap(self, **kwargs):
     {transparency}
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
+    if not args_in_kwargs(args=["B", "L", "Td", "Tm", "c"], kwargs=kwargs):
+        raise GMTInvalidInput(
+            "At least one of frame, map_scale, compass, rose, or panel must be specified."
+        )
     with Session() as lib:
         lib.call_module(module="basemap", args=build_arg_string(kwargs))

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -34,7 +34,7 @@ def basemap(self, **kwargs):
     gridlines. A simple map scale or directional rose may also be plotted.
 
     At least one of the parameters ``frame``, ``map_scale``, ``rose`` or
-    ``compass`` must be specified.
+    ``compass`` must be specified if not in subplot mode.
 
     Full option list at :gmt-docs:`basemap.html`
 

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -3,12 +3,7 @@ basemap - Plot base maps and frames for the figure.
 """
 
 from pygmt.clib import Session
-from pygmt.helpers import (
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 
 @fmt_docstring

--- a/pygmt/tests/baseline/test_basemap_required_args.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_required_args.png.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 36f8200a27d23e19951c2a3823a28faa
-  size: 6163
-  path: test_basemap_required_args.png

--- a/pygmt/tests/baseline/test_basemap_subplot.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_subplot.png.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 1b4ae53658eec125ebf8ab4eac78d729
+  size: 8733
+  path: test_basemap_subplot.png

--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -3,16 +3,16 @@ Tests Figure.basemap.
 """
 import pytest
 from pygmt import Figure
+from pygmt.exceptions import GMTInvalidInput
 
 
-@pytest.mark.mpl_image_compare
 def test_basemap_required_args():
     """
-    Automatically set `frame=True` when required arguments are not given.
+    Figure.basemap fails when not given required arguments.
     """
     fig = Figure()
-    fig.basemap(region=[10, 70, -3, 8], projection="X8c/6c")
-    return fig
+    with pytest.raises(GMTInvalidInput):
+        fig.basemap(region=[10, 70, -3, 8], projection="X8c/6c")
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -6,15 +6,6 @@ from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput
 
 
-def test_basemap_required_args():
-    """
-    Figure.basemap fails when not given required arguments.
-    """
-    fig = Figure()
-    with pytest.raises(GMTInvalidInput):
-        fig.basemap(region=[10, 70, -3, 8], projection="X8c/6c")
-
-
 @pytest.mark.mpl_image_compare
 def test_basemap():
     """

--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -131,8 +131,8 @@ def test_basemap_map_scale():
 @pytest.mark.mpl_image_compare
 def test_basemap_subplot():
     """
-    Test in subplot mode for the case that the frame parameter of
-    basemap is not specified.
+    Test in subplot mode for the case that the frame parameter of basemap is
+    not specified.
     """
     nrows = 1
     ncols = 2

--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -3,7 +3,6 @@ Tests Figure.basemap.
 """
 import pytest
 from pygmt import Figure
-from pygmt.exceptions import GMTInvalidInput
 
 
 @pytest.mark.mpl_image_compare

--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -134,8 +134,6 @@ def test_basemap_subplot():
     Test in subplot mode for the case that the frame parameter of basemap is
     not specified.
     """
-    nrows = 1
-    ncols = 2
     fig = Figure()
     with fig.subplot(nrows=1, ncols=2, figsize=("10c", "5c")):
         with fig.set_panel(panel=0):

--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -137,17 +137,9 @@ def test_basemap_subplot():
     nrows = 1
     ncols = 2
     fig = Figure()
-    with fig.subplot(
-        nrows=nrows,
-        ncols=ncols,
-        figsize=("10c", "5c"),
-        sharex="b+llabel_x",
-        sharey="l+llabel_y",
-        frame="a1f0.5g2",
-    ):
-        for i in range(nrows):
-            for j in range(ncols):
-                index = i * nrows + j
-                with fig.set_panel(panel=index):
-                    fig.basemap(region=[0, 10, 0, 10], projection="X?")
+    with fig.subplot(nrows=1, ncols=2, figsize=("10c", "5c")):
+        with fig.set_panel(panel=0):
+            fig.basemap(region=[0, 10, 0, 10], projection="X?")
+        with fig.set_panel(panel=1):
+            fig.basemap(region=[0, 10, 0, 10], projection="X?")
     return fig

--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -126,3 +126,28 @@ def test_basemap_map_scale():
         map_scale="jMC+c26.5+w10k+f+l",
     )
     return fig
+
+
+@pytest.mark.mpl_image_compare
+def test_basemap_subplot():
+    """
+    Test in subplot mode for the case that the frame parameter of
+    basemap is not specified.
+    """
+    nrows = 1
+    ncols = 2
+    fig = Figure()
+    with fig.subplot(
+        nrows=nrows,
+        ncols=ncols,
+        figsize=("10c", "5c"),
+        sharex="b+llabel_x",
+        sharey="l+llabel_y",
+        frame="a1f0.5g2",
+    ):
+        for i in range(nrows):
+            for j in range(ncols):
+                index = i * nrows + j
+                with fig.set_panel(panel=index):
+                    fig.basemap(region=[0, 10, 0, 10], projection="X?")
+    return fig


### PR DESCRIPTION
**Description of proposed changes**

For context please see issue #2365

This PR aims to test the suggestion in comment https://github.com/GenericMappingTools/pygmt/issues/2365#issuecomment-1465765646.

First PR #2418 has to be merged.

Fixes issue #2365 

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
