### PR TITLE
Fix tests for Aug 2023 updated remote datasets

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -12,7 +12,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  pull_request:
+  # pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -12,7 +12,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  # pull_request:
+  pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/pygmt/tests/test_datasets_earth_age.py
+++ b/pygmt/tests/test_datasets_earth_age.py
@@ -40,8 +40,8 @@ def test_earth_age_01d():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), 0.167381, rtol=1e-5)
-    npt.assert_allclose(data.max(), 338.0274, rtol=1e-5)
+    npt.assert_allclose(data.min(), 0.17, atol=0.01)
+    npt.assert_allclose(data.max(), 338.02, atol=0.01)
 
 
 def test_earth_age_01d_with_region():
@@ -53,8 +53,8 @@ def test_earth_age_01d_with_region():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), 11.293945, rtol=1e-5)
-    npt.assert_allclose(data.max(), 125.1189, rtol=1e-5)
+    npt.assert_allclose(data.min(), 11.29, atol=0.01)
+    npt.assert_allclose(data.max(), 125.12, atol=0.01)
 
 
 def test_earth_age_01m_without_region():
@@ -86,5 +86,5 @@ def test_earth_age_01m_default_registration():
     assert data.coords["lat"].data.max() == 5.0
     assert data.coords["lon"].data.min() == -10.0
     assert data.coords["lon"].data.max() == -9.0
-    npt.assert_allclose(data.min(), 88.63)
-    npt.assert_allclose(data.max(), 125.25)
+    npt.assert_allclose(data.min(), 88.63, atol=0.01)
+    npt.assert_allclose(data.max(), 125.25, atol=0.01)

--- a/pygmt/tests/test_datasets_earth_free_air_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_free_air_anomaly.py
@@ -40,8 +40,8 @@ def test_earth_faa_01d():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -275.75)
-    npt.assert_allclose(data.max(), 308.375)
+    npt.assert_allclose(data.min(), -275.85, atol=0.025)
+    npt.assert_allclose(data.max(), 308.35, atol=0.025)
 
 
 def test_earth_faa_01d_with_region():
@@ -53,8 +53,8 @@ def test_earth_faa_01d_with_region():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -58.75)
-    npt.assert_allclose(data.max(), 69.524994)
+    npt.assert_allclose(data.min(), -58.475, atol=0.025)
+    npt.assert_allclose(data.max(), 69.975, atol=0.025)
 
 
 def test_earth_faa_01m_without_region():
@@ -78,5 +78,5 @@ def test_earth_faa_01m_default_registration():
     npt.assert_allclose(data.coords["lat"].data.max(), 4.991666666)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.99166666)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.00833333)
-    npt.assert_allclose(data.min(), -51)
-    npt.assert_allclose(data.max(), 113.675)
+    npt.assert_allclose(data.min(), -49.225, atol=0.025)
+    npt.assert_allclose(data.max(), 115., atol=0.025)

--- a/pygmt/tests/test_datasets_earth_free_air_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_free_air_anomaly.py
@@ -79,4 +79,4 @@ def test_earth_faa_01m_default_registration():
     npt.assert_allclose(data.coords["lon"].data.min(), -9.99166666)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.00833333)
     npt.assert_allclose(data.min(), -49.225, atol=0.025)
-    npt.assert_allclose(data.max(), 115., atol=0.025)
+    npt.assert_allclose(data.max(), 115.0, atol=0.025)

--- a/pygmt/tests/test_datasets_earth_geoid.py
+++ b/pygmt/tests/test_datasets_earth_geoid.py
@@ -40,8 +40,8 @@ def test_earth_geoid_01d():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -106.45)
-    npt.assert_allclose(data.max(), 83.619995)
+    npt.assert_allclose(data.min(), -106.45, atol=0.01)
+    npt.assert_allclose(data.max(), 83.62, atol=0.01)
 
 
 def test_earth_geoid_01d_with_region():
@@ -53,8 +53,8 @@ def test_earth_geoid_01d_with_region():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), 4.87)
-    npt.assert_allclose(data.max(), 29.89)
+    npt.assert_allclose(data.min(), 4.87, atol=0.01)
+    npt.assert_allclose(data.max(), 29.89, atol=0.01)
 
 
 def test_earth_geoid_01m_without_region():
@@ -86,5 +86,5 @@ def test_earth_geoid_01m_default_registration():
     assert data.coords["lat"].data.max() == 5.0
     assert data.coords["lon"].data.min() == -10.0
     assert data.coords["lon"].data.max() == -9.0
-    npt.assert_allclose(data.min(), 20.34)
-    npt.assert_allclose(data.max(), 30.039999)
+    npt.assert_allclose(data.min(), 20.34, atol=0.01)
+    npt.assert_allclose(data.max(), 30.04, atol=0.01)

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -40,7 +40,7 @@ def test_earth_mag_01d():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -384., atol=0.2)
+    npt.assert_allclose(data.min(), -384.0, atol=0.2)
     npt.assert_allclose(data.max(), 1057.2, atol=0.2)
 
 
