### PR TITLE
Use substitutions to show the minimum required Python and GMT versions dynamically in installation guides

### DIFF
--- a/.github/ISSUE_TEMPLATE/bump_gmt_checklist.md
+++ b/.github/ISSUE_TEMPLATE/bump_gmt_checklist.md
@@ -28,7 +28,6 @@ assignees: ''
 **To-Do for bumping the minimum required GMT version**:
 
 - [ ] Bump the minimum required GMT version (1 PR)
-  - [ ] Update `doc/install.rst`
   - [ ] Update `required_version` in `pygmt/clib/session.py`
   - [ ] Update `test_get_default` in `pygmt/tests/test_clib.py`
   - [ ] Update compatibility table in `README.rst`

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,12 +5,14 @@ Sphinx documentation configuration file.
 # pylint: disable=invalid-name
 
 import datetime
+from importlib.metadata import metadata
 
 # isort: off
 from sphinx_gallery.sorting import (  # pylint: disable=no-name-in-module
     ExplicitOrder,
     ExampleTitleSortKey,
 )
+import pygmt
 from pygmt import __commit__, __version__
 from pygmt.sphinx_gallery import PyGMTScraper
 
@@ -149,9 +151,15 @@ else:
     html_baseurl = "https://pygmt.org/latest/"
 release = __version__
 
+requires_python = metadata("pygmt")["Requires-Python"]
+with pygmt.clib.Session() as lib:
+    requires_gmt = ">=" + lib.required_version
+
 # These enable substitutions using |variable| in the rst files
 rst_epilog = f"""
 .. |year| replace:: {year}
+.. |requires_python| replace:: {requires_python}
+.. |requires_gmt| replace:: {requires_gmt}
 """
 
 html_last_updated_fmt = "%b %d, %Y"

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -64,7 +64,7 @@ Start by looking at the tutorials on our sidebar, good luck!
 Which Python?
 -------------
 
-PyGMT is tested to run on **Python 3.8 or greater**.
+PyGMT is tested to run on Python |requires_python|.
 
 We recommend using the `Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`__
 Python distribution to ensure you have all dependencies installed and the
@@ -77,12 +77,9 @@ installations on your system.
 Which GMT?
 ----------
 
-PyGMT requires Generic Mapping Tools (GMT) version 6 as a minimum, which is the
-latest released version that can be found at
-the `GMT official site <https://www.generic-mapping-tools.org>`__.
-We need the latest GMT (>=6.3.0) since there are many changes being made to GMT
-itself in response to the development of PyGMT, mainly the new
-:gmt-docs:`modern execution mode <cookbook/introduction.html#modern-and-classic-mode>`.
+PyGMT requires Generic Mapping Tools (GMT) |requires_gmt| since there
+are many changes being made to GMT itself in response to the development of PyGMT,
+mainly the new :gmt-docs:`modern execution mode <cookbook/introduction.html#modern-and-classic-mode>`.
 
 Compiled conda packages of GMT for Linux, macOS and Windows are provided
 through `conda-forge <https://anaconda.org/conda-forge/gmt>`__.


### PR DESCRIPTION
**Description of proposed changes**

Use sphinx's substitutions feature (https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#substitutions) to insert the minimum required Python and GMT versions. The version strings are obtained from the PyGMT package dynamically so that we don't have to manually update the `doc/install.rst` file.

Preview: https://pygmt-dev--2488.org.readthedocs.build/en/2488/install.html


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
