### PR TITLE
Expand gallery example "Focal mechanisms" to use "*fill" and "pen"

### DIFF
--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -45,8 +45,7 @@ fig.meca(
     # [Default is "white"]
     extensionfill="cornsilk",
     # Draw a 0.5 points thick dark gray ("gray30") solid outline via
-    # the pen parameter
-    # [Default is "0.25p,black,solid"]
+    # the pen parameter [Default is "0.25p,black,solid"]
     pen="0.5p,gray30,solid",
 )
 

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -35,6 +35,14 @@ fig.meca(
     longitude=-124.3,
     latitude=48.1,
     depth=12.0,
+    # fill compressional quadrants with color "gray70" (light gray)
+    # [Default is "black"]
+    compressionfill="gray70",
+    # fill extension quadrants with color "cornsilk"
+    # [Default is "white"]
+    extensionfill="cornsilk",
+    # use a 0.5 points thick dark gray ("gray30") outline
+    pen="0.5p,gray30",
 )
 
 fig.show()

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -5,8 +5,8 @@ Focal mechanisms
 The :meth:`pygmt.Figure.meca` method can plot focal mechanisms or beachballs.
 We can specify the focal mechanism nodal planes or moment tensor components as
 a dictionary using the ``spec`` parameter (or they can be specified as a 1-D
-or 2-D array, or within a specified file). The size of plotted beachballs can
-be specified using the ``scale`` parameter. The compressive and extensive
+or 2-D array, or within a file). The size of plotted beachballs can
+be set using the ``scale`` parameter. The compressive and extensive
 quadrants can be filled either with a color or a pattern via the
 ``compressionfill`` and ``extensionfill`` parameters, respectively.
 """

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -5,11 +5,11 @@ Focal mechanisms
 The :meth:`pygmt.Figure.meca` method can plot focal mechanisms or beachballs.
 We can specify the focal mechanism nodal planes or moment tensor components as
 a dictionary using the ``spec`` parameter (or they can be specified as a 1-D
-or 2-D array, or within a file). The size of plotted beachballs can
-be set using the ``scale`` parameter. The compressive and extensive
-quadrants can be filled either with a color or a pattern via the
-``compressionfill`` and ``extensionfill`` parameters, respectively. Use the
-``pen`` parameter to draw the outline of the beachballs.
+or 2-D array, or within a file). The size of plotted beachballs can be set
+using the ``scale`` parameter. The compressive and extensive quadrants can be
+filled either with a color or a pattern via the ``compressionfill`` and
+``extensionfill`` parameters, respectively. Use the ``pen`` parameter to draw
+the outline of the beachballs.
 """
 
 import pygmt

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -7,7 +7,7 @@ We can specify the focal mechanism nodal planes or moment tensor components as
 a dictionary using the ``spec`` parameter (or they can be specified as a 1-D
 or 2-D array, or within a specified file). The size of plotted beachballs can
 be specified using the ``scale`` parameter. The compressive and extensive
-quadrants can be filled with a standard color (or a pattern) via the
+quadrants can be filled with a color (or a pattern) via the
 ``compressionfill`` and ``extensionfill`` parameters, respectively.
 """
 
@@ -43,7 +43,7 @@ fig.meca(
     # Fill extensive quadrants with color "cornsilk"
     # [Default is "white"]
     extensionfill="cornsilk",
-    # Use a 0.5 points thick dark gray ("gray30") outline
+    # Use a pen thickness of 0.5 points to draw a dark gray ("gray30") outline
     pen="0.5p,gray30",
 )
 

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -7,7 +7,7 @@ We can specify the focal mechanism nodal planes or moment tensor components as
 a dictionary using the ``spec`` parameter (or they can be specified as a 1-D
 or 2-D array, or within a specified file). The size of plotted beachballs can
 be specified using the ``scale`` parameter. The compressive and extensive
-quadrants can be filled with a color (or a pattern) via the
+quadrants can be filled either with a color or a pattern via the
 ``compressionfill`` and ``extensionfill`` parameters, respectively.
 """
 
@@ -43,7 +43,8 @@ fig.meca(
     # Fill extensive quadrants with color "cornsilk"
     # [Default is "white"]
     extensionfill="cornsilk",
-    # Use a pen thickness of 0.5 points to draw a dark gray ("gray30") outline
+    # Draw a 0.5 points thick dark gray ("gray30") outline via
+    # the pen parameter
     pen="0.5p,gray30",
 )
 

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -13,7 +13,7 @@ import pygmt
 
 fig = pygmt.Figure()
 
