### PR TITLE
Recommend Python 3.11 in the install instructions and fix some typos

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -190,7 +190,7 @@ We highly recommend using [Mambaforge](https://github.com/conda-forge/miniforge#
 and the `mamba` package manager to install and manage your Python packages.
 It will make your life a lot easier!
 
-The repository includes a conda environment file `environment.yml` with the
+The repository includes a virtual environment file `environment.yml` with the
 specification for all development requirements to build and test the project.
 In particular, these are some of the key development dependencies you will need
 to install to build the documentation and run the unit tests locally:

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -134,14 +134,14 @@ want):
 
         ::
 
-            mamba create --name pygmt python=3.9 numpy pandas xarray netcdf4 packaging gmt
+            mamba create --name pygmt python=3.11 numpy pandas xarray netcdf4 packaging gmt
 
     .. tab-item:: conda
         :sync: conda
 
         ::
 
-            conda create --name pygmt python=3.9 numpy pandas xarray netcdf4 packaging gmt
+            conda create --name pygmt python=3.11 numpy pandas xarray netcdf4 packaging gmt
 
 Activate the environment by running the following (**do not forget this step!**):
 
@@ -171,7 +171,7 @@ Installing PyGMT
 Now that you have GMT installed and your conda virtual environment activated,
 you can install PyGMT using any of the following methods:
 
-Using conda/mamba (recommended)
+Using mamba/conda (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This installs the latest stable release of PyGMT from
@@ -232,9 +232,8 @@ Alternatively, you can install the latest development version from
 To upgrade the installed stable release or development version to be the latest
 one, just add ``--upgrade`` to the corresponding command above.
 
-Any of the above methods (conda/pip) should allow you to use the PyGMT package
-from Python.
-
+Any of the above methods (mamba/conda/pip) should allow you to use the PyGMT
+package from Python.
 
 Testing your install
 --------------------
@@ -267,7 +266,7 @@ respectively.
 For Linux/macOS, add the following line to your shell configuration file
 (usually ``~/.bashrc`` for Bash on Linux and ``~/.zshrc`` for Zsh on macOS)::
 
-    export GMT_LIBRARY_PATH=$HOME/anaconda3/envs/pygmt/lib
+    export GMT_LIBRARY_PATH=$HOME/mambaforge/envs/pygmt/lib
 
 For Windows, add the ``GMT_LIBRARY_PATH`` environment variable following these
 `instructions <https://www.wikihow.com/Create-an-Environment-Variable-in-Windows-10>`__
@@ -280,9 +279,9 @@ Notes for Jupyter users
 
 If you can successfully import pygmt in a Python interpreter or IPython, but
 get a ``ModuleNotFoundError`` when importing pygmt in Jupyter, you may need to
-install a ``pygmt`` kernel following the commands below::
+activate your ``pygmt`` virtual environment (using ``conda activate pygmt`` or
+``mamba activate pygmt``) and install a ``pygmt`` kernel following the commands below::
 
-    conda activate pygmt
     python -m ipykernel install --user --name pygmt  # install conda environment properly
     jupyter kernelspec list --json
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -115,7 +115,7 @@ Installing GMT and other dependencies
 Before installing PyGMT, we must install GMT itself along with the other
 dependencies. The easiest way to do this is via the ``mamba`` or ``conda`` package manager.
 We recommend working in an isolated
-`conda environment <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__
+`virtual environment <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__
 to avoid issues with conflicting versions of dependencies.
 
 First, we must configure conda to get packages from the
@@ -123,7 +123,7 @@ First, we must configure conda to get packages from the
 
     conda config --prepend channels conda-forge
 
-Now we can create a new conda environment with Python and all our dependencies
+Now we can create a new virtual environment with Python and all our dependencies
 installed (we'll call it ``pygmt`` but feel free to change it to whatever you
 want):
 
@@ -279,10 +279,10 @@ Notes for Jupyter users
 
 If you can successfully import pygmt in a Python interpreter or IPython, but
 get a ``ModuleNotFoundError`` when importing pygmt in Jupyter, you may need to
-activate your ``pygmt`` virtual environment (using ``conda activate pygmt`` or
-``mamba activate pygmt``) and install a ``pygmt`` kernel following the commands below::
+activate your ``pygmt`` virtual environment (using ``mamba activate pygmt`` or
+``conda activate pygmt``) and install a ``pygmt`` kernel following the commands below::
 
-    python -m ipykernel install --user --name pygmt  # install conda environment properly
+    python -m ipykernel install --user --name pygmt  # install virtual environment properly
     jupyter kernelspec list --json
 
 After that, you need to restart Jupyter, open your notebook, select the

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -161,15 +161,15 @@ Activate the environment by running the following (**do not forget this step!**)
 
             conda activate pygmt
 
-From now on, all commands will take place inside the conda virtual environment
-called ``pygmt`` and won't affect your default ``base`` installation.
+From now on, all commands will take place inside the virtual environment called
+``pygmt`` and won't affect your default ``base`` installation.
 
 
 Installing PyGMT
 ----------------
 
-Now that you have GMT installed and your conda virtual environment activated,
-you can install PyGMT using any of the following methods:
+Now that you have GMT installed and your virtual environment activated, you can
+install PyGMT using any of the following methods:
 
 Using mamba/conda (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**Description of proposed changes**

Recommend Python 3.11 in the install instructions because it's currently tested in our CI.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Supersedes #740


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
