### PR TITLE
Pin pandas to <2.0

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -39,7 +39,7 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          mamba install gmt=6.4.0 numpy pandas xarray netCDF4 packaging \
+          mamba install gmt=6.4.0 numpy 'pandas<2.0' xarray netCDF4 packaging \
                         build
 
       # Install the package that we want to test

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -70,7 +70,7 @@ jobs:
       # Install GMT and other required dependencies from conda-forge
       - name: Install dependencies
         run: |
-          mamba install gmt=6.4.0 numpy pandas xarray netCDF4 packaging \
+          mamba install gmt=6.4.0 numpy 'pandas<2.0' xarray netCDF4 packaging \
                         build ipython make myst-parser contextily geopandas rioxarray \
                         sphinx sphinx-copybutton sphinx-design sphinx-gallery sphinx_rtd_theme
 

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Install dependencies
         run: |
           mamba install gmt=6.4.0 numpy=${{ matrix.numpy-version }} \
-                        pandas xarray netCDF4 packaging \
+                        'pandas<2.0' xarray netCDF4 packaging \
                         ${{ matrix.optional-packages }} \
                         build dvc make 'pytest>=6.0' \
                         pytest-cov pytest-doctestplus pytest-mpl sphinx-gallery

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -100,7 +100,7 @@ jobs:
                         ninja cmake libblas libcblas liblapack fftw libgdal \
                         geopandas ghostscript libnetcdf hdf5 zlib curl pcre make
           pip install --pre --prefer-binary \
-                        numpy pandas xarray netCDF4 packaging \
+                        numpy 'pandas<2.0' xarray netCDF4 packaging \
                         build contextily dvc ipython rioxarray \
                         'pytest>=6.0' pytest-cov pytest-doctestplus pytest-mpl \
                         sphinx-gallery

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Install dependencies
         run: |
           mamba install gmt=${{ matrix.gmt_version }} numpy \
-                        pandas xarray netCDF4 packaging \
+                        'pandas<2.0' xarray netCDF4 packaging \
                         contextily geopandas ipython rioxarray \
                         build dvc make 'pytest>=6.0' \
                         pytest-cov pytest-doctestplus pytest-mpl sphinx-gallery

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     - pip
     - gmt=6.4.0
     - numpy>=1.21
-    - pandas
+    - pandas<2.0
     - xarray
     - netCDF4
     - packaging


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/pydata/xarray/issues/7716 for context.

The latest xarray release doesn't work with pandas 2.0, so pinning pandas<2.0 as a temporary workaround.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
