### PR TITLE
load_earth_mask: Keep data's encoding to correctly infer data's registration and gtype information

### DIFF
--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -89,4 +89,7 @@ def load_earth_mask(resolution="01d", region=None, registration=None):
         region=region,
         registration=registration,
     )
-    return grid.astype("int8")
+    # `return grid.astype("int8")` doesn't work because grid encoding is lost.
+    # See https://github.com/GenericMappingTools/pygmt/issues/2629.
+    grid.data = grid.data.astype("int8")
+    return grid

--- a/pygmt/tests/test_datasets_earth_mask.py
+++ b/pygmt/tests/test_datasets_earth_mask.py
@@ -54,6 +54,7 @@ def test_earth_mask_01d_with_region():
     assert data.shape == (7, 12)
     assert data.gmt.registration == 0
     assert data.gmt.gtype == 1
+    assert data.dtype == "int8"
     npt.assert_allclose(data.lat, np.arange(13, 20, 1))
     npt.assert_allclose(data.lon, np.arange(-7, 5, 1))
     npt.assert_allclose(data[1, 5], 1)

--- a/pygmt/tests/test_datasets_earth_mask.py
+++ b/pygmt/tests/test_datasets_earth_mask.py
@@ -37,6 +37,7 @@ def test_earth_mask_01d():
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
     assert data.gmt.registration == 0
+    assert data.gmt.gtype == 1
     assert data.dtype == "int8"
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
@@ -52,6 +53,7 @@ def test_earth_mask_01d_with_region():
     data = load_earth_mask(resolution="01d", region=[-7, 4, 13, 19])
     assert data.shape == (7, 12)
     assert data.gmt.registration == 0
+    assert data.gmt.gtype == 1
     npt.assert_allclose(data.lat, np.arange(13, 20, 1))
     npt.assert_allclose(data.lon, np.arange(-7, 5, 1))
     npt.assert_allclose(data[1, 5], 1)


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/GenericMappingTools/pygmt/issues/2629 for the bug report.

The bug is because:

1. In the GMT accessor, we rely on `grid.encoding["source"]` to determine the grid's registration and gtype
2. For the earth_mask dataset, we use `return grid.astype("int8")`. It copies the old xarray object to a new one, converts the new grid's data array to `int8` type and returns the new xarary object. (ref: https://docs.xarray.dev/en/stable/generated/xarray.DataArray.astype.html)
3. During the "int8" conversion, the `grid.encoding` information is lost.

This PR fixes the bug by directly working on the grid's data array. I also updated the test to check if the returned grid has the correct gtype.

Closes https://github.com/GenericMappingTools/pygmt/issues/2629.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
