### PR TITLE
Use np.asarray to convert a 1-D array to datetime type in array_to_datetime

### DIFF
--- a/examples/tutorials/advanced/date_time_charts.py
+++ b/examples/tutorials/advanced/date_time_charts.py
@@ -125,6 +125,13 @@ fig.plot(
 fig.show()
 
 ###############################################################################
+#
+# PyGMT doesn't recognize non-ISO datetime strings like "Jun 05, 2018". If your
+# data contain non-ISO datetime strings, you can convert them to a recognized
+# format using :func:`pandas.to_datetime` and then pass to PyGMT.
+#
+
+###############################################################################
 # Mixing and matching Python ``datetime`` and ISO dates
 # -----------------------------------------------------
 #

--- a/examples/tutorials/advanced/date_time_charts.py
+++ b/examples/tutorials/advanced/date_time_charts.py
@@ -128,7 +128,7 @@ fig.show()
 #
 # PyGMT doesn't recognize non-ISO datetime strings like "Jun 05, 2018". If your
 # data contain non-ISO datetime strings, you can convert them to a recognized
-# format using :func:`pandas.to_datetime` and then pass to PyGMT.
+# format using :func:`pandas.to_datetime` and then pass it to PyGMT.
 #
 
 ###############################################################################

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -251,7 +251,7 @@ def kwargs_to_ctypes_array(argument, kwargs, dtype):
 
 def array_to_datetime(array):
     """
-    Convert n 1-D datetime array from various types into numpy.datetime64.
+    Convert a 1-D datetime array from various types into numpy.datetime64.
 
     If the input array is not in legal datetime formats, raise a ValueError
     exception.

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -4,7 +4,6 @@ Functions to convert data types into ctypes friendly formats.
 import warnings
 
 import numpy as np
-import pandas as pd
 from pygmt.exceptions import GMTInvalidInput
 
 
@@ -252,10 +251,9 @@ def kwargs_to_ctypes_array(argument, kwargs, dtype):
 
 def array_to_datetime(array):
     """
-    Convert an 1-D datetime array from various types into pandas.DatetimeIndex
-    (i.e., numpy.datetime64).
+    Convert an 1-D datetime array from various types into numpy.datetime64.
 
-    If the input array is not in legal datetime formats, raise a "ParseError"
+    If the input array is not in legal datetime formats, raise a ValueError
     exception.
 
     Parameters
@@ -272,7 +270,12 @@ def array_to_datetime(array):
 
     Returns
     -------
-    array : 1-D datetime array in pandas.DatetimeIndex (i.e., numpy.datetime64)
+    array : 1-D datetime array in numpy.datetime64
+
+    Raises
+    ------
+    ValueError
+        If the datetime string is invalid.
 
     Examples
     --------
@@ -283,21 +286,21 @@ def array_to_datetime(array):
     ...     dtype="datetime64[ns]",
     ... )
     >>> array_to_datetime(x)
-    DatetimeIndex(['2010-06-01 00:00:00', '2011-06-01 12:00:00',
-                   '2012-01-01 12:34:56'],
-                  dtype='datetime64[ns]', freq=None)
+    array(['2010-06-01T00:00:00.000000000', '2011-06-01T12:00:00.000000000',
+           '2012-01-01T12:34:56.000000000'], dtype='datetime64[ns]')
 
     >>> # pandas.DateTimeIndex array
+    >>> import pandas as pd
     >>> x = pd.date_range("2013", freq="YS", periods=3)
-    >>> array_to_datetime(x)  # doctest: +NORMALIZE_WHITESPACE
-    DatetimeIndex(['2013-01-01', '2014-01-01', '2015-01-01'],
-                  dtype='datetime64[ns]', freq='AS-JAN')
+    >>> array_to_datetime(x)
+    array(['2013-01-01T00:00:00.000000000', '2014-01-01T00:00:00.000000000',
+           '2015-01-01T00:00:00.000000000'], dtype='datetime64[ns]')
 
     >>> # Python's built-in date and datetime
     >>> x = [datetime.date(2018, 1, 1), datetime.datetime(2019, 1, 1)]