@@ -92,7 +92,7 @@ def test_earth_mag_02m_default_registration():
     npt.assert_allclose(data.coords["lat"].data.max(), 4.983333333)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.98333333)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.01666667)
-    npt.assert_allclose(data.min(), -231., atol=0.2)
+    npt.assert_allclose(data.min(), -231.0, atol=0.2)
     npt.assert_allclose(data.max(), 131.8, atol=0.2)
 
 
@@ -199,7 +199,7 @@ def test_earth_mag_03m_wdmam_with_region():
     assert data.lon.min() == 10
     assert data.lon.max() == 13
     npt.assert_allclose(data.min(), -790.2, atol=0.2)
-    npt.assert_allclose(data.max(), 528., atol=0.2)
+    npt.assert_allclose(data.max(), 528.0, atol=0.2)
 
 
 def test_earth_mag_03m_wdmam_without_region():

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -40,8 +40,8 @@ def test_earth_mag_01d():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -384)
-    npt.assert_allclose(data.max(), 1057.2)
+    npt.assert_allclose(data.min(), -384., atol=0.2)
+    npt.assert_allclose(data.max(), 1057.2, atol=0.2)
 
 
 def test_earth_mag_01d_with_region():
@@ -53,8 +53,8 @@ def test_earth_mag_01d_with_region():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -180.40002, rtol=1e-5)
-    npt.assert_allclose(data.max(), 127.39996, rtol=1e-5)
+    npt.assert_allclose(data.min(), -180.4, atol=0.2)
+    npt.assert_allclose(data.max(), 127.4, atol=0.2)
 
 
 def test_earth_mag_02m_without_region():
@@ -92,8 +92,8 @@ def test_earth_mag_02m_default_registration():
     npt.assert_allclose(data.coords["lat"].data.max(), 4.983333333)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.98333333)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.01666667)
-    npt.assert_allclose(data.min(), -231)
-    npt.assert_allclose(data.max(), 131.79999)
+    npt.assert_allclose(data.min(), -231., atol=0.2)
+    npt.assert_allclose(data.max(), 131.8, atol=0.2)
 
 
 def test_earth_mag4km_01d():
@@ -109,8 +109,8 @@ def test_earth_mag4km_01d():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -799.19995)
-    npt.assert_allclose(data.max(), 3226.4)
+    npt.assert_allclose(data.min(), -799.2, atol=0.2)
+    npt.assert_allclose(data.max(), 3226.4, atol=0.2)
 
 
 def test_earth_mag4km_01d_with_region():
@@ -126,8 +126,8 @@ def test_earth_mag4km_01d_with_region():
     assert data.shape == (11, 21)
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -153.19995, rtol=1e-5)
-    npt.assert_allclose(data.max(), 113.59985, rtol=1e-5)
+    npt.assert_allclose(data.min(), -153.2, atol=0.2)
+    npt.assert_allclose(data.max(), 113.6, atol=0.2)
 
 
 def test_earth_mag4km_02m_default_registration():
@@ -146,8 +146,8 @@ def test_earth_mag4km_02m_default_registration():
     npt.assert_allclose(data.coords["lat"].data.max(), 5.98333333)
     npt.assert_allclose(data.coords["lon"].data.min(), -114.98333333)
     npt.assert_allclose(data.coords["lon"].data.max(), -112.01666667)
-    npt.assert_allclose(data.min(), -132.80005, rtol=1e-5)
-    npt.assert_allclose(data.max(), 79.59985, rtol=1e-5)
+    npt.assert_allclose(data.min(), -132.8, atol=0.2)
+    npt.assert_allclose(data.max(), 79.6, atol=0.2)
 
 
 def test_earth_mag_01d_wdmam():
@@ -164,8 +164,8 @@ def test_earth_mag_01d_wdmam():
     assert data.shape == (181, 361)
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -773.5)
-    npt.assert_allclose(data.max(), 1751.3)
+    npt.assert_allclose(data.min(), -794.0, atol=0.2)
+    npt.assert_allclose(data.max(), 2169.8, atol=0.2)
 
 
 def test_earth_mag_01d_wdmam_with_region():
@@ -181,8 +181,8 @@ def test_earth_mag_01d_wdmam_with_region():
     assert data.shape == (11, 21)
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -103.900024, rtol=1e-5)
-    npt.assert_allclose(data.max(), 102.19995, rtol=1e-5)
+    npt.assert_allclose(data.min(), -145.6, atol=0.2)
+    npt.assert_allclose(data.max(), 107.6, atol=0.2)
 
 
 def test_earth_mag_03m_wdmam_with_region():
