### PR TITLE
Figure.image: Add alias "bitcolor" for "G"

### DIFF
--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -11,6 +11,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     J="projection",
     D="position",
     F="box",
+    G="bit_color",
     M="monochrome",
     V="verbose",
     c="panel",

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -52,6 +52,12 @@ def image(self, imagefile, **kwargs):
         using :gmt-term:`MAP_FRAME_PEN`.
     bit_color : str
         [*color*][**+b**\|\ **f**\|\ **t**]
+        Change certain pixel values to another color or make them transparent.
+        For 1-bit images you can specify an alternate *color* for the
+        background (**+b**) or the foreground (**+f**) pixels, or give no color
+        to make those pixels transparent. Alternatively, for color images you
+        can select a single *color* that should be made transparent instead
+        (**+t**). This option may be repeated with different settings.
     monochrome : bool
         Convert color image to monochrome grayshades using the (television)
         YIQ-transformation.

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -55,9 +55,9 @@ def image(self, imagefile, **kwargs):
         Change certain pixel values to another color or make them transparent.
         For 1-bit images you can specify an alternate *color* for the
         background (**+b**) or the foreground (**+f**) pixels, or give no color
-        to make those pixels transparent. Alternatively, for color images you
-        can select a single *color* that should be made transparent instead
-        (**+t**). Can be repeated with different settings.
+        to make those pixels transparent. Can be repeated with different
+        settings. Alternatively, for color images you can select a single
+        *color* that should be made transparent instead (**+t**).
     monochrome : bool
         Convert color image to monochrome grayshades using the (television)
         YIQ-transformation.

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -11,7 +11,7 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
     J="projection",
     D="position",
     F="box",
-    G="bit_color",
+    G="bitcolor",
     M="monochrome",
     V="verbose",
     c="panel",
@@ -50,7 +50,7 @@ def image(self, imagefile, **kwargs):
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
         If set to ``True``, draw a rectangular border around the image
         using :gmt-term:`MAP_FRAME_PEN`.
-    bit_color : str
+    bitcolor : str
         [*color*][**+b**\|\ **f**\|\ **t**]
         Change certain pixel values to another color or make them transparent.
         For 1-bit images you can specify an alternate *color* for the

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -50,7 +50,7 @@ def image(self, imagefile, **kwargs):
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
         If set to ``True``, draw a rectangular border around the image
         using :gmt-term:`MAP_FRAME_PEN`.
-    bitcolor : str
+    bitcolor : str or list
         [*color*][**+b**\|\ **f**\|\ **t**].
         Change certain pixel values to another color or make them transparent.
         For 1-bit images you can specify an alternate *color* for the

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -57,7 +57,7 @@ def image(self, imagefile, **kwargs):
         background (**+b**) or the foreground (**+f**) pixels, or give no color
         to make those pixels transparent. Alternatively, for color images you
         can select a single *color* that should be made transparent instead
-        (**+t**).
+        (**+t**). Can be repeated with different settings.
     monochrome : bool
         Convert color image to monochrome grayshades using the (television)
         YIQ-transformation.

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -7,12 +7,12 @@ from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, us
 
 @fmt_docstring
 @use_alias(
-    R="region",
-    J="projection",
     D="position",
     F="box",
     G="bitcolor",
+    J="projection",
     M="monochrome",
+    R="region",
     V="verbose",
     c="panel",
     p="perspective",

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -57,7 +57,7 @@ def image(self, imagefile, **kwargs):
         background (**+b**) or the foreground (**+f**) pixels, or give no color
         to make those pixels transparent. Alternatively, for color images you
         can select a single *color* that should be made transparent instead
-        (**+t**). This option may be repeated with different settings.
+        (**+t**).
     monochrome : bool
         Convert color image to monochrome grayshades using the (television)
         YIQ-transformation.

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -50,6 +50,8 @@ def image(self, imagefile, **kwargs):
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].
         If set to ``True``, draw a rectangular border around the image
         using :gmt-term:`MAP_FRAME_PEN`.
+    bit_color : str
+        [*color*][**+b**\|\ **f**\|\ **t**]
     monochrome : bool
         Convert color image to monochrome grayshades using the (television)
         YIQ-transformation.

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -51,7 +51,7 @@ def image(self, imagefile, **kwargs):
         If set to ``True``, draw a rectangular border around the image
         using :gmt-term:`MAP_FRAME_PEN`.
     bitcolor : str
-        [*color*][**+b**\|\ **f**\|\ **t**]
+        [*color*][**+b**\|\ **f**\|\ **t**].
         Change certain pixel values to another color or make them transparent.
         For 1-bit images you can specify an alternate *color* for the
         background (**+b**) or the foreground (**+f**) pixels, or give no color


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to add the alias `bitcolor` for **G** of the method `pygmt.Figure.image`.
Following the Code Style, no underscore is used (please see https://www.pygmt.org/dev/contributing.html#contributing-code). However, the GMTjl documentation uses an underscore, i.e., `bit_color` (please see https://www.generic-mapping-tools.org/GMTjl_doc/documentation/modules/image/index.html#imag).

**Upstream GMT documentation**: https://docs.generic-mapping-tools.org/dev/image.html#g

**Preview**: https://pygmt-dev--2615.org.readthedocs.build/en/2615/api/generated/pygmt.Figure.image.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
