### PR TITLE
Set rtol=1e-5 to fix broken tests on macOS due to floating point precision

### DIFF
--- a/pygmt/tests/test_datasets_earth_age.py
+++ b/pygmt/tests/test_datasets_earth_age.py
@@ -53,8 +53,8 @@ def test_earth_age_01d_with_region():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), 11.293945)
-    npt.assert_allclose(data.max(), 125.1189)
+    npt.assert_allclose(data.min(), 11.293945, rtol=1e-5)
+    npt.assert_allclose(data.max(), 125.1189, rtol=1e-5)
 
 
 def test_earth_age_01m_without_region():

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -53,8 +53,8 @@ def test_earth_mag_01d_with_region():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -180.40002)
-    npt.assert_allclose(data.max(), 127.39996)
+    npt.assert_allclose(data.min(), -180.40002, rtol=1e-5)
+    npt.assert_allclose(data.max(), 127.39996, rtol=1e-5)
 
 
 def test_earth_mag_02m_without_region():
@@ -126,8 +126,8 @@ def test_earth_mag4km_01d_with_region():
     assert data.shape == (11, 21)
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -153.19995)
-    npt.assert_allclose(data.max(), 113.59985)
+    npt.assert_allclose(data.min(), -153.19995, rtol=1e-5)
+    npt.assert_allclose(data.max(), 113.59985, rtol=1e-5)
 
 
 def test_earth_mag4km_02m_default_registration():
@@ -146,8 +146,8 @@ def test_earth_mag4km_02m_default_registration():
     npt.assert_allclose(data.coords["lat"].data.max(), 5.98333333)
     npt.assert_allclose(data.coords["lon"].data.min(), -114.98333333)
     npt.assert_allclose(data.coords["lon"].data.max(), -112.01666667)
-    npt.assert_allclose(data.min(), -132.80005)
-    npt.assert_allclose(data.max(), 79.59985)
+    npt.assert_allclose(data.min(), -132.80005, rtol=1e-5)
+    npt.assert_allclose(data.max(), 79.59985, rtol=1e-5)
 
 
 def test_earth_mag_01d_wdmam():
@@ -181,8 +181,8 @@ def test_earth_mag_01d_wdmam_with_region():
     assert data.shape == (11, 21)
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -103.900024)
-    npt.assert_allclose(data.max(), 102.19995)
+    npt.assert_allclose(data.min(), -103.900024, rtol=1e-5)
+    npt.assert_allclose(data.max(), 102.19995, rtol=1e-5)
 
 
 def test_earth_mag_03m_wdmam_with_region():


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/GenericMappingTools/pygmt/actions/runs/5217144872/jobs/9416664148. Some tests fail on macOS. For example:

```
________________________ test_earth_age_01d_with_region ________________________

    def test_earth_age_01d_with_region():
        """
        Test loading low-resolution earth age with 'region'.
        """
        data = load_earth_age(resolution="01d", region=[-10, 10, -5, 5])
        assert data.shape == (11, 21)
        assert data.gmt.registration == 0
        npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
        npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
>       npt.assert_allclose(data.min(), 11.293945)

../pygmt/tests/test_datasets_earth_age.py:56: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

args = (<function assert_allclose.<locals>.compare at 0x150579bc0>, array(11.293947, dtype=float32), array(11.293945))
kwds = {'equal_nan': True, 'err_msg': '', 'header': 'Not equal to tolerance rtol=1e-07, atol=0', 'verbose': True}

    @wraps(func)
    def inner(*args, **kwds):
        with self._recreate_cm():
>           return func(*args, **kwds)
E           AssertionError: 
E           Not equal to tolerance rtol=1e-07, atol=0
E           
E           Mismatched elements: 1 / 1 (100%)
E           Max absolute difference: 2.21984863e-06
E           Max relative difference: 1.96552102e-07
E            x: array(11.293947, dtype=float32)
E            y: array(11.293945)
```

These tests fail because the default `rtol` value of `npt.assert_allclose` is 1e-7. This PR changes `rtol` to 1e-5.