### PR TITLE
Better handling of optional virtual files (e.g., shading in Figure.grdimage)

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1537,13 +1537,14 @@ class Session:
             data, x, y, z, required_z=required_z, required_data=required_data
         )
 
-        if check_kind == "raster" and kind not in ("file", "grid"):
+        if check_kind == "raster" and kind not in ("file", "grid", "arg"):
             raise GMTInvalidInput(f"Unrecognized data type for grid: {type(data)}")
         if check_kind == "vector" and kind not in (
             "file",
             "matrix",
             "vectors",
             "geojson",
+            "arg",
         ):
             raise GMTInvalidInput(f"Unrecognized data type for vector: {type(data)}")
 

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1537,10 +1537,10 @@ class Session:
             data, x, y, z, required_z=required_z, required_data=required_data
         )
 
-        if check_kind == "raster" and kind not in ("file_or_arg", "grid"):
+        if check_kind == "raster" and kind not in ("file", "grid"):
             raise GMTInvalidInput(f"Unrecognized data type for grid: {type(data)}")
         if check_kind == "vector" and kind not in (
-            "file_or_arg",
+            "file",
             "matrix",
             "vectors",
             "geojson",
@@ -1549,7 +1549,7 @@ class Session:
 
         # Decide which virtualfile_from_ function to use
         _virtualfile_from = {
-            "file_or_arg": nullcontext,
+            "file": nullcontext,
             "geojson": tempfile_from_geojson,
             "grid": self.virtualfile_from_grid,
             # Note: virtualfile_from_matrix is not used because a matrix can be
@@ -1560,7 +1560,7 @@ class Session:
         }[kind]
 
         # Ensure the data is an iterable (Python list or tuple)
-        if kind in ("geojson", "grid", "file_or_arg"):
+        if kind in ("geojson", "grid", "file"):
             _data = (data,) if not isinstance(data, pathlib.PurePath) else (str(data),)
         elif kind == "vectors":
             _data = [np.atleast_1d(x), np.atleast_1d(y)]

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1542,7 +1542,9 @@ class Session:
         elif check_kind == "vector":
             valid_kinds = ("file", "matrix", "vectors", "geojson")
         else:
-            valid_kinds = ()
+            raise GMTInvalidInput(
+                "Invalid check_kind. Should be either 'raster' or 'vector'."
+            )
         if required_data is False:
             valid_kinds += ("arg",)
         if kind not in valid_kinds:

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1475,7 +1475,7 @@ class Session:
         z=None,
         extra_arrays=None,
         required_z=False,
-        optional_data=False,
+        required_data=True,
     ):
         """
         Store any data inside a virtual file.
@@ -1500,7 +1500,7 @@ class Session:
             All of these arrays must be of the same size as the x/y/z arrays.
         required_z : bool
             State whether the 'z' column is required.
-        optional_data : bool
+        required_data : bool
             State whether the 'data' is optional.
 
         Returns
@@ -1533,7 +1533,7 @@ class Session:
         <vector memory>: N = 3 <7/9> <4/6> <1/3>
         """
         kind = data_kind(
-            data, x, y, z, required_z=required_z, optional_data=optional_data
+            data, x, y, z, required_z=required_z, required_data=required_data
         )
 
         if check_kind == "raster" and kind not in ("file_or_arg", "grid"):

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -5,6 +5,7 @@ access to the API functions.
 Uses ctypes to wrap most of the core functions from the C API.
 """
 import ctypes as ctp
+import pathlib
 import sys
 from contextlib import contextmanager, nullcontext
 
@@ -1535,21 +1536,19 @@ class Session:
             data, x, y, z, required_z=required_z, optional_data=optional_data
         )
 
-        if check_kind == "raster" and kind not in ("file", "grid", "null"):
+        if check_kind == "raster" and kind not in ("file_or_arg", "grid"):
             raise GMTInvalidInput(f"Unrecognized data type for grid: {type(data)}")
         if check_kind == "vector" and kind not in (
-            "file",
+            "file_or_arg",
             "matrix",
             "vectors",
             "geojson",
-            "null",
         ):
             raise GMTInvalidInput(f"Unrecognized data type for vector: {type(data)}")
 
         # Decide which virtualfile_from_ function to use
         _virtualfile_from = {
-            "file": nullcontext,
-            "null": nullcontext,
+            "file_or_arg": nullcontext,
             "geojson": tempfile_from_geojson,
             "grid": self.virtualfile_from_grid,
             # Note: virtualfile_from_matrix is not used because a matrix can be
@@ -1560,11 +1559,8 @@ class Session:
         }[kind]
 
         # Ensure the data is an iterable (Python list or tuple)
-        if kind in ("geojson", "grid", "null"):
-            _data = (data,)
-        elif kind == "file":
-            # Useful to handle `pathlib.PurePath` and string file path alike
-            _data = (str(data),)
+        if kind in ("geojson", "grid", "file_or_arg"):
+            _data = (data,) if not isinstance(data, pathlib.PurePath) else (str(data),)
         elif kind == "vectors":
             _data = [np.atleast_1d(x), np.atleast_1d(y)]
             if z is not None:

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1501,8 +1501,8 @@ class Session:
         required_z : bool
             State whether the 'z' column is required.
         required_data : bool
-            State whether 'data' is required (useful for dealing with optional
-            virtual files).
+            Set to True when 'data' is required, or False when dealing with
+            optional virtual files. [Default is True].
 
         Returns
         -------
@@ -1537,16 +1537,15 @@ class Session:
             data, x, y, z, required_z=required_z, required_data=required_data
         )
 
+        valid_kinds = ("file", "arg") if required_data is False else ("file",)
         if check_kind == "raster":
-            valid_kinds = ("file", "grid")
+            valid_kinds += ("grid",)
         elif check_kind == "vector":
-            valid_kinds = ("file", "matrix", "vectors", "geojson")
+            valid_kinds += ("matrix", "vectors", "geojson")
         else:
             raise GMTInvalidInput(
                 "Invalid check_kind. Should be either 'raster' or 'vector'."
             )
-        if required_data is False:
-            valid_kinds += ("arg",)
         if kind not in valid_kinds:
             raise GMTInvalidInput(
                 f"Unrecognized data type for {check_kind}: {type(data)}"

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1537,19 +1537,16 @@ class Session:
             data, x, y, z, required_z=required_z, required_data=required_data
         )
 
-        valid_kinds = ("file", "arg") if required_data is False else ("file",)
-        if check_kind == "raster":
-            valid_kinds += ("grid",)
-        elif check_kind == "vector":
-            valid_kinds += ("matrix", "vectors", "geojson")
-        else:
-            raise GMTInvalidInput(
-                "Invalid check_kind. Should be either 'raster' or 'vector'."
-            )
-        if kind not in valid_kinds:
-            raise GMTInvalidInput(
-                f"Unrecognized data type for {check_kind}: {type(data)}"
-            )
+        if check_kind:
+            valid_kinds = ("file", "arg") if required_data is False else ("file",)
+            if check_kind == "raster":
+                valid_kinds += ("grid",)
+            elif check_kind == "vector":
+                valid_kinds += ("matrix", "vectors", "geojson")
+            if kind not in valid_kinds:
+                raise GMTInvalidInput(
+                    f"Unrecognized data type for {check_kind}: {type(data)}"
+                )
 
         # Decide which virtualfile_from_ function to use
         _virtualfile_from = {

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1486,7 +1486,7 @@ class Session:
 
         Parameters
         ----------
-        check_kind : str
+        check_kind : str or None
             Used to validate the type of data that can be passed in. Choose
             from 'raster', 'vector', or None. Default is None (no validation).
         data : str or pathlib.Path or xarray.DataArray or {table-like} or None

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1501,7 +1501,8 @@ class Session:
         required_z : bool
             State whether the 'z' column is required.
         required_data : bool
-            State whether the 'data' is optional.
+            State whether 'data' is required (useful for dealing with optional
+            virtual files).
 
         Returns
         -------

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1537,16 +1537,18 @@ class Session:
             data, x, y, z, required_z=required_z, required_data=required_data
         )
 
-        if check_kind == "raster" and kind not in ("file", "grid", "arg"):
-            raise GMTInvalidInput(f"Unrecognized data type for grid: {type(data)}")
-        if check_kind == "vector" and kind not in (
-            "file",
-            "matrix",
-            "vectors",
-            "geojson",
-            "arg",
-        ):
-            raise GMTInvalidInput(f"Unrecognized data type for vector: {type(data)}")
+        if check_kind == "raster":
+            valid_kinds = ("file", "grid")
+        elif check_kind == "vector":
+            valid_kinds = ("file", "matrix", "vectors", "geojson")
+        else:
+            valid_kinds = ()
+        if required_data is False:
+            valid_kinds += ("arg",)
+        if kind not in valid_kinds:
+            raise GMTInvalidInput(
+                f"Unrecognized data type for {check_kind}: {type(data)}"
+            )
 
         # Decide which virtualfile_from_ function to use
         _virtualfile_from = {

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -5,6 +5,7 @@ access to the API functions.
 Uses ctypes to wrap most of the core functions from the C API.
 """
 import ctypes as ctp
