### PR TITLE
Bump actions/setup-node from 1 to 3.6.0

### DIFF
--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -34,7 +34,7 @@ jobs:
 
     # workaround from https://github.com/iterative/cml/issues/1377
     - name: Setup NodeJS
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3.6.0
       with:
         node-version: '16'
 


### PR DESCRIPTION
**Description of proposed changes**

The latest version of `actions/setup-node` is 3.6.0 (https://github.com/actions/setup-node/tags).