### PR TITLE
Figure.meca: Refactor tests for plotting a single focal mechanism

### DIFF
--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -58,13 +58,6 @@ jobs:
         awk 'NF==5 && NR>=7 && $2=="added" {print $4}' report.md > added_files.txt
         awk 'NF==5 && NR>=7 && $2=="modified" {print $4}' report.md > modified_files.txt
 
-        # Backup the new images in the "baseline-new" directory
-        mkdir pygmt/tests/baseline-new
-        cp pygmt/tests/baseline/*.png pygmt/tests/baseline-new
-        # Pull images in the main branch from cloud storage
-        git checkout main
-        dvc pull --remote upstream
-
         # Append each image to the markdown report
         echo -e "## Image diff(s)\n" >> report.md
         echo -e "<details>\n" >> report.md
@@ -73,22 +66,34 @@ jobs:
         echo -e "### Added images\n" >> report.md
         while IFS= read -r line; do
           echo -e "- $line \n" >> report.md
-          echo -e "![](${line/baseline/baseline-new})" >> report.md
+          cml-publish --title $line --md "$line" >> report.md < /dev/null
         done < added_files.txt
 
         # Modified images
         echo -e "### Modified images\n" >> report.md
+        # Upload new images
+        while IFS= read -r line; do
+          cml-publish --title $line --md "$line" >> modified_images_new.md < /dev/null
+        done < modified_files.txt
+
+        # Pull images in the main branch from cloud storage
+        git checkout main
+        dvc pull --remote upstream
+        # Upload old images
+        while IFS= read -r line; do
+          cml-publish --title $line --md "$line" >> modified_images_old.md < /dev/null
+        done < modified_files.txt
+
+        # Append image report for modified images
         echo -e "| Path | Old | New |" >> report.md
         echo -e "|---|---|---|" >> report.md
-        awk -F"|" 'function basename(file) {sub(".*/", "", file); return file} {printf("| %s | ![](%s) | ![](%s) |\n",  basename($1), $2, $3)}' modified_files.txt >> report.md
+        paste modified_files.txt modified_images_old.md modified_images_new.md -d"|" |
+          awk -F"|" 'function basename(file) {sub(".*/", "", file); return file} {printf("| %s | %s | %s |\n",  basename($1), $2, $3)}' >> report.md
+
         echo -e "</details>\n" >> report.md
 
         # Mention git commit SHA in the report
         echo -e "Report last updated at commit ${{ github.event.pull_request.head.sha }}" >> report.md
-
-        cat report.md
-
-        #cml comment update report.md
 
         # Save the report content to the output parameter 'report'
         echo 'report<<EOF' >> $GITHUB_OUTPUT

--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -58,6 +58,13 @@ jobs:
         awk 'NF==5 && NR>=7 && $2=="added" {print $4}' report.md > added_files.txt
         awk 'NF==5 && NR>=7 && $2=="modified" {print $4}' report.md > modified_files.txt
 
+        # Backup the new images in the "baseline-new" directory
+        mkdir pygmt/tests/baseline-new
+        cp pygmt/tests/baseline/*.png pygmt/tests/baseline-new
+        # Pull images in the main branch from cloud storage
+        git checkout main
+        dvc pull --remote upstream
+
         # Append each image to the markdown report
         echo -e "## Image diff(s)\n" >> report.md
         echo -e "<details>\n" >> report.md
@@ -66,34 +73,22 @@ jobs:
         echo -e "### Added images\n" >> report.md
         while IFS= read -r line; do
           echo -e "- $line \n" >> report.md
-          cml-publish --title $line --md "$line" >> report.md < /dev/null
+          echo -e "![](${line/baseline/baseline-new})" >> report.md
         done < added_files.txt
 
         # Modified images
         echo -e "### Modified images\n" >> report.md
-        # Upload new images
-        while IFS= read -r line; do
-          cml-publish --title $line --md "$line" >> modified_images_new.md < /dev/null
-        done < modified_files.txt
-
-        # Pull images in the main branch from cloud storage
-        git checkout main
-        dvc pull --remote upstream
-        # Upload old images
-        while IFS= read -r line; do
-          cml-publish --title $line --md "$line" >> modified_images_old.md < /dev/null
-        done < modified_files.txt
-
-        # Append image report for modified images
         echo -e "| Path | Old | New |" >> report.md
         echo -e "|---|---|---|" >> report.md
-        paste modified_files.txt modified_images_old.md modified_images_new.md -d"|" |
-          awk -F"|" 'function basename(file) {sub(".*/", "", file); return file} {printf("| %s | %s | %s |\n",  basename($1), $2, $3)}' >> report.md
-
+        awk -F"|" 'function basename(file) {sub(".*/", "", file); return file} {printf("| %s | ![](%s) | ![](%s) |\n",  basename($1), $2, $3)}' modified_files.txt >> report.md
         echo -e "</details>\n" >> report.md
 
         # Mention git commit SHA in the report
         echo -e "Report last updated at commit ${{ github.event.pull_request.head.sha }}" >> report.md
+
+        cat report.md
+
+        #cml comment update report.md
 
         # Save the report content to the output parameter 'report'
         echo 'report<<EOF' >> $GITHUB_OUTPUT

