### PR TITLE
Figure.timestamp: Let the 'text' parameter work for GMT<=6.4.0 and raise a warning for long text

### DIFF
--- a/pygmt/src/timestamp.py
+++ b/pygmt/src/timestamp.py
@@ -88,7 +88,7 @@ def timestamp(
         if len(str(text)) > 64:
             msg = (
                 "Argument of 'text' must be no longer than 64 characters. "
-                "The text string will be truncated to 64 characters."
+                "The given text string will be truncated to 64 characters."
             )
             warnings.warn(message=msg, category=RuntimeWarning, stacklevel=2)
         if Version(__gmt_version__) <= Version("6.4.0"):

--- a/pygmt/src/timestamp.py
+++ b/pygmt/src/timestamp.py
@@ -1,10 +1,11 @@
 """
 timestamp - Plot the GMT timestamp logo.
 """
+import warnings
+
 from packaging.version import Version
 from pygmt import __gmt_version__
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import build_arg_string, is_nonstr_iter
 
 __doctest_skip__ = ["timestamp"]
@@ -28,7 +29,6 @@ def timestamp(
         If ``None``, the current UNIX timestamp is shown in the GMT timestamp
         logo. Set this parameter to replace the UNIX timestamp with a
         custom text string instead. The text must be less than 64 characters.
-        *Requires GMT>=6.5.0*.
     label : None or str
         The text string shown after the GMT timestamp logo.
     justification : str
@@ -85,13 +85,17 @@ def timestamp(
     # The +t modifier was added in GMT 6.5.0.
     # See https://github.com/GenericMappingTools/gmt/pull/7127.
     if text is not None:
-        if Version(__gmt_version__) < Version("6.5.0"):
-            raise GMTInvalidInput("The parameter 'text' requires GMT>=6.5.0.")
         if len(str(text)) > 64:
-            raise GMTInvalidInput(
-                "The parameter 'text' must be less than 64 characters."
+            msg = (
+                "Argument of 'text' must be no longer than 64 characters. "
+                "The text string will be truncated to 64 characters."
             )
-        kwdict["U"] += f"+t{text}"
+            warnings.warn(message=msg, category=RuntimeWarning, stacklevel=2)
+        if Version(__gmt_version__) <= Version("6.4.0"):
+            # workaround for GMT<=6.4.0 by overriding the 'timefmt' parameter
+            timefmt = text[:64]
+        else:
+            kwdict["U"] += f"+t{text}"
 
     with Session() as lib:
         lib.call_module(

--- a/pygmt/tests/baseline/test_timestamp_text_truncated.png.dvc
+++ b/pygmt/tests/baseline/test_timestamp_text_truncated.png.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 14b0d80e2b31ee0c7fb61cf0b9f4f73f
+  size: 3491
+  path: test_timestamp_text_truncated.png

--- a/pygmt/tests/test_timestamp.py
+++ b/pygmt/tests/test_timestamp.py
@@ -2,8 +2,7 @@
 Tests for Figure.timestamp.
 """
 import pytest
-from packaging.version import Version
-from pygmt import Figure, __gmt_version__, config
+from pygmt import Figure, config
 
 
 @pytest.fixture(scope="module", name="faketime")
@@ -72,19 +71,29 @@ def test_timestamp_font(faketime):
     return fig
 
 
-@pytest.mark.skipif(
-    Version(__gmt_version__) < Version("6.5.0"),
-    reason="The 'text' parameter requires GMT>=6.5.0",
-)
 @pytest.mark.mpl_image_compare(filename="test_timestamp.png")
 def test_timestamp_text(faketime):
     """
     Test if the "text" parameter works.
+    """
+    fig = Figure()
+    fig.timestamp(text=faketime)
+    return fig
+
+
+@pytest.mark.mpl_image_compare
+def test_timestamp_text_truncated():
+    """
+    Passing a text string longer than 64 characters raises a warning and the
+    string will be truncated.
 
     Requires GMT>=6.5.0.
     """
     fig = Figure()
-    fig.timestamp(text=faketime)
+    with pytest.warns(expected_warning=RuntimeWarning) as record:
+        # a string with 70 characters will be truncated to 64 characters
+        fig.timestamp(text="0123456789" * 7)
+        assert len(record) == 1  # check that only one warning was raised
     return fig
 
 


### PR DESCRIPTION
**Description of proposed changes**

Changes in this PR:

1. `-U`'s `+t` modifier was added https://github.com/GenericMappingTools/gmt/pull/7127, so the `text` parameter doesn't work for GMT<=6.4.0. This PR implements the same feature for GMT<=6.4.0 by overrriding the `timefmt` parameter that will be passed to `FORMAT_TIME_STAMP`. Now, the `text` parameter works the same for any GMT versions.
2. Text string passed to the `text` parameter will be truncated to 64 characters if its length exceeds 64. Now `Figure.timestamp()` raise a warning instead of an exception when getting a too long `text` argument.
3. Add a test for passing a very long text string to the `text` parameter.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