-    >>> array_to_datetime(x)  # doctest: +NORMALIZE_WHITESPACE
-    DatetimeIndex(['2018-01-01', '2019-01-01'],
-        dtype='datetime64[ns]', freq=None)
+    >>> array_to_datetime(x)
+    array(['2018-01-01T00:00:00.000000', '2019-01-01T00:00:00.000000'],
+          dtype='datetime64[us]')
 
     >>> # Raw datetime strings in various format
     >>> x = [
@@ -305,16 +308,11 @@ def array_to_datetime(array):
     ...     "2018-02",
     ...     "2018-03-01",
     ...     "2018-04-01T01:02:03",
-    ...     "5/1/2018",
-    ...     "Jun 05, 2018",
-    ...     "2018/07/02",
     ... ]
     >>> array_to_datetime(x)
-    DatetimeIndex(['2018-01-01 00:00:00', '2018-02-01 00:00:00',
-                   '2018-03-01 00:00:00', '2018-04-01 01:02:03',
-                   '2018-05-01 00:00:00', '2018-06-05 00:00:00',
-                   '2018-07-02 00:00:00'],
-                  dtype='datetime64[ns]', freq=None)
+    array(['2018-01-01T00:00:00', '2018-02-01T00:00:00',
+           '2018-03-01T00:00:00', '2018-04-01T01:02:03'],
+          dtype='datetime64[s]')
 
     >>> # Mixed datetime types
     >>> x = [
@@ -322,8 +320,8 @@ def array_to_datetime(array):
     ...     np.datetime64("2018-01-01"),
     ...     datetime.datetime(2018, 1, 1),
     ... ]
-    >>> array_to_datetime(x)  # doctest: +NORMALIZE_WHITESPACE
-    DatetimeIndex(['2018-01-01', '2018-01-01', '2018-01-01'],
-                  dtype='datetime64[ns]', freq=None)
+    >>> array_to_datetime(x)
+    array(['2018-01-01T00:00:00.000000', '2018-01-01T00:00:00.000000',
+           '2018-01-01T00:00:00.000000'], dtype='datetime64[us]')
     """
-    return pd.to_datetime(array)
+    return np.asarray(array, dtype=np.datetime64)

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -280,7 +280,7 @@ def array_to_datetime(array):
     >>> # numpy.datetime64 array
     >>> x = np.array(
     ...     ["2010-06-01", "2011-06-01T12", "2012-01-01T12:34:56"],
-    ...     dtype="datetime64",
+    ...     dtype="datetime64[ns]",
     ... )
     >>> array_to_datetime(x)
     DatetimeIndex(['2010-06-01 00:00:00', '2011-06-01 12:00:00',

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -251,7 +251,7 @@ def kwargs_to_ctypes_array(argument, kwargs, dtype):
 
 def array_to_datetime(array):
     """
-    Convert an 1-D datetime array from various types into numpy.datetime64.
+    Convert n 1-D datetime array from various types into numpy.datetime64.
 
     If the input array is not in legal datetime formats, raise a ValueError
     exception.

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -745,7 +745,7 @@ class Session:
         if array.dtype.type not in DTYPES:
             try:
                 # Try to convert any unknown numpy data types to np.datetime64
-                array = np.asarray(array, dtype=np.datetime64)
+                array = array_to_datetime(array)
             except ValueError as e:
                 raise GMTInvalidInput(
                     f"Unsupported numpy data type '{array.dtype.type}'."


### PR DESCRIPTION
**Description of proposed changes**

Address https://github.com/GenericMappingTools/pygmt/issues/2480.

The initial purpose of this PR is to fix the failing doctests as mentioned in #2480, but in comment https://github.com/GenericMappingTools/pygmt/pull/2481#issuecomment-1497355885 I decided to refactor the `array_to_datetime` function.

---

This PR fixes the following failing test:
```
______________ [doctest] pygmt.clib.conversion.array_to_datetime _______________
276 
277     Examples
278     --------
279     >>> import datetime
280     >>> # numpy.datetime64 array
281     >>> x = np.array(
282     ...     ["2010-06-01", "2011-06-01T12", "2012-01-01T12:34:56"],
283     ...     dtype="datetime64",
284     ... )
285     >>> array_to_datetime(x)
Differences (unified diff with -expected +actual):
    @@ -1,3 +1,3 @@
     DatetimeIndex(['2010-06-01 00:00:00', '2011-06-01 12:00:00',
                    '2012-01-01 12:34:56'],
    -              dtype='datetime64[ns]', freq=None)
    +              dtype='datetime64[s]', freq=None)
```
It's caused by incompatible changes as documented in 
https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#construction-with-datetime64-or-timedelta64-dtype-with-unsupported-resolution.



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
