### PR TITLE
Allow passing RGB xarray.DataArray images into grdimage

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -25,7 +25,12 @@ from pygmt.exceptions import (
     GMTInvalidInput,
     GMTVersionError,
 )
-from pygmt.helpers import data_kind, fmt_docstring, tempfile_from_geojson
+from pygmt.helpers import (
+    data_kind,
+    fmt_docstring,
+    tempfile_from_geojson,
+    tempfile_from_image,
+)
 
 FAMILIES = [
     "GMT_IS_DATASET",  # Entity is a data table
@@ -1530,7 +1535,7 @@ class Session:
         """
         kind = data_kind(data, x, y, z, required_z=required_z)
 
-        if check_kind == "raster" and kind not in ("file", "grid"):
+        if check_kind == "raster" and kind not in ("file", "grid", "image"):
             raise GMTInvalidInput(f"Unrecognized data type for grid: {type(data)}")
         if check_kind == "vector" and kind not in (
             "file",
@@ -1545,6 +1550,7 @@ class Session:
             "file": nullcontext,
             "geojson": tempfile_from_geojson,
             "grid": self.virtualfile_from_grid,
+            "image": tempfile_from_image,
             # Note: virtualfile_from_matrix is not used because a matrix can be
             # converted to vectors instead, and using vectors allows for better
             # handling of string type inputs (e.g. for datetime data types)
@@ -1553,7 +1559,7 @@ class Session:
         }[kind]
 
         # Ensure the data is an iterable (Python list or tuple)
-        if kind in ("geojson", "grid"):
+        if kind in ("geojson", "grid", "image"):
             _data = (data,)
         elif kind == "file":
             # Useful to handle `pathlib.Path` and string file path alike

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -6,6 +6,7 @@ Uses ctypes to wrap most of the core functions from the C API.
 """
 import ctypes as ctp
 import sys
+import warnings
 from contextlib import contextmanager, nullcontext
 
 import numpy as np
@@ -1560,6 +1561,15 @@ class Session:
 
         # Ensure the data is an iterable (Python list or tuple)
         if kind in ("geojson", "grid", "image"):
+            if kind == "image" and data.dtype != "uint8":
+                msg = (
+                    f"Input image has dtype: {data.dtype} which is unsupported, "
+                    "and may result in an incorrect output. Please recast image "
+                    "to a uint8 dtype and/or scale to 0-255 range, e.g. "
+                    "using a histogram equalization function like "
+                    "skimage.exposure.equalize_hist."
+                )
+                warnings.warn(message=msg, category=RuntimeWarning, stacklevel=2)
             _data = (data,)
         elif kind == "file":
             # Useful to handle `pathlib.Path` and string file path alike

--- a/pygmt/helpers/__init__.py
+++ b/pygmt/helpers/__init__.py
@@ -7,7 +7,12 @@ from pygmt.helpers.decorators import (
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.helpers.tempfile import GMTTempFile, tempfile_from_geojson, unique_name
+from pygmt.helpers.tempfile import (
+    GMTTempFile,
+    tempfile_from_geojson,
+    tempfile_from_image,
+    unique_name,
+)
 from pygmt.helpers.utils import (
     args_in_kwargs,
     build_arg_string,

--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -147,3 +147,34 @@ def tempfile_from_geojson(geojson):
                     geoseries.to_file(**ogrgmt_kwargs)
 
         yield tmpfile.name
+
+
+@contextmanager
+def tempfile_from_image(image):
+    """
+    Saves a 3-band `xarray.DataArray` to a temporary GeoTIFF file via
+    rioxarray.
+
+    Parameters
+    ----------
+    image : xarray.DataArray
+        An xarray.DataArray with three dimensions, having a shape like
+        (3, Y, X).
+
+    Yields
+    ------
+    tmpfilename : str
+        A temporary GeoTIFF file holding the image data. E.g. '1a2b3c4d5.tif'.
+    """
+    with GMTTempFile(suffix=".tif") as tmpfile:
+        os.remove(tmpfile.name)  # ensure file is deleted first
+        try:
+            image.rio.to_raster(raster_path=tmpfile.name)
+        except AttributeError as e:  # object has no attribute 'rio'
+            raise ImportError(
+                "Package `rioxarray` is required to be installed to use this function. "
+                "Please use `python -m pip install rioxarray` or "
+                "`mamba install -c conda-forge rioxarray` "
+                "to install the package."
+            ) from e
+        yield tmpfile.name

--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -152,7 +152,7 @@ def tempfile_from_geojson(geojson):
 @contextmanager
 def tempfile_from_image(image):
     """
-    Saves a 3-band `xarray.DataArray` to a temporary GeoTIFF file via
+    Saves a 3-band :class:`xarray.DataArray` to a temporary GeoTIFF file via
     rioxarray.
 
     Parameters

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -45,7 +45,7 @@ def data_kind(data, x=None, y=None, z=None, required_z=False):
     Returns
     -------
     kind : str
-        One of: ``'file'``, ``'grid'``, ``'matrix'``, ``'vectors'``.
+        One of: ``'file'``, ``'grid'``, ``image``, ``'matrix'``, ``'vectors'``.
 
     Examples
     --------
@@ -63,6 +63,8 @@ def data_kind(data, x=None, y=None, z=None, required_z=False):
     'file'
     >>> data_kind(data=xr.DataArray(np.random.rand(4, 3)))
     'grid'
+    >>> data_kind(data=xr.DataArray(np.random.rand(3, 4, 5)))
+    'image'
     """
     if data is None and x is None and y is None:
         raise GMTInvalidInput("No input data provided.")
@@ -76,7 +78,10 @@ def data_kind(data, x=None, y=None, z=None, required_z=False):
     if isinstance(data, (str, pathlib.PurePath)):
         kind = "file"
     elif isinstance(data, xr.DataArray):
-        kind = "grid"
+        if len(data.dims) == 3:
+            kind = "image"
+        else:
+            kind = "grid"
     elif hasattr(data, "__geo_interface__"):
         kind = "geojson"
     elif data is not None:

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -136,10 +136,7 @@ def data_kind(data=None, x=None, y=None, z=None, required_z=False):
     if isinstance(data, (str, pathlib.PurePath)):
         kind = "file"
     elif isinstance(data, xr.DataArray):
-        if len(data.dims) == 3:
-            kind = "image"
-        else:
-            kind = "grid"
+        kind = "image" if len(data.dims) == 3 else "grid"
     elif hasattr(data, "__geo_interface__"):
         kind = "geojson"
     elif data is not None:

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -5,7 +5,6 @@ import contextlib
 
 from pygmt.clib import Session
 from pygmt.helpers import (
-    GMTTempFile,
     build_arg_string,
     data_kind,
     fmt_docstring,
@@ -181,24 +180,17 @@ def grdimage(self, grid, **kwargs):
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
 
-    with GMTTempFile(suffix=".tif") as tmpfile:
-        if hasattr(grid, "dims") and len(grid.dims) == 3:
-            grid.rio.to_raster(raster_path=tmpfile.name)
-            _grid = tmpfile.name
-        else:
-            _grid = grid
-
-        with Session() as lib:
-            file_context = lib.virtualfile_from_data(check_kind="raster", data=_grid)
-            with contextlib.ExitStack() as stack:
-                # shading using an xr.DataArray
-                if kwargs.get("I") is not None and data_kind(kwargs["I"]) == "grid":
-                    shading_context = lib.virtualfile_from_data(
-                        check_kind="raster", data=kwargs["I"]
-                    )
-                    kwargs["I"] = stack.enter_context(shading_context)
-
-                fname = stack.enter_context(file_context)
-                lib.call_module(
-                    module="grdimage", args=build_arg_string(kwargs, infile=fname)
+    with Session() as lib:
+        file_context = lib.virtualfile_from_data(check_kind="raster", data=grid)
+        with contextlib.ExitStack() as stack:
+            # shading using an xr.DataArray
+            if kwargs.get("I") is not None and data_kind(kwargs["I"]) == "grid":
+                shading_context = lib.virtualfile_from_data(
+                    check_kind="raster", data=kwargs["I"]
                 )
+                kwargs["I"] = stack.enter_context(shading_context)
+
+            fname = stack.enter_context(file_context)
+            lib.call_module(
+                module="grdimage", args=build_arg_string(kwargs, infile=fname)
+            )

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -49,11 +49,11 @@ def grdimage(self, grid, **kwargs):
     instructions to derive intensities from the input data grid. Values outside
     this range will be clipped. Such intensity files can be created from the
     grid using :func:`pygmt.grdgradient` and, optionally, modified by
-    :gmt-docs:`grdmath.html` or :class:`pygmt.grdhisteq`. If GMT is built
-    with GDAL support, ``grid`` can be an image file (geo-referenced or not).
-    In this case the image can optionally be illuminated with the file
-    provided via the ``shading`` parameter. Here, if image has no coordinates
-    then those of the intensity file will be used.
+    :gmt-docs:`grdmath.html` or :class:`pygmt.grdhisteq`. Alternatively, pass
+    *image* which can be an image file (geo-referenced or not). In this case
+    the image can optionally be illuminated with the file provided via the
+    ``shading`` parameter. Here, if image has no coordinates then those of the
+    intensity file will be used.
 
     When using map projections, the grid is first resampled on a new
     rectangular grid with the same dimensions. Higher resolution images can
@@ -82,10 +82,7 @@ def grdimage(self, grid, **kwargs):
         :gmt-docs:`grdimage.html#grid-file-formats`).
     img_out : str
         *out_img*\[=\ *driver*].
-        Save an image in a raster format instead of PostScript. Use
-        extension .ppm for a Portable Pixel Map format which is the only
-        raster format GMT can natively write. For GMT installations
-        configured with GDAL support there are more choices: Append
+        Save an image in a raster format instead of PostScript. Append
         *out_img* to select the image file name and extension. If the
         extension is one of .bmp, .gif, .jpg, .png, or .tif then no driver
         information is required. For other output formats you must append
@@ -139,8 +136,8 @@ def grdimage(self, grid, **kwargs):
         :func:`pygmt.grdgradient` separately first. If we should derive
         intensities from another file than grid, specify the file with
         suitable modifiers [Default is no illumination]. **Note**: If the
-        input data is an *image* then an *intensfile* or constant *intensity*
-        must be provided.
+        input data represent an *image* then an *intensfile* or constant
+        *intensity* must be provided.
     {projection}
     monochrome : bool
         Force conversion to monochrome image using the (television) YIQ
@@ -152,10 +149,9 @@ def grdimage(self, grid, **kwargs):
         [**+z**\ *value*][*color*]
         Make grid nodes with z = NaN transparent, using the color-masking
         feature in PostScript Level 3 (the PS device must support PS Level
-        3). If the input is a grid, use **+z** with a *value* to select
-        another grid value than NaN. If the input is instead an image,
-        append an alternate *color* to select another pixel value to be
-        transparent [Default is ``"black"``].
+        3). If the input is a grid, use **+z** to select another grid value
+        than NaN. If input is instead an image, append an alternate *color* to
+        select another pixel value to be transparent [Default is ``"black"``].
     {region}
     {verbose}
     {panel}

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -3,13 +3,7 @@ tilemap - Plot XYZ tile maps.
 """
 from pygmt.clib import Session
 from pygmt.datasets.tile_map import load_tile_map
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 
 @fmt_docstring

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     rioxarray = None
 
+
 @fmt_docstring
 @use_alias(
     B="frame",

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -5,6 +5,10 @@ from pygmt.clib import Session
 from pygmt.datasets.tile_map import load_tile_map
 from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
+try:
+    import rioxarray
+except ImportError:
+    rioxarray = None
 
 @fmt_docstring
 @use_alias(
@@ -108,6 +112,14 @@ def tilemap(
         function.
     """
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
+
+    if rioxarray is None:
+        raise ImportError(
+            "Package `rioxarray` is required to be installed to use this function. "
+            "Please use `python -m pip install rioxarray` or "
+            "`mamba install -c conda-forge rioxarray` "
+            "to install the package."
+        )
 
     raster = load_tile_map(
         region=region,

--- a/pygmt/tests/baseline/test_grdimage_image.png.dvc
+++ b/pygmt/tests/baseline/test_grdimage_image.png.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 2e919645d5af956ec4f8aa054a86a70a
+  size: 110214
+  path: test_grdimage_image.png

--- a/pygmt/tests/test_grdimage_image.py
+++ b/pygmt/tests/test_grdimage_image.py
@@ -61,3 +61,19 @@ def test_grdimage_image_dataarray(xr_image):
     fig = Figure()
     fig.grdimage(grid=xr_image)
     return fig
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    ["int8", "uint16", "int16", "uint32", "int32", "float32", "float64"],
+)
+def test_grdimage_image_dataarray_unsupported_dtype(dtype, xr_image):
+    """
+    Plot a 3-band RGB image using xarray.DataArray input, with an unsupported
+    data type.
+    """
+    fig = Figure()
+    image = xr_image.astype(dtype=dtype)
+    with pytest.warns(expected_warning=RuntimeWarning) as record:
+        fig.grdimage(grid=image)
+        assert len(record) == 1

--- a/pygmt/tests/test_grdimage_image.py
+++ b/pygmt/tests/test_grdimage_image.py
@@ -1,0 +1,63 @@
+"""
+Test Figure.grdimage on 3-band RGB images.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from pygmt import Figure, which
+
+rasterio = pytest.importorskip("rasterio")
+rioxarray = pytest.importorskip("rioxarray")
+
+
+@pytest.fixture(scope="module", name="xr_image")
+def fixture_xr_image():
+    """
+    Load the image data from Blue Marble as an xarray.DataArray with shape
+    {"band": 3, "y": 180, "x": 360}.
+    """
+    geotiff = which(fname="@earth_day_01d_p", download="c")
+    with rioxarray.open_rasterio(filename=geotiff) as rda:
+        if len(rda.band) == 1:
+            with rasterio.open(fp=geotiff) as src:
+                df_colormap = pd.DataFrame.from_dict(
+                    data=src.colormap(1), orient="index"
+                )
+                array = src.read()
+
+                red = np.vectorize(df_colormap[0].get)(array)
+                green = np.vectorize(df_colormap[1].get)(array)
+                blue = np.vectorize(df_colormap[2].get)(array)
+                # alpha = np.vectorize(df_colormap[3].get)(array)
+
+            rda.data = red
+            da_red = rda.astype(dtype=np.uint8).copy()
+            rda.data = green
+            da_green = rda.astype(dtype=np.uint8).copy()
+            rda.data = blue
+            da_blue = rda.astype(dtype=np.uint8).copy()
+
+            xr_image = xr.concat(objs=[da_red, da_green, da_blue], dim="band")
+        assert xr_image.sizes == {"band": 3, "y": 180, "x": 360}
+        return xr_image
+
+
+@pytest.mark.mpl_image_compare
+def test_grdimage_image():
+    """
+    Plot a 3-band RGB image using file input.
+    """
+    fig = Figure()
+    fig.grdimage(grid="@earth_day_01d")
+    return fig
+
+
+@pytest.mark.mpl_image_compare(filename="test_grdimage_image.png")
+def test_grdimage_image_dataarray(xr_image):
+    """
+    Plot a 3-band RGB image using xarray.DataArray input.
+    """
+    fig = Figure()
+    fig.grdimage(grid=xr_image)
+    return fig


### PR DESCRIPTION
**Description of proposed changes**

Enables `grdimage` to plot 3-band RGB images stored in an `xarray.DataArray` with a shape like (3, Y, X).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Example usage based on https://corteva.github.io/rioxarray/stable/examples/COG.html:

```python
import pygmt
import rioxarray

image = rioxarray.open_rasterio(
    "https://oin-hotosm.s3.amazonaws.com/5d7dad0becaf880008a9bc88/0/5d7dad0becaf880008a9bc89.tif",
    masked=True,
    overview_level=4,
)
assert image.sizes == {"band": 3, "y": 312, "x": 688}

fig = pygmt.Figure()
fig.grdimage(grid=image, frame=True)
fig.show()
```
produces

![rgb_image](https://github.com/GenericMappingTools/pygmt/assets/23487320/23b9b3ce-3ce6-48ef-8901-df0b4ee5e195)

Implementation currently saves the 3-band `xarray.DataArray` image to a temporary GeoTIFF before passing it to `grdimage`, similar to what `tilemap` did in #2394 https://github.com/GenericMappingTools/pygmt/blob/e98efe16c22fb7eb3f20e2004248bc71c6f68097/pygmt/src/tilemap.py#L151-L156

Notes:
- Conversion of `xarray.DataArray` to temporary GeoTIFF file requires `rioxarray`.
- Only certain dtypes like uint8 and float32 are supported for plotting, so need to either warn users if other dtypes are passed in. Best scenario is if histogram equalization via `grdhisteq` #1433 or normalization to 0-255 via `grdmix` (#1437) is applied
- This implementation will need to be refactored when `GMT_IMAGE` is wrapped in PyGMT so that temporary files can be avoided, see #1555. The unit tests in this PR should still be valid though.

TODO:
- [x] Initial implementation using tempfile
- [x] Raise error on missing `rioxarray` dependency
- [x] Raise warning when unsupported dtypes are passed in
- [ ] Maybe implement same logic for `grdview` too?

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Closes #370, partially addresses #1555.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
