### PR TITLE
Unpin docformatter 1.5.1

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -32,7 +32,7 @@ jobs:
       # Install formatting tools
       - name: Install formatting tools
         run: |
-          python -m pip install black blackdoc docformatter==1.5.1 flakeheaven isort
+          python -m pip install black blackdoc docformatter flakeheaven isort
           sudo apt-get install dos2unix
 
       # Run "make format" and commit the change to the PR branch

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install packages
         run: |
-          python -m pip install black blackdoc docformatter==1.5.1 flakeheaven pylint isort
+          python -m pip install black blackdoc docformatter flakeheaven pylint isort
           sudo apt-get install dos2unix
 
       - name: Formatting check (black, blackdoc, docformatter, flakeheaven and isort)

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
     # Dev dependencies (style checks)
     - black
     - blackdoc
-    - docformatter>=1.5.0,<1.6.0
+    - docformatter>=1.7.0
     - flakeheaven>=3
     - isort>=5
     - pylint

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
     # Dev dependencies (style checks)
     - black
     - blackdoc
-    - docformatter>=1.7.0
+    - docformatter>=1.7.2
     - flakeheaven>=3
     - isort>=5
     - pylint

--- a/pygmt/tests/test_grdcut.py
+++ b/pygmt/tests/test_grdcut.py
@@ -44,7 +44,7 @@ def fixture_expected_grid():
 
 def test_grdcut_dataarray_in_file_out(grid, expected_grid, region):
     """
-    grdcut an input DataArray, and output to a grid file.
+    Test grdcut on an input DataArray, and output to a grid file.
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         result = grdcut(grid, outgrid=tmpfile.name, region=region)
@@ -55,7 +55,7 @@ def test_grdcut_dataarray_in_file_out(grid, expected_grid, region):
 
 def test_grdcut_dataarray_in_dataarray_out(grid, expected_grid, region):
     """
-    grdcut an input DataArray, and output as DataArray.
+    Test grdcut on an input DataArray, and output as DataArray.
     """
     outgrid = grdcut(grid, region=region)
     assert isinstance(outgrid, xr.DataArray)

--- a/pygmt/tests/test_grdproject.py
+++ b/pygmt/tests/test_grdproject.py
@@ -42,7 +42,7 @@ def fixture_expected_grid():
 
 def test_grdproject_file_out(grid, expected_grid):
     """
-    grdproject with an outgrid set.
+    Test grdproject with an outgrid set.
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         result = grdproject(

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -381,11 +381,11 @@ def test_plot_lines_with_arrows():
     """
     Plot lines with arrows.
 
-    The test is slightly different from test_plot_vectors().
-    Here the vectors are plotted as lines, with arrows at the end.
+    The test is slightly different from test_plot_vectors(). Here the vectors
+    are plotted as lines, with arrows at the end.
 
-    The test also checks if the API crashes.
-    See https://github.com/GenericMappingTools/pygmt/issues/406.
+    The test also checks if the API crashes. See
+    https://github.com/GenericMappingTools/pygmt/issues/406.
     """
     fig = Figure()
     fig.basemap(region=[-2, 2, -2, 2], frame=True)

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -33,8 +33,7 @@ def fixture_region():
 @pytest.mark.mpl_image_compare
 def test_plot3d_red_circles_zscale(data, region):
     """
-    Plot the 3-D data in red circles passing in vectors and setting
-    zscale = 5
+    Plot the 3-D data in red circles passing in vectors and setting zscale=5.
     """
     fig = Figure()
     fig.plot3d(
@@ -55,8 +54,7 @@ def test_plot3d_red_circles_zscale(data, region):
 @pytest.mark.mpl_image_compare
 def test_plot3d_red_circles_zsize(data, region):
     """
-    Plot the 3-D data in red circles passing in vectors and setting
-    zsize = "6c"
+    Plot the 3-D data in red circles passing in vectors and setting zsize="6c".
     """
     fig = Figure()
     fig.plot3d(

--- a/pygmt/tests/test_psconvert.py
+++ b/pygmt/tests/test_psconvert.py
@@ -10,7 +10,7 @@ from pygmt.exceptions import GMTInvalidInput
 
 def test_psconvert():
     """
-    psconvert creates a figure in the current directory.
+    Check that psconvert creates a figure in the current directory.
     """
     fig = Figure()
     fig.basemap(region="10/70/-3/8", projection="X4i/3i", frame="a")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ line-length = 79
 omit = ["*/tests/*", "*pygmt/__init__.py"]
 
 [tool.docformatter]
+black = true
 recursive = true
 pre-summary-newline = true
 make-summary-multi-line = true


### PR DESCRIPTION
**Description of proposed changes**

[Docformatter=1.7.0](https://github.com/PyCQA/docformatter/releases/tag/v1.7.0) has a `--black` option to make it compatible with the black linter. Also updated a few docstrings in the unit test where docformatter tried to capitalize the first letter.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Thanks @seisman for checking the docformatter 1.7.0 RC releases too at https://github.com/PyCQA/docformatter/issues/199!

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Reverts #2482, resolves #2476.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