--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -30,7 +30,7 @@ jobs:
       uses: iterative/setup-dvc@v1.1.1
 
     - name: Setup continuous machine learning (CML)
-      uses: iterative/setup-cml@v1.2.2
+      uses: iterative/setup-cml@v1.2.3
 
     - name: Pull image data from cloud storage
       run: dvc pull --remote upstream

--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -30,7 +30,7 @@ jobs:
       uses: iterative/setup-dvc@v1.1.1
 
     - name: Setup continuous machine learning (CML)
-      uses: iterative/setup-cml@v1.2.3
+      uses: iterative/setup-cml@v1.2.2
 
     - name: Pull image data from cloud storage
       run: dvc pull --remote upstream

--- a/pygmt/tests/baseline/test_meca_gcmt_convention.png.dvc
+++ b/pygmt/tests/baseline/test_meca_gcmt_convention.png.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: a44dc0f1af50958aeff2d359ea8b03a7
-  size: 8732
-  path: test_meca_gcmt_convention.png

--- a/pygmt/tests/baseline/test_meca_spec_1d_array.png.dvc
+++ b/pygmt/tests/baseline/test_meca_spec_1d_array.png.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 916dd79b35defcb6b6c1464f4a279790
-  size: 3216
-  path: test_meca_spec_1d_array.png

--- a/pygmt/tests/baseline/test_meca_spec_dictionary.png.dvc
+++ b/pygmt/tests/baseline/test_meca_spec_dictionary.png.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 8581943564134f58b295ec633acb8d1e
-  size: 17901
-  path: test_meca_spec_dictionary.png

--- a/pygmt/tests/baseline/test_meca_spec_file.png.dvc
+++ b/pygmt/tests/baseline/test_meca_spec_file.png.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: ad602355748d74a76edfa5cef4100b13
-  size: 3179
-  path: test_meca_spec_file.png

--- a/pygmt/tests/baseline/test_meca_spec_single_focalmecha.png.dvc
+++ b/pygmt/tests/baseline/test_meca_spec_single_focalmecha.png.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: fc7c271049fc8583914b508c4bee08fe
+  size: 9830
+  path: test_meca_spec_single_focalmecha.png

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -59,6 +59,25 @@ def test_meca_spec_single_focalmecha(inputtype):
     return fig
 
 
+@pytest.mark.mpl_image_compare(filename="test_meca_spec_single_focalmecha.png")
+def test_meca_spec_single_focalmecha_file():
+    """
+    Test supplying a file containing focal mechanisms and locations to the spec
+    parameter.
+    """
+    fig = Figure()
+    fig.basemap(region=[-1, 1, 4, 6], projection="M8c", frame=2)
+    with GMTTempFile() as temp:
+        with open(temp.name, mode="w", encoding="utf8") as temp_file:
+            temp_file.write("0 5 0 0 90 0 5")
+        fig.meca(
+            spec=temp.name,
+            convention="aki",
+            scale="2.5c",
+        )
+    return fig
+
+
 @pytest.mark.mpl_image_compare
 def test_meca_spec_dict_list():
     """
@@ -178,30 +197,6 @@ def test_meca_spec_2d_array():
         scale="2c",
         projection="M14c",
     )
-    return fig
-
-
-@pytest.mark.mpl_image_compare
-def test_meca_spec_file():
-    """
-    Test supplying a file containing focal mechanisms and locations to the spec
-    parameter.
-    """
-    fig = Figure()
-    focal_mechanism = [-127.43, 40.81, 12, -3.19, 1.16, 3.93, -1.02, -3.93, -1.02, 23]
-    # writes temp file to pass to gmt
-    with GMTTempFile() as temp:
-        with open(temp.name, mode="w", encoding="utf8") as temp_file:
-            temp_file.write(" ".join([str(x) for x in focal_mechanism]))
-        # supply focal mechanisms to meca as a file
-        fig.meca(
-            spec=temp.name,
-            convention="mt",
-            component="full",
-            region=[-128, -127, 40, 41],
-            scale="2c",
-            projection="M14c",
-        )
     return fig
 
 

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -9,22 +9,18 @@ from pygmt.helpers import GMTTempFile
 
 
 @pytest.mark.mpl_image_compare
-def test_meca_spec_dictionary():
+def test_meca_spec_single_focalmecha():
     """
