### PR TITLE
"pygmt.Figure.grdimage": Expand docstring for "nan_transparent" parameter

### DIFF
--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -152,10 +152,10 @@ def grdimage(self, grid, **kwargs):
         [**+z**\ *value*][*color*]
         Make grid nodes with z = NaN transparent, using the color-masking
         feature in PostScript Level 3 (the PS device must support PS Level
-        3). If the input is a grid, use **+z** to select another grid
-        *value* than NaN. If the input is instead an image, append an
-        alternate *color* to select another pixel value to be transparent
-        [Default is ``"black"``].
+        3). If the input is a grid, use **+z** with a *value* to select
+        another grid value than NaN. If the input is instead an image,
+        append an alternate *color* to select another pixel value to be
+        transparent [Default is ``"black"``].
     {region}
     {verbose}
     {panel}

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -155,7 +155,7 @@ def grdimage(self, grid, **kwargs):
         3). If the input is a grid, use **+z** to select another grid
         *value* than NaN. If the input is instead an image, append an
         alternate *color* to select another pixel value to be transparent
-        [Default is `"black"`].
+        [Default is ``"black"``].
     {region}
     {verbose}
     {panel}

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -148,7 +148,8 @@ def grdimage(self, grid, **kwargs):
     no_clip : bool
         Do **not** clip the image at the frame boundaries (only relevant
         for non-rectangular maps) [Default is ``False``].
-    nan_transparent : bool
+    nan_transparent : bool or str
+        [**+z**\ *value*][*color*]
         Make grid nodes with z = NaN transparent, using the color-masking
         feature in PostScript Level 3 (the PS device must support PS Level
         3). If the input is a grid, use **+z** to select another grid value

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -152,9 +152,10 @@ def grdimage(self, grid, **kwargs):
         [**+z**\ *value*][*color*]
         Make grid nodes with z = NaN transparent, using the color-masking
         feature in PostScript Level 3 (the PS device must support PS Level
-        3). If the input is a grid, use **+z** to select another grid *value*
-        than NaN. If input is instead an image, append an alternate *color*
-        to select another pixel value to be transparent [Default is black].
+        3). If the input is a grid, use **+z** to select another grid
+        *value* than NaN. If the input is instead an image, append an
+        alternate *color* to select another pixel value to be transparent
+        [Default is `"black"`].
     {region}
     {verbose}
     {panel}

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -151,7 +151,9 @@ def grdimage(self, grid, **kwargs):
     nan_transparent : bool
         Make grid nodes with z = NaN transparent, using the color-masking
         feature in PostScript Level 3 (the PS device must support PS Level
-        3).
+        3). If the input is a grid, use **+z** to select another grid value
+        than NaN. If input is instead an image, append an alternate color to
+        select another pixel value to be transparent [Default is black].
     {region}
     {verbose}
     {panel}

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -152,9 +152,9 @@ def grdimage(self, grid, **kwargs):
         [**+z**\ *value*][*color*]
         Make grid nodes with z = NaN transparent, using the color-masking
         feature in PostScript Level 3 (the PS device must support PS Level
-        3). If the input is a grid, use **+z** to select another grid value
-        than NaN. If input is instead an image, append an alternate color to
-        select another pixel value to be transparent [Default is black].
+        3). If the input is a grid, use **+z** to select another grid *value*
+        than NaN. If input is instead an image, append an alternate *color*
+        to select another pixel value to be transparent [Default is black].
     {region}
     {verbose}
     {panel}


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to expand the docstring for the `nan_transparent` parameter of [`pygmt.Figure.grdimage`](https://www.pygmt.org/dev/api/generated/pygmt.Figure.grdimage.html#pygmt.Figure.grdimage), based on the [upstream GMT documentation for **Q**](https://docs.generic-mapping-tools.org/dev/grdimage.html#q).

Somehow / Maybe related to this forum post: https://forum.generic-mapping-tools.org/t/how-to-not-plot-value-zero-on-grid/3783/5

**Preview** at https://pygmt-dev--2461.org.readthedocs.build/en/2461/api/generated/pygmt.Figure.grdimage.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
