### PR TITLE
Figure.meca: Expand docstring for the scale parameter

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -161,7 +161,7 @@ def meca(
           ``convention`` is not needed and is ignored if specified.
     scale : str
         *scale*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*]\
-        [**+l**][**+m**][**+o**\ *dx*\ [/\ *dy*]][**+s**\ *reference*]
+        [**+l**][**+m**][**+o**\ *dx*\ [/\ *dy*]][**+s**\ *reference*].
         Adjust scaling of the radius of the beachball, which is
         proportional to the magnitude. By default, *scale* defines the
         size for magnitude = 5 (i.e., scalar seismic moment

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -159,10 +159,9 @@ def meca(
           ``convention`` parameter is required so we know how to interpret the
           columns. If ``spec`` is a dictionary or a pd.DataFrame,
           ``convention`` is not needed and is ignored if specified.
-
     scale : str
         *scale*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*]\
-        [**+l**][**+m**][**+o**\ *dx*[/*dy*]][**+s**\ *reference*]
+        [**+l**][**+m**][**+o**\ *dx*\ [/\ *dy*]][**+s**\ *reference*]
         Adjust scaling of the radius of the beachball, which is
         proportional to the magnitude. By default, *scale* defines the
         size for magnitude = 5 (i.e., scalar seismic moment
@@ -177,7 +176,6 @@ def meca(
         append **+j**\ *justify* to change the text location relative
         to the beachball [Default is ``"TC"``, i.e., Top Center];
         append **+o** to offset the text string by *dx*\ /*dy*.
-
     convention : str
         Focal mechanism convention. Choose from:
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -161,9 +161,23 @@ def meca(
           ``convention`` is not needed and is ignored if specified.
 
     scale : str
-        Adjust the scaling of the radius of the beachball, which is
-        proportional to the magnitude. *scale* defines the size for
-        magnitude = 5 (i.e. scalar seismic moment M0 = 4.0E23 dynes-cm).
+        *scale*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*]\
+        [**+l**][**+m**][**+o**\ *dx*[/*dy*]][**+s**\ *reference*]
+        Adjust scaling of the radius of the beachball, which is
+        proportional to the magnitude. By default, *scale* defines the
+        size for magnitude = 5 (i.e., scalar seismic moment
+        M0 = 4.0E23 dynes-cm). If **+l** is used the radius will be
+        proportional to the seismic moment instead. Use **+s** and give
+        a *reference* to change the reference magnitude (or moment), and
+        use **+m** to plot all beachballs with the same size. A text
+        string can be specified to appear near the beachball
+        (corresponding to column or parameter ``event_name``).
+        Append **+a**\ *angle* to change the angle of the text string;
+        append **+f**\ *font* to change its font (size,fontname,color);
+        append **+j**\ *justify* to change the text location relative
+        to the beachball [Default is ``"TC"``, i.e., Top Center];
+        append **+o** to offset the text string by *dx*\ /*dy*.
+
     convention : str
         Focal mechanism convention. Choose from:
 


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to expand the docstring for the `scale` parameter of `pygmt.Figure.meca`.

**Upstream GMT documentation**: https://docs.generic-mapping-tools.org/dev/supplements/seis/meca.html#s

**Preview**: https://pygmt-dev--2552.org.readthedocs.build/en/2552/api/generated/pygmt.Figure.meca.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
