### PR TITLE
Change compressionfill color in meca gallery example

### DIFF
--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -38,9 +38,9 @@ fig.meca(
     longitude=-124.3,
     latitude=48.1,
     depth=12.0,
-    # Fill compressive quadrants with color "gray70" (light gray)
+    # Fill compressive quadrants with color "red"
     # [Default is "black"]
-    compressionfill="gray70",
+    compressionfill="red",
     # Fill extensive quadrants with color "cornsilk"
     # [Default is "white"]
     extensionfill="cornsilk",


### PR DESCRIPTION
**Description of proposed changes**

Change the color fill for `compressionfill` in meca gallery example since it's hard to distinguish it from the land masses fill. 

**Preview**: https://pygmt-dev--2474.org.readthedocs.build/en/2475/gallery/seismology/meca.html

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
