### PR TITLE
Move Figure.shift_origin to a standalone Python file

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -418,40 +418,6 @@ class Figure:
             )
             launch_external_viewer(pdf, waiting=waiting)
 
-    def shift_origin(self, xshift=None, yshift=None):
-        """
-        Shift plot origin in x and/or y directions.
-
-        This method shifts the plot origin relative to the current origin
-        by (*xshift*, *yshift*). Optionally, append the length unit (**c**,
-        **i**, or **p**). Default unit if not given is **c** for centimeter.
-
-        Prepend **a** to shift the origin back to the original position after
-        plotting, prepend **c** to center the plot on the center of the paper
-        (optionally add shift), prepend **f** to shift the origin relative to
-        the fixed lower left corner of the page, or prepend **r** [Default] to
-        move the origin relative to its current location.
-
-        Detailed usage at
-        :gmt-docs:`cookbook/options.html#plot-positioning-and-layout-the-x-y-options`
-
-        Parameters
-        ----------
-        xshift : str
-            Shift plot origin in x direction.
-        yshift : str
-            Shift plot origin in y direction.
-        """
-        self._preprocess()
-        args = ["-T"]
-        if xshift:
-            args.append(f"-X{xshift}")
-        if yshift:
-            args.append(f"-Y{yshift}")
-
-        with Session() as lib:
-            lib.call_module(module="plot", args=" ".join(args))
-
     def _preview(self, fmt, dpi, as_bytes=False, **kwargs):
         """
         Grab a preview of the figure.
@@ -519,6 +485,7 @@ class Figure:
         plot3d,
         rose,
         set_panel,
+        shift_origin,
         solar,
         subplot,
         ternary,

--- a/pygmt/src/__init__.py
+++ b/pygmt/src/__init__.py
@@ -43,6 +43,7 @@ from pygmt.src.plot3d import plot3d
 from pygmt.src.project import project
 from pygmt.src.rose import rose
 from pygmt.src.select import select
+from pygmt.src.shift_origin import shift_origin
 from pygmt.src.solar import solar
 from pygmt.src.sph2grd import sph2grd
 from pygmt.src.sphdistance import sphdistance

--- a/pygmt/src/shift_origin.py
+++ b/pygmt/src/shift_origin.py
@@ -11,7 +11,7 @@ def shift_origin(self, xshift=None, yshift=None):
 
     This method shifts the plot origin relative to the current origin
     by (*xshift*, *yshift*). Optionally, append the length unit (**c**,
-    **i**, or **p**). Default unit if not given is **c** for centimeter.
+    **i**, or **p**). Default unit if not given is **c** for centimeters.
 
     Prepend **a** to shift the origin back to the original position after
     plotting, prepend **c** to center the plot on the center of the paper

--- a/pygmt/src/shift_origin.py
+++ b/pygmt/src/shift_origin.py
@@ -1,0 +1,40 @@
+"""
+shift_origin - Shift plotting origin.
+"""
+
+from pygmt.clib import Session
+
+
+def shift_origin(self, xshift=None, yshift=None):
+    """
+    Shift plot origin in x and/or y directions.
+
+    This method shifts the plot origin relative to the current origin
+    by (*xshift*, *yshift*). Optionally, append the length unit (**c**,
+    **i**, or **p**). Default unit if not given is **c** for centimeter.
+
+    Prepend **a** to shift the origin back to the original position after
+    plotting, prepend **c** to center the plot on the center of the paper
+    (optionally add shift), prepend **f** to shift the origin relative to
+    the fixed lower left corner of the page, or prepend **r** [Default] to
+    move the origin relative to its current location.
+
+    Detailed usage at
+    :gmt-docs:`cookbook/options.html#plot-positioning-and-layout-the-x-y-options`
+
+    Parameters
+    ----------
+    xshift : str
+        Shift plot origin in x direction.
+    yshift : str
+        Shift plot origin in y direction.
+    """
+    self._preprocess()  # pylint: disable=protected-access
+    args = ["-T"]
+    if xshift:
+        args.append(f"-X{xshift}")
+    if yshift:
+        args.append(f"-Y{yshift}")
+
+    with Session() as lib:
+        lib.call_module(module="plot", args=" ".join(args))

--- a/pygmt/src/shift_origin.py
+++ b/pygmt/src/shift_origin.py
@@ -1,5 +1,5 @@
 """
-shift_origin - Shift plotting origin.
+shift_origin - Shift plot origin in x and/or y directions.
 """
 
 from pygmt.clib import Session


### PR DESCRIPTION
**Description of proposed changes**

Move the codes of `Figure.shift_origin` from `pygmt/figure.py` to `pygmt/src/shift_origin.py`.

This is the first PR for https://github.com/GenericMappingTools/pygmt/issues/2401.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
