### PR TITLE
Exclude DVC files from source/binary distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,4 @@ exclude CONTRIBUTING.md
 exclude Makefile
 exclude environment.yml
 exclude requirements.txt
+exclude pygmt/tests/baseline/*.dvc


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/GenericMappingTools/pygmt/issues/1086 for context.

This PR excludes all the `*.dvc` files from the source/binary distributions to reduce the tarball sizes. The source tarball size is reduced from 251K to 238K.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
