### PR TITLE
Use consistent term for the main line in the gallery examples "Line fronts", "Quoted lines", and "Decorated lines"

### DIFF
--- a/examples/gallery/lines/decorated_lines.py
+++ b/examples/gallery/lines/decorated_lines.py
@@ -8,8 +8,8 @@ desired modifiers. A colon (``":"``) is used to separate the
 algorithm settings from the symbol information.
 This example shows how to adjust the symbols.
 Beside the built-in symbols also custom symbols can be used.
-For modifying the baseline via the ``pen`` parameter, see the
-:doc:`Line styles example </gallery/lines/linestyles>`.
+For modifying the main decorated line via the ``pen`` parameter,
+see the :doc:`Line styles example </gallery/lines/linestyles>`.
 For details on the input data see the upstream GMT documentation
 at https://docs.generic-mapping-tools.org/latest/plot.html#s.
 Furthermore, there are so-called *line fronts*, which are often
@@ -49,13 +49,14 @@ for decoline in [
     # Line with squares ("s") with a size of 0.7 centimeters in a distance of
     # 1 centimeter
     "~d1c:+ss0.7c+gtan+p1p,black",
-    # Shift symbols using "+n" in x and y directions relative to the baseline
+    # Shift symbols using "+n" in x and y directions relative to the main
+    # decorated line
     "~d1c:+sd0.5c+gtan+p1p,black+n-0.2c/0.1c",
     # Give the number of equally spaced symbols by using "n" instead of "d"
     "~n6:+sn0.5c+gtan+p1p,black",
     # Use upper-case "N" to have symbols at the start and end of the line
     "~N6:+sh0.5c+gtan+p1p,black",
-    # Suppress the baseline by appending "+i"
+    # Suppress the main decorated line by appending "+i"
     "~d1c:+sg0.5c+gtan+p1p,black+i",
     # To only plot a symbol at the start of the line use "N-1"
     "~N-1:+sp0.2c+gblack",

--- a/examples/gallery/lines/quoted_lines.py
+++ b/examples/gallery/lines/quoted_lines.py
@@ -27,7 +27,7 @@ fig.basemap(region=[0, 10, 0, 20], projection="X15c/15c", frame="+tQuoted Lines"
 for quotedline in [
     # Line with labels ("+l") "text" in distance ("d") of 1 centimeter
     "qd1c:+ltext",
-    # Suppress main quoted line by appending "+i"
+    # Suppress the main quoted line by appending "+i"
     "qd1c:+ltext+i",
     # Give the number of equally spaced labels by using "n" instead of "d"
     "qn5:+ltext",

--- a/examples/gallery/lines/quoted_lines.py
+++ b/examples/gallery/lines/quoted_lines.py
@@ -7,8 +7,8 @@ or curve, use the ``style`` parameter of the
 desired modifiers. A colon (``":"``) is used to separate the
 algorithm settings from the label information.
 This example shows how to adjust the labels.
-For modifying the baseline via the ``pen`` parameter, see the
-:doc:`Line styles example </gallery/lines/linestyles>`.
+For modifying the main quoted line via the ``pen`` parameter,
+see the :doc:`Line styles example </gallery/lines/linestyles>`.
 For details on the input data see the upstream GMT documentation
 at https://docs.generic-mapping-tools.org/latest/plot.html#s.
 """
@@ -27,7 +27,7 @@ fig.basemap(region=[0, 10, 0, 20], projection="X15c/15c", frame="+tQuoted Lines"
 for quotedline in [
     # Line with labels ("+l") "text" in distance ("d") of 1 centimeter
     "qd1c:+ltext",
-    # Suppress baseline by appending "+i"
+    # Suppress main quoted line by appending "+i"
     "qd1c:+ltext+i",
     # Give the number of equally spaced labels by using "n" instead of "d"
     "qn5:+ltext",
@@ -39,7 +39,8 @@ for quotedline in [
     "qN+1:+ltext",
     # Adjust the justification of the labels via "+j", here Top Center
     "qd1c:+ltext+jTC",
-    # Shift labels using "+n" in x and y directions relative to the baseline
+    # Shift labels using "+n" in x and y directions relative to the main
+    # quoted line
     "qd1c:+ltext+n-0.5c/0.1c",
     # Rotate labels via "+a" (counter-clockwise from horizontal)
     "qd1c:+ltext+a20",


### PR DESCRIPTION
**Description of proposed changes**

To be consistent with the upstream GMT docs at https://docs.generic-mapping-tools.org/latest/plot.html#s and the gallery example [Line Fronts](https://www.pygmt.org/dev/gallery/lines/linefronts.html#sphx-glr-gallery-lines-linefronts-py), I renamed "baseline" to  "main quoted line" or "main decorated line" in the gallery examples [Quoted lines](https://www.pygmt.org/dev/gallery/lines/quoted_lines.html) and [Decorated lines](https://www.pygmt.org/dev/gallery/lines/decorated_lines.html).

> To make the main front line invisible, add +i.

> +i
> Make the main quoted line invisible [Draw it per [-W](https://docs.generic-mapping-tools.org/dev/plot.html#w)].

> +i
> Make the main decorated line invisible [Draw it using pen settings provided by [-W](https://docs.generic-mapping-tools.org/dev/plot.html#w)].

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
