### PR TITLE
Use consistently "netCDF"

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -67,7 +67,7 @@ the problem:
   where `<test>` is the name of your test script. Note that this script works only with GMT>=6.4
 * If the bug is produced when passing an in-memory data object (e.g., a
   pandas.DataFrame or xarray.DataArray) to a PyGMT function, try writing the
-  data to a file (e.g., a NetCDF or ASCII txt file) and passing the data file
+  data to a file (e.g., a netCDF or ASCII txt file) and passing the data file
   to the PyGMT function instead. In the GitHub issue, please share the results
   for both cases along with your code.
 

--- a/examples/gallery/images/track_sampling.py
+++ b/examples/gallery/images/track_sampling.py
@@ -10,7 +10,7 @@ x and y (or longitude and latitude). Note also that there is a ``newcolname``
 parameter that will be used to name the new column of values sampled from the
 grid.
 
-Alternatively, a NetCDF file path can be passed to ``grid``. An ASCII file path
+Alternatively, a netCDF file path can be passed to ``grid``. An ASCII file path
 can also be accepted for ``points``. To save an output ASCII file, a file name
 argument needs to be passed to the ``outfile`` parameter.
 """

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -124,7 +124,7 @@ def grdfilter(grid, **kwargs):
     >>> import os
     >>> import pygmt
     >>> # Apply a filter of 600 km (full width) to the @earth_relief_30m_g file
-    >>> # and return a filtered field (saved as NetCDF)
+    >>> # and return a filtered field (saved as netCDF)
     >>> pygmt.grdfilter(
     ...     grid="@earth_relief_30m_g",
     ...     filter="m600",

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -68,7 +68,7 @@ def grdtrack(grid, points=None, newcolname=None, outfile=None, **kwargs):
     Parameters
     ----------
     grid : xarray.DataArray or str
-        Gridded array from which to sample values from, or a file name (netcdf
+        Gridded array from which to sample values from, or a file name (netCDF
         format).
 
     points : str or {table-like}

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -93,7 +93,7 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
         close to a node.
 
     outgrid : str
-        Optional. The file name for the output netcdf file with extension .nc
+        Optional. The file name for the output netCDF file with extension .nc
         to store the grid in.
 
     empty : str

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -86,7 +86,7 @@ def surface(data=None, x=None, y=None, z=None, **kwargs):
     {region}
 
     outgrid : str
-        Optional. The file name for the output netcdf file with extension .nc
+        Optional. The file name for the output netCDF file with extension .nc
         to store the grid in.
     convergence : float
         Optional. Convergence limit. Iteration is assumed to have converged

--- a/pygmt/tests/test_clib_put_matrix.py
+++ b/pygmt/tests/test_clib_put_matrix.py
@@ -66,7 +66,7 @@ def test_put_matrix_fails():
 
 def test_put_matrix_grid(dtypes):
     """
-    Check that assigning a numpy 2-D array to an ASCII and NetCDF grid works.
+    Check that assigning a numpy 2-D array to an ASCII and netCDF grid works.
     """
     wesn = [10, 15, 30, 40, 0, 0]
     inc = [1, 1]

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -25,7 +25,7 @@ def fixture_grid_360(grid):
     180).
     """
     _grid = grid.copy()  # get a copy of original earth_relief grid
-    _grid.encoding.pop("source")  # unlink earth_relief NetCDF source
+    _grid.encoding.pop("source")  # unlink earth_relief netCDF source
     _grid["lon"] = np.arange(0, 361, 1)  # convert longitude from -180:180 to 0:360
     return _grid
 
@@ -212,7 +212,7 @@ def test_grdimage_central_meridians(grid, proj_type, lon0):
     return fig_ref, fig_test
 
 
-# Cylindrical Equidistant (Q) projections plotted with xarray and NetCDF grids
+# Cylindrical Equidistant (Q) projections plotted with xarray and netCDF grids
 # are still slightly different with an RMS error of 25, see issue at
 # https://github.com/GenericMappingTools/pygmt/issues/390
 # TO-DO remove tol=1.5 and pytest.mark.xfail once bug is solved in upstream GMT

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -80,7 +80,7 @@ def test_grdtrack_input_csvfile_and_dataarray(dataarray, expected_array):
 
 def test_grdtrack_input_dataframe_and_ncfile(dataframe, expected_array):
     """
-    Run grdtrack by passing in a pandas.DataFrame and netcdf file as inputs.
+    Run grdtrack by passing in a pandas.DataFrame and netCDF file as inputs.
     """
     output = grdtrack(
         points=dataframe, grid="@static_earth_relief.nc", newcolname="bathymetry"
@@ -92,7 +92,7 @@ def test_grdtrack_input_dataframe_and_ncfile(dataframe, expected_array):
 
 def test_grdtrack_input_csvfile_and_ncfile_to_dataframe(expected_array):
     """
-    Run grdtrack by passing in a csv file and netcdf file as inputs with a
+    Run grdtrack by passing in a csv file and netCDF file as inputs with a
     pandas.DataFrame output.
     """
     output = grdtrack(points=POINTS_DATA, grid="@static_earth_relief.nc")

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -27,7 +27,7 @@ def fixture_grid():
 @pytest.fixture(scope="module", name="gridfile")
 def fixture_gridfile(grid, region):
     """
-    Load the NetCDF grid file from the sample earth_relief file.
+    Load the netCDF grid file from the sample earth_relief file.
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         grdcut(grid=grid, region=region, outgrid=tmpfile.name)

--- a/pygmt/tests/test_io.py
+++ b/pygmt/tests/test_io.py
@@ -10,7 +10,7 @@ from pygmt.io import load_dataarray
 
 def test_io_load_dataarray():
     """
-    Check that load_dataarray works to read a NetCDF grid with
+    Check that load_dataarray works to read a netCDF grid with
     GMTDataArrayAccessor information loaded.
     """
     with GMTTempFile(suffix=".nc") as tmpfile:

--- a/pygmt/tests/test_nearneighbor.py
+++ b/pygmt/tests/test_nearneighbor.py
@@ -81,6 +81,6 @@ def test_nearneighbor_with_outgrid_param(ship_data):
         assert output is None  # check that output is None since outgrid is set
         assert Path(tmpfile.name).stat().st_size > 0  # check that outgrid exists
         with xr.open_dataarray(tmpfile.name) as grid:
-            assert isinstance(grid, xr.DataArray)  # ensure netcdf grid loads ok
+            assert isinstance(grid, xr.DataArray)  # ensure netCDF grid loads ok
             assert grid.shape == (121, 121)
             npt.assert_allclose(grid.mean(), -2378.2385)


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to use consistently `netCDF` (not `NetCDF` or `netcdf`).
For context please see: https://github.com/GenericMappingTools/pygmt/pull/2617#issuecomment-1663097861

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
