### PR TITLE
WIP: CI: Improve the "GMT Legacy Tests" workflow

### DIFF
--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -11,7 +11,7 @@ name: GMT Legacy Tests
 on:
   # push:
   #   branches: [ main ]
-  # pull_request:
+  pull_request:
     # types: [ready_for_review]
     # paths-ignore:
     #  - 'doc/**'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -98,8 +98,10 @@ jobs:
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote
         run: |
-          dvc pull pygmt/tests/baseline/test_logo.png --verbose
+          # test_logo.png is required by the test_image.py tests
+          dvc pull pygmt/tests/baseline/test_logo.png
           ls -lhR pygmt/tests/baseline/
+          
       # Install the package that we want to test
       - name: Install the package
         run: make install

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -76,8 +76,6 @@ jobs:
             make
             pip
             pytest
-            pytest-doctestplus
-            pytest-mpl
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -73,7 +73,6 @@ jobs:
             ipython
             rioxarray
             build
-            dvc
             make
             pip
             pytest
@@ -97,12 +96,6 @@ jobs:
           # Change modification times of the two files, so GMT won't refresh it
           touch ~/.gmt/server/gmt_data_server.txt ~/.gmt/server/gmt_hash_server.txt
           ls -lhR ~/.gmt
-
-      # Pull baseline image data from dvc remote (DAGsHub)
-      - name: Pull baseline image data from dvc remote
-        run: |
-          dvc pull pygmt/tests/baseline/test_logo.png --verbose
-          ls -lhR pygmt/tests/baseline/
 
       # Install the package that we want to test
       - name: Install the package

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -101,7 +101,6 @@ jobs:
           # test_logo.png is required by the test_image.py tests
           dvc pull pygmt/tests/baseline/test_logo.png
           ls -lhR pygmt/tests/baseline/
-          
       # Install the package that we want to test
       - name: Install the package
         run: make install

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -71,6 +71,7 @@ jobs:
             ipython
             rioxarray
             build
+            dvc
             make
             pip
             pytest
@@ -94,6 +95,11 @@ jobs:
           touch ~/.gmt/server/gmt_data_server.txt ~/.gmt/server/gmt_hash_server.txt
           ls -lhR ~/.gmt
 
+      # Pull baseline image data from dvc remote (DAGsHub)
+      - name: Pull baseline image data from dvc remote
+        run: |
+          dvc pull pygmt/tests/baseline/test_logo.png --verbose
+          ls -lhR pygmt/tests/baseline/
       # Install the package that we want to test
       - name: Install the package
         run: make install

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -74,6 +74,7 @@ jobs:
             make
             pip
             pytest
+            pytest-mpl
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -75,6 +75,7 @@ jobs:
             make
             pip
             pytest
+            pytest-doctestplus
             pytest-mpl
 
       # Download cached remote files (artifacts) from GitHub

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -102,7 +102,6 @@ jobs:
           # test_logo.png is required by the test_image.py tests
           dvc pull pygmt/tests/baseline/test_logo.png
           ls -lhR pygmt/tests/baseline/
-          
       # Install the package that we want to test
       - name: Install the package
         run: make install

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -102,6 +102,7 @@ jobs:
           # test_logo.png is required by the test_image.py tests
           dvc pull pygmt/tests/baseline/test_logo.png
           ls -lhR pygmt/tests/baseline/
+          
       # Install the package that we want to test
       - name: Install the package
         run: make install

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -58,8 +58,6 @@ jobs:
           environment-name: pygmt
           environment-file: false
           channels: conda-forge,nodefaults
-          cache-downloads: true
-          cache-env: true
           extra-specs: |
             python=3.9
             gmt=${{ matrix.gmt_version }}


### PR DESCRIPTION
**Description of proposed changes**

- pytest-doctestplus is not used in the workflow
- No need to cache env and downloads because the cache expires in one day and the job is scheduled to run weekly, thus the cache is useless