### PR TITLE
pygmt.set_display: Do nothing when the display method is set to 'none'

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -393,7 +393,7 @@ class Figure:
                 )
             )
 
-        if method in ["notebook", "none"]:
+        if method == "notebook":
             if IPython is None:
                 raise GMTError(
                     (

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -200,7 +200,6 @@ def coast(self, **kwargs):
     ... )
     >>> # Show the plot
     >>> fig.show()
-    <IPython.core.display.Image object>
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
     if not args_in_kwargs(args=["C", "G", "S", "I", "N", "E", "Q", "W"], kwargs=kwargs):

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -175,7 +175,6 @@ def grd2cpt(grid, **kwargs):
     >>> fig.grdimage(grid=grid)
     >>> # show the plot
     >>> fig.show()
-    <IPython.core.display.Image object>
     """
     if kwargs.get("W") is not None and kwargs.get("Ww") is not None:
         raise GMTInvalidInput("Set only categorical or cyclic to True, not both.")

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -120,7 +120,6 @@ def grdcontour(self, grid, **kwargs):
     ... )
     >>> # show the plot
     >>> fig.show()
-    <IPython.core.display.Image object>
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
     with Session() as lib:

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -173,7 +173,6 @@ def grdimage(self, grid, **kwargs):
     >>> fig.grdimage(grid=grid, cmap="geo", projection="W10c", frame="ag")
     >>> # show the plot
     >>> fig.show()
-    <IPython.core.display.Image object>
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
     with Session() as lib:

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -130,8 +130,7 @@ def inset(self, **kwargs):
     ...
     >>> # Map elements outside the "with" block are plotted in the main figure
     >>> fig.logo(position="jBR+o0.2c+w3c")
-    >>> fig.show()  # doctest: +SKIP
-    <IPython.core.display.Image object>
+    >>> fig.show()
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
     with Session() as lib:

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -87,7 +87,6 @@ def solar(self, terminator="d", terminator_datetime=None, **kwargs):
     ... )
     >>> # show the plot
     >>> fig.show()
-    <IPython.core.display.Image object>
     """
 
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access

--- a/pygmt/src/timestamp.py
+++ b/pygmt/src/timestamp.py
@@ -68,13 +68,11 @@ def timestamp(
     >>> fig = pygmt.Figure()
     >>> fig.timestamp()
     >>> fig.show()
-    <IPython.core.display.Image object>
 
     >>> # Plot the GMT timestamp logo with a custom label.
     >>> fig = pygmt.Figure()
     >>> fig.timestamp(label="Powered by PyGMT")
     >>> fig.show()
-    <IPython.core.display.Image object>
     """
     self._preprocess()  # pylint: disable=protected-access
 


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #2447.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
