### PR TITLE
Figure.image: Deprecate parameter "bit_color" to "bitcolor" (remove in v0.12.0)

### DIFF
--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -4,8 +4,8 @@ grdimage - Plot grids or images.
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_string,
-    fmt_docstring,
     deprecate_parameter,
+    fmt_docstring,
     kwargs_to_strings,
     use_alias,
 )

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -14,7 +14,7 @@ __doctest_skip__ = ["grdimage"]
     C="cmap",
     D="img_in",
     E="dpi",
-    G="bit_color",
+    G="bitcolor",
     I="shading",
     J="projection",
     M="monochrome",
@@ -107,7 +107,7 @@ def grdimage(self, grid, **kwargs):
         same size (rows and columns) as the input file. Specify **i** to
         use the PostScript image operator to interpolate the image at the
         device resolution.
-    bit_color : str
+    bitcolor : str
         *color*\ [**+b**\|\ **f**\].
         This parameter only applies when a resulting 1-bit image otherwise
         would consist of only two colors: black (0) and white (255). If so,

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -2,12 +2,19 @@
 grdimage - Plot grids or images.
 """
 from pygmt.clib import Session
-from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
+from pygmt.helpers import (
+    build_arg_string,
+    fmt_docstring,
+    deprecate_parameter,
+    kwargs_to_strings,
+    use_alias,
+)
 
 __doctest_skip__ = ["grdimage"]
 
 
 @fmt_docstring
+@deprecate_parameter("bit_color", "bitcolor", "v0.10.0", remove_version="v0.12.0")
 @use_alias(
     A="img_out",
     B="frame",


### PR DESCRIPTION
**Description of proposed changes**

To follow the Code style and to be consistent with  the similar parameter of [`pygmt.Figure.image`](https://www.pygmt.org/dev/api/generated/pygmt.Figure.image.html#pygmt.Figure.image), this PR aims to deprecate the parameter `bit_color` to `bitcolor` of [`pygmt.Figure.grdimage`](https://www.pygmt.org/dev/api/generated/pygmt.Figure.grdimage.html#pygmt.Figure.grdimage). The `FutureWarning` warning is currently raised for 2 minor releases.

For context see: https://github.com/GenericMappingTools/pygmt/pull/2615#issuecomment-1683393120 and https://github.com/GenericMappingTools/pygmt/pull/2615#issuecomment-1684643810

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
