### PR TITLE
Fix typos in docstrings of "pygmt.Figure.histogram"

### DIFF
--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -81,7 +81,7 @@ def histogram(self, data, **kwargs):
     distribution : bool or int or float or str
         [*mode*][**+p**\ *pen*].
         Draw the equivalent normal distribution; append desired
-        *pen* [Default is 0.25p,black].
+        *pen* [Default is ``"0.25p,black,solid"``].
         The *mode* selects which central location and scale to use:
 
         * 0 = mean and standard deviation [Default];

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -65,7 +65,7 @@ def histogram(self, data, **kwargs):
         following modifiers: Use **+b** to place the labels beneath the bars
         instead of above; use **+f** to change to another font than the default
         annotation font; use **+o** to change the offset between bar and
-        label [Default is ``"6p"`` ]; use **+r** to rotate the labels from
+        label [Default is ``"6p"``]; use **+r** to rotate the labels from
         horizontal to vertical.
     barwidth : int or float or str
         *width*\ [**+o**\ *offset*].

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -65,8 +65,8 @@ def histogram(self, data, **kwargs):
         following modifiers: Use **+b** to place the labels beneath the bars
         instead of above; use **+f** to change to another font than the default
         annotation font; use **+o** to change the offset between bar and
-        label [6p]; use **+r** to rotate the labels from horizontal to
-        vertical.
+        label [Default is ``"6p"`` ]; use **+r** to rotate the labels from
+        horizontal to vertical.
     barwidth : int or float or str
         *width*\ [**+o**\ *offset*].
         Use an alternative histogram bar width than the default set via

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -61,7 +61,7 @@ def histogram(self, data, **kwargs):
     {panel}
     annotate : bool or str
         [**+b**][**+f**\ *font*][**+o**\ *off*][**+r**].
-        Annotate each bar with the count it represents.  Append any of the
+        Annotate each bar with the count it represents. Append any of the
         following modifiers: Use **+b** to place the labels beneath the bars
         instead of above; use **+f** to change to another font than the default
         annotation font; use **+o** to change the offset between bar and
@@ -70,7 +70,7 @@ def histogram(self, data, **kwargs):
     barwidth : int or float or str
         *width*\ [**+o**\ *offset*].
         Use an alternative histogram bar width than the default set via
-        ``series``, and optionally shift all bars by an *offset*.  Here
+        ``series``, and optionally shift all bars by an *offset*. Here
         *width* is either an alternative width in data units, or the user may
         append a valid plot dimension unit (**c**\|\ **i**\|\ **p**) for a
         fixed dimension instead. Optionally, all bins may be shifted along the
@@ -94,7 +94,7 @@ def histogram(self, data, **kwargs):
     extreme : str
         **l**\|\ **h**\|\ **b**.
         The modifiers specify the handling of extreme values that fall outside
-        the range set by ``series``.  By default these values are ignored.
+        the range set by ``series``. By default these values are ignored.
         Append **b** to let these values be included in the first or last
         bins. To only include extreme values below first bin into the first
         bin, use **l**, and to only include extreme values above the last bin

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -94,7 +94,7 @@ def histogram(self, data, **kwargs):
     extreme : str
         **l**\|\ **h**\|\ **b**.
         The modifiers specify the handling of extreme values that fall outside
-        the range set by ``series``. By default these values are ignored.
+        the range set by ``series``. By default, these values are ignored.
         Append **b** to let these values be included in the first or last
         bins. To only include extreme values below first bin into the first
         bin, use **l**, and to only include extreme values above the last bin


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix some typos in the docstrings of [`pygmt.Figure.histogram`](https://www.pygmt.org/dev/api/generated/pygmt.Figure.histogram.html).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
