### PR TITLE
Remove dummy_context and use contextlib.nullcontext instead

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -6,7 +6,7 @@ Uses ctypes to wrap most of the core functions from the C API.
 """
 import ctypes as ctp
 import sys
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 
 import numpy as np
 import pandas as pd
@@ -25,7 +25,7 @@ from pygmt.exceptions import (
     GMTInvalidInput,
     GMTVersionError,
 )
-from pygmt.helpers import data_kind, dummy_context, fmt_docstring, tempfile_from_geojson
+from pygmt.helpers import data_kind, fmt_docstring, tempfile_from_geojson
 
 FAMILIES = [
     "GMT_IS_DATASET",  # Entity is a data table
@@ -1451,7 +1451,7 @@ class Session:
 
         # Decide which virtualfile_from_ function to use
         _virtualfile_from = {
-            "file": dummy_context,
+            "file": nullcontext,
             "geojson": tempfile_from_geojson,
             "grid": self.virtualfile_from_grid,
             # Note: virtualfile_from_matrix is not used because a matrix can be

--- a/pygmt/helpers/__init__.py
+++ b/pygmt/helpers/__init__.py
@@ -12,7 +12,6 @@ from pygmt.helpers.utils import (
     args_in_kwargs,
     build_arg_string,
     data_kind,
-    dummy_context,
     is_nonstr_iter,
     launch_external_viewer,
 )

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -9,7 +9,6 @@ import sys
 import time
 import webbrowser
 from collections.abc import Iterable
-from contextlib import contextmanager
 
 import xarray as xr
 from pygmt.exceptions import GMTInvalidInput
@@ -90,33 +89,6 @@ def data_kind(data, x=None, y=None, z=None, required_z=False):
     else:
         kind = "vectors"
     return kind
-
-
-@contextmanager
-def dummy_context(arg):
-    """
-    Dummy context manager.
-
-    Does nothing when entering or exiting a ``with`` block and yields the
-    argument passed to it.
-
-    Useful when you have a choice of context managers but need one that does
-    nothing.
-
-    Parameters
-    ----------
-    arg : anything
-        The argument that will be returned by the context manager.
-
-    Examples
-    --------
-
-    >>> with dummy_context("some argument") as temp:
-    ...     print(temp)
-    ...
-    some argument
-    """
-    yield arg
 
 
 def build_arg_string(kwdict, confdict=None, infile=None, outfile=None):

--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -12,7 +12,6 @@ from pygmt.helpers import (
     GMTTempFile,
     build_arg_string,
     data_kind,
-    dummy_context,
     fmt_docstring,
     kwargs_to_strings,
     unique_name,
@@ -196,7 +195,7 @@ def x2sys_cross(tracks=None, outfile=None, **kwargs):
         for track in tracks:
             kind = data_kind(track)
             if kind == "file":
-                file_contexts.append(dummy_context(track))
+                file_contexts.append(contextlib.nullcontext(track))
             elif kind == "matrix":
                 # find suffix (-E) of trackfiles used (e.g. xyz, csv, etc) from
                 # $X2SYS_HOME/TAGNAME/TAGNAME.tag file


### PR DESCRIPTION
**Description of proposed changes**

`dummy_context` is a dummy context manager which does nothing but returns the argument. It was originally added in PR https://github.com/GenericMappingTools/pygmt/pull/93 in 2017.

Python provides the [`contextlib.nullcontext`](https://docs.python.org/3/library/contextlib.html#contextlib.nullcontext) function which does exactly the same thing since Python 3.7.

This PR replaces the `dummy_context` function with `contextlib.nullcontext`.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
