### PR TITLE
Figure.meca: Fix beachball offsetting for ndarray input (requires GMT>=6.5.0)

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -100,6 +100,41 @@ def convention_code(convention, component="full"):
     raise GMTInvalidInput(f"Invalid convention '{convention}'.")
 
 
+def convention_name(code):
+    """
+    Determine the name of a focal mechanism convention from its code.
+
+    Parameters
+    ----------
+    code : str
+        The single-letter convention code.
+
+    Returns
+    -------
+    str
+        The name of the focal mechanism convention.
+
+    Examples
+    --------
+    >>> convention_name("a")
+    'aki'
+    >>> convention_name("aki")
+    'aki'
+    """
+    name = {
+        "a": "aki",
+        "c": "gcmt",
+        "p": "partial",
+        "z": "mt",
+        "d": "mt",
+        "m": "mt",
+        "x": "principal_axis",
+        "y": "principal_axis",
+        "t": "principal_axis",
+    }.get(code)
+    return name if name is not None else code
+
+
 @fmt_docstring
 @use_alias(
     A="offset",

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -8,44 +8,71 @@ from pygmt.exceptions import GMTError, GMTInvalidInput
 from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 
-def data_format_code(convention, component="full"):
+def convention_code(convention, component="full"):
     """
-    Determine the data format code for meca's -S option.
+    Determine the convention code for focal mechanisms.
 
-    See the meca() method for explanations of the parameters.
+    The convention code can be used in meca's -S option.
+
+    Parameters
+    ----------
+    convention : str
+        The focal mechanism convention. Can be one of the following:
+
+        - ``"aki"``: Aki and Richards
+        - ``"gcmt"``: Global Centroid Moment Tensor
+        - ``"partial"``: Partial focal mechanism
+        - ``"mt"``: Moment tensor
+        - ``"principal_axis"``: Principal axis
+
+        Single letter convention codes like ``"a"`` and ``"c"`` are also
+        supported but undocumented.
+
+    component : str
+        The component of the focal mechanism. Only used when ``convention`` is
+        ``"mt"`` or ``"principal_axis"``. Can be one of the following:
+
+        - ``"full"``: Full moment tensor
+        - ``"deviatoric"``: Deviatoric moment tensor
+        - ``"dc"``: Double couple
+
+    Returns
+    -------
+    str
+        The single-letter convention code used in meca's -S option.
 
     Examples
     --------
-    >>> data_format_code("aki")
+    >>> convention_code("aki")
     'a'
-    >>> data_format_code("gcmt")
+    >>> convention_code("gcmt")
     'c'
-    >>> data_format_code("partial")
+    >>> convention_code("partial")
     'p'
 
-    >>> data_format_code("mt", component="full")
+    >>> convention_code("mt", component="full")
     'm'
-    >>> data_format_code("mt", component="deviatoric")
+    >>> convention_code("mt", component="deviatoric")
     'z'
-    >>> data_format_code("mt", component="dc")
+    >>> convention_code("mt", component="dc")
     'd'
-    >>> data_format_code("principal_axis", component="full")
+    >>> convention_code("principal_axis", component="full")
     'x'
-    >>> data_format_code("principal_axis", component="deviatoric")
+    >>> convention_code("principal_axis", component="deviatoric")
     't'
-    >>> data_format_code("principal_axis", component="dc")
+    >>> convention_code("principal_axis", component="dc")
     'y'
 
     >>> for code in ["a", "c", "m", "d", "z", "p", "x", "y", "t"]:
-    ...     assert data_format_code(code) == code
+    ...     assert convention_code(code) == code
     ...
 
-    >>> data_format_code("invalid")
+    >>> convention_code("invalid")
     Traceback (most recent call last):
       ...
     pygmt.exceptions.GMTInvalidInput: Invalid convention 'invalid'.
 
-    >>> data_format_code("mt", "invalid")  # doctest: +NORMALIZE_WHITESPACE
+    >>> convention_code("mt", "invalid")  # doctest: +NORMALIZE_WHITESPACE
     Traceback (most recent call last):
       ...
     pygmt.exceptions.GMTInvalidInput:
@@ -372,7 +399,7 @@ def meca(
         spec = np.atleast_2d(spec)
 
     # determine data_format from convention and component
-    data_format = data_format_code(convention=convention, component=component)
+    data_format = convention_code(convention=convention, component=component)
 
     # Assemble -S flag
     kwargs["S"] = f"{data_format}{scale}"

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -312,7 +312,7 @@ def test_meca_spec_ndarray_no_convention():
 
 def test_meca_spec_ndarray_mismatched_columns():
     """
-    Raise an exception if the ndarray input doesn't have expected number of
+    Raise an exception if the ndarray input doesn't have the expected number of
     columns.
     """
     with pytest.raises(GMTInvalidInput):

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 from packaging.version import Version
 from pygmt import Figure, __gmt_version__
+from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 
 
@@ -297,3 +298,35 @@ def test_meca_spec_dict_all_scalars():
         scale=1.0,  # make sure a non-str scale works
     )
     return fig
+
+
+def test_meca_spec_ndarray_no_convention():
+    """
+    Raise an exception if convention is not given for an ndarray input.
+    """
+    with pytest.raises(GMTInvalidInput):
+        fig = Figure()
+        fig.basemap(region=[-125, -122, 47, 49], projection="M6c", frame=True)
+        fig.meca(spec=np.array([[-124, 48, 12.0, 330, 30, 90, 3]]), scale="1c")
+
+
+def test_meca_spec_ndarray_mismatched_columns():
+    """
+    Raise an exception if the ndarray input doesn't have expected number of
+    columns.
+    """
+    with pytest.raises(GMTInvalidInput):
+        fig = Figure()
+        fig.basemap(region=[-125, -122, 47, 49], projection="M6c", frame=True)
+        fig.meca(
+            spec=np.array([[-124, 48, 12.0, 330, 30, 90]]), convention="aki", scale="1c"
+        )
+
+    with pytest.raises(GMTInvalidInput):
+        fig = Figure()
+        fig.basemap(region=[-125, -122, 47, 49], projection="M6c", frame=True)
+        fig.meca(
+            spec=np.array([[-124, 48, 12.0, 330, 30, 90, 3, -124.5, 47.5, 30.0, 50.0]]),
+            convention="aki",
+            scale="1c",
+        )

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -143,7 +143,7 @@ def test_meca_spec_multiple_focalmecha(inputtype):
 
 
 @pytest.mark.mpl_image_compare(filename="test_meca_offset.png")
-@pytest.mark.parametrize("inputtype", ["offset_args", "offset_dict"])
+@pytest.mark.parametrize("inputtype", ["offset_args", "offset_dict", "ndarray"])
 def test_meca_offset(inputtype):
     """
     Test offsetting beachballs.
@@ -172,6 +172,13 @@ def test_meca_offset(inputtype):
             "longitude": -124,
             "latitude": 48,
             "depth": 12.0,
+        }
+    elif inputtype == "ndarray":
+        # Test ndarray input reported in
+        # https://github.com/GenericMappingTools/pygmt/issues/2016
+        args = {
+            "spec": np.array([[-124, 48, 12.0, 330, 30, 90, 3, -124.5, 47.5]]),
+            "convention": "aki",
         }
 
     fig = Figure()

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -143,12 +143,12 @@ def test_meca_spec_multiple_focalmecha(inputtype):
 
 
 @pytest.mark.mpl_image_compare(filename="test_meca_offset.png")
