### PR TITLE
Highlight arguments for "style" attribute of "pen" parameter in Gallery example "Line styles"

### DIFF
--- a/examples/gallery/lines/linestyles.py
+++ b/examples/gallery/lines/linestyles.py
@@ -8,9 +8,9 @@ customized with the ``pen`` parameter.
 
 A *pen* in GMT has three attributes: *width*, *color*, and *style*.
 The *style* attribute controls the appearance of the line.
-Giving "dotted" or "." yields a dotted line, whereas a dashed pen is requested
-with "dashed" or "-". Also combinations of dots and dashes, like ".-" for a
-dot-dashed line, are allowed.
+Giving ``"dotted"`` or ``"."`` yields a dotted line, whereas a dashed pen is
+requested with ``"dashed"`` or ``"-"``. Also combinations of dots and dashes,
+like ``".-"`` for a dot-dashed line, are allowed.
 
 For more advanced *pen* attributes, see the GMT cookbook
 :gmt-docs:`cookbook/features.html#wpen-attrib`.


### PR DESCRIPTION
**Description of proposed changes**

This PR adds highlighting for the arguments allowed for the *style* attribute of the `pen` parameter in the Gallery example [Line styles](https://www.pygmt.org/dev/gallery/lines/linestyles.html#sphx-glr-download-gallery-lines-linestyles-py).

**Preview**: https://pygmt-dev--2520.org.readthedocs.build/en/2520/gallery/lines/linestyles.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
