### PR TITLE
geopandas: Mapping int/int64 to int32 for OGR_GMT format

### DIFF
--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -132,7 +132,7 @@ def tempfile_from_geojson(geojson):
         os.remove(tmpfile.name)  # ensure file is deleted first
         ogrgmt_kwargs = {"filename": tmpfile.name, "driver": "OGR_GMT", "mode": "w"}
         try:
-            # Workaround to map int/int64 to int32
+            # Map int/int64 to int32 because OGR_GMT only supports 32-bit integer
             # https://github.com/geopandas/geopandas/issues/967#issuecomment-842877704
             # https://github.com/GenericMappingTools/pygmt/issues/2497
             schema = gpd.io.file.infer_schema(geojson)

--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -135,6 +135,9 @@ def tempfile_from_geojson(geojson):
             # Map int/int64 to int32 since OGR_GMT only supports 32-bit integer
             # https://github.com/geopandas/geopandas/issues/967#issuecomment-842877704
             # https://github.com/GenericMappingTools/pygmt/issues/2497
+            if geojson.index.name is None:
+                geojson.index.name = "index"
+            geojson = geojson.reset_index(drop=False)
             schema = gpd.io.file.infer_schema(geojson)
             for col, dtype in schema["properties"].items():
                 if dtype in ("int", "int64"):

--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -132,7 +132,7 @@ def tempfile_from_geojson(geojson):
         os.remove(tmpfile.name)  # ensure file is deleted first
         ogrgmt_kwargs = {"filename": tmpfile.name, "driver": "OGR_GMT", "mode": "w"}
         try:
-            # Map int/int64 to int32 because OGR_GMT only supports 32-bit integer
+            # Map int/int64 to int32 since OGR_GMT only supports 32-bit integer
             # https://github.com/geopandas/geopandas/issues/967#issuecomment-842877704
             # https://github.com/GenericMappingTools/pygmt/issues/2497
             schema = gpd.io.file.infer_schema(geojson)

--- a/pygmt/tests/baseline/test_geopandas_plot_int_dtypes.png.dvc
+++ b/pygmt/tests/baseline/test_geopandas_plot_int_dtypes.png.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 6ce1b73d25ac10900a2ce4c7148d2953
+  size: 43434
+  path: test_geopandas_plot_int_dtypes.png

--- a/pygmt/tests/baseline/test_geopandas_plot_int_dtypes.png.dvc
+++ b/pygmt/tests/baseline/test_geopandas_plot_int_dtypes.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 6ce1b73d25ac10900a2ce4c7148d2953
-  size: 43434
+- md5: c1c6eda2a88adf4d96f18f4e0c5db4d5
+  size: 43582
   path: test_geopandas_plot_int_dtypes.png

--- a/pygmt/tests/test_geopandas.py
+++ b/pygmt/tests/test_geopandas.py
@@ -134,7 +134,17 @@ def test_geopandas_plot3d_non_default_circle():
     return fig
 
 
-@pytest.mark.parametrize("dtype", ["int32", "int64", pd.Int32Dtype(), pd.Int64Dtype()])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "int32",
+        "int64",
+        # Enable Int32/Int64 dtypes when geopandas>=0.13.3 is released with
+        # patch https://github.com/geopandas/geopandas/pull/2950
+        # pd.Int32Dtype(),
+        # pd.Int64Dtype(),
+    ],
+)
 @pytest.mark.mpl_image_compare(filename="test_geopandas_plot_int_dtypes.png")
 def test_geopandas_plot_int_dtypes(dtype):
     """

--- a/pygmt/tests/test_geopandas.py
+++ b/pygmt/tests/test_geopandas.py
@@ -2,7 +2,6 @@
 Test integration with geopandas.
 """
 import numpy.testing as npt
-import pandas as pd
 import pytest
 from pygmt import Figure, info, makecpt, which
 

--- a/pygmt/tests/test_geopandas.py
+++ b/pygmt/tests/test_geopandas.py
@@ -4,7 +4,7 @@ Test integration with geopandas.
 import numpy.testing as npt
 import pandas as pd
 import pytest
-from pygmt import Figure, info, which, makecpt
+from pygmt import Figure, info, makecpt, which
 
 gpd = pytest.importorskip("geopandas")
 shapely = pytest.importorskip("shapely")

--- a/pygmt/tests/test_geopandas.py
+++ b/pygmt/tests/test_geopandas.py
@@ -161,7 +161,7 @@ def test_geopandas_plot_int_dtypes(dtype):
 
     # Plot figure with three polygons colored based on NPOINTS value
     fig = Figure()
-    makecpt(cmap="lajolla", series=[10, 60, 10], continuous=True)
+    makecpt(cmap="lisbon", series=[10, 60, 10], continuous=True)
     fig.plot(
         data=gdf,
         frame=True,

--- a/pygmt/tests/test_geopandas.py
+++ b/pygmt/tests/test_geopandas.py
@@ -2,8 +2,9 @@
 Test integration with geopandas.
 """
 import numpy.testing as npt
+import pandas as pd
 import pytest
-from pygmt import Figure, info
+from pygmt import Figure, info, which, makecpt
 
 gpd = pytest.importorskip("geopandas")
 shapely = pytest.importorskip("shapely")
@@ -130,4 +131,45 @@ def test_geopandas_plot3d_non_default_circle():
         zscale=1.5,
         style="c0.2c",
     )
+    return fig
+
+
+@pytest.mark.parametrize("dtype", ["int32", "int64", pd.Int32Dtype(), pd.Int64Dtype()])
+@pytest.mark.mpl_image_compare(filename="test_geopandas_plot_int_dtypes.png")
+def test_geopandas_plot_int_dtypes(dtype):
+    """
+    Check that plotting a geopandas GeoDataFrame with integer columns works,
+    including int32 and int64 (non-nullable), Int32 and Int64 (nullable).
+
+    This is a regression test for
+    https://github.com/GenericMappingTools/pygmt/issues/2497
+    """
+    # Read shapefile in geopandas.GeoDataFrame
+    shapefile = which(
+        fname="@RidgeTest.shp @RidgeTest.shx @RidgeTest.dbf @RidgeTest.prj",
+        download="c",
+    )
+    gdf = gpd.read_file(shapefile[0])
+
+    # Reproject geometry and change dtype of NPOINTS column
+    gdf["geometry"] = (
+        gdf.to_crs(crs="EPSG:3857")
+        .buffer(distance=100000)
+        .to_crs(crs="OGC:CRS84")  # convert to lon/lat to prevent @null in PROJ CRS
+    )
+    gdf["NPOINTS"] = gdf.NPOINTS.astype(dtype=dtype)
+
+    # Plot figure with three polygons colored based on NPOINTS value
+    fig = Figure()
+    makecpt(cmap="lajolla", series=[10, 60, 10], continuous=True)
+    fig.plot(
+        data=gdf,
+        frame=True,
+        pen="1p,black",
+        close=True,
+        fill="+z",
+        cmap=True,
+        aspatial="Z=NPOINTS",
+    )
+    fig.colorbar()
     return fig


### PR DESCRIPTION
**Description of proposed changes**



Fixes https://github.com/GenericMappingTools/pygmt/issues/2497

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
