### PR TITLE
Fix the command to extract GMT CLI for GMT>=6.4.0

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -62,7 +62,7 @@ the problem:
   filter the messages to include only the GMT-equivalent commands using a command
   such as:
 
-      python <test>.py 2>&1 | awk -F': ' '$2=="GMT_Call_Command string" {print "gmt", $3}'
+	  python <test>.py 2>&1 | awk -F': ' '$2=="GMT_Call_Command string" {print $3}'
 
   where `<test>` is the name of your test script.
 * If the bug is produced when passing an in-memory data object (e.g., a

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -64,7 +64,7 @@ the problem:
 
       python <test>.py 2>&1 | awk -F': ' '$2=="GMT_Call_Command string" {print $3}'
 
-  where `<test>` is the name of your test script.
+  where `<test>` is the name of your test script. Note that this script works with GMT>=6.4
 * If the bug is produced when passing an in-memory data object (e.g., a
   pandas.DataFrame or xarray.DataArray) to a PyGMT function, try writing the
   data to a file (e.g., a NetCDF or ASCII txt file) and passing the data file

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -62,7 +62,7 @@ the problem:
   filter the messages to include only the GMT-equivalent commands using a command
   such as:
 
-	  python <test>.py 2>&1 | awk -F': ' '$2=="GMT_Call_Command string" {print $3}'
+      python <test>.py 2>&1 | awk -F': ' '$2=="GMT_Call_Command string" {print $3}'
 
   where `<test>` is the name of your test script.
 * If the bug is produced when passing an in-memory data object (e.g., a

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -64,7 +64,7 @@ the problem:
 
       python <test>.py 2>&1 | awk -F': ' '$2=="GMT_Call_Command string" {print $3}'
 
-  where `<test>` is the name of your test script. Note that this script works with GMT>=6.4
+  where `<test>` is the name of your test script. Note that this script works only with GMT>=6.4
 * If the bug is produced when passing an in-memory data object (e.g., a
   pandas.DataFrame or xarray.DataArray) to a PyGMT function, try writing the
   data to a file (e.g., a NetCDF or ASCII txt file) and passing the data file


### PR DESCRIPTION
**Description of proposed changes**

See #2416 for context. In short, for GMT 6.3, we need to use:
```
python <test>.py 2>&1 | awk -F': ' '$2=="GMT_Call_Command string" {print "gmt", $3}'
```
but for GMT>=6.4, we need to use 
```
python <test>.py 2>&1 | awk -F': ' '$2=="GMT_Call_Command string" {print $3}'
```

It's possible to have a more complicated command which works for both GMT 6.3 and GMT>=6.4, but I don't think it's necessary. I prefer a simple command, even though it works for GMT>=6.4 only,

Closes https://github.com/GenericMappingTools/pygmt/issues/2416.