@@ -198,8 +198,8 @@ def test_earth_mag_03m_wdmam_with_region():
     assert data.lat.max() == -58
     assert data.lon.min() == 10
     assert data.lon.max() == 13
-    npt.assert_allclose(data.min(), -639.7001)
-    npt.assert_allclose(data.max(), 629.6)
+    npt.assert_allclose(data.min(), -790.2, atol=0.2)
+    npt.assert_allclose(data.max(), 528., atol=0.2)
 
 
 def test_earth_mag_03m_wdmam_without_region():

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -37,8 +37,8 @@ def test_earth_relief_01d_igpp_synbath(data_source):
     assert data.shape == (181, 361)
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -8600.5)
-    npt.assert_allclose(data.max(), 5559.0)
+    npt.assert_allclose(data.min(), -8600.5, atol=0.5)
+    npt.assert_allclose(data.max(), 5559.0, atol=0.5)
 
 
 @pytest.mark.parametrize("data_source", ["gebco", "gebcosi"])
@@ -69,8 +69,8 @@ def test_earth_relief_01d_with_region_srtm():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -5154)
-    npt.assert_allclose(data.max(), 805.5)
+    npt.assert_allclose(data.min(), -5154, atol=0.5)
+    npt.assert_allclose(data.max(), 805.5, atol=0.5)
 
 
 def test_earth_relief_01d_with_region_gebco():
@@ -99,8 +99,8 @@ def test_earth_relief_30m():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-90, 90.5, 0.5))
     npt.assert_allclose(data.lon, np.arange(-180, 180.5, 0.5))
-    npt.assert_allclose(data.min(), -9454.5)
-    npt.assert_allclose(data.max(), 5887.5)
+    npt.assert_allclose(data.min(), -9454.5, atol=0.5)
+    npt.assert_allclose(data.max(), 5887.5, atol=0.5)
 
 
 def test_earth_gebcosi_15m_with_region():
@@ -117,8 +117,8 @@ def test_earth_gebcosi_15m_with_region():
     assert data.gmt.registration == 1
     npt.assert_allclose(data.lat, np.arange(-87.875, -84, 0.25))
     npt.assert_allclose(data.lon, np.arange(85.125, 87, 0.25))
-    npt.assert_allclose(data.min(), -531)
-    npt.assert_allclose(data.max(), 474)
+    npt.assert_allclose(data.min(), -531, atol=1.0)
+    npt.assert_allclose(data.max(), 474, atol=1.0)
 
 
 def test_earth_relief_30s_synbath():
@@ -244,8 +244,8 @@ def test_earth_relief_15s_default_registration():
     npt.assert_allclose(data.coords["lat"].data.max(), 4.997917)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.997917)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.502083)
