### PR TITLE
Fix typo in docs of "Figure.rose"

### DIFF
--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -108,7 +108,7 @@ def rose(self, data=None, length=None, azimuth=None, **kwargs):
 
     frame : str
          Set map boundary frame and axes attributes. Remember that *x*
-         here is radial distance and *y* is azimuth. The ylabel may be
+         here is radial distance and *y* is azimuth. The y label may be
          used to plot a figure caption. The scale bar length is determined
          by the radial gridline spacing.
 


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a tiny typo in the documenation of [`pygmt.Figure.rose`](https://www.pygmt.org/dev/api/generated/pygmt.Figure.rose.html#pygmt.Figure.rose).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