-    Test supplying a dictionary containing a single focal mechanism to the spec
-    parameter.
+    Test passing a single focal mechanism to the spec parameter.
     """
     fig = Figure()
-    # Right lateral strike slip focal mechanism
+    fig.basemap(region=[-1, 1, 4, 6], projection="M8c", frame=2)
     fig.meca(
         spec={"strike": 0, "dip": 90, "rake": 0, "magnitude": 5},
         longitude=0,
         latitude=5,
         depth=0,
         scale="2.5c",
-        region=[-1, 1, 4, 6],
-        projection="M14c",
-        frame=2,
     )
     return fig
 

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -8,20 +8,54 @@ from pygmt import Figure
 from pygmt.helpers import GMTTempFile
 
 
-@pytest.mark.mpl_image_compare
-def test_meca_spec_single_focalmecha():
+@pytest.mark.mpl_image_compare(filename="test_meca_spec_single_focalmecha.png")
+@pytest.mark.parametrize("inputtype", ["dict_mecha", "dict_full", "array1d", "pandas"])
+def test_meca_spec_single_focalmecha(inputtype):
     """
     Test passing a single focal mechanism to the spec parameter.
     """
+    if inputtype == "dict_mecha":
+        args = {
+            "spec": {"strike": 0, "dip": 90, "rake": 0, "magnitude": 5},
+            "longitude": 0,
+            "latitude": 5,
+            "depth": 0,
+        }
+    elif inputtype == "dict_full":
+        args = {
+            "spec": {
+                "longitude": 0,
+                "latitude": 5,
+                "depth": 0,
+                "strike": 0,
+                "dip": 90,
+                "rake": 0,
+                "magnitude": 5,
+            }
+        }
+    elif inputtype == "array1d":
+        args = {
+            "spec": np.array([0, 5, 0, 0, 90, 0, 5]),
+            "convention": "a",
+        }
+    elif inputtype == "pandas":
+        args = {
+            "spec": pd.DataFrame(
+                {
+                    "longitude": 0,
+                    "latitude": 5,
+                    "depth": 0,
+                    "strike": 0,
+                    "dip": 90,
+                    "rake": 0,
+                    "magnitude": 5,
+                },
+                index=[0],
+            )
+        }
     fig = Figure()
     fig.basemap(region=[-1, 1, 4, 6], projection="M8c", frame=2)
-    fig.meca(
-        spec={"strike": 0, "dip": 90, "rake": 0, "magnitude": 5},
-        longitude=0,
-        latitude=5,
-        depth=0,
-        scale="2.5c",
-    )
+    fig.meca(scale="2.5c", **args)
     return fig
 
 

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -133,44 +133,6 @@ def test_meca_spec_dataframe():
 
 
 @pytest.mark.mpl_image_compare
-def test_meca_spec_1d_array():
-    """
-    Test supplying a 1-D numpy array containing focal mechanisms and locations
-    to the spec parameter.
-    """
-    fig = Figure()
-    # supply focal mechanisms to meca as a 1-D numpy array, here we are using
-    # the Harvard CMT zero trace convention but the focal mechanism
-    # parameters may be specified any of the available conventions. Since we
-    # are not using a dict or dataframe the convention and component should
-    # be specified.
-    focal_mechanism = [
-        -127.40,  # longitude
-        40.87,  # latitude
-        12,  # depth
-        -3.19,  # mrr
-        0.16,  # mtt
-        3.03,  # mff
-        -1.02,  # mrt
-        -3.93,  # mrf
-        -0.02,  # mtf
-        23,  # exponent
-        0,  # plot_lon, 0 to plot at event location
-        0,  # plot_lat, 0 to plot at event location
-    ]
-    focal_mech_array = np.asarray(focal_mechanism)
-    fig.meca(
-        spec=focal_mech_array,
-        convention="mt",
-        component="full",
-        region=[-128, -127, 40, 41],
-        scale="2c",
-        projection="M14c",
-    )
-    return fig
-
-
-@pytest.mark.mpl_image_compare
 def test_meca_spec_2d_array():
     """
     Test supplying a 2-D numpy array containing focal mechanisms and locations
@@ -228,37 +190,6 @@ def test_meca_loc_array():
         depth=depth,
         region=[-125, -122, 47, 49],
         projection="M14c",
-    )
-    return fig
-
-
-@pytest.mark.mpl_image_compare
-def test_meca_gcmt_convention():
-    """
-    Test plotting beachballs using the global CMT convention.
-    """
-    fig = Figure()
-    # specify focal mechanisms
-    focal_mechanisms = {
-        "strike1": 180,
-        "dip1": 18,
-        "rake1": -88,
-        "strike2": 0,
-        "dip2": 72,
-        "rake2": -90,
-        "mantissa": 5.5,
-        "exponent": 0,
-    }
-    fig.meca(
-        spec=focal_mechanisms,
-        scale="1c",
-        longitude=239.384,
-        latitude=34.556,
-        depth=12,
-        convention="gcmt",
-        region=[239, 240, 34, 35.2],
-        projection="m2.5c",
-        frame=True,
     )
     return fig
 


### PR DESCRIPTION
**Description of proposed changes**

The `Figure.meca` tests are a little messy and difficult to maintain because each test uses different focal mechanisms and event information. 

I plan to refactor the tests. This PR focuses on testing passing a single focal mechanism to the spec parameter using different data types (dict, file, 1darray and DataFrame). Note that all tests now single a single baseline image test_meca_spec_dict.png.

Changes in this PR:

- Rename test_meca_spec_dictionary to test_meca_spec_single_focalmecha
- Test different input types for a single focal mechanism
- Remove test_meca_spec_file and add test_meca_spec_single_focalmecha_file
- Remove two tests test_meca_gcmt_convention and test_meca_spec_1d_array

This PR is a rework of PR https://github.com/GenericMappingTools/pygmt/pull/2219.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
