### PR TITLE
Gitignore .flakeheaven_cache folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,12 @@ dist/
 .eggs/
 MANIFEST
 
-# Unit test / coverage reports
+# Unit test / coverage reports / linter cache
 .cache
 .coverage
 coverage.xml
 htmlcov/
+.flakeheaven_cache/
 .pytest_cache/
 results/
 result_images/


### PR DESCRIPTION
**Description of proposed changes**

Flakeheaven 3.3.0 defaults to storing the cache in the working directory, see https://github.com/flakeheaven/flakeheaven/releases/tag/3.3.0.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Noticed that running `make check` locally created a `.flakeheaven_cache/` folder that wasn't gitignored. We could also change the default cache location if desired following https://flakeheaven.readthedocs.io/en/latest/config.html?#cache-settings

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
