### PR TITLE
pygmt.grdfill: Add alias "no_data" for "N"

### DIFF
--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -53,6 +53,9 @@ def grdfill(grid, **kwargs):
         where (*X,Y*) are the node dimensions of the grid]), or
         **s** for bicubic spline (optionally append a *tension*
         parameter [Default is no tension]).
+    no_data : int or float
+        Set the node value used to identify a point as a member of a hole
+        [Default is NaN].
 
     {region}
     {verbose}

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -20,6 +20,7 @@ __doctest_skip__ = ["grdfill"]
 @use_alias(
     A="mode",
     G="outgrid",
+    N="no_data",
     R="region",
     V="verbose",
 )

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -29,10 +29,10 @@ def grdfill(grid, **kwargs):
     r"""
     Fill blank areas from a grid file.
 
-    Read a grid that presumably has unfilled holes that the user
-    wants to fill in some fashion. Holes are identified by NaN values but
-    this criteria can be changed. There are several different algorithms that
-    can be used to replace the hole values.
+    Read a grid that presumably has unfilled holes that the user wants to
+    fill in some fashion. Holes are identified by NaN values but this
+    criteria can be changed via the `no_data` parameter. There are several
+    different algorithms that can be used to replace the hole values.
 
     Full option list at :gmt-docs:`grdfill.html`
 

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -31,7 +31,7 @@ def grdfill(grid, **kwargs):
 
     Read a grid that presumably has unfilled holes that the user wants to
     fill in some fashion. Holes are identified by NaN values but this
-    criteria can be changed via the `no_data` parameter. There are several
+    criteria can be changed via the ``no_data`` parameter. There are several
     different algorithms that can be used to replace the hole values.
 
     Full option list at :gmt-docs:`grdfill.html`


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to add the alias `no_data`  for **N** of [`pygmt.grdfill`](https://www.pygmt.org/dev/api/generated/pygmt.grdfill.html). Following the Code Style (please see https://www.pygmt.org/dev/contributing.html#code-style) an underscore is used, despite the Julia documentation uses `nodata` (please see https://www.generic-mapping-tools.org/GMTjl_doc/documentation/modules/grdfill/index.html#grdfill).


**Upstream GMT documentation**: https://docs.generic-mapping-tools.org/dev/grdfill.html#n

**Preview**:  https://pygmt-dev--2618.org.readthedocs.build/en/2618/api/generated/pygmt.grdfill.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
