### PR TITLE
Add link to upstream GMT docs in pygmt.Figure.legend

### DIFF
--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -33,7 +33,7 @@ def legend(self, spec=None, position="JTR+jTR+o0.2c", box="+gwhite+p1p", **kwarg
     legend-related information from an input file, or automatically creates
     legend entries from plotted symbols that have labels. Unless otherwise
     noted, annotations will be made using the primary annotation font and
-    size in effect (i.e., FONT_ANNOT_PRIMARY).
+    size in effect (i.e., :gmt-term:`FONT_ANNOT_PRIMARY`).
 
     Full option list at :gmt-docs:`legend.html`
 


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a link to the upstream GMT documentation in the docstrings for [pygmt.Figure.legend](https://www.pygmt.org/dev/api/generated/pygmt.Figure.legend.html).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
