### PR TITLE
Figure.meca: Add a test for passing event names via pandas.DataFrame

### DIFF
--- a/pygmt/tests/baseline/test_meca_eventname.png.dvc
+++ b/pygmt/tests/baseline/test_meca_eventname.png.dvc
@@ -1,4 +1,4 @@
 outs:
 - md5: 81203f9e3a43ec235cf4b5068f928b56
   size: 10689
-  path: test_meca_dict_eventname.png
+  path: test_meca_eventname.png

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -189,7 +189,7 @@ def test_meca_offset(inputtype):
         "args",
         pytest.param(
             "pandas",
-            marks=pytest.mark.xfail(
+            marks=pytest.mark.skipif(
                 condition=Version(__gmt_version__) < Version("6.5.0"),
                 reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/7557",
             ),

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -179,22 +179,23 @@ def test_meca_offset(inputtype):
     return fig
 
 
-@pytest.mark.mpl_image_compare
-def test_meca_dict_eventname():
+@pytest.mark.mpl_image_compare(filename="test_meca_eventname.png")
+@pytest.mark.parametrize("inputtype", ["eventname_args"])
+def test_meca_eventname(inputtype):
     """
-    Test offsetting beachballs for a dict input.
+    Test passing event names.
     """
+    if inputtype == "eventname_args":
+        args = {
+            "spec": {"strike": 330, "dip": 30, "rake": 90, "magnitude": 3},
+            "longitude": -124,
+            "latitude": 48,
+            "depth": 12.0,
+            "event_name": "Event20220311",
+        }
     fig = Figure()
-    focal_mechanism = {"strike": 330, "dip": 30, "rake": 90, "magnitude": 3}
     fig.basemap(region=[-125, -122, 47, 49], projection="M6c", frame=True)
-    fig.meca(
-        spec=focal_mechanism,
-        scale="1c",
-        longitude=-124,
-        latitude=48,
-        depth=12.0,
-        event_name="Event20220311",
-    )
+    fig.meca(scale="1c", **args)
     return fig
 
 
@@ -219,7 +220,7 @@ def test_meca_dict_offset_eventname():
     return fig
 
 
-@pytest.mark.mpl_image_compare(filename="test_meca_dict_eventname.png")
+@pytest.mark.mpl_image_compare(filename="test_meca_eventname.png")
 def test_meca_spec_dict_all_scalars():
     """
     Test supplying a dict with scalar values for all focal parameters.

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -188,7 +188,7 @@ def test_meca_offset(inputtype):
     [
         "args",
         pytest.param(
-            "pandas",
+            "dataframe",
             marks=pytest.mark.skipif(
                 condition=Version(__gmt_version__) < Version("6.5.0"),
                 reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/7557",
@@ -208,8 +208,8 @@ def test_meca_eventname(inputtype):
             "depth": 12.0,
             "event_name": "Event20220311",
         }
-    elif inputtype == "pandas":
-        # Test pandas input. Requires GMT>=6.5.
+    elif inputtype == "dataframe":
+        # Test pandas.DataFrame input. Requires GMT>=6.5.
         # See https://github.com/GenericMappingTools/pygmt/issues/2524.
         # The numeric columns must be in float type to trigger the bug.
         args = {


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/GenericMappingTools/pygmt/issues/2524 for context.

The failure is caused by an upstream bug, which was already fixed in https://github.com/GenericMappingTools/gmt/pull/7557.

In this PR, I renamed the old `test_meca_dict_eventname` test to `test_meca_eventname`, and add a new test following #2524. The new test passes in the "GMT Tests Dev" workflow (https://github.com/GenericMappingTools/pygmt/actions/runs/5346800096) and is skipped in the "Tests" workflow (because it crashes with GMT 6.4)

Fixes https://github.com/GenericMappingTools/pygmt/issues/2524

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
