### PR TITLE
Add a new target 'doctest' to run doctests only and simplify Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 PROJECT=pygmt
 TESTDIR=tmp-test-dir-with-unique-name
 PYTEST_COV_ARGS=--cov=$(PROJECT) --cov-config=../pyproject.toml \
-			--cov-report=term-missing --cov-report=xml --cov-report=html \
-			--pyargs ${PYTEST_EXTRA}
+			--cov-report=term-missing --cov-report=xml --cov-report=html
 FORMAT_FILES=$(PROJECT) doc/conf.py examples
 LINT_FILES=$(PROJECT) doc/conf.py
 
@@ -13,7 +12,8 @@ help:
 	@echo "  install        install in editable mode"
 	@echo "  package        build source and wheel distributions"
 	@echo "  test           run the test suite (including some doctests) and report coverage"
-	@echo "  fulltest       run the test suite (including all doctests) and report coverage"
+	@echo "  fulltest       run the test suite (including all doctests)"
+	@echo "  doctest        run the doctests only"
 	@echo "  test_no_images run the test suite (including all doctests) but skip image comparisons"
 	@echo "  format         run black, blackdoc, docformatter and isort to automatically format the code"
 	@echo "  check          run code style and quality checks (black, blackdoc, docformatter, flakeheaven and isort)"
@@ -28,41 +28,35 @@ install:
 package:
 	python -m build
 
-test:
-	# Run a tmp folder to make sure the tests are run on the installed version
+_runtest:
+	# Run in a tmp folder to make sure the tests are run on the installed version
 	mkdir -p $(TESTDIR)
 	@echo ""
 	@cd $(TESTDIR); python -c "import $(PROJECT); $(PROJECT).show_versions()"
 	@echo ""
-	cd $(TESTDIR); PYGMT_USE_EXTERNAL_DISPLAY="false" pytest $(PYTEST_COV_ARGS) --doctest-plus $(PROJECT)
-	cp $(TESTDIR)/coverage.xml .
-	cp -r $(TESTDIR)/htmlcov .
+	cd $(TESTDIR); PYGMT_USE_EXTERNAL_DISPLAY="false" pytest $(PYTEST_ARGS) --pyargs $(PROJECT)
+	@echo ""
+	if [ -e $(TESTDIR)/coverage.xml ]; then cp $(TESTDIR)/coverage.xml .; fi
+	if [ -e $(TESTDIR)/htmlcov ]; then cp -r $(TESTDIR)/htmlcov .; fi
 	rm -r $(TESTDIR)
 
-fulltest:
-	# Run a tmp folder to make sure the tests are run on the installed version
-	mkdir -p $(TESTDIR)
-	@echo ""
-	@cd $(TESTDIR); python -c "import $(PROJECT); $(PROJECT).show_versions()"
-	@echo ""
-	cd $(TESTDIR); PYGMT_USE_EXTERNAL_DISPLAY="false" pytest $(PYTEST_COV_ARGS) $(PROJECT)
-	cp $(TESTDIR)/coverage.xml .
-	cp -r $(TESTDIR)/htmlcov .
-	rm -r $(TESTDIR)
+# run regular tests (unit tests + some doctests)
+test: PYTEST_ARGS=--doctest-plus $(PYTEST_COV_ARGS) ${PYTEST_EXTRA}
+test: _runtest
 
-test_no_images:
-	# Run a tmp folder to make sure the tests are run on the installed version
-	mkdir -p $(TESTDIR)
-	@echo ""
-	@cd $(TESTDIR); python -c "import $(PROJECT); $(PROJECT).show_versions()"
-	@echo ""
-	# run pytest without the --mpl option to disable image comparisons
-	# use -o to override the addopts in pyproject.toml file
-	cd $(TESTDIR); \
-		PYGMT_USE_EXTERNAL_DISPLAY="false" \
-		pytest -o addopts="--verbose --durations=0 --durations-min=0.2 --doctest-modules" \
-		$(PYTEST_COV_ARGS) $(PROJECT)
-	rm -r $(TESTDIR)
+# run full tests (unit tests + all doctests)
+fulltest: PYTEST_ARGS=${PYTEST_EXTRA}
+fulltest: _runtest
+
+# run doctests only
+doctest: PYTEST_ARGS=--ignore=../pygmt/tests ${PYTEST_EXTRA}
+doctest: _runtest
+
+# run tests without image comparisons
+# run pytest without the --mpl option to disable image comparisons
+# use '-o addopts' to override 'addopts' settings in pyproject.toml file
+test_no_images: PYTEST_ARGS=-o addopts="--verbose --durations=0 --durations-min=0.2 --doctest-modules"
+test_no_images: _runtest
 
 format:
 	isort .


### PR DESCRIPTION
**Description of proposed changes**

This is the first step to address https://github.com/GenericMappingTools/pygmt/issues/2286#issuecomment-1475300763.

Changes in this PR:

- Use Makefile's [Target-specific Variable Values](https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html) to simplify the Makefile targets related to tests. Now we have the `_runtest` target to run the tests. Other targets `tests`, `fulltests`, `doctest`, `test_no_images` all depend on the `_runtest` target. For each target, different values for `PYTEST_ARGS` are passed, so that different tests are execuated.
- Add a `doctest` target which only runs the doctests, as suggested in https://github.com/GenericMappingTools/pygmt/issues/2286#issuecomment-1475300763
- Only generate coverage reports for the `test` target

To test this PR, you can run `make <target>` to see which tests run. 

To save your time, you can simply add `--collect-only` (only collect the tests and don't run them) to pytest, i.e., changing line 37 to
```
cd $(TESTDIR); PYGMT_USE_EXTERNAL_DISPLAY="false" pytest --collect-only $(PYTEST_ARGS) --pyargs $(PROJECT)
``` 

Here are the counts of tests when I run these targets:

- `make test`: 659
- `make fulltest`: 696
- `make doctest`: 68
- `make test_no_images`: 696

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
