### PR TITLE
Figure.meca: Expand docstrings for "compressionfill", "cmap", and "offset"

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -232,7 +232,7 @@ def meca(
         *color1,color2,color3*) to build a linear continuous CPT from those
         colors automatically. The color of the compressive quadrants is
         determined by the z-value (i.e., event depth or the third column for
-        an input file). This setting applies also to the fill of the circle
+        an input file). This setting also applies to the fill of the circle
         defined via ``offset``.
     no_clip : bool
         Do **not** skip symbols that fall outside the frame boundaries

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -219,7 +219,7 @@ def meca(
         of the compressive quadrants.
     compressionfill : str
         Set color or pattern for filling compressive quadrants
-        [Default is ``"black"``]. This setting applies also to the fill of
+        [Default is ``"black"``]. This setting also applies to the fill of
         the circle defined via ``offset``.
     extensionfill : str
         Set color or pattern for filling extensive quadrants

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -215,8 +215,8 @@ def meca(
         to the circle. Use **+s**\ *size* to set the diameter of the circle
         [Default is no circle]. Use **+p**\ *pen* to set the line pen
         attributes [Default is ``"0.25p"``]. The fill of the circle is set
-        via ``compressionfill``, i.e., corresponds to the fill of the
-        compressive quadrants.
+        via ``compressionfill`` or ``cmap``, i.e., corresponds to the fill
+        of the compressive quadrants.
     compressionfill : str
         Set color or pattern for filling compressive quadrants
         [Default is ``"black"``]. This setting applies also to the fill of
@@ -232,7 +232,8 @@ def meca(
         *color1,color2,color3*) to build a linear continuous CPT from those
         colors automatically. The color of the compressive quadrants is
         determined by the z-value (i.e., event depth or the third column for
-        an input file).
+        an input file). This setting applies also to the fill of the circle
+        defined via ``offset``.
     no_clip : bool
         Do **not** skip symbols that fall outside the frame boundaries
         [Default is ``False``, i.e., plot symbols inside the frame

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -214,10 +214,13 @@ def meca(
         is plotted at the initial location and a line connects the beachball
         to the circle. Use **+s**\ *size* to set the diameter of the circle
         [Default is no circle]. Use **+p**\ *pen* to set the line pen
-        attributes [Default is ``"0.25p"``].
+        attributes [Default is ``"0.25p"``]. The fill of the circle is set
+        via ``compressionfill``, i.e., corresponds to the fill of the
+        compressive quadrants.
     compressionfill : str
         Set color or pattern for filling compressive quadrants
-        [Default is ``"black"``].
+        [Default is ``"black"``]. This setting applies also to the fill of
+        the circle defined via ``offset``.
     extensionfill : str
         Set color or pattern for filling extensive quadrants
         [Default is ``"white"``].


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to expand the docstrings for the parameters `compressionfill` , `cmap`, and `offset` of `pygmt.Figure.meca` regarding the fill of the small circle, which can be plotted at the initial location in case the beachball is plotted with an offset to the initial location. I really like this feature, and feel it would be nice to state this explicitly in the documentation.

**Preview**: 

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
