### PR TITLE
pygmt.set_display: Add inline examples and improve documentation

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -339,7 +339,7 @@ class Figure:
         (falls back to the default web browser).
 
         :func:`pygmt.set_display` can select the default display method
-        (**notebook**, **external**, or **none**).
+        (``"notebook"``, ``"external"``, ``"none"`` or ``None``).
 
         The ``method`` parameter can also override the default display method
         for the current figure. Parameters ``dpi`` and ``width`` can be used
@@ -362,12 +362,16 @@ class Figure:
             The image resolution (dots per inch) in Jupyter notebooks.
         width : int
             The image width (in pixels) in Jupyter notebooks.
-        method : str
-            How the current figure will be displayed. Options are
+        method : str or None
+            How the current figure will be displayed. Choose from:
 
-            - **external**: PDF preview in an external program [Default]
-            - **notebook**: PNG preview [Default in Jupyter notebooks]
-            - **none**: Disable image preview
+            - ``"external"``: External PDF preview using the default PDF viewer
+            - ``"notebook"``: Inline PNG preview in the current notebook
+            - ``"none"``: Disable image preview
+            - ``None``: Reset to the default display method
+
+            The default display method is ``"external"`` in Python consoles or
+            ``"notebook"`` in Jupyter Notebooks.
         waiting : float
             Suspend the execution of the current process for a given number of
             seconds after launching an external viewer.
@@ -526,16 +530,41 @@ class Figure:
 
 def set_display(method=None):
     """
-    Set the display method.
+    Set the display method when calling :meth:`pygmt.Figure.show`.
 
     Parameters
     ----------
     method : str or None
-        The method to display an image. Choose from:
+        The method to display an image preview. Choose from:
 
-        - **external**: PDF preview in an external program [Default]
-        - **notebook**: PNG preview [Default in Jupyter notebooks]
-        - **none**: Disable image preview
+        - ``"external"``: External PDF preview using the default PDF viewer
+        - ``"notebook"``: Inline PNG preview in the current notebook
+        - ``"none"``: Disable image preview
+        - ``None``: Reset to the default display method
+
+        The default display method is ``"external"`` in Python consoles or
+        ``"notebook"`` in Jupyter Notebooks.
+
+    Examples
+    --------
+    Let's assume that you're using a Jupyter Notebook:
+
+    >>> import pygmt
+    >>> fig = pygmt.Figure()
+    >>> fig.basemap(region=[0, 10, 0, 10], projection="X10c/5c", frame=True)
+    >>> fig.show()  # will display a PNG image in the current notebook
+    >>>
+    >>> # set the display method to "external"
+    >>> pygmt.set_display(method="external")  # doctest: +SKIP
+    >>> fig.show()  # will display a PDF image using the default PDF viewer
+    >>>
+    >>> # set the display method to "none"
+    >>> pygmt.set_display(method="none")
+    >>> fig.show()  # will not show any image
+    >>>
+    >>> # reset to the default display method
+    >>> pygmt.set_display(method=None)
+    >>> fig.show()  # again, will show a PNG image in the current notebook
     """
     if method in ["notebook", "external", "none"]:
         SHOW_CONFIG["method"] = method
@@ -543,6 +572,6 @@ def set_display(method=None):
         raise GMTInvalidInput(
             (
                 f"Invalid display mode '{method}', "
-                "should be either 'notebook', 'external' or 'none'."
+                "should be either 'notebook', 'external', 'none' or None."
             )
         )

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -371,7 +371,8 @@ class Figure:
             - ``None``: Reset to the default display method
 
             The default display method is ``"external"`` in Python consoles or
-            ``"notebook"`` in Jupyter Notebooks.
+            ``"notebook"`` in Jupyter Notebooks, but can be changed by
+            :func:`pygmt.set_display`.
         waiting : float
             Suspend the execution of the current process for a given number of
             seconds after launching an external viewer.

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -371,7 +371,7 @@ class Figure:
             - ``None``: Reset to the default display method
 
             The default display method is ``"external"`` in Python consoles or
-            ``"notebook"`` in Jupyter Notebooks, but can be changed by
+            ``"notebook"`` in Jupyter notebooks, but can be changed by
             :func:`pygmt.set_display`.
         waiting : float
             Suspend the execution of the current process for a given number of
@@ -544,7 +544,7 @@ def set_display(method=None):
         - ``None``: Reset to the default display method
 
         The default display method is ``"external"`` in Python consoles or
-        ``"notebook"`` in Jupyter Notebooks.
+        ``"notebook"`` in Jupyter notebooks.
 
     Examples
     --------


### PR DESCRIPTION
**Description of proposed changes**

Address https://github.com/GenericMappingTools/pygmt/issues/1666.

Preview:

- https://pygmt-dev--2458.org.readthedocs.build/en/2458/api/generated/pygmt.set_display.html
- https://pygmt-dev--2458.org.readthedocs.build/en/2458/api/generated/pygmt.Figure.show.html


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
