### PR TITLE
Mention GMT docs regarding more complicated legends in gallery example "Legends"

### DIFF
--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -6,7 +6,7 @@ The :meth:`pygmt.Figure.legend` method can automatically create a legend for
 symbols plotted using :meth:`pygmt.Figure.plot`. Legend entries are only
 created when the ``label`` parameter is used. For more complicated legends,
 including legends with multiple columns, users have to write an ASCII file
-with instructions for the layout of the items in the legend and pass it
+with instructions for the layout of the legend items and pass it
 to the ``spec`` parameter of :meth:`pygmt.Figure.legend`. For details on
 how to set up such a file, please see the GMT documentation at
 https://docs.generic-mapping-tools.org/latest/legend.html#legend-codes.

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -4,7 +4,12 @@ Legend
 
 The :meth:`pygmt.Figure.legend` method can automatically create a legend for
 symbols plotted using :meth:`pygmt.Figure.plot`. Legend entries are only
-created when the ``label`` parameter is used.
+created when the ``label`` parameter is used. For more complicated legends,
+including legends with multiple columns, users have to write an ASCII file
+with instructions for the layout of the items in the legend and pass it
+to the `spec` parameter of :meth:`pygmt.Figure.legend`. For details on how
+to set up such a file, please see the GMT documentation at
+https://docs.generic-mapping-tools.org/latest/legend.html#legend-codes.
 """
 import pygmt
 

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -7,8 +7,8 @@ symbols plotted using :meth:`pygmt.Figure.plot`. Legend entries are only
 created when the ``label`` parameter is used. For more complicated legends,
 including legends with multiple columns, users have to write an ASCII file
 with instructions for the layout of the items in the legend and pass it
-to the `spec` parameter of :meth:`pygmt.Figure.legend`. For details on how
-to set up such a file, please see the GMT documentation at
+to the ``spec`` parameter of :meth:`pygmt.Figure.legend`. For details on
+how to set up such a file, please see the GMT documentation at
 https://docs.generic-mapping-tools.org/latest/legend.html#legend-codes.
 """
 import pygmt


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to mention the upstream GMT documentation regarding more complicated legends in the gallery example [Legends](https://www.pygmt.org/dev/gallery/embellishments/legend.html).

Related to issue #2603.

**Preview**: https://pygmt-dev--2606.org.readthedocs.build/en/2606/gallery/embellishments/legend.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
