### PR TITLE
Improve docs of "pygmt.grd2cpt" and "pygmt.makecpt"

### DIFF
--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -94,7 +94,8 @@ def grd2cpt(grid, **kwargs):
         ``background="i"`` to match the colors for the lowest and highest
         values in the input (instead of the output) CPT.
     color_model : str
-        [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*\|\ *start*\ [**-**]]].
+        [**R**\|\ **r**\|\ **h**\|\ **c**]\
+        [**+c**\ [*label*\|\ *start*\ [**-**]]].
         Force output CPT to be written with r/g/b codes, gray-scale values or
         color name (**R**, default) or r/g/b codes only (**r**), or h-s-v codes
         (**h**), or c/m/y/k codes (**c**).  Optionally or alternatively, append

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -126,8 +126,8 @@ def grd2cpt(grid, **kwargs):
         also :gmt-docs:`cookbook/features.html#manipulating-cpts`.
     output : str
         Optional parameter to set the file name with extension .cpt to store
-        the generated CPT file. If not given or False [Default], saves the CPT
-        as the session current CPT.
+        the generated CPT file. If not given or ``False`` [Default], saves the
+        CPT as the session current CPT.
     reverse : str
         Set this to True or c [Default] to reverse the sense of color
         progression in the master CPT. Set this to z to reverse the sign of

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -102,9 +102,9 @@ def grd2cpt(grid, **kwargs):
         appended then we create labels for each category to be used when the
         CPT is plotted. The *label* may be a comma-separated list of category
         names (you can skip a category by not giving a name), or give
-        *start*\[-], where we automatically build monotonically increasing
+        *start*, where we automatically build monotonically increasing
         labels from *start* (a single letter or an integer). Append ``-`` to
-        build ranges *start*-*start+1* instead.
+        build ranges *start*-*start+1* instead [Default].
     nlevels : bool or int or str
         Set to ``True`` to create a linear color table by using the grid
         z-range as the new limits in the CPT. Alternatively, set *nlevels*

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -93,7 +93,7 @@ def grd2cpt(grid, **kwargs):
         :gmt-term:`COLOR_FOREGROUND`, and :gmt-term:`COLOR_NAN`]. Use
         ``background="i"`` to match the colors for the lowest and highest
         values in the input (instead of the output) CPT.
-    color_model :
+    color_model : str
         [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*\|\ *start*\ [**-**]]].
         Force output CPT to be written with r/g/b codes, gray-scale values or
         color name (**R**, default) or r/g/b codes only (**r**), or h-s-v codes

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -35,9 +35,13 @@ def grd2cpt(grid, **kwargs):
     r"""
     Make GMT color palette tables from a grid file.
 
-    This is a function that will help you make static color palette tables
-    (CPTs). By default, the CPT will simply be saved to the current session,
-    but you can use ``output`` to save it to a file. The CPT is based on an
+    This function will help you to make static color palette tables (CPTs).
+    By default, the CPT will be saved as the current CPT of the session,
+    figure, subplot, panel, or inset depending on which level
+    :func:`pygmt.grd2cpt` is called (for details on how GMT modern mode
+    maintains different levels of colormaps please see
+    https://docs.generic-mapping-tools.org/latest/cookbook/features.html#gmt-modern-mode-hierarchical-levels).
+    You can use ``output`` to save the CPT to a file. The CPT is based on an
     existing dynamic master CPT of your choice, and the mapping from data value
     to colors is through the data's cumulative distribution function (CDF), so
     that the colors are histogram equalized. Thus if the grid(s) and the
@@ -126,9 +130,10 @@ def grd2cpt(grid, **kwargs):
         the CPT alone. The truncation takes place before any resampling. See
         also :gmt-docs:`cookbook/features.html#manipulating-cpts`.
     output : str
-        Optional parameter to set the file name with extension .cpt to store
-        the generated CPT file. If not given or ``False`` [Default], saves the
-        CPT as the session current CPT.
+        Optional. The file name with extension .cpt to store the generated CPT
+        file. If not given or ``False`` [Default], saves the CPT as the current
+        CPT of the session, figure, subplot, panel, or inset depending on which
+        level :func:`pygmt.grd2cpt` is called.
     reverse : str
         Set this to ``True`` or **c** [Default] to reverse the sense of color
         progression in the master CPT. Set this to **z** to reverse the sign

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -129,11 +129,11 @@ def grd2cpt(grid, **kwargs):
         the generated CPT file. If not given or ``False`` [Default], saves the
         CPT as the session current CPT.
     reverse : str
-        Set this to True or c [Default] to reverse the sense of color
-        progression in the master CPT. Set this to z to reverse the sign of
-        z-values in the color table. Note that this change of z-direction
-        happens before *truncate* and *series* values are used so the latter
-        must be compatible with the changed *z*-range. See also
+        Set this to ``True`` or **c** [Default] to reverse the sense of color
+        progression in the master CPT. Set this to **z** to reverse the sign
+        of z-values in the color table. Note that this change of z-direction
+        happens before ``truncate`` and ``series`` values are used so the
+        latter must be compatible with the changed z-range. See also
         :gmt-docs:`cookbook/features.html#manipulating-cpts`.
     overrule_bg : str
         Overrule background, foreground, and NaN colors specified in the master

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -40,7 +40,7 @@ def grd2cpt(grid, **kwargs):
     figure, subplot, panel, or inset depending on which level
     :func:`pygmt.grd2cpt` is called (for details on how GMT modern mode
     maintains different levels of colormaps please see
-    https://docs.generic-mapping-tools.org/latest/cookbook/features.html#gmt-modern-mode-hierarchical-levels).
+    :gmt-docs:`cookbook/features.html#gmt-modern-mode-hierarchical-levels`).
     You can use ``output`` to save the CPT to a file. The CPT is based on an
     existing dynamic master CPT of your choice, and the mapping from data value
     to colors is through the data's cumulative distribution function (CDF), so

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -94,7 +94,7 @@ def grd2cpt(grid, **kwargs):
         ``background="i"`` to match the colors for the lowest and highest
         values in the input (instead of the output) CPT.
     color_model :
-        [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*]].
+        [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*\|\ *start*[-]]].
         Force output CPT to be written with r/g/b codes, gray-scale values or
         color name (**R**, default) or r/g/b codes only (**r**), or h-s-v codes
         (**h**), or c/m/y/k codes (**c**).  Optionally or alternatively, append
@@ -103,8 +103,8 @@ def grd2cpt(grid, **kwargs):
         CPT is plotted. The *label* may be a comma-separated list of category
         names (you can skip a category by not giving a name), or give
         *start*, where we automatically build monotonically increasing
-        labels from *start* (a single letter or an integer). Append ``-`` to
-        build ranges *start*-*start+1* instead [Default].
+        labels from *start* (a single letter or an integer). Additionally
+        append **-** to build ranges *start*-*start+1* as labels instead.
     nlevels : bool or int or str
         Set to ``True`` to create a linear color table by using the grid
         z-range as the new limits in the CPT. Alternatively, set *nlevels*

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -94,7 +94,7 @@ def grd2cpt(grid, **kwargs):
         ``background="i"`` to match the colors for the lowest and highest
         values in the input (instead of the output) CPT.
     color_model :
-        [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*\|\ *start*[-]]].
+        [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*\|\ *start*\ [**-**]]].
         Force output CPT to be written with r/g/b codes, gray-scale values or
         color name (**R**, default) or r/g/b codes only (**r**), or h-s-v codes
         (**h**), or c/m/y/k codes (**c**).  Optionally or alternatively, append

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -29,9 +29,14 @@ def makecpt(**kwargs):
     r"""
     Make GMT color palette tables.
 
