### PR TITLE
Fix typo in documentation of Robinson projection

### DIFF
--- a/examples/projections/misc/misc_robinson.py
+++ b/examples/projections/misc/misc_robinson.py
@@ -10,9 +10,10 @@ analytic expressions to make the world map "look" right. Robinson provided a
 table of y-coordinates for latitudes every 5°. To project values for
 intermediate latitudes one must interpolate the table. Different interpolants
 may result in slightly different maps. GMT uses the interpolant selected by
-the parameter :gmt-term:`GMT_INTERPOLANT` in the file. The scale is true along
-latitudes of 38° North and South. The projection was originally developed for
-use by Rand McNally and is currently used by the National Geographic Society.
+the parameter :gmt-term:`GMT_INTERPOLANT` in the gmt.conf file.
+The scale is true along latitudes of 38° North and South. The projection was
+originally developed for use by Rand McNally and is currently used by the
+National Geographic Society.
 
 **n**\ [*lon0/*]\ *scale* or **N**\ [*lon0/*]\ *width*
 

--- a/examples/projections/misc/misc_robinson.py
+++ b/examples/projections/misc/misc_robinson.py
@@ -6,8 +6,12 @@ The Robinson projection, presented by the American geographer and cartographer
 Arthur H. Robinson in 1963, is a modified cylindrical projection that is
 neither conformal nor equal-area. Central meridian and all parallels are
 straight lines; other meridians are curved. It uses lookup tables rather than
-analytic expressions to make the world map "look" right. The scale is true
-along latitudes 38. The projection was originally developed for use by Rand
+analytic expressions to make the world map "look" right. Robinson provided a
+table of y-coordinates for latitudes every 5 degrees. To project values for
+intermediate latitudes one must interpolate the table. Different interpolants
+may result in slightly different maps. GMT uses the interpolant selected by
+the parameter :gmt-term:`GMT_INTERPOLANT` in the file.
+The scale is true along latitudes 38. The projection was originally developed for use by Rand
 McNally and is currently used by the National Geographic Society.
 
 **n**\ [*lon0/*]\ *scale* or **N**\ [*lon0/*]\ *width*

--- a/examples/projections/misc/misc_robinson.py
+++ b/examples/projections/misc/misc_robinson.py
@@ -11,7 +11,7 @@ table of y-coordinates for latitudes every 5°. To project values for
 intermediate latitudes one must interpolate the table. Different interpolants
 may result in slightly different maps. GMT uses the interpolant selected by
 the parameter :gmt-term:`GMT_INTERPOLANT` in the gmt.conf file.
-The scale is true along latitudes of 38° North and South. The projection was
+The scale is true along latitudes 38° north and south. The projection was
 originally developed for use by Rand McNally and is currently used by the
 National Geographic Society.
 

--- a/examples/projections/misc/misc_robinson.py
+++ b/examples/projections/misc/misc_robinson.py
@@ -6,7 +6,7 @@ The Robinson projection, presented by the American geographer and cartographer
 Arthur H. Robinson in 1963, is a modified cylindrical projection that is
 neither conformal nor equal-area. Central meridian and all parallels are
 straight lines; other meridians are curved. It uses lookup tables rather than
-analytic expressions to make the world map "look" right 22. The scale is true
+analytic expressions to make the world map "look" right. The scale is true
 along latitudes 38. The projection was originally developed for use by Rand
 McNally and is currently used by the National Geographic Society.
 

--- a/examples/projections/misc/misc_robinson.py
+++ b/examples/projections/misc/misc_robinson.py
@@ -7,7 +7,7 @@ Arthur H. Robinson in 1963, is a modified cylindrical projection that is
 neither conformal nor equal-area. Central meridian and all parallels are
 straight lines; other meridians are curved. It uses lookup tables rather than
 analytic expressions to make the world map "look" right. Robinson provided a
-table of y-coordinates for latitudes every 5 degrees. To project values for
+table of y-coordinates for latitudes every 5°. To project values for
 intermediate latitudes one must interpolate the table. Different interpolants
 may result in slightly different maps. GMT uses the interpolant selected by
 the parameter :gmt-term:`GMT_INTERPOLANT` in the file. The scale is true along

--- a/examples/projections/misc/misc_robinson.py
+++ b/examples/projections/misc/misc_robinson.py
@@ -6,11 +6,7 @@ The Robinson projection, presented by the American geographer and cartographer
 Arthur H. Robinson in 1963, is a modified cylindrical projection that is
 neither conformal nor equal-area. Central meridian and all parallels are
 straight lines; other meridians are curved. It uses lookup tables rather than
-analytic expressions to make the world map "look" right. Robinson provided a
-table of y-coordinates for latitudes every 5°. To project values for
-intermediate latitudes one must interpolate the table. Different interpolants
-may result in slightly different maps. GMT uses the interpolant selected by
-the parameter :gmt-term:`GMT_INTERPOLANT` in the gmt.conf file.
+analytic expressions to make the world map "look" right [#f1]_.
 The scale is true along latitudes 38° north and south. The projection was
 originally developed for use by Rand McNally and is currently used by the
 National Geographic Society.
@@ -19,6 +15,14 @@ National Geographic Society.
 
 The projection is set with **n** or **N**. The central meridian is set with the
 optional *lon0*, and the figure size is set with *scale* or *width*.
+
+.. rubric:: Footnotes
+
+.. [#f1] Robinson provided a table of y-coordinates for latitudes every 5°.
+         To project values for intermediate latitudes one must interpolate
+         the table. Different interpolants may result in slightly different
+         maps. GMT uses the interpolant selected by the parameter
+         :gmt-term:`GMT_INTERPOLANT` in the gmt.conf file.
 """
 import pygmt
 

--- a/examples/projections/misc/misc_robinson.py
+++ b/examples/projections/misc/misc_robinson.py
@@ -10,9 +10,9 @@ analytic expressions to make the world map "look" right. Robinson provided a
 table of y-coordinates for latitudes every 5 degrees. To project values for
 intermediate latitudes one must interpolate the table. Different interpolants
 may result in slightly different maps. GMT uses the interpolant selected by
-the parameter :gmt-term:`GMT_INTERPOLANT` in the file.
-The scale is true along latitudes 38. The projection was originally developed for use by Rand
-McNally and is currently used by the National Geographic Society.
+the parameter :gmt-term:`GMT_INTERPOLANT` in the file. The scale is true along
+latitudes of 38° North and South. The projection was originally developed for
+use by Rand McNally and is currently used by the National Geographic Society.
 
 **n**\ [*lon0/*]\ *scale* or **N**\ [*lon0/*]\ *width*
 


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a (copy-paste) typo in the documentation of the [Robinson projection](https://www.pygmt.org/dev/projections/misc/misc_robinson.html).
The `22` origins from a footnote in the upstream [GMT documentation](https://docs.generic-mapping-tools.org/dev/cookbook/map-projections.html#robinson-projection-jn-jn). ~So far, I added [the text of the footnote](https://docs.generic-mapping-tools.org/dev/cookbook/map-projections.html#id6) as normal text.~ It is converted in commit https://github.com/GenericMappingTools/pygmt/pull/2548/commits/dffc3ca2143c9bced8fa08306584fdc65a70e00a to a footnote.

**Preview**: https://pygmt-dev--2548.org.readthedocs.build/en/2548/projections/misc/misc_robinson.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
