### PR TITLE
Use the minigallery directive to insert mini gallery in API documentation

### DIFF
--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -24,7 +24,8 @@
     {% endfor %}
 {% endif %}
 
-.. include:: backreferences/{{ fullname }}.examples
+.. minigallery:: {{ fullname }}
+    :add-heading:
 
 .. raw:: html
 

--- a/doc/_templates/autosummary/function.rst
+++ b/doc/_templates/autosummary/function.rst
@@ -4,7 +4,8 @@
 
 .. autofunction:: {{ objname }}
 
-.. include:: backreferences/{{ fullname }}.examples
+.. minigallery:: {{ fullname }}
+    :add-heading:
 
 .. raw:: html
 

--- a/doc/_templates/autosummary/method.rst
+++ b/doc/_templates/autosummary/method.rst
@@ -4,7 +4,8 @@
 
 .. automethod:: {{ objname }}
 
-.. include:: backreferences/{{ fullname }}.examples
+.. minigallery:: {{ fullname }}
+    :add-heading:
 
 .. raw:: html
 


### PR DESCRIPTION
**Description of proposed changes**

Currently, the mini-gallery at the end of each API documentation is added using the following `include` directive:
```
.. include:: backreferences/{{ fullname }}.examples
```
This `include` directive was originally added to the `class` template in PR https://github.com/GenericMappingTools/pygmt/pull/383 (Nov, 2019) since there are no other way to insert mini galleries at that time. The same `include` directive was then added to the `method` and `function` template in PR https://github.com/GenericMappingTools/pygmt/pull/648 (Oct, 2020). 

Since v0.7.0 (PR https://github.com/sphinx-gallery/sphinx-gallery/pull/685, released in May, 2020), Sphinx-Gallery provided the `minigallery` directive (https://sphinx-gallery.github.io/stable/configuration.html#add-mini-galleries-for-api-documentation) to add mini gallery. 

This PR replaces the outdated `include` directive with the better `minigallery` directive as suggested by the official sphinx-gallery documentation (https://sphinx-gallery.github.io/stable/configuration.html#add-mini-galleries-for-api-documentation).

**Preview**: https://pygmt-dev--2459.org.readthedocs.build/en/2459/api/index.html



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
