### PR TITLE
Replace ModuleNotFoundError with the more general ImportError

### DIFF
--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -112,7 +112,7 @@ def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_ret
         raise ImportError(
             "Package `contextily` is required to be installed to use this function. "
             "Please use `pip install contextily` or "
-            "`mamba install -c conda-forge contextily` "
+            "`conda install -c conda-forge contextily` "
             "to install the package."
         )
 

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -84,8 +84,8 @@ def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_ret
 
     Raises
     ------
-    ModuleNotFoundError
-        If ``contextily`` is not installed. Follow
+    ImportError
+        If ``contextily`` is not installed or can't be imported. Follow
         :doc:`install instructions for contextily <contextily:index>`, (e.g.
         via ``pip install contextily``) before using this function.
 
@@ -109,10 +109,10 @@ def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_ret
     """
     # pylint: disable=too-many-locals
     if contextily is None:
-        raise ModuleNotFoundError(
+        raise ImportError(
             "Package `contextily` is required to be installed to use this function. "
             "Please use `pip install contextily` or "
-            "`conda install -c conda-forge contextily` "
+            "`mamba install -c conda-forge contextily` "
             "to install the package."
         )
 

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -8,7 +8,7 @@ from tempfile import TemporaryDirectory
 
 try:
     import IPython
-except ModuleNotFoundError:
+except ImportError:
     IPython = None  # pylint: disable=invalid-name
 
 

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 try:
     import IPython
-except ModuleNotFoundError:
+except ImportError:
     IPython = None  # pylint: disable=invalid-name
 
 


### PR DESCRIPTION
**Description of proposed changes**

ref: https://stackoverflow.com/questions/62854761/

Fixes #2436.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
