### PR TITLE
Figure.meca: Refactor the two tests for offsetting beachballs

### DIFF
--- a/pygmt/tests/baseline/test_meca_offset.png.dvc
+++ b/pygmt/tests/baseline/test_meca_offset.png.dvc
@@ -1,4 +1,4 @@
 outs:
 - md5: 6f800af07e13d59e4927b499cf3d035e
   size: 10027
-  path: test_meca_dict_offset.png
+  path: test_meca_offset.png

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -142,9 +142,9 @@ def test_meca_spec_multiple_focalmecha(inputtype):
 
 
 @pytest.mark.mpl_image_compare
-def test_meca_dict_offset():
+def test_meca_offset():
     """
-    Test offsetting beachballs for a dict input.
+    Test offsetting beachballs.
     """
     fig = Figure()
     focal_mechanism = {"strike": 330, "dip": 30, "rake": 90, "magnitude": 3}
@@ -161,7 +161,7 @@ def test_meca_dict_offset():
     return fig
 
 
-@pytest.mark.mpl_image_compare(filename="test_meca_dict_offset.png")
+@pytest.mark.mpl_image_compare(filename="test_meca_offset.png")
 def test_meca_dict_offset_in_dict():
     """
     Test offsetting beachballs for a dict input with offset parameters in the

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -142,7 +142,7 @@ def test_meca_spec_multiple_focalmecha(inputtype):
 
 
 @pytest.mark.mpl_image_compare(filename="test_meca_offset.png")
-@pytest.mark.parametrize("inputtype", ["offset_args"])
+@pytest.mark.parametrize("inputtype", ["offset_args", "offset_dict"])
 def test_meca_offset(inputtype):
     """
     Test offsetting beachballs.
@@ -156,38 +156,26 @@ def test_meca_offset(inputtype):
             "plot_longitude": -124.5,
             "plot_latitude": 47.5,
         }
+    elif inputtype == "offset_dict":
+        # Test https://github.com/GenericMappingTools/pygmt/issues/2016
+        # offset parameters are in the dict.
+        args = {
+            "spec": {
+                "strike": 330,
+                "dip": 30,
+                "rake": 90,
+                "magnitude": 3,
+                "plot_longitude": -124.5,
+                "plot_latitude": 47.5,
+            },
+            "longitude": -124,
+            "latitude": 48,
+            "depth": 12.0,
+        }
 
     fig = Figure()
     fig.basemap(region=[-125, -122, 47, 49], projection="M6c", frame=True)
     fig.meca(scale="1c", **args)
-    return fig
-
-
-@pytest.mark.mpl_image_compare(filename="test_meca_offset.png")
-def test_meca_dict_offset_in_dict():
-    """
-    Test offsetting beachballs for a dict input with offset parameters in the
-    dict.
-
-    See https://github.com/GenericMappingTools/pygmt/issues/2016.
-    """
-    fig = Figure()
-    focal_mechanism = {
-        "strike": 330,
-        "dip": 30,
-        "rake": 90,
-        "magnitude": 3,
-        "plot_longitude": -124.5,
-        "plot_latitude": 47.5,
-    }
-    fig.basemap(region=[-125, -122, 47, 49], projection="M6c", frame=True)
-    fig.meca(
-        spec=focal_mechanism,
-        scale="1c",
-        longitude=-124,
-        latitude=48,
-        depth=12.0,
-    )
     return fig
 
 

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -141,23 +141,25 @@ def test_meca_spec_multiple_focalmecha(inputtype):
     return fig
 
 
-@pytest.mark.mpl_image_compare
-def test_meca_offset():
+@pytest.mark.mpl_image_compare(filename="test_meca_offset.png")
+@pytest.mark.parametrize("inputtype", ["offset_args"])
+def test_meca_offset(inputtype):
     """
     Test offsetting beachballs.
     """
+    if inputtype == "offset_args":
+        args = {
+            "spec": {"strike": 330, "dip": 30, "rake": 90, "magnitude": 3},
+            "longitude": -124,
+            "latitude": 48,
+            "depth": 12.0,
+            "plot_longitude": -124.5,
+            "plot_latitude": 47.5,
+        }
+
     fig = Figure()
-    focal_mechanism = {"strike": 330, "dip": 30, "rake": 90, "magnitude": 3}
     fig.basemap(region=[-125, -122, 47, 49], projection="M6c", frame=True)
-    fig.meca(
-        spec=focal_mechanism,
-        scale="1c",
-        longitude=-124,
-        latitude=48,
-        depth=12.0,
-        plot_longitude=-124.5,
-        plot_latitude=47.5,
-    )
+    fig.meca(scale="1c", **args)
     return fig
 
 


### PR DESCRIPTION
Followup PR of https://github.com/GenericMappingTools/pygmt/pull/2533 and https://github.com/GenericMappingTools/pygmt/pull/2565.

Changes in this PR:

- Rename test test_meca_dict_offset to test_meca_offset
- Refactor test_meca_offset so that it can be reused
- Merge test_meca_dict_offset_in_dict into test_meca_offset