-    This is a function that will help you make static color palette tables
-    (CPTs). By default, the CPT will simply be saved to the current session,
-    but you can use ``output`` to save it to a file. You define an equidistant
+    This function will help you to make static color palette tables (CPTs).
+    By default, the CPT will be saved as the current CPT of the session,
+    figure, subplot, panel, or inset depending on which level
+    :func:`pygmt.grd2cpt` is called (for details on how GMT modern mode
+    maintains different levels of colormaps please see
+    https://docs.generic-mapping-tools.org/latest/cookbook/features.html#gmt-modern-mode-hierarchical-levels).
+    You can use ``output`` to save the CPT to a file.
+    You define an equidistant
     set of contour intervals or pass your own z-table or list, and create a new
     CPT based on an existing master (dynamic) CPT. The resulting CPT can be
     reversed relative to the master cpt, and can be made continuous or
@@ -110,8 +115,9 @@ def makecpt(**kwargs):
         also :gmt-docs:`cookbook/features.html#manipulating-cpts`.
     output : str
         Optional. The file name with extension .cpt to store the generated CPT
-        file. If not given or False [Default], saves the CPT as the session
-        current CPT.
+        file. If not given or ``False`` [Default], saves the CPT as the current
+        CPT of the session, figure, subplot, panel, or inset depending on which
+        level :func:`pygmt.grd2cpt` is called.
     reverse : str
         Set this to True or **c** [Default] to reverse the sense of color
         progression in the master CPT. Set this to z to reverse the sign of

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -117,7 +117,7 @@ def makecpt(**kwargs):
         Optional. The file name with extension .cpt to store the generated CPT
         file. If not given or ``False`` [Default], saves the CPT as the current
         CPT of the session, figure, subplot, panel, or inset depending on which
-        level :func:`pygmt.grd2cpt` is called.
+        level :func:`pygmt.makecpt` is called.
     reverse : str
         Set this to True or **c** [Default] to reverse the sense of color
         progression in the master CPT. Set this to z to reverse the sign of

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -34,7 +34,7 @@ def makecpt(**kwargs):
     figure, subplot, panel, or inset depending on which level
     :func:`pygmt.makecpt` is called (for details on how GMT modern mode
     maintains different levels of colormaps please see
-    https://docs.generic-mapping-tools.org/latest/cookbook/features.html#gmt-modern-mode-hierarchical-levels).
+    :gmt-docs:`cookbook/features.html#gmt-modern-mode-hierarchical-levels`).
     You can use ``output`` to save the CPT to a file.
     You define an equidistant
     set of contour intervals or pass your own z-table or list, and create a new

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -32,7 +32,7 @@ def makecpt(**kwargs):
     This function will help you to make static color palette tables (CPTs).
     By default, the CPT will be saved as the current CPT of the session,
     figure, subplot, panel, or inset depending on which level
-    :func:`pygmt.grd2cpt` is called (for details on how GMT modern mode
+    :func:`pygmt.makecpt` is called (for details on how GMT modern mode
     maintains different levels of colormaps please see
     https://docs.generic-mapping-tools.org/latest/cookbook/features.html#gmt-modern-mode-hierarchical-levels).
     You can use ``output`` to save the CPT to a file.


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix typos in the docstrings for [pygmt.grd2cpt](https://www.pygmt.org/dev/api/generated/pygmt.grd2cpt.html).
Regarding the `color_model` parameter or [**F**](https://docs.generic-mapping-tools.org/dev/grd2cpt.html#f) also a upstream PR seems needed (at least adding a space and escaping it), but first I have to be sure, that my changes are correct 🙂.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
