### PR TITLE
Fix the failing test for PyGMTScraper when sphinx-gallery is not installed

### DIFF
--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -11,7 +11,7 @@ name: GMT Legacy Tests
 on:
   # push:
   #   branches: [ main ]
-  # pull_request:
+  pull_request:
     # types: [ready_for_review]
     # paths-ignore:
     #  - 'doc/**'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -11,7 +11,7 @@ name: GMT Legacy Tests
 on:
   # push:
   #   branches: [ main ]
-  pull_request:
+  # pull_request:
     # types: [ready_for_review]
     # paths-ignore:
     #  - 'doc/**'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -75,6 +75,7 @@ jobs:
             geopandas
             ipython
             rioxarray
+            sphinx-gallery
             build
             dvc
             make

--- a/pygmt/tests/test_sphinx_gallery.py
+++ b/pygmt/tests/test_sphinx_gallery.py
@@ -6,10 +6,9 @@ from tempfile import TemporaryDirectory
 
 import pytest
 from pygmt.figure import SHOWED_FIGURES, Figure
+from pygmt.sphinx_gallery import PyGMTScraper
 
-pygmt_sphinx_gallery = pytest.importorskip(
-    "pygmt.sphinx_gallery", reason="Requires sphinx-gallery to be installed"
-)
+pytest.importorskip("sphinx-gallery", reason="Requires sphinx-gallery to be installed")
 pytest.importorskip("IPython", reason="Requires IPython to be installed")
 
 
@@ -26,7 +25,7 @@ def test_pygmtscraper():
         fig.show()
         assert len(SHOWED_FIGURES) == 1
         assert SHOWED_FIGURES[0] is fig
-        scraper = pygmt_sphinx_gallery.PyGMTScraper()
+        scraper = PyGMTScraper()
         with TemporaryDirectory(dir=os.getcwd()) as tmpdir:
             conf = {"src_dir": "meh"}
             fname = os.path.join(tmpdir, "meh.png")


### PR DESCRIPTION
**Description of proposed changes**

The `test_pygmtscraper` test fails in the "GMT Legacy Tests" workflow (see https://github.com/GenericMappingTools/pygmt/actions/runs/5186205046/jobs/9347012124?pr=2567) because `sphinx-gallery` is not installed in this workflow.

However, when `sphinx-gallery` is not installed, this test should be skipped. It's not skipped because we use `pytest.importorskip("pygmt.sphinx_gallery")` which always succeeds after PR #2439.

This PR tries to fix the issue.

After commit f30dfe844f112b96db8e971ea37d86aab6139af4, the workflow now passes (https://github.com/GenericMappingTools/pygmt/actions/runs/5195604161/jobs/9368493213?pr=2567).



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
