### PR TITLE
Figure.subplot: Fix strange positioning issues after exiting subplot 

### DIFF
--- a/examples/gallery/images/grdgradient_shading.py
+++ b/examples/gallery/images/grdgradient_shading.py
@@ -57,6 +57,6 @@ with fig.subplot(
                 panel=True,
             )
 
-fig.colorbar(position="x9.0c/-1.1c+w10c/0.25c+h", frame="a2000f500+lElevation (m)")
+fig.colorbar(position="JBC+w10c/0.25c+h", frame="a2000f500+lElevation (m)")
 
 fig.show()

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -155,8 +155,9 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
         )
 
     # Need to use separate sessions for "subplot begin" and "subplot end".
-    # Otherwise, "subplot end" will use the last session, which may causes
-    # strange behavior like https://github.com/GenericMappingTools/pygmt/issues/2426
+    # Otherwise, "subplot end" will use the last session, which may cause
+    # strange positioning issues for later plotting calls.
+    # See https://github.com/GenericMappingTools/pygmt/issues/2426.
     try:
         with Session() as lib:
             arg_str = " ".join(["begin", f"{nrows}x{ncols}", build_arg_string(kwargs)])

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -154,12 +154,16 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
             "Please provide either one of 'figsize' or 'subsize' only."
         )
 
-    with Session() as lib:
-        try:
+    # Need to use separate sessions for "subplot begin" and "subplot end".
+    # Otherwise, "subplot end" will use the last session, which may causes
+    # strange behavior like https://github.com/GenericMappingTools/pygmt/issues/2426
+    try:
+        with Session() as lib:
             arg_str = " ".join(["begin", f"{nrows}x{ncols}", build_arg_string(kwargs)])
             lib.call_module(module="subplot", args=arg_str)
             yield
-        finally:
+    finally:
+        with Session() as lib:
             v_arg = build_arg_string({"V": kwargs.get("V")})
             lib.call_module(module="subplot", args=f"end {v_arg}")
 

--- a/pygmt/tests/baseline/test_subplot_outside_plotting_positioning.png.dvc
+++ b/pygmt/tests/baseline/test_subplot_outside_plotting_positioning.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 14da5db0ab63addd8a6d52d6746d9da2
-  size: 12124
+- md5: 60b51be2c54ccd6edf627a6fdae1d6ee
+  size: 12117
   path: test_subplot_outside_plotting_positioning.png

--- a/pygmt/tests/baseline/test_subplot_outside_plotting_positioning.png.dvc
+++ b/pygmt/tests/baseline/test_subplot_outside_plotting_positioning.png.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 14da5db0ab63addd8a6d52d6746d9da2
+  size: 12124
+  path: test_subplot_outside_plotting_positioning.png

--- a/pygmt/tests/baseline/test_subplot_outside_plotting_positioning.png.dvc
+++ b/pygmt/tests/baseline/test_subplot_outside_plotting_positioning.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 60b51be2c54ccd6edf627a6fdae1d6ee
-  size: 12117
+- md5: 976a01a8c9f583918c00b5a81fddaf84
+  size: 12112
   path: test_subplot_outside_plotting_positioning.png

--- a/pygmt/tests/test_subplot.py
+++ b/pygmt/tests/test_subplot.py
@@ -107,7 +107,8 @@ def test_subplot_outside_plotting_positioning():
     """
     Plotting calls are correctly positioned after exiting subplot.
 
-    See https://github.com/GenericMappingTools/pygmt/issues/2426.
+    This is a regression test for
+    https://github.com/GenericMappingTools/pygmt/issues/2426.
     """
     fig = Figure()
     with fig.subplot(nrows=1, ncols=2, figsize=(10, 5)):

--- a/pygmt/tests/test_subplot.py
+++ b/pygmt/tests/test_subplot.py
@@ -100,3 +100,18 @@ def test_subplot_nrows_ncols_less_than_one_error():
     with pytest.raises(GMTInvalidInput):
         with fig.subplot(nrows=0, ncols=-1, figsize=("2c", "1c")):
             pass
+
+
+@pytest.mark.mpl_image_compare
+def test_subplot_outside_plotting_positioning():
+    """
+    Plotting calls are correctly positioned after exiting subplot.
+
+    See https://github.com/GenericMappingTools/pygmt/issues/2426.
+    """
+    fig = Figure()
+    with fig.subplot(nrows=1, ncols=2, figsize=(10, 5)):
+        fig.basemap(region=[0, 10, 0, 10], projection="X?", frame=True, panel=True)
+        fig.basemap(region=[0, 10, 0, 10], projection="X?", frame=True, panel=True)
+    fig.colorbar(position="JBC+w5c+h", cmap="turbo", frame=True)
+    return fig


### PR DESCRIPTION
**Description of proposed changes**

Need to use separate sessions for `subplot begin` and `subplot end`. Otherwise, `subplot end` will use the "last session" (i.e., the `lib` variable created by other calls), which may cause strange behaviors like https://github.com/GenericMappingTools/pygmt/issues/2426.

After this PR, the PyGMT example in https://github.com/GenericMappingTools/pygmt/issues/2426 works as expected.

**TODOs**:

- [x] Add a unit test for it
- [x] Use `position="JBC+w10c/0.25c+h"` in https://github.com/GenericMappingTools/pygmt/pull/2354's gallery example
- [x] Check if any tests are affected (**NO**)
- [x] Check if any other examples need revision (**NO**)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
