### PR TITLE
Add a gallery example or tutorial showing how to use the "error_bar" parameter of "pygmt.Figure.plot"

### DIFF
--- a/examples/gallery/symbols/errorbars.py
+++ b/examples/gallery/symbols/errorbars.py
@@ -1,0 +1,141 @@
+r"""
+Error bars
+----------
+The ``error_bar`` parameter of the :meth:`pygmt.Figure.plot` method
+can be used to add error bars to data points.
+
+The general syntax is:
+
+[**x**\|\ **y**\|\ **X**\|\ **Y**][**+a**\|\ **A**][**+cl**\|\ **f**][**+n**][**+w**\ *cap*][**+p**\ *pen*]
+
+TODO
+"""
+
+# sphinx_gallery_thumbnail_number = 2
+
+
+import pandas as pd
+import pygmt
+
+
+###############################################################################
+# Default
+
+# Define DataFrame with columns for x and y as well as x-error and y-error
+df = pd.DataFrame(
+    data={
+    "x": [1, 3, 5, 7, 9],
+    "y": [0.5, -0.7, 0.8, -0.3, 0.1],
+    "x-error": [0.5, 0.2, 0.2, 0.2, 0.3],
+    "y-error": [0.2, 0.2, 0.3, 0.4, 0.2],
+    }
+)
+
+# Create Figure instance
+fig = pygmt.Figure()
+
+# Plot the data points
+fig.plot(
+    region=[0, 10, -2, 2],
+    projection="X10c",
+    data=df,
+    # Add symmetric error bars
+    error_bar=True,
+    style="c0.3c",  # circles with a diameter of 0.3 centimeters
+    pen="1.25p,black",
+    fill="green3",
+    frame=["a1fg1", "x+lx label", "y+ly label"],
+)
+
+fig.show()
+
+###############################################################################
+# Adjust bars and caps
+
+# Create Figure instance
+fig = pygmt.Figure()
+
+# Plot the data points
+fig.plot(
+    region=[0, 10, -2, 2],
+    projection="X10c",
+    data=df,
+    # +w size of cap
+    # +p width, color of bar
+    error_bar="+w10p+p2p,dodgerblue",
+    style="c0.3c",
+    pen="1.25p,black",
+    fill="green3",
+    frame=["a1fg1", "x+lx label", "y+ly label"],
+)
+
+fig.show()
+
+###############################################################################
+# Asymmetric error bars
+
+# Define DataFrame with columns for x and y as well as lower and upper x-error
+# and y-error
+df = pd.DataFrame(
+    data={
+    "x": [1, 3, 5, 7, 9],
+    "y": [0.5, -0.7, 0.8, -0.3, 0.1],
+    "x-error-low": [0.5, 0.2, 0.2, 0.2, 0.3],
+    "x-error-upp": [0.2, 0.2, 0.3, 0.4, 0.2],
+    "y-error-low": [0.5, 0.2, 0.2, 0.2, 0.3],
+    "y-error-upp": [0.2, 0.2, 0.3, 0.4, 0.2],
+    }
+)
+
+# Create Figure instance
+fig = pygmt.Figure()
+
+# Plot the data points
+fig.plot(
+    region=[0, 10, -2, 2],
+    projection="X10c",
+    data=df,
+    # +a asymmetric error bars
+    error_bar="+a+w10p+p2p,dodgerblue",
+    style="c0.3c",
+    pen="1p,black",
+    fill="green3",
+    frame=["a1fg1", "x+lx label", "y+ly label"],
+)
+
+fig.show()
+
+###############################################################################
+# Low and high bounds
+
+# Define DataFrame with columns for x and y as well as x and y low and high
+# bounds
+# TODO - adjust values
+df = pd.DataFrame(
+    data={
+    "x": [1, 3, 5, 7, 9],
+    "y": [0.5, -0.7, 0.8, -0.3, 0.1],
+    "x-error-low": [0.5, 2.2, 4.2, 6.2, 8.3],
+    "x-error-upp": [1.2, 3.4, 5.3, 7.4, 9.2],
+    "y-error-low": [0.2, -1.2, 0.2, -1.0, -0.8],
+    "y-error-upp": [1.2, -0.2, 1.3, 0.0, 0.9],
+    }
+)
+
+# Create Figure instance
+fig = pygmt.Figure()
+
+# Plot the data points
+fig.plot(
+    region=[0, 10, -2, 2],
+    projection="X10c",
+    data=df,
+    # +A low and high bounds
+    error_bar="+A+w10p+p2p,dodgerblue",
+    style="c0.3c",
+    pen="1p,black",
+    fill="green3",
+    frame=["a1fg1", "x+lx label", "y+ly label"],
+)
+
+fig.show()


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to add an example showing how to add error bars to data points using the `error_bar` parameter of `pygmt.Figure.plot`:
- [ ] Write documentation for general syntax
- [ ] Set up different code examples
- [ ] Add comments to the code examples 
- [ ] Decide whether this will be a gallery example or a tutorial

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
