### PR TITLE
Fix typo in tutorial "Cartesian histograms"

### DIFF
--- a/examples/tutorials/advanced/cartesian_histograms.py
+++ b/examples/tutorials/advanced/cartesian_histograms.py
@@ -221,7 +221,7 @@ fig.histogram(
     histtype=0,
     # Show cumulative counts
     cumulative=True,
-    # Offest (+o) the label by 10 points in negative y-direction
+    # Offset (+o) the label by 10 points in negative y-direction
     annotate="+o-10p",
 )
 


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a typo in the tutorial [Cartesian histograms](https://www.pygmt.org/dev/tutorials/advanced/cartesian_histograms.html).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
