### PR TITLE
Remove --sdist --wheel flags from the build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ install:
 	pip install --no-deps -e .
 
 package:
-	python -m build --sdist --wheel
+	python -m build
 
 test:
 	# Run a tmp folder to make sure the tests are run on the installed version


### PR DESCRIPTION
**Description of proposed changes**

Simply use `python -m build` without any flags following the official recommendations (https://pypa-build.readthedocs.io/en/stable/index.html).

Please note that both `python -m build` and `python -m build --sdist --wheel` can build source and binary distributions but the details are different:

> By default, a source distribution (sdist) is built from {srcdir} and a binary distribution (wheel) is built from the sdist. This is recommended as it will ensure the sdist can be used to build wheels. Pass -s/–sdist and/or -w/–wheel to build a specific distribution. If you do this, the default behavior will be disabled, and all artifacts will be built from {srcdir} (even if you combine -w/–wheel with -s/–sdist, the wheel will be built from {srcdir}).