### PR TITLE
Figure.meca: the 'scale' parameter can accept int/float/str values

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -160,7 +160,7 @@ def meca(
           columns. If ``spec`` is a dictionary or a pd.DataFrame,
           ``convention`` is not needed and is ignored if specified.
 
-    scale : str
+    scale : int or float or str
         Adjust the scaling of the radius of the beachball, which is
         proportional to the magnitude. *scale* defines the size for
         magnitude = 5 (i.e. scalar seismic moment M0 = 4.0E23 dynes-cm).
@@ -335,7 +335,7 @@ def meca(
     data_format = data_format_code(convention=convention, component=component)
 
     # Assemble -S flag
-    kwargs["S"] = data_format + scale
+    kwargs["S"] = f"{data_format}{scale}"
     with Session() as lib:
         # Choose how data will be passed into the module
         file_context = lib.virtualfile_from_data(check_kind="vector", data=spec)

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -303,6 +303,6 @@ def test_meca_spec_dict_all_scalars():
             "depth": 12.0,
             "event_name": "Event20220311",
         },
-        scale="1c",
+        scale=1.0,  # make sure a non-str scale works
     )
     return fig


### PR DESCRIPTION
**Description of proposed changes**

Currently, the `scale` parameter doesn't accept int or float values like `scale=1.0`, because we use `kwargs["S"] = data_format + scale` to build the `-S` argument. int/float scales are valid and should be supported.

This PR fixes the issue. The `test_meca_spec_dict_all_scalars` is updated to catch the bug.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
