### PR TITLE
CI: Run dev tests on Scientific Python nightly wheels

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -1,4 +1,4 @@
-# Tests PyGMT on Linux/macOS/Windows
+# Test PyGMT on Linux/macOS/Windows
 #
 # This workflow runs regular PyGMT tests and uploads test coverage reports stored
 # in `.coverage.xml` to https://app.codecov.io/gh/GenericMappingTools/pygmt

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -18,7 +18,7 @@ on:
   # push:
   #   branches: [ main ]
   pull_request:
-    types: [ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths-ignore:
       - 'doc/**'
       - 'examples/**'

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -1,4 +1,4 @@
-# Tests PyGMT with GMT dev version on Linux/macOS/Windows
+# Test PyGMT with GMT dev version on Linux/macOS/Windows
 #
 # This workflow runs regular PyGMT tests with the GMT dev version, and also
 # pre-release versions of several dependencies like NumPy, Pandas, Xarray, etc.

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -1,6 +1,7 @@
 # Tests PyGMT with GMT dev version on Linux/macOS/Windows
 #
-# This workflow runs regular PyGMT tests with the GMT dev version.
+# This workflow runs regular PyGMT tests with the GMT dev version, and also
+# pre-release versions of several dependencies like NumPy, Pandas, Xarray, etc.
 # If any tests fail, it also uploads the diff images as workflow artifacts.
 # On Linux/macOS, GMT dev version is installed by fetching the latest source
 # codes from the GMT master branch and compiling.
@@ -119,6 +120,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --pre --prefer-binary \
+                        --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
                         numpy pandas xarray netCDF4 packaging \
                         build contextily dvc geopandas ipython rioxarray \
                         'pytest>=6.0' pytest-cov pytest-doctestplus pytest-mpl \

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -18,7 +18,7 @@ on:
   # push:
   #   branches: [ main ]
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [ready_for_review]
     paths-ignore:
       - 'doc/**'
       - 'examples/**'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -1,4 +1,4 @@
-# Tests PyGMT with GMT legacy versions on Linux/macOS/Windows
+# Test PyGMT with GMT legacy versions on Linux/macOS/Windows
 #
 # This workflow runs regular PyGMT tests with GMT legacy versions. Due to the
 # minor baseline image changes between GMT versions, the workflow only runs


### PR DESCRIPTION
**Description of proposed changes**

Check that PyGMT will work on future versions of numpy>=2.0.0, pandas>=2.1.0, xarray>=2023.7.1 and so on.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

References:
- Pre-built wheels are at https://anaconda.org/scientific-python-nightly-wheels
- [SPEC](https://scientific-python.org/specs) 4 — Using and Creating Nightly Wheels at https://scientific-python.org/specs/spec-0004

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Extends #1105 when `pip install --pre` started being used. The nightly wheels from https://pypi.anaconda.org/scientific-python-nightly-wheels/simple are a lot more up to date than those on the default PyPI index.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
