### PR TITLE
Pin docformatter to 1.5.1 in workflows and <1.6.0 in environment.yml

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -28,7 +28,7 @@ jobs:
       # Install formatting tools
       - name: Install formatting tools
         run: |
-          pip install black blackdoc docformatter flakeheaven isort
+          pip install black blackdoc docformatter==1.5.1 flakeheaven isort
           sudo apt-get install dos2unix
 
       # Run "make format" and commit the change to the PR branch

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install packages
         run: |
-          pip install black blackdoc docformatter flakeheaven pylint isort
+          pip install black blackdoc docformatter==1.5.1 flakeheaven pylint isort
           sudo apt-get install dos2unix
 
       - name: Formatting check (black, blackdoc, docformatter, flakeheaven and isort)

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
     # Dev dependencies (style checks)
     - black
     - blackdoc
-    - docformatter>=1.5.0
+    - docformatter>=1.5.0,<1.6.0
     - flakeheaven>=3
     - isort>=5
     - pylint


### PR DESCRIPTION
**Description of proposed changes**

Closes https://github.com/GenericMappingTools/pygmt/pull/2476.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