-@pytest.mark.parametrize("inputtype", ["offset_args", "offset_dict", "ndarray"])
+@pytest.mark.parametrize("inputtype", ["args", "dict", "ndarray"])
 def test_meca_offset(inputtype):
     """
     Test offsetting beachballs.
     """
-    if inputtype == "offset_args":
+    if inputtype == "args":
         args = {
             "spec": {"strike": 330, "dip": 30, "rake": 90, "magnitude": 3},
             "longitude": -124,
@@ -157,7 +157,7 @@ def test_meca_offset(inputtype):
             "plot_longitude": -124.5,
             "plot_latitude": 47.5,
         }
-    elif inputtype == "offset_dict":
+    elif inputtype == "dict":
         # Test https://github.com/GenericMappingTools/pygmt/issues/2016
         # offset parameters are in the dict.
         args = {

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -143,7 +143,20 @@ def test_meca_spec_multiple_focalmecha(inputtype):
 
 
 @pytest.mark.mpl_image_compare(filename="test_meca_offset.png")
-@pytest.mark.parametrize("inputtype", ["args", "dict", "ndarray"])
+@pytest.mark.parametrize(
+    "inputtype",
+    [
+        "args",
+        "dict",
+        pytest.param(
+            "ndarray",
+            marks=pytest.mark.skipif(
+                condition=Version(__gmt_version__) < Version("6.5.0"),
+                reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/7557",
+            ),
+        ),
+    ],
+)
 def test_meca_offset(inputtype):
     """
     Test offsetting beachballs.


### PR DESCRIPTION
**Description of proposed changes**

Changes in this PR:

1. 96b5c5121c008326f05a672e133af9acdf5be19c: Rename function `data_format_code` to `convention_code` and update docstrings 
2. 5e93de08189fb95e7bfc5bddaa9db461b19cca06: Add a new function `convention_name` which determine the convention name (e.g., `"aki"`) from convention code (e.g., `"a"`)
3. 6de0907e288a24b0f13c5c254b20635867a290b6: Add a new function `convention_params` to return the list of focal parameters
4. 7ae88164b3c7c9616ad5bc05a084fbe9c53610bc: Add a test for offsetting beachballs with ndarray input based on #2016 
5. a87c0c5e04918424f39fc12051920174174dbab1: Refactor the `Figure.meca` method to make it work with ndarray input.
6. cc748142d88fa1816e3515ec15f6d8db2b1f8819: Skip the new test for GMT<6.5, because the new test requires the upstream fix https://github.com/GenericMappingTools/gmt/pull/7557.

Offsetting beachballs for ndarray input requires GMT>=6.5, due to an upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/7557.

Fixes https://github.com/GenericMappingTools/pygmt/issues/2016


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
