### PR TITLE
Silent a pandas 2.0 warning by speicifying the time precision

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -679,7 +679,7 @@ def kwargs_to_strings(**conversions):
     >>> import xarray as xr
     >>> module(
     ...     R=[
-    ...         xr.DataArray(data=np.datetime64("2005-01-01T08:00:00")),
+    ...         xr.DataArray(data=np.datetime64("2005-01-01T08:00:00", "ns")),
     ...         pd.Timestamp("2015-01-01T12:00:00.123456789"),
     ...     ]
     ... )


### PR DESCRIPTION
**Description of proposed changes**

Fixes the following warning due to pandas 2.0. 

> pygmt/helpers/decorators.py::pygmt.helpers.decorators.kwargs_to_strings
>
>  <doctest pygmt.helpers.decorators.kwargs_to_strings[13]>:3: UserWarning: Converting non-nanosecond precision datetime values to nanosecond precision. This behavior can eventually be relaxed in xarray, as it is an artifact from pandas which is now beginning to support non-nanosecond precision values. This warning is caused by passing non-nanosecond np.datetime64 or np.timedelta64 values to the DataArray or Variable constructor; it can be silenced by converting the values to nanosecond precision ahead of time.

Related to https://github.com/GenericMappingTools/pygmt/issues/2480.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
