### PR TITLE
Fix typo in docstrings of pygmt.Figure.colorbar

### DIFF
--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -85,8 +85,8 @@ def colorbar(self, **kwargs):
         rectangular borders instead, with a 6p corner radius. You can override
         this radius by appending another value. Finally, append **+s** to draw
         an offset background shaded region. Here, *dx/dy* indicates the shift
-        relative to the foreground frame [4p/-4p] and shade sets the fill
-        style to use for shading [Default is ``"gray50"``].
+        relative to the foreground frame [Default is ``"4p/-4p"``] and shade
+        sets the fill style to use for shading [Default is ``"gray50"``].
     truncate : list or str
         *zlo*/*zhi*.
         Truncate the incoming CPT so that the lowest and highest z-levels are


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a typo in the docstrings for [pygmt.Figure.colorbar](https://www.pygmt.org/dev/api/generated/pygmt.Figure.colorbar.html).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
