### PR TITLE
Expand histogram gallery example to show usage of pattern as fill

### DIFF
--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -4,7 +4,8 @@ Histogram
 The :meth:`pygmt.Figure.histogram` method can plot regular histograms.
 Using the ``series`` parameter allows to set the interval for the width of
 each bar. The type of the histogram (frequency count or percentage) can be
-selected via the ``histtype`` parameter.
+selected via the ``histtype`` parameter. The fill can be either a 
+standard color name or a pattern. 
 """
 
 import numpy as np
@@ -19,19 +20,37 @@ data = mean + stddev * np.random.randn(521)
 
 fig = pygmt.Figure()
 
-fig.histogram(
-    data=data,
-    # Define the frame, add a title, and set the background color to
-    # "lightgray". Add labels to the x-axis and y-axis
-    frame=["WSne+tHistogram+glightgray", "x+lElevation (m)", "y+lCounts"],
-    # Generate evenly spaced bins by increments of 5
-    series=5,
-    # Use "red3" as color fill for the bars
-    fill="red3",
-    # Use the pen parameter to draw the outlines with a width of 1 point
-    pen="1p",
-    # Choose histogram type 0, i.e., counts [Default]
-    histtype=0,
-)
+with fig.subplot(
+    nrows=1, ncols=2, figsize=("13.5c", "5c"), title="Histogram",
+):
+        
+    with fig.set_panel(panel=0):        
+        fig.histogram(
+            data=data,
+            # Define the frame, add title and set background color to
+            # "lightgray", add labels for x and y axes
+            frame=["WSne+glightgray", "x+lElevation in m", "y+lCounts"],
+            # Generate evenly spaced bins by increments of 5
+            series=5,
+            # Use "red3" as color fill for the bars
+            fill="red3",
+            # Use a pen size of 1 point to draw the outlines
+            pen="1p",
+            # Choose histogram type 0, i.e., counts [Default]
+            histtype=0,
+        )
+        
+    with fig.set_panel(panel=1):
+        fig.histogram(
+            data=data,
+            frame=["wSne+glightgray", "x+lElevation in m"],
+            series=5,
+            # Use pattern number 8 as fill for the bars
+            # with "lightblue" as background color (+b) and
+            # "black" as foreground color (+f)
+            fill="p8+blightblue+fblack",
+            pen="1p",
+            histtype=0,
+        )
 
 fig.show()

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -29,8 +29,8 @@ with fig.subplot(
     with fig.set_panel(panel=0):
         fig.histogram(
             data=data,
-            # Define the frame, add title and set background color to
-            # "lightgray", add labels for x and y axes
+            # Define the frame and set background color to "lightgray",
+            # add labels for x and y axes
             frame=["WSne+glightgray", "x+lElevation in m", "y+lCounts"],
             # Generate evenly spaced bins by increments of 5
             series=5,

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -4,8 +4,8 @@ Histogram
 The :meth:`pygmt.Figure.histogram` method can plot regular histograms.
 Using the ``series`` parameter allows to set the interval for the width of
 each bar. The type of the histogram (frequency count or percentage) can be
-selected via the ``histtype`` parameter. The fill can be either a
-standard color name or a pattern.
+selected via the ``histtype`` parameter. The ``fill`` of the
+bars can be either a standard color name or a pattern.
 """
 
 import numpy as np
@@ -36,7 +36,7 @@ with fig.subplot(
             series=5,
             # Use "red3" as color fill for the bars
             fill="red3",
-            # Use a pen size of 1 point to draw the outlines
+            # Use a pen thickness of 1 point to draw the outlines
             pen="1p",
             # Choose histogram type 0, i.e., counts [Default]
             histtype=0,
@@ -47,7 +47,7 @@ with fig.subplot(
             data=data,
             frame=["wSne+glightgray", "x+lElevation in m"],
             series=5,
-            # Use pattern number 8 as fill for the bars
+            # Use pattern (p) number 8 as fill for the bars
             # with "lightblue" as background color (+b) and
             # "black" as foreground color (+f)
             fill="p8+blightblue+fblack",

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -21,10 +21,12 @@ data = mean + stddev * np.random.randn(521)
 fig = pygmt.Figure()
 
 with fig.subplot(
-    nrows=1, ncols=2, figsize=("13.5c", "5c"), title="Histogram",
+    nrows=1,
+    ncols=2,
+    figsize=("13.5c", "5c"),
+    title="Histogram",
 ):
-        
-    with fig.set_panel(panel=0):        
+    with fig.set_panel(panel=0):
         fig.histogram(
             data=data,
             # Define the frame, add title and set background color to
@@ -39,7 +41,7 @@ with fig.subplot(
             # Choose histogram type 0, i.e., counts [Default]
             histtype=0,
         )
-        
+
     with fig.set_panel(panel=1):
         fig.histogram(
             data=data,

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -4,8 +4,8 @@ Histogram
 The :meth:`pygmt.Figure.histogram` method can plot regular histograms.
 Using the ``series`` parameter allows to set the interval for the width of
 each bar. The type of the histogram (frequency count or percentage) can be
-selected via the ``histtype`` parameter. The fill can be either a 
-standard color name or a pattern. 
+selected via the ``histtype`` parameter. The fill can be either a
+standard color name or a pattern.
 """
 
 import numpy as np

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -5,7 +5,7 @@ The :meth:`pygmt.Figure.histogram` method can plot regular histograms.
 Using the ``series`` parameter allows to set the interval for the width of
 each bar. The type of the histogram (frequency count or percentage) can be
 selected via the ``histtype`` parameter. The ``fill`` of the
-bars can be either a standard color name or a pattern.
+bars can be either a color or a pattern.
 """
 
 import numpy as np
@@ -24,7 +24,7 @@ with fig.subplot(
     nrows=1,
     ncols=2,
     figsize=("13.5c", "5c"),
-    title="Histogram",
+    title="Histograms",
 ):
     with fig.set_panel(panel=0):
         fig.histogram(


### PR DESCRIPTION
**Description of proposed changes**

Adresses #2323 and expands the histogram example to show the use of a pattern as fill.

**Preview:** https://pygmt-dev--2421.org.readthedocs.build/en/2421/gallery/histograms/histogram.html

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
