### PR TITLE
Move pip as a dev dependency and ipython as an optional dependency

### DIFF
--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -1,10 +1,9 @@
 name: pygmt
 channels:
     - conda-forge
-    - defaults
+    - nodefaults
 dependencies:
     # Required dependencies
-    - pip
     - gmt=6.4.0
     - numpy>=1.21
     - pandas
@@ -14,11 +13,12 @@ dependencies:
     # Optional dependencies
     - contextily
     - geopandas
+    - ipython
     - rioxarray
     # Development dependencies (general)
     - build
-    - ipython
     - make
+    - pip
     # Dev dependencies (building documentation)
     - myst-parser
     - sphinx

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
     - nodefaults
 dependencies:
     # Required dependencies
-    - pip
     - gmt=6.4.0
     - numpy>=1.21
     - pandas
@@ -21,6 +20,7 @@ dependencies:
     - dvc
     - jupyter
     - make
+    - pip
     # Dev dependencies (style checks)
     - black
     - blackdoc


### PR DESCRIPTION
**Description of proposed changes**

1. Do not use the `default` channel when building docs
2. Move `pip` as a dev dependency
3. Move `ipython` as an optional dependency.

The changes in this PR were initially made in PR https://github.com/GenericMappingTools/pygmt/pull/2435. I cherry-picked these changes and made a separate PR to make PR #2435 smaller and thus easier to review.