### PR TITLE
Update the test_subplot_outside_plotting_positioning test and increase the RMS tolerance

### DIFF
--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -5,7 +5,7 @@ name: GMT Legacy Tests
 on:
   # push:
   #   branches: [ main ]
-  pull_request:
+  # pull_request:
     # types: [ready_for_review]
     # paths-ignore:
     #  - 'doc/**'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -5,7 +5,7 @@ name: GMT Legacy Tests
 on:
   # push:
   #   branches: [ main ]
-  # pull_request:
+  pull_request:
     # types: [ready_for_review]
     # paths-ignore:
     #  - 'doc/**'

--- a/pygmt/tests/test_subplot.py
+++ b/pygmt/tests/test_subplot.py
@@ -112,7 +112,7 @@ def test_subplot_outside_plotting_positioning():
     """
     fig = Figure()
     with fig.subplot(nrows=1, ncols=2, figsize=(10, 5)):
-        fig.basemap(region=[0, 10, 0, 10], projection="X?", frame=True, panel=True)
-        fig.basemap(region=[0, 10, 0, 10], projection="X?", frame=True, panel=True)
+        fig.basemap(region=[0, 10, 0, 10], projection="X?", panel=True)
+        fig.basemap(region=[0, 10, 0, 10], projection="X?", panel=True)
     fig.colorbar(position="JBC+w5c+h", cmap="turbo", frame=True)
     return fig

--- a/pygmt/tests/test_subplot.py
+++ b/pygmt/tests/test_subplot.py
@@ -102,6 +102,8 @@ def test_subplot_nrows_ncols_less_than_one_error():
             pass
 
 
+# Increase tolerance for compatibility with GMT 6.3 and 6.4, see
+# https://github.com/GenericMappingTools/pygmt/pull/2454
 @pytest.mark.mpl_image_compare(tolerance=4.0)
 def test_subplot_outside_plotting_positioning():
     """

--- a/pygmt/tests/test_subplot.py
+++ b/pygmt/tests/test_subplot.py
@@ -102,7 +102,7 @@ def test_subplot_nrows_ncols_less_than_one_error():
             pass
 
 
-@pytest.mark.mpl_image_compare
+@pytest.mark.mpl_image_compare(tolerance=4.0)
 def test_subplot_outside_plotting_positioning():
     """
     Plotting calls are correctly positioned after exiting subplot.


### PR DESCRIPTION
**Description of proposed changes**

The test `test_subplot_outside_plotting_positioning` fails in the latest run of the "GMT Legacy Tests" (see https://github.com/GenericMappingTools/pygmt/actions/runs/4474241635/jobs/7862497307). 

It fails due to an upstream bug that affects GMT 6.3.0 only (see https://github.com/GenericMappingTools/gmt/issues/6100). 

In this PR, I remove `frame=True` from the test so that it works with both GMT 6.3 and 6.4.

I also increase the RMS tolerance to 4.0 so that the test passes for GMT master branch.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