-    npt.assert_allclose(data.min(), -3897)
-    npt.assert_allclose(data.max(), -74)
+    npt.assert_allclose(data.min(), -3897, atol=0.5)
+    npt.assert_allclose(data.max(), -74, atol=0.5)
 
 
 def test_earth_relief_03s_default_registration():

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -48,6 +48,10 @@ def test_earth_relief_01d_gebco(data_source):
     data.
     """
     data = load_earth_relief(resolution="01d", data_source=data_source)
+    assert data.attrs["units"] == "meters"
+    assert data.attrs["long_name"] == "Earth elevation relative to the geoid"
+    assert data.attrs["vertical_datum"] == "EGM96"
+    assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -52,8 +52,8 @@ def test_earth_relief_01d_gebco(data_source):
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -8598)
-    npt.assert_allclose(data.max(), 5559.0)
+    npt.assert_allclose(data.min(), -8597.0, atol=1.0)
+    npt.assert_allclose(data.max(), 5559.0, atol=1.0)
 
 
 def test_earth_relief_01d_with_region_srtm():
@@ -86,8 +86,8 @@ def test_earth_relief_01d_with_region_gebco():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -5146)
-    npt.assert_allclose(data.max(), 806)
+    npt.assert_allclose(data.min(), -5151.0, atol=1.0)
+    npt.assert_allclose(data.max(), 806.0, atol=1.0)
 
 
 def test_earth_relief_30m():

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -69,7 +69,7 @@ def test_earth_relief_01d_with_region_srtm():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -5154, atol=0.5)
+    npt.assert_allclose(data.min(), -5151, atol=0.5)
     npt.assert_allclose(data.max(), 805.5, atol=0.5)
 
 
@@ -132,8 +132,8 @@ def test_earth_relief_30s_synbath():
         data_source="synbath",
     )
     assert data.shape == (60, 120)
-    npt.assert_allclose(data.min(), -3552.5)
-    npt.assert_allclose(data.max(), -2154)
+    npt.assert_allclose(data.min(), -3552.5, atol=0.5)
+    npt.assert_allclose(data.max(), -2257.5, atol=0.5)
 
 
 def test_earth_relief_01m_without_region():
@@ -245,7 +245,7 @@ def test_earth_relief_15s_default_registration():
     npt.assert_allclose(data.coords["lon"].data.min(), -9.997917)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.502083)
     npt.assert_allclose(data.min(), -3897, atol=0.5)
-    npt.assert_allclose(data.max(), -74, atol=0.5)
+    npt.assert_allclose(data.max(), -71, atol=0.5)
 
 
 def test_earth_relief_03s_default_registration():
@@ -260,5 +260,5 @@ def test_earth_relief_03s_default_registration():
     npt.assert_allclose(data.coords["lat"].data.max(), 5)
     npt.assert_allclose(data.coords["lon"].data.min(), -10)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.8)
-    npt.assert_allclose(data.min(), -2069.996)
-    npt.assert_allclose(data.max(), -924.0801)
+    npt.assert_allclose(data.min(), -2070.0, atol=0.5)
+    npt.assert_allclose(data.max(), -924.5, atol=0.5)

--- a/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
+++ b/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
@@ -42,8 +42,8 @@ def test_earth_vertical_gravity_gradient_01d():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -137.125, atol=1/32)
-    npt.assert_allclose(data.max(), 104.59375, atol=1/32)
+    npt.assert_allclose(data.min(), -137.125, atol=1 / 32)
+    npt.assert_allclose(data.max(), 104.59375, atol=1 / 32)
     assert data[1, 1].isnull()
 
 
@@ -58,8 +58,8 @@ def test_earth_vertical_gravity_gradient_01d_with_region():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -15.6875, atol=1/32)
-    npt.assert_allclose(data.max(), 19.875, atol=1/32)
+    npt.assert_allclose(data.min(), -15.6875, atol=1 / 32)
+    npt.assert_allclose(data.max(), 19.875, atol=1 / 32)
 
 
 def test_earth_vertical_gravity_gradient_01m_without_region():
@@ -95,5 +95,5 @@ def test_earth_vertical_gravity_gradient_01m_default_registration():
     npt.assert_allclose(data.coords["lat"].data.max(), 4.991666666)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.99166666)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.00833333)
-    npt.assert_allclose(data.min(), -37.5625, atol=1/32)
-    npt.assert_allclose(data.max(), 82.59375, atol=1/32)
+    npt.assert_allclose(data.min(), -37.5625, atol=1 / 32)
+    npt.assert_allclose(data.max(), 82.59375, atol=1 / 32)

--- a/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
+++ b/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
@@ -42,8 +42,8 @@ def test_earth_vertical_gravity_gradient_01d():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -136.34375)
-    npt.assert_allclose(data.max(), 104.59375)
+    npt.assert_allclose(data.min(), -137.125, atol=1/32)
+    npt.assert_allclose(data.max(), 104.59375, atol=1/32)
     assert data[1, 1].isnull()
 
 
@@ -58,8 +58,8 @@ def test_earth_vertical_gravity_gradient_01d_with_region():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -16.34375)
-    npt.assert_allclose(data.max(), 19.78125)
+    npt.assert_allclose(data.min(), -15.6875, atol=1/32)
+    npt.assert_allclose(data.max(), 19.875, atol=1/32)
 
 
 def test_earth_vertical_gravity_gradient_01m_without_region():
@@ -95,5 +95,5 @@ def test_earth_vertical_gravity_gradient_01m_default_registration():
     npt.assert_allclose(data.coords["lat"].data.max(), 4.991666666)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.99166666)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.00833333)
-    npt.assert_allclose(data.min(), -40.25)
-    npt.assert_allclose(data.max(), 81.75)
+    npt.assert_allclose(data.min(), -37.5625, atol=1/32)
+    npt.assert_allclose(data.max(), 82.59375, atol=1/32)


### PR DESCRIPTION
**Description of proposed changes**

Some tests related to the GMT remote datasets are failing due to the recent updates of these datasets (see https://www.generic-mapping-tools.org/remote-datasets/changes.html for a list of these changes). The min/max values of these datasets change slightly in the new versions.

This PR fixes these failing tests by updating the min/max values.

**Notes:**

1. In the tests, we use statements like `npt.assert_allclose(data.min(), -180.40002, rtol=1e-5)` to compare the grid value with the expected value. All datasets have a specific precision (e.g., the `earth_geoid` dataset has a precision of 0.01), thus it makes no sense to compare `earth_geoid` value with a number like `-180.40002` and a relative tolerance of 1.0e-5.  Instead, it makes more sense to compare the value with `-180.4` and an absolute tolerance of 0.01 (the precision of the earth_geoid dataset). I've changed `rtol` to `atol` in all these tests.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
