### PR TITLE
Improve comment in example "Cartesian, circular, and geographic vectors"

### DIFF
--- a/examples/gallery/lines/vector_styles.py
+++ b/examples/gallery/lines/vector_styles.py
@@ -5,7 +5,7 @@ Cartesian, circular, and geographic vectors
 The :meth:`pygmt.Figure.plot` method can plot Cartesian, circular, and
 geographic vectors. The ``style`` parameter controls vector attributes.
 See also
-:doc:`Vector attributes documentation </gallery/lines/vector_heads_tails>`.
+:doc:`Vector attributes example </gallery/lines/vector_heads_tails>`.
 
 """
 import numpy as np

--- a/examples/gallery/lines/vector_styles.py
+++ b/examples/gallery/lines/vector_styles.py
@@ -28,7 +28,7 @@ x = np.linspace(-116, -116, 12)  # x vector coordinates
 y = np.linspace(33.5, 42.5, 12)  # y vector coordinates
 direction = np.zeros(x.shape)  # direction of vectors
 length = np.linspace(0.5, 2.4, 12)  # length of vectors
-# Cartesian vectors (v) with red pen and fill (+g, +p), vector head at
+# Cartesian vectors (v) with red fill and pen (+g, +p), vector head at
 # end (+e), and 40 degree angle (+a) with no indentation for vector head (+h)
 style = "v0.2c+e+a40+gred+h0+p1p,red"
 fig.plot(x=x, y=y, style=style, pen="1p,red", direction=[direction, length])


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to improve a comment in the Gallery example [Cartesian, circular, and geographic vectors](https://www.pygmt.org/dev/gallery/lines/vector_styles.html).

**Preview**: https://pygmt-dev--2556.org.readthedocs.build/en/2556/gallery/lines/vector_styles.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
