### PR TITLE
Fix typo in gallery example "Color points by categories"

### DIFF
--- a/examples/gallery/symbols/points_categorical.py
+++ b/examples/gallery/symbols/points_categorical.py
@@ -74,9 +74,9 @@ fig.plot(
     # Use bill length and bill depth as x and y data input, respectively
     x=df.bill_length_mm,
     y=df.bill_depth_mm,
-    # Vary symbol size according the body mass, scaled by 7.5e-5
+    # Vary symbol size according to the body mass, scaled by 7.5e-5
     size=df.body_mass_g * 7.5e-5,
-    # Points colored by categorical number code (refers to the species)
+    # Points colored by categorical number code, refers to the species
     fill=df.species.cat.codes.astype(int),
     # Use colormap created by makecpt
     cmap=True,

--- a/examples/gallery/symbols/points_categorical.py
+++ b/examples/gallery/symbols/points_categorical.py
@@ -76,7 +76,7 @@ fig.plot(
     y=df.bill_depth_mm,
     # Vary symbol size according to the body mass, scaled by 7.5e-5
     size=df.body_mass_g * 7.5e-5,
-    # Points colored by categorical number code, refers to the species
+    # Points colored by categorical number code (refers to the species)
     fill=df.species.cat.codes.astype(int),
     # Use colormap created by makecpt
     cmap=True,


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes a typo in the comments of the gallery example [Color points by categories](https://www.pygmt.org/dev/gallery/symbols/points_categorical.html) introduced in PR #2512.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
