### PR TITLE
CI: Do not use geopandas 0.13.0 in docs

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -82,7 +82,7 @@ jobs:
             netCDF4
             packaging
             contextily
-            geopandas
+            geopandas!=0.13.0
             ipython
             rioxarray
             build

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -12,7 +12,7 @@ dependencies:
     - packaging
     # Optional dependencies
     - contextily
-    - geopandas
+    - geopandas!=0.13.0
     - ipython
     - rioxarray
     # Development dependencies (general)


### PR DESCRIPTION
**Description of proposed changes**

As mentioned in https://github.com/GenericMappingTools/pygmt/pull/2536#issuecomment-1545307758, our docs CI fail due to changes with the geopandas 0.13.0 release (https://github.com/geopandas/geopandas/pull/2796#discussion_r1191760864), which is an unexpected regression.

Before the next geopandas patch version is released, we need to skip geopandas 0.13.0 in the docs workflow so that the docs can be correctly built and updated.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
