### PR TITLE
Move sphinx-gallery as an optional dependency for testing

### DIFF
--- a/.github/workflows/ci_doctests.yaml
+++ b/.github/workflows/ci_doctests.yaml
@@ -64,7 +64,6 @@ jobs:
             pytest
             pytest-doctestplus
             pytest-mpl
-            sphinx-gallery
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -72,6 +72,7 @@ jobs:
               geopandas
               ipython
               rioxarray
+              sphinx-gallery
 
     timeout-minutes: 30
     defaults:
@@ -123,7 +124,6 @@ jobs:
             pytest-cov
             pytest-doctestplus
             pytest-mpl
-            sphinx-gallery
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -79,7 +79,6 @@ jobs:
             pytest
             pytest-doctestplus
             pytest-mpl
-            sphinx-gallery
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub

--- a/pygmt/sphinx_gallery.py
+++ b/pygmt/sphinx_gallery.py
@@ -2,7 +2,10 @@
 Utilities for using pygmt with sphinx-gallery.
 """
 
-import sphinx_gallery.scrapers
+try:
+    from sphinx_gallery.scrapers import figure_rst
+except ImportError:
+    figure_rst = None
 from pygmt.figure import SHOWED_FIGURES
 
 
@@ -29,4 +32,4 @@ class PyGMTScraper:  # pylint: disable=too-few-public-methods
             fig = figures.pop(0)
             fig.savefig(fname, transparent=True, dpi=200)
             image_names.append(fname)
-        return sphinx_gallery.scrapers.figure_rst(image_names, gallery_conf["src_dir"])
+        return figure_rst(image_names, gallery_conf["src_dir"])


### PR DESCRIPTION
**Description of proposed changes**

Sphinx-Gallery is a required dependency for building the PyGMT documentation. Since we write our own [PyGMT scraper](https://github.com/GenericMappingTools/pygmt/blob/main/pygmt/sphinx_gallery.py) and we have a test for it (https://github.com/GenericMappingTools/pygmt/blob/main/pygmt/tests/test_sphinx_gallery.py), it's also required for the PyGMT tests, but it should be an optional dependency for testing.

What this PR does:

1. In `Doctests` workflow: remove `sphinx-gallery` because it's not needed
2. In `Tests` workflow: move `sphinx-gallery` as an optional dependency, thus sphinx-gallery is not installed in the Python 3.9 job but is installed in the Python 3.11 workflow.
3. In `Tests Legacy` workflow, remove `sphinx-gallery` because I think we don't care whether `PyGMTScraper` works with Python 3.9 but I keep it in the `Tests Dev` workflow

Since `sphinx-gallery` is optional when running the tests, we need to use `try-except` clause to check if `sphinx-gallery` is installed (see the changes in `pygmt/sphinx_gallery.py`).

This PR reverts some changes in https://github.com/GenericMappingTools/pygmt/pull/1525.

The "GMT Dev Tests" workflow failures are tracked in https://github.com/GenericMappingTools/pygmt/issues/2511.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
