### PR TITLE
NEP29: Set minimum required version to Python 3.9+

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -28,21 +28,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.11']
+        python-version: ['3.9', '3.11']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # Is it a draft Pull Request (true or false)?
         isDraft:
           - ${{ github.event.pull_request.draft }}
-        # Only run two jobs (Ubuntu + Python 3.8/3.11) for draft PRs
+        # Only run two jobs (Ubuntu + Python 3.9/3.11) for draft PRs
         exclude:
           - os: macOS-latest
             isDraft: true
           - os: windows-latest
             isDraft: true
-        # Pair Python 3.8 with NumPy 1.21 and Python 3.11 with NumPy 1.24
+        # Pair Python 3.9 with NumPy 1.21 and Python 3.11 with NumPy 1.24
         # Only install optional packages on Python 3.11/NumPy 1.24
         include:
-          - python-version: '3.8'
+          - python-version: '3.9'
             numpy-version: '1.21'
             optional-packages: ''
           - python-version: '3.11'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.9']
         os: [ubuntu-20.04, macOS-11, windows-2019]
         gmt_version: ['6.3']
     timeout-minutes: 30

--- a/README.rst
+++ b/README.rst
@@ -262,7 +262,7 @@ Compatibility with GMT/Python/NumPy versions
     * - `Dev <https://github.com/GenericMappingTools/pygmt/milestones>`_ (upcoming release)
       - `Dev Documentation <https://www.pygmt.org/dev>`_ (reflects `main branch <https://github.com/GenericMappingTools/pygmt>`_)
       - >=6.3.0
-      - >=3.8
+      - >=3.9
       - >=1.21
     * - `v0.9.0 <https://github.com/GenericMappingTools/pygmt/releases/tag/v0.9.0>`_ (latest release)
       - `v0.9.0 Documentation <https://www.pygmt.org/v0.9.0>`_

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -64,7 +64,7 @@ Start by looking at the tutorials on our sidebar, good luck!
 Which Python?
 -------------
 
-PyGMT is tested to run on **Python 3.8 or greater**.
+PyGMT is tested to run on **Python 3.9 or greater**.
 
 We recommend using the `Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`__
 Python distribution to ensure you have all dependencies installed and the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pygmt"
 description = "A Python interface for the Generic Mapping Tools"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "BSD License"}
 authors = [{name = "The PyGMT Developers", email = "pygmt.team@gmail.com"}]
 keywords = [
@@ -25,7 +25,6 @@ classifiers = [
     "Intended Audience :: Education",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
**Description of proposed changes**

Following [NEP29 policy](https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table) where Python 3.8 will be dropped on or after Apr 14, 2023.

Changes in this PR:

- [x] Update the minimum Python version in `ci_tests.yaml`
- [x] Update the minimum Python version in `ci_tests_legacy.yaml`
- [x] Update the minimum Python version in the compatibility table in README
- [x] Update the minimum Python version in `doc/install.rst`
- [x] Update the Python version in the `requires-python` field and remove the related entry from `classifiers` in `pyproject.toml`.
- [ ] Update [branch protection rules](https://github.com/GenericMappingTools/pygmt/settings/branches) 

Supersedes PR #1676 and afed7c9046c0fb0399926733ec58110eb56b1d3c

Fixes #2300.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
