### PR TITLE
Add checking NEP29 in the release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -16,6 +16,7 @@ assignees: ''
 - [ ] Wrap Y ()
 
 **Before release**:
+- [ ] Check [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) to see if we need to bump the minimum Python and NumPy version
 - [ ] Check to ensure that:
   - [ ] All tests pass in the ["GMT Legacy Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_legacy.yaml)
   - [ ] All tests pass in the ["GMT Dev Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_dev.yaml)

--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -16,7 +16,7 @@ assignees: ''
 - [ ] Wrap Y ()
 
 **Before release**:
-- [ ] Check [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) to see if we need to bump the minimum Python and NumPy version
+- [ ] Check [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) to see if we need to bump the minimum Python and NumPy versions
 - [ ] Check to ensure that:
   - [ ] All tests pass in the ["GMT Legacy Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_legacy.yaml)
   - [ ] All tests pass in the ["GMT Dev Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_dev.yaml)


### PR DESCRIPTION
**Description of proposed changes**

So we won't forget to bump the minimum supported Python and NumPy version.

