### PR TITLE
Set "frame" parameter for  the first figure of the gallery example "Timestamp"

### DIFF
--- a/examples/gallery/embellishments/timestamp.py
+++ b/examples/gallery/embellishments/timestamp.py
@@ -15,7 +15,7 @@ of the figure. By default, the ``offset`` and
 import pygmt
 
 fig = pygmt.Figure()
-fig.basemap(region=[20, 30, -10, 10], projection="X10c/5c")
+fig.basemap(region=[20, 30, -10, 10], projection="X10c/5c", frame=True)
 fig.timestamp()
 fig.show()
 

--- a/examples/gallery/embellishments/timestamp.py
+++ b/examples/gallery/embellishments/timestamp.py
@@ -10,7 +10,7 @@ of the figure. By default, the ``offset`` and
 (bottom-left), respectively.
 """
 
-# sphinx_gallery_thumbnail_number = 1
+# sphinx_gallery_thumbnail_number = 2
 
 import pygmt
 


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to set the `frame` parameter of `pygmt.Figure.basemap` for the first figure of the gallery example [Timestamp](https://www.pygmt.org/dev/gallery/embellishments/timestamp.html).

Related to the changes in PR #2417 to fix issue #2356.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