+import pathlib
 import sys
 from contextlib import contextmanager
 
@@ -1383,6 +1384,7 @@ class Session:
         z=None,
         extra_arrays=None,
         required_z=False,
+        optional_data=False,
     ):
         """
         Store any data inside a virtual file.
@@ -1407,6 +1409,8 @@ class Session:
             All of these arrays must be of the same size as the x/y/z arrays.
         required_z : bool
             State whether the 'z' column is required.
+        optional_data : bool
+            State whether the 'data' is optional.
 
         Returns
         -------
@@ -1437,7 +1441,9 @@ class Session:
         ...
         <vector memory>: N = 3 <7/9> <4/6> <1/3>
         """
-        kind = data_kind(data, x, y, z, required_z=required_z)
+        kind = data_kind(
+            data, x, y, z, required_z=required_z, optional_data=optional_data
+        )
 
         if check_kind == "raster" and kind not in ("file", "grid"):
             raise GMTInvalidInput(f"Unrecognized data type for grid: {type(data)}")
@@ -1466,7 +1472,7 @@ class Session:
             _data = (data,)
         elif kind == "file":
             # Useful to handle `pathlib.Path` and string file path alike
-            _data = (str(data),)
+            _data = (str(data),) if isinstance(data, pathlib.PurePath) else (data,)
         elif kind == "vectors":
             _data = [np.atleast_1d(x), np.atleast_1d(y)]
             if z is not None:

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1550,6 +1550,7 @@ class Session:
         # Decide which virtualfile_from_ function to use
         _virtualfile_from = {
             "file": nullcontext,
+            "arg": nullcontext,
             "geojson": tempfile_from_geojson,
             "grid": self.virtualfile_from_grid,
             # Note: virtualfile_from_matrix is not used because a matrix can be
@@ -1560,7 +1561,7 @@ class Session:
         }[kind]
 
         # Ensure the data is an iterable (Python list or tuple)
