### PR TITLE
Set date_format to ISO8601 to silence pandas 2.0 UserWarning on read_csv

### DIFF
--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -11,7 +11,7 @@ name: GMT Legacy Tests
 on:
   # push:
   #   branches: [ main ]
-  pull_request:
+  # pull_request:
     # types: [ready_for_review]
     # paths-ignore:
     #  - 'doc/**'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -11,7 +11,7 @@ name: GMT Legacy Tests
 on:
   # push:
   #   branches: [ main ]
-  # pull_request:
+  pull_request:
     # types: [ready_for_review]
     # paths-ignore:
     #  - 'doc/**'
@@ -67,7 +67,7 @@ jobs:
             python=3.9
             gmt=${{ matrix.gmt_version }}
             numpy
-            pandas
+            pandas<2
             xarray
             netCDF4
             packaging

--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -241,7 +241,7 @@ def x2sys_cross(tracks=None, outfile=None, **kwargs):
                     header=2,  # Column names are on 2nd row
                     comment=">",  # Skip the 3rd row with a ">"
                     parse_dates=[2, 3],  # Datetimes on 3rd and 4th column
-                    *date_format_kwarg,  # Parse dates in ISO8601 format on pandas>=2
+                    **date_format_kwarg,  # Parse dates in ISO8601 format on pandas>=2
                 )
                 # Remove the "# " from "# x" in the first column
                 table = table.rename(columns={table.columns[0]: table.columns[0][2:]})

--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 import pandas as pd
+from packaging.version import Version
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -229,13 +230,18 @@ def x2sys_cross(tracks=None, outfile=None, **kwargs):
             # Read temporary csv output to a pandas table
             if outfile == tmpfile.name:  # if outfile isn't set, return pd.DataFrame
                 # Read the tab-separated ASCII table
+                date_format_kwarg = (
+                    {"date_format": "ISO8601"}
+                    if Version(pd.__version__) >= Version("2.0.0")
+                    else {}
+                )
                 table = pd.read_csv(
                     tmpfile.name,
                     sep="\t",
                     header=2,  # Column names are on 2nd row
                     comment=">",  # Skip the 3rd row with a ">"
                     parse_dates=[2, 3],  # Datetimes on 3rd and 4th column
-                    date_format="ISO8601",
+                    *date_format_kwarg,  # Parse dates in ISO8601 format on pandas>=2
                 )
                 # Remove the "# " from "# x" in the first column
                 table = table.rename(columns={table.columns[0]: table.columns[0][2:]})

--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -47,7 +47,7 @@ def tempfile_from_dftrack(track, suffix):
             sep="\t",
             index=False,
             na_rep="NaN",  # write a NaN value explicitly instead of a blank string
-            date_format="%Y-%m-%dT%H:%M:%S.%fZ",
+            date_format="%Y-%m-%dT%H:%M:%S.%fZ",  # ISO8601 format
         )
         yield tmpfilename
     finally:
@@ -235,6 +235,7 @@ def x2sys_cross(tracks=None, outfile=None, **kwargs):
                     header=2,  # Column names are on 2nd row
                     comment=">",  # Skip the 3rd row with a ">"
                     parse_dates=[2, 3],  # Datetimes on 3rd and 4th column
+                    date_format="ISO8601",
                 )
                 # Remove the "# " from "# x" in the first column
                 table = table.rename(columns={table.columns[0]: table.columns[0][2:]})

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -112,7 +112,7 @@ def test_x2sys_cross_input_two_dataframes(mock_x2sys_home):
         for i in range(2):
             np.random.seed(seed=i)
             track = pd.DataFrame(data=np.random.rand(10, 3), columns=("x", "y", "z"))
-            track["time"] = pd.date_range(start=f"2020-{i}1-01", periods=10, freq="ms")
+            track["time"] = pd.date_range(start=f"2020-{i}1-01", periods=10, freq="min")
             tracks.append(track)
 
         output = x2sys_cross(tracks=tracks, tag=tag, coe="e")


### PR DESCRIPTION
**Description of proposed changes**

Use `pd.read_csv(..., date_format="ISO8601")` to silence `UserWarning: Could not infer format, so each element will be parsed individually, falling back to `dateutil`. To ensure parsing is consistent and as-expected, please specify a format.`.

Note that this requires `pandas>=2.0` to work.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

References:
- https://github.com/pandas-dev/pandas/issues/50601
- https://pandas.pydata.org/pandas-docs/version/2.0/reference/api/pandas.read_csv.html
- https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.to_datetime.html?highlight=iso8601

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #2480


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
