### PR TITLE
WIP: CI: Use iterative/setup-dvc to install dvc

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -93,7 +93,7 @@ jobs:
           mamba install gmt=6.4.0 numpy=${{ matrix.numpy-version }} \
                         pandas xarray netCDF4 packaging \
                         ${{ matrix.optional-packages }} \
-                        build dvc make 'pytest>=6.0' \
+                        build make 'pytest>=6.0' \
                         pytest-cov pytest-doctestplus pytest-mpl sphinx-gallery
 
       # Show installed pkg information for postmortem diagnostic
@@ -117,6 +117,9 @@ jobs:
           # Change modification times of the two files, so GMT won't refresh it
           touch ~/.gmt/server/gmt_data_server.txt ~/.gmt/server/gmt_hash_server.txt
           ls -lhR ~/.gmt
+
+      - name: Setup data version control (DVC)
+        uses: iterative/setup-dvc@v1.1.1
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -101,9 +101,12 @@ jobs:
                         geopandas ghostscript libnetcdf hdf5 zlib curl pcre make
           pip install --pre --prefer-binary \
                         numpy pandas xarray netCDF4 packaging \
-                        build contextily dvc ipython rioxarray \
+                        build contextily ipython rioxarray \
                         'pytest>=6.0' pytest-cov pytest-doctestplus pytest-mpl \
                         sphinx-gallery
+
+      - name: Setup data version control (DVC)
+        uses: iterative/setup-dvc@v1.1.1
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -67,7 +67,7 @@ jobs:
           mamba install gmt=${{ matrix.gmt_version }} numpy \
                         pandas xarray netCDF4 packaging \
                         contextily geopandas ipython rioxarray \
-                        build dvc make 'pytest>=6.0' \
+                        build make 'pytest>=6.0' \
                         pytest-cov pytest-doctestplus pytest-mpl sphinx-gallery
 
       # Show installed pkg information for postmortem diagnostic
@@ -91,6 +91,9 @@ jobs:
           # Change modification times of the two files, so GMT won't refresh it
           touch ~/.gmt/server/gmt_data_server.txt ~/.gmt/server/gmt_hash_server.txt
           ls -lhR ~/.gmt
+
+      - name: Setup data version control (DVC)
+        uses: iterative/setup-dvc@v1.1.1
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote


### PR DESCRIPTION
**Description of proposed changes**

dvc has a complicated dependency and sometimes dvc fails to work due to incompatible changes of other packges (e.g., https://github.com/GenericMappingTools/pygmt/issues/1693, https://github.com/GenericMappingTools/pygmt/issues/1543, https://github.com/GenericMappingTools/pygmt/pull/2338, and recent https://github.com/GenericMappingTools/pygmt/pull/2464#issuecomment-1487613519).

In this PR, I tried to use the [`iterative/setup-dvc`](https://github.com/iterative/setup-dvc) action to install dvc instead of manually installing `dvc` using mamba. It turns out the `iterative/setup-dvc` action provides a more stable dvc installation. However, `iteractive/setup-dvc` is extremely slow on Windows (takes about 2.5 minutes).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