-        if kind in ("geojson", "grid", "file"):
+        if kind in ("geojson", "grid", "file", "arg"):
             _data = (data,) if not isinstance(data, pathlib.PurePath) else (str(data),)
         elif kind == "vectors":
             _data = [np.atleast_1d(x), np.atleast_1d(y)]

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -135,8 +135,8 @@ def data_kind(data=None, x=None, y=None, z=None, required_z=False, required_data
     required_z : bool
         State whether the 'z' column is required.
     required_data : bool
-        State whether 'data' is required (useful for dealing with optional
-        virtual files).
+        Set to True when 'data' is required, or False when dealing with
+        optional virtual files. [Default is True].
 
     Returns
     -------

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -15,13 +15,14 @@ import xarray as xr
 from pygmt.exceptions import GMTInvalidInput
 
 
-def data_kind(data, x=None, y=None, z=None, required_z=False):
+def data_kind(data, x=None, y=None, z=None, required_z=False, optional_data=False):
     """
     Check what kind of data is provided to a module.
 
     Possible types:
 
     * a file name provided as 'data'
+    * an option argument provided as 'data'
     * a pathlib.Path provided as 'data'
     * an xarray.DataArray provided as 'data'
     * a matrix provided as 'data'
@@ -35,18 +36,21 @@ def data_kind(data, x=None, y=None, z=None, required_z=False):
     data : str or pathlib.Path or xarray.DataArray or {table-like} or None
         Pass in either a file name or :class:`pathlib.Path` to an ASCII data
         table, an :class:`xarray.DataArray`, a 1-D/2-D
-        {table-classes}.
+        {table-classes} or an option argument.
     x/y : 1-D arrays or None
         x and y columns as numpy arrays.
     z : 1-D array or None
         z column as numpy array. To be used optionally when x and y are given.
     required_z : bool
         State whether the 'z' column is required.
+    optional_data : bool
+        State whether the 'data' is optional.
 
     Returns
     -------
     kind : str
-        One of: ``'file'``, ``'grid'``, ``'matrix'``, ``'vectors'``.
+        One of: ``'file'``, ``'grid'``, ``'geojson'``, ``'matrix'``, or
+        ``'vectors'``.
 
     Examples
     --------
@@ -62,19 +66,21 @@ def data_kind(data, x=None, y=None, z=None, required_z=False):
     'file'
     >>> data_kind(data=pathlib.Path("my-data-file.txt"), x=None, y=None)
     'file'
+    >>> data_kind(data=None, x=None, y=None, optional_data=True)
+    'file'
     >>> data_kind(data=xr.DataArray(np.random.rand(4, 3)))
     'grid'
     """
-    if data is None and x is None and y is None:
+    if data is None and not optional_data and x is None and y is None:
         raise GMTInvalidInput("No input data provided.")
     if data is not None and (x is not None or y is not None or z is not None):
         raise GMTInvalidInput("Too much data. Use either data or x and y.")
-    if data is None and (x is None or y is None):
+    if data is None and not optional_data and (x is None or y is None):
         raise GMTInvalidInput("Must provide both x and y.")
     if data is None and required_z and z is None:
         raise GMTInvalidInput("Must provide x, y, and z.")
 
-    if isinstance(data, (str, pathlib.PurePath)):
+    if data is None or isinstance(data, (bool, int, float, str, pathlib.PurePath)):
         kind = "file"
     elif isinstance(data, xr.DataArray):
         kind = "grid"

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -25,7 +25,8 @@ def data_kind(data, x=None, y=None, z=None, required_z=False, optional_data=Fals
     * an xarray.DataArray object provided as 'data'
     * a 2-D matrix provided as 'data'
     * 1-D arrays x and y (and z, optionally)
-    * an option argument (None, bool, int, float or str type) provided as 'data'
+    * an optional argument (None, bool, int, float or str type) provided as
+      'data'
 
     Arguments should be ``None`` if not used. If doesn't fit any of these
     categories (or fits more than one), will raise an exception.

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -117,8 +117,8 @@ def data_kind(data=None, x=None, y=None, z=None, required_z=False, required_data
     Returns
     -------
     kind : str
-        One of ``'file'``, ``'grid'``, ``'geojson'``, ``'matrix'``, ``'null'``,
-        or ``'vectors'``.
+        One of ``'file_or_arg'``, ``'grid'``, ``'geojson'``, ``'matrix'``, or
+        ``'vectors'``.
 
     Examples
     --------

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -42,6 +42,30 @@ def _validate_data_input(
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Must provide x, y, and z.
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> import xarray as xr
+    >>> data = np.arange(8).reshape((4, 2))
+    >>> _validate_data_input(data=data, required_z=True, kind="matrix")
+    Traceback (most recent call last):
+        ...
+    pygmt.exceptions.GMTInvalidInput: data must provide x, y, and z columns.
+    >>> _validate_data_input(
+    ...     data=pd.DataFrame(data, columns=["x", "y"]),
+    ...     required_z=True,
+    ...     kind="matrix",
+    ... )
+    Traceback (most recent call last):
+        ...
+    pygmt.exceptions.GMTInvalidInput: data must provide x, y, and z columns.
+    >>> _validate_data_input(
+    ...     data=xr.Dataset(pd.DataFrame(data, columns=["x", "y"])),
+    ...     required_z=True,
+    ...     kind="matrix",
+    ... )
+    Traceback (most recent call last):
+        ...
+    pygmt.exceptions.GMTInvalidInput: data must provide x, y, and z columns.
     >>> _validate_data_input(data="infile", x=[1, 2, 3])
     Traceback (most recent call last):
         ...

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -117,8 +117,8 @@ def data_kind(data=None, x=None, y=None, z=None, required_z=False, required_data
     Returns
     -------
     kind : str
-        One of ``'file'``, ``'grid'``, ``'geojson'``, ``'matrix'``, or
-        ``'vectors'``.
+        One of ``'arg'``, ``'file'``, ``'grid'``, ``'geojson'``, ``'matrix'``,
+        or ``'vectors'``.
 
     Examples
     --------
@@ -135,18 +135,18 @@ def data_kind(data=None, x=None, y=None, z=None, required_z=False, required_data
     >>> data_kind(data=pathlib.Path("my-data-file.txt"), x=None, y=None)
     'file'
     >>> data_kind(data=None, x=None, y=None, required_data=False)
-    'file'
+    'arg'
     >>> data_kind(data=2.0, x=None, y=None, required_data=False)
-    'file'
+    'arg'
     >>> data_kind(data=True, x=None, y=None, required_data=False)
-    'file'
+    'arg'
     >>> data_kind(data=xr.DataArray(np.random.rand(4, 3)))
     'grid'
     """
     # determine the data kind
     if isinstance(data, (str, pathlib.PurePath)):
         kind = "file"
-    elif not required_data and (data is None or isinstance(data, (bool, int, float))):
+    elif isinstance(data, (bool, int, float)) or (data is None and not required_data):
         kind = "arg"
     elif isinstance(data, xr.DataArray):
         kind = "grid"

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -61,14 +61,12 @@ def _validate_data_input(
         If the data input is not valid.
     """
     if data is None:  # data is None
-        # both x and y are None and data is not optional
-        if x is None and y is None and required_data:
-            raise GMTInvalidInput("No input data provided.")
-        # either x or y is None
-        if x is None or y is None:
+        if x is None and y is None:  # both x and y are None
+            if required_data:  # data is not optional
+                raise GMTInvalidInput("No input data provided.")
+        if x is None or y is None:  # either x or y is None
             raise GMTInvalidInput("Must provide both x and y.")
-        # both x and y are not None, now check z
-        if required_z and z is None:
+        if required_z and z is None:  # both x and y are not None, now check z
             raise GMTInvalidInput("Must provide x, y, and z.")
     else:  # data is not None
         if x is not None or y is not None or z is not None:

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -86,8 +86,10 @@ def data_kind(data, x=None, y=None, z=None, required_z=False, optional_data=Fals
             raise GMTInvalidInput("Must provide x, y, and z.")
 
     # determine the data kind
-    if isinstance(data, (bool, int, float, str, pathlib.Path)) or (
-        data is None and optional_data
+    if isinstance(data, (str, pathlib.Path)):
+        kind = "file"
+    elif optional_data and (
+        data is None or isinstance(data, (bool, int, float, str, pathlib.Path))
     ):
         # a null context manager will be created for "file-like" kind
         kind = "file"

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -63,15 +63,15 @@ def data_kind(data, x=None, y=None, z=None, required_z=False, optional_data=Fals
     >>> data_kind(data=np.arange(10).reshape((5, 2)), x=None, y=None)
     'matrix'
     >>> data_kind(data="my-data-file.txt", x=None, y=None)
-    'file'
+    'file_or_arg'
     >>> data_kind(data=pathlib.Path("my-data-file.txt"), x=None, y=None)
-    'file'
+    'file_or_arg'
     >>> data_kind(data=None, x=None, y=None, optional_data=True)
-    'null'
+    'file_or_arg'
     >>> data_kind(data=2.0, x=None, y=None, optional_data=True)
-    'null'
+    'file_or_arg'
     >>> data_kind(data=True, x=None, y=None, optional_data=True)
-    'null'
+    'file_or_arg'
     >>> data_kind(data=xr.DataArray(np.random.rand(4, 3)))
     'grid'
     """
@@ -91,11 +91,10 @@ def data_kind(data, x=None, y=None, z=None, required_z=False, optional_data=Fals
             raise GMTInvalidInput("Must provide x, y, and z.")
 
     # determine the data kind
-    if isinstance(data, (str, pathlib.PurePath)):
-        kind = "file"
-    elif optional_data and (data is None or isinstance(data, (bool, int, float))):
-        # a nullcontext will be created for "null" kind
-        kind = "null"
+    if isinstance(data, (str, pathlib.PurePath)) or (
+        optional_data and (data is None or isinstance(data, (bool, int, float)))
+    ):
+        kind = "file_or_arg"
     elif isinstance(data, xr.DataArray):
         kind = "grid"
     elif hasattr(data, "__geo_interface__"):

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -117,7 +117,7 @@ def data_kind(data=None, x=None, y=None, z=None, required_z=False, required_data
     Returns
     -------
     kind : str
-        One of ``'file_or_arg'``, ``'grid'``, ``'geojson'``, ``'matrix'``, or
+        One of ``'file'``, ``'grid'``, ``'geojson'``, ``'matrix'``, or
         ``'vectors'``.
 
     Examples
@@ -131,23 +131,23 @@ def data_kind(data=None, x=None, y=None, z=None, required_z=False, required_data
     >>> data_kind(data=np.arange(10).reshape((5, 2)), x=None, y=None)
     'matrix'
     >>> data_kind(data="my-data-file.txt", x=None, y=None)
-    'file_or_arg'
+    'file'
     >>> data_kind(data=pathlib.Path("my-data-file.txt"), x=None, y=None)
-    'file_or_arg'
+    'file'
     >>> data_kind(data=None, x=None, y=None, required_data=False)
-    'file_or_arg'
+    'file'
     >>> data_kind(data=2.0, x=None, y=None, required_data=False)
-    'file_or_arg'
+    'file'
     >>> data_kind(data=True, x=None, y=None, required_data=False)
-    'file_or_arg'
+    'file'
     >>> data_kind(data=xr.DataArray(np.random.rand(4, 3)))
     'grid'
     """
     # determine the data kind
-    if isinstance(data, (str, pathlib.PurePath)) or (
-        not required_data and (data is None or isinstance(data, (bool, int, float)))
-    ):
-        kind = "file_or_arg"
+    if isinstance(data, (str, pathlib.PurePath)):
+        kind = "file"
+    elif not required_data and (data is None or isinstance(data, (bool, int, float))):
+        kind = "arg"
     elif isinstance(data, xr.DataArray):
         kind = "grid"
     elif hasattr(data, "__geo_interface__"):

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -15,7 +15,7 @@ from pygmt.exceptions import GMTInvalidInput
 
 
 def _validate_data_input(
-    data=None, x=None, y=None, z=None, required_z=False, optional_data=False, kind=None
+    data=None, x=None, y=None, z=None, required_z=False, required_data=True, kind=None
 ):
     """
     Check if the combination of data/x/y/z is valid.
@@ -25,6 +25,7 @@ def _validate_data_input(
     >>> _validate_data_input(data="infile")
     >>> _validate_data_input(x=[1, 2, 3], y=[4, 5, 6])
     >>> _validate_data_input(x=[1, 2, 3], y=[4, 5, 6], z=[7, 8, 9])
+    >>> _validate_data_input(data=None, required_data=False)
     >>> _validate_data_input()
     Traceback (most recent call last):
         ...
@@ -61,7 +62,7 @@ def _validate_data_input(
     """
     if data is None:  # data is None
         # both x and y are None and data is not optional
-        if x is None and y is None and not optional_data:
+        if x is None and y is None and required_data:
             raise GMTInvalidInput("No input data provided.")
         # either x or y is None
         if x is None or y is None:
@@ -83,7 +84,7 @@ def _validate_data_input(
                 raise GMTInvalidInput("data must provide x, y, and z columns.")
 
 
-def data_kind(data=None, x=None, y=None, z=None, required_z=False, optional_data=False):
+def data_kind(data=None, x=None, y=None, z=None, required_z=False, required_data=True):
     """
     Check what kind of data is provided to a module.
 
@@ -111,8 +112,8 @@ def data_kind(data=None, x=None, y=None, z=None, required_z=False, optional_data
         z column as numpy array. To be used optionally when x and y are given.
     required_z : bool
         State whether the 'z' column is required.
-    optional_data : bool
-        State whether 'data' is optional (useful for dealing with optional
+    required_data : bool
+        State whether 'data' is required (useful for dealing with optional
         virtual files).
 
     Returns
@@ -135,18 +136,18 @@ def data_kind(data=None, x=None, y=None, z=None, required_z=False, optional_data
     'file_or_arg'
     >>> data_kind(data=pathlib.Path("my-data-file.txt"), x=None, y=None)
     'file_or_arg'
-    >>> data_kind(data=None, x=None, y=None, optional_data=True)
+    >>> data_kind(data=None, x=None, y=None, required_data=False)
     'file_or_arg'
-    >>> data_kind(data=2.0, x=None, y=None, optional_data=True)
+    >>> data_kind(data=2.0, x=None, y=None, required_data=False)
     'file_or_arg'
-    >>> data_kind(data=True, x=None, y=None, optional_data=True)
+    >>> data_kind(data=True, x=None, y=None, required_data=False)
     'file_or_arg'
     >>> data_kind(data=xr.DataArray(np.random.rand(4, 3)))
     'grid'
     """
     # determine the data kind
     if isinstance(data, (str, pathlib.PurePath)) or (
-        optional_data and (data is None or isinstance(data, (bool, int, float)))
+        not required_data and (data is None or isinstance(data, (bool, int, float)))
     ):
         kind = "file_or_arg"
     elif isinstance(data, xr.DataArray):
@@ -165,7 +166,7 @@ def data_kind(data=None, x=None, y=None, z=None, required_z=False, optional_data
         y=y,
         z=z,
         required_z=required_z,
-        optional_data=optional_data,
+        required_data=required_data,
         kind=kind,
     )
     return kind

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -80,21 +80,22 @@ def data_kind(data, x=None, y=None, z=None, required_z=False, optional_data=Fals
     if data is None and required_z and z is None:
         raise GMTInvalidInput("Must provide x, y, and z.")
 
-    if data is None or isinstance(data, (bool, int, float, str, pathlib.PurePath)):
-        kind = "file"
-    elif isinstance(data, xr.DataArray):
-        kind = "grid"
-    elif hasattr(data, "__geo_interface__"):
-        kind = "geojson"
-    elif data is not None:
-        if required_z and (
-            getattr(data, "shape", (3, 3))[1] < 3  # np.array, pd.DataFrame
-            or len(getattr(data, "data_vars", (0, 1, 2))) < 3  # xr.Dataset
-        ):
-            raise GMTInvalidInput("data must provide x, y, and z columns.")
-        kind = "matrix"
-    else:
+    if x is not None or y is not None or z is not None:
         kind = "vectors"
+    else:
+        if data is None or isinstance(data, (bool, int, float, str, pathlib.PurePath)):
+            kind = "file"
+        elif isinstance(data, xr.DataArray):
+            kind = "grid"
+        elif hasattr(data, "__geo_interface__"):
+            kind = "geojson"
+        else:
+            if required_z and (
+                getattr(data, "shape", (3, 3))[1] < 3  # np.array, pd.DataFrame
+                or len(getattr(data, "data_vars", (0, 1, 2))) < 3  # xr.Dataset
+            ):
+                raise GMTInvalidInput("data must provide x, y, and z columns.")
+            kind = "matrix"
     return kind
 
 

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -75,6 +75,7 @@ def data_kind(data, x=None, y=None, z=None, required_z=False, optional_data=Fals
     >>> data_kind(data=xr.DataArray(np.random.rand(4, 3)))
     'grid'
     """
+    # pylint: disable=too-many-branches
     # validate the combinations of data/x/y/z
     if x is None and y is None:  # both x and y are not given
         if data is None and not optional_data:

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -75,6 +75,8 @@ def data_kind(data, x=None, y=None, z=None, required_z=False, optional_data=Fals
     if x is None and y is None:  # both x and y are not given
         if data is None and not optional_data:
             raise GMTInvalidInput("No input data provides")
+        if data is not None and z is not None:
+            raise GMTInvalidInput("Too much data. Use either data or x/y/z.")
     elif x is None or y is None:  # either x or y is not given
         raise GMTInvalidInput("Must provide both x and y.")
     else:  # both x and y are given

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -10,8 +10,6 @@ import time
 import webbrowser
 from collections.abc import Iterable
 
-import numpy as np
-import pandas as pd
 import xarray as xr
 from pygmt.exceptions import GMTInvalidInput
 
@@ -34,7 +32,7 @@ def data_kind(data, x=None, y=None, z=None, required_z=False, optional_data=Fals
 
     Parameters
     ----------
-    data : str or pathlib.Path or xarray.DataArray or {table-like} or None or bool
+    data : str, pathlib.PurePath, None, bool, xarray.DataArray or {table-like}
         Pass in either a file name or :class:`pathlib.Path` to an ASCII data
         table, an :class:`xarray.DataArray`, a 1-D/2-D
         {table-classes} or an option argument.

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -21,12 +21,11 @@ def data_kind(data, x=None, y=None, z=None, required_z=False, optional_data=Fals
     Possible types:
 
     * a file name provided as 'data'
-    * a pathlib.Path object provided as 'data'
+    * a pathlib.PurePath object provided as 'data'
     * an xarray.DataArray object provided as 'data'
     * a 2-D matrix provided as 'data'
     * 1-D arrays x and y (and z, optionally)
-    * an optional argument (None, bool, int, float or str type) provided as
-      'data'
+    * an optional argument (None, bool, int or float) provided as 'data'
 
     Arguments should be ``None`` if not used. If doesn't fit any of these
     categories (or fits more than one), will raise an exception.
@@ -50,8 +49,8 @@ def data_kind(data, x=None, y=None, z=None, required_z=False, optional_data=Fals
     Returns
     -------
     kind : str
-        One of ``'file'``, ``'grid'``, ``'geojson'``, ``'matrix'``, or
-        ``'vectors'``.
+        One of ``'file'``, ``'grid'``, ``'geojson'``, ``'matrix'``, ``'null'``,
+        or ``'vectors'``.
 
     Examples
     --------
@@ -68,7 +67,11 @@ def data_kind(data, x=None, y=None, z=None, required_z=False, optional_data=Fals
     >>> data_kind(data=pathlib.Path("my-data-file.txt"), x=None, y=None)
     'file'
     >>> data_kind(data=None, x=None, y=None, optional_data=True)
-    'file'
+    'null'
+    >>> data_kind(data=2.0, x=None, y=None, optional_data=True)
+    'null'
+    >>> data_kind(data=True, x=None, y=None, optional_data=True)
+    'null'
     >>> data_kind(data=xr.DataArray(np.random.rand(4, 3)))
     'grid'
     """
@@ -89,11 +92,9 @@ def data_kind(data, x=None, y=None, z=None, required_z=False, optional_data=Fals
     # determine the data kind
     if isinstance(data, (str, pathlib.PurePath)):
         kind = "file"
-    elif optional_data and (
-        data is None or isinstance(data, (bool, int, float, str, pathlib.PurePath))
-    ):
-        # a null context manager will be created for "file-like" kind
-        kind = "file"
+    elif optional_data and (data is None or isinstance(data, (bool, int, float))):
+        # a nullcontext will be created for "null" kind
+        kind = "null"
     elif isinstance(data, xr.DataArray):
         kind = "grid"
     elif hasattr(data, "__geo_interface__"):

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -64,7 +64,7 @@ def _validate_data_input(
         if x is None and y is None:  # both x and y are None
             if required_data:  # data is not optional
                 raise GMTInvalidInput("No input data provided.")
-        if x is None or y is None:  # either x or y is None
+        elif x is None or y is None:  # either x or y is None
             raise GMTInvalidInput("Must provide both x and y.")
         if required_z and z is None:  # both x and y are not None, now check z
             raise GMTInvalidInput("Must provide x, y, and z.")

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -86,10 +86,10 @@ def data_kind(data, x=None, y=None, z=None, required_z=False, optional_data=Fals
             raise GMTInvalidInput("Must provide x, y, and z.")
 
     # determine the data kind
-    if isinstance(data, (str, pathlib.Path)):
+    if isinstance(data, (str, pathlib.PurePath)):
         kind = "file"
     elif optional_data and (
-        data is None or isinstance(data, (bool, int, float, str, pathlib.Path))
+        data is None or isinstance(data, (bool, int, float, str, pathlib.PurePath))
     ):
         # a null context manager will be created for "file-like" kind
         kind = "file"

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -154,7 +154,7 @@ def dimfilter(grid, **kwargs):
 
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_from_data(check_kind=None, data=grid)
+            file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
             with file_context as infile:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -180,16 +180,12 @@ def grdimage(self, grid, **kwargs):
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
     with Session() as lib:
-        file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
-        with contextlib.ExitStack() as stack:
-            # shading using an xr.DataArray
-            if kwargs.get("I") is not None and data_kind(kwargs["I"]) == "grid":
-                shading_context = lib.virtualfile_from_data(
-                    check_kind="raster", data=kwargs["I"]
-                )
-                kwargs["I"] = stack.enter_context(shading_context)
-
-            fname = stack.enter_context(file_context)
+        with lib.virtualfile_from_data(
+            check_kind="raster", data=grid
+        ) as infile, lib.virtualfile_from_data(
+            check_kind="raster", data=kwargs.get("I"), optional_data=True
+        ) as shading:
+            kwargs["I"] = shading
             lib.call_module(
-                module="grdimage", args=build_arg_string(kwargs, infile=fname)
+                module="grdimage", args=build_arg_string(kwargs, infile=infile)
             )

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -174,10 +174,10 @@ def grdimage(self, grid, **kwargs):
     with Session() as lib:
         with lib.virtualfile_from_data(
             check_kind="raster", data=grid
-        ) as infile, lib.virtualfile_from_data(
+        ) as fname, lib.virtualfile_from_data(
             check_kind="raster", data=kwargs.get("I"), optional_data=True
-        ) as shading:
-            kwargs["I"] = shading
+        ) as shadegrid:
+            kwargs["I"] = shadegrid
             lib.call_module(
-                module="grdimage", args=build_arg_string(kwargs, infile=infile)
+                module="grdimage", args=build_arg_string(kwargs, infile=fname)
             )

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -175,7 +175,7 @@ def grdimage(self, grid, **kwargs):
         with lib.virtualfile_from_data(
             check_kind="raster", data=grid
         ) as fname, lib.virtualfile_from_data(
-            check_kind="raster", data=kwargs.get("I"), optional_data=False
+            check_kind="raster", data=kwargs.get("I"), required_data=False
         ) as shadegrid:
             kwargs["I"] = shadegrid
             lib.call_module(

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -175,7 +175,7 @@ def grdimage(self, grid, **kwargs):
         with lib.virtualfile_from_data(
             check_kind="raster", data=grid
         ) as fname, lib.virtualfile_from_data(
-            check_kind="raster", data=kwargs.get("I"), optional_data=True
+            check_kind="raster", data=kwargs.get("I"), optional_data=False
         ) as shadegrid:
             kwargs["I"] = shadegrid
             lib.call_module(

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -1,16 +1,8 @@
 """
 grdimage - Plot grids or images.
 """
-import contextlib
-
 from pygmt.clib import Session
-from pygmt.helpers import (
-    build_arg_string,
-    data_kind,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["grdimage"]
 

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -1,17 +1,8 @@
 """
 grdview - Create a three-dimensional plot from a grid.
 """
-import contextlib
-
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import (
-    build_arg_string,
-    data_kind,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["grdview"]
 

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -152,12 +152,6 @@ def grdview(self, grid, **kwargs):
     >>> fig.show()
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
-
-    if kwargs.get("G") is not None and data_kind(kwargs["G"]) not in ("file", "grid"):
-        raise GMTInvalidInput(
-            f"Unrecognized data type for drapegrid: {type(kwargs['G'])}"
-        )
-
     with Session() as lib:
         with lib.virtualfile_from_data(
             check_kind="raster", data=grid

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -3,13 +3,7 @@ grdview - Create a three-dimensional plot from a grid.
 """
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import (
-    build_arg_string,
-    data_kind,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["grdview"]
 

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -2,7 +2,6 @@
 grdview - Create a three-dimensional plot from a grid.
 """
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["grdview"]

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -162,7 +162,7 @@ def grdview(self, grid, **kwargs):
         with lib.virtualfile_from_data(
             check_kind="raster", data=grid
         ) as fname, lib.virtualfile_from_data(
-            check_kind="raster", data=kwargs.get("G"), optional_data=True
+            check_kind="raster", data=kwargs.get("G"), required_data=False
         ) as drapegrid:
             kwargs["G"] = drapegrid
             lib.call_module(

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -2,7 +2,14 @@
 grdview - Create a three-dimensional plot from a grid.
 """
 from pygmt.clib import Session
-from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.helpers import (
+    build_arg_string,
+    data_kind,
+    fmt_docstring,
+    kwargs_to_strings,
+    use_alias,
+)
 
 __doctest_skip__ = ["grdview"]
 
@@ -145,6 +152,12 @@ def grdview(self, grid, **kwargs):
     >>> fig.show()
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
+
+    if kwargs.get("G") is not None and data_kind(kwargs["G"]) not in ("file", "grid"):
+        raise GMTInvalidInput(
+            f"Unrecognized data type for drapegrid: {type(kwargs['G'])}"
+        )
+
     with Session() as lib:
         with lib.virtualfile_from_data(
             check_kind="raster", data=grid

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -439,7 +439,9 @@ def test_virtualfile_from_data_required_z_matrix(array_func, kind):
     )
     data = array_func(dataframe)
     with clib.Session() as lib:
-        with lib.virtualfile_from_data(data=data, required_z=True) as vfile:
+        with lib.virtualfile_from_data(
+            data=data, required_z=True, check_kind="vector"
+        ) as vfile:
             with GMTTempFile() as outfile:
                 lib.call_module("info", f"{vfile} ->{outfile.name}")
                 output = outfile.read(keep_tabs=True)
@@ -461,7 +463,9 @@ def test_virtualfile_from_data_required_z_matrix_missing():
     data = np.ones((5, 2))
     with clib.Session() as lib:
         with pytest.raises(GMTInvalidInput):
-            with lib.virtualfile_from_data(data=data, required_z=True):
+            with lib.virtualfile_from_data(
+                data=data, required_z=True, check_kind="vector"
+            ):
                 pass
 
 


### PR DESCRIPTION
### Background

Some GMT modules (e.g., `grdimage` and `grdview`) can accept a primary input file and an optional input file. Here, I'll take `grdimage` as an example. 

`grdimage` can accept an input grid file and an optional intensity grid for shading (`-I` option). Thus, in PyGMT, `Figure.grdimage`'s `shading` parameter can be given in many different ways:

1. `shading=None`: meaning no shading
2. `shading=True` or `shading=False`: shading or no shading
3. `shading=0.5`: a constant intensity to apply everywhere
4. `shading="+a30+nt0.8"`: derive the intensity from the primary input grid
5. `shading="intensity.nc"`: an intensity grid file
6. `shaidng="intensity.nc+a30+nt0.8"`: an intensity grid file plus more parameters
7. `shading=xrgrid` in which `xrgrid` is an xarray.DataArray object
8. more?

For cases 1-6, the `shading` parameter can be directly processed by the `build_arg_string` function, but for case 7, we need to create a virtual file for the xarray.DataArray grid.

### Motivations

Since the virtual file for shading depends on the value and data type of the `shading` parameter, thus we have to use [contextlib.ExitStack](https://docs.python.org/3/library/contextlib.html#contextlib.ExitStack), which is designed to make it easy to work with optional context manager. However, using `contextlib.ExitStack` still makes the codes complicated and also make it hard to reuse the codes:

https://github.com/GenericMappingTools/pygmt/blob/d2b0c39b075c41f55f67f1a9daa94365f3c6fce1/pygmt/src/grdimage.py#L182-L195

The main goal of this PR is to simplify the above codes to:
```python
    with Session() as lib:
        file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
        shade_context = lib.virtualfile_from_data(check_kind="raster", data=kwargs.get("I"))
        with file_context as fname, shade_context as shade_fname:
            kwargs["I"] = shade_fname
            lib.call_module(
                module="grdimage", args=build_arg_string(kwargs, infile=fname)
            )
```
which is more compact and more intuitive to read.

### Implementations

To achieve this, the `virtualfile_from_data` context manager must work for all cases. It's actually very simple. If `data` is not an xarray.DataArray object (cases 1-6), `virtualfile_from_data` should simply return a dummy context manager which does nothing but yield the argument passed to it (see the [`dummy_context`](https://github.com/GenericMappingTools/pygmt/blob/d2b0c39b075c41f55f67f1a9daa94365f3c6fce1/pygmt/helpers/utils.py#L96) function but also see https://github.com/GenericMappingTools/pygmt/pull/2491). This is done by changing the `data_kind` function to take arguments like None, True, False, 0.5, `"+a30+nt0.8"`, `"intensity.nc+a30+nt0.8"` as a "file" (see the changes in the `data_kind` function).


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
