### PR TITLE
Add link to GMT docs "Vector Attributes" in Gallery example "Vector heads and tails" ?

### DIFF
--- a/examples/gallery/lines/vector_heads_tails.py
+++ b/examples/gallery/lines/vector_heads_tails.py
@@ -20,8 +20,7 @@ The angle of the vector head apex can be set using **+a**\ *angle*
 (default is 30). The shape of the vector head can be adjusted using
 **+h**\ *shape* (e.g. ``+h0.5``).
 
-For further modifiers see the *Vector Attributes* subsection of the
-corresponding method.
+For further modifiers see :gmt-docs:`plot.html#vector-attributes`.
 
 In the following we use the :meth:`pygmt.Figure.plot` method to plot vectors
 with individual heads and tails. We must specify the modifiers (together with


### PR DESCRIPTION
**Description of proposed changes**

In the Gallery example [Vector heads and tails](https://www.pygmt.org/dev/gallery/lines/vector_heads_tails.html) we write:

> For further modifiers see the _Vector Attributes_ subsection of the corresponding method.

In the PyGMT documentation, we do not have a "Vector Attributes" subsection in any of the docstrings for the different plotting methods. For `pygmt.Figure.plot` we simply say:

> style ([str](https://docs.python.org/3/library/stdtypes.html#str)) – Plot symbols (including vectors, pie slices, fronts, decorated or quoted lines).

Probably this statement is referring to the upstream GMT documentation? I am a little bit concerned, whether this is straight forward to find.

It seems like that the links `"xyz#vector-attributes"` for different modules link to the same GMT documentation part, at least the one for `plot` https://docs.generic-mapping-tools.org/dev/plot.html#vector-attributes looks similar to the one for `velo` https://docs.generic-mapping-tools.org/dev/supplements/geodesy/velo.html#vector-attributes. So, I am wondering whether it is more helpful to state the link to the upstream GMT documentation of one module, e.g., `plot`, instead of writing "Vector Attributes subsection of the corresponding method"  in the Gallery example (see commit https://github.com/GenericMappingTools/pygmt/commit/f7d7cdae09e8c546291a266058cc0ce97b5455a5)?

**Preview**: https://pygmt-dev--2521.org.readthedocs.build/en/2521/gallery/lines/vector_heads_tails.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
