### PR TITLE
Fix typo in documentation of "Figure.meca"

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -124,7 +124,7 @@ def meca(
           - Columns 1 and 2: event longitude and latitude
           - Column 3: event depth (in km)
           - Columns 4 to 3+n: focal mechanism parameters. The number of columns
-            *n* depends on the choice of ``convection``, which will be
+            *n* depends on the choice of ``convention``, which will be
             described below.
           - Columns 4+n and 5+n: longitude, latitude at which to place
             beachball. Using ``0 0`` will plot the beachball at the longitude,


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a tiny typo in the docstring for the `spec` parameter of `pygmt.Figure.meca`.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