-# generate a map near Washington State showing land, water, and shorelines
+# Generate a map near Washington State showing land, water, and shorelines
 fig.coast(
     region=[-125, -122, 47, 49],
     projection="M6c",
@@ -23,11 +23,11 @@ fig.coast(
     frame="a",
 )
 
-# store focal mechanism parameters in a dictionary based on the Aki & Richards
+# Store focal mechanism parameters in a dictionary based on the Aki & Richards
 # convention
 focal_mechanism = dict(strike=330, dip=30, rake=90, magnitude=3)
 
-# pass the focal mechanism data through the spec parameter. In addition provide
+# Pass the focal mechanism data through the spec parameter. In addition provide
 # scale, event location, and event depth
 fig.meca(
     spec=focal_mechanism,
@@ -35,13 +35,13 @@ fig.meca(
     longitude=-124.3,
     latitude=48.1,
     depth=12.0,
-    # fill compressional quadrants with color "gray70" (light gray)
+    # Fill compressional quadrants with color "gray70" (light gray)
     # [Default is "black"]
     compressionfill="gray70",
-    # fill extension quadrants with color "cornsilk"
+    # Fill extension quadrants with color "cornsilk"
     # [Default is "white"]
     extensionfill="cornsilk",
-    # use a 0.5 points thick dark gray ("gray30") outline
+    # Use a 0.5 points thick dark gray ("gray30") outline
     pen="0.5p,gray30",
 )
 

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -6,7 +6,9 @@ The :meth:`pygmt.Figure.meca` method can plot focal mechanisms or beachballs.
 We can specify the focal mechanism nodal planes or moment tensor components as
 a dictionary using the ``spec`` parameter (or they can be specified as a 1-D
 or 2-D array, or within a specified file). The size of plotted beachballs can
-be specified using the ``scale`` parameter.
+be specified using the ``scale`` parameter. The compressive and extensive
+quadrants can be filled with a standard color (or a pattern) via the
+``compressionfill`` and ``extensionfill`` parameters, respectively.
 """
 
 import pygmt
@@ -35,10 +37,10 @@ fig.meca(
     longitude=-124.3,
     latitude=48.1,
     depth=12.0,
-    # Fill compressional quadrants with color "gray70" (light gray)
+    # Fill compressive quadrants with color "gray70" (light gray)
     # [Default is "black"]
     compressionfill="gray70",
-    # Fill extension quadrants with color "cornsilk"
+    # Fill extensive quadrants with color "cornsilk"
     # [Default is "white"]
     extensionfill="cornsilk",
     # Use a 0.5 points thick dark gray ("gray30") outline

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -8,7 +8,8 @@ a dictionary using the ``spec`` parameter (or they can be specified as a 1-D
 or 2-D array, or within a file). The size of plotted beachballs can
 be set using the ``scale`` parameter. The compressive and extensive
 quadrants can be filled either with a color or a pattern via the
-``compressionfill`` and ``extensionfill`` parameters, respectively.
+``compressionfill`` and ``extensionfill`` parameters, respectively. Use the
+``pen`` parameter to draw the outline of the beachballs.
 """
 
 import pygmt

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -5,7 +5,7 @@ Focal mechanisms
 The :meth:`pygmt.Figure.meca` method can plot focal mechanisms or beachballs.
 We can specify the focal mechanism nodal planes or moment tensor components
 as a dictionary using the ``spec`` parameter (or they can be specified as a
- 1-D or 2-D array, or within a file). The size of the beachballs can be set
+1-D or 2-D array, or within a file). The size of the beachballs can be set
 using the ``scale`` parameter. The compressive and extensive quadrants can
 be filled either with a color or a pattern via the ``compressionfill`` and
 ``extensionfill`` parameters, respectively. Use the ``pen`` parameter to

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -3,13 +3,13 @@ Focal mechanisms
 ----------------
 
 The :meth:`pygmt.Figure.meca` method can plot focal mechanisms or beachballs.
-We can specify the focal mechanism nodal planes or moment tensor components as
-a dictionary using the ``spec`` parameter (or they can be specified as a 1-D
-or 2-D array, or within a file). The size of plotted beachballs can be set
-using the ``scale`` parameter. The compressive and extensive quadrants can be
-filled either with a color or a pattern via the ``compressionfill`` and
-``extensionfill`` parameters, respectively. Use the ``pen`` parameter to draw
-the outline of the beachballs.
+We can specify the focal mechanism nodal planes or moment tensor components
+as a dictionary using the ``spec`` parameter (or they can be specified as a
+ 1-D or 2-D array, or within a file). The size of the beachballs can be set
+using the ``scale`` parameter. The compressive and extensive quadrants can
+be filled either with a color or a pattern via the ``compressionfill`` and
+``extensionfill`` parameters, respectively. Use the ``pen`` parameter to
+adjust the outline of the beachballs.
 """
 
 import pygmt
@@ -44,9 +44,10 @@ fig.meca(
     # Fill extensive quadrants with color "cornsilk"
     # [Default is "white"]
     extensionfill="cornsilk",
-    # Draw a 0.5 points thick dark gray ("gray30") outline via
+    # Draw a 0.5 points thick dark gray ("gray30") solid outline via
     # the pen parameter
-    pen="0.5p,gray30",
+    # [Default is "0.25p,black,solid"]
+    pen="0.5p,gray30,solid",
 )
 
 fig.show()


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to extend the gallery example [Focal mechanisms](https://www.pygmt.org/dev/gallery/seismology/meca.html) to use the parameters `compressionfill`, `extensionfill`, and `pen` added in PR #2345.

**Preview**: https://pygmt-dev--2433.org.readthedocs.build/en/2433/gallery/seismology/meca.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
