### PR TITLE
Figure.text: Support non-ASCII characters in the 'text' parameter

### DIFF
--- a/pygmt/helpers/__init__.py
+++ b/pygmt/helpers/__init__.py
@@ -19,4 +19,5 @@ from pygmt.helpers.utils import (
     data_kind,
     is_nonstr_iter,
     launch_external_viewer,
+    non_ascii_to_octal,
 )

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -69,7 +69,7 @@ def text_(
     The text strings passed via the ``text`` parameter can contain ASCII
     characters and non-ASCII characters defined in the ISOLatin1+ encoding
     (i.e., IEC_8859-1), and the Symbol and ZapfDingbats character sets.
-    Ses :gmt-docs:`cookbook/octal-codes.html` for the full list of supported
+    See :gmt-docs:`cookbook/octal-codes.html` for the full list of supported
     non-ASCII characters.
 
     Full option list at :gmt-docs:`text.html`

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -10,6 +10,7 @@ from pygmt.helpers import (
     fmt_docstring,
     is_nonstr_iter,
     kwargs_to_strings,
+    non_ascii_to_octal,
     use_alias,
 )
 
@@ -223,7 +224,9 @@ def text_(
 
     # Append text at last column. Text must be passed in as str type.
     if kind == "vectors":
-        extra_arrays.append(np.atleast_1d(text).astype(str))
+        extra_arrays.append(
+            list(map(non_ascii_to_octal, np.atleast_1d(text).astype(str)))
+        )
 
     with Session() as lib:
         file_context = lib.virtualfile_from_data(

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -231,7 +231,7 @@ def text_(
     # Append text at last column. Text must be passed in as str type.
     if kind == "vectors":
         extra_arrays.append(
-            list(map(non_ascii_to_octal, np.atleast_1d(text).astype(str)))
+            np.vectorize(non_ascii_to_octal)(np.atleast_1d(text).astype(str))
         )
 
     with Session() as lib:

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -66,6 +66,12 @@ def text_(
     - ``x``/``y``, and ``text``
     - ``position`` and ``text``
 
+    The text strings passed via the ``text`` parameter can contain ASCII
+    characters and non-ASCII characters defined in the ISOLatin1+ encoding
+    (i.e., IEC_8859-1), and the Symbol and ZapfDingbats character sets.
+    Ses :gmt-docs:`cookbook/octal-codes.html` for the full list of supported
+    non-ASCII characters.
+
     Full option list at :gmt-docs:`text.html`
 
     {aliases}

--- a/pygmt/tests/baseline/test_text_nonascii.png.dvc
+++ b/pygmt/tests/baseline/test_text_nonascii.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 75db22909db0fbdb2a31edab357ed8b9
-  size: 16418
+- md5: fd8e9b79cd847837464c244563eb5d1a
+  size: 17341
   hash: md5
   path: test_text_nonascii.png

--- a/pygmt/tests/baseline/test_text_nonascii.png.dvc
+++ b/pygmt/tests/baseline/test_text_nonascii.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: fd8e9b79cd847837464c244563eb5d1a
-  size: 17341
+- md5: aca7c6732bc8410a6299582a2bf3b997
+  size: 17350
   hash: md5
   path: test_text_nonascii.png

--- a/pygmt/tests/baseline/test_text_nonascii.png.dvc
+++ b/pygmt/tests/baseline/test_text_nonascii.png.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 75db22909db0fbdb2a31edab357ed8b9
+  size: 16418
+  hash: md5
+  path: test_text_nonascii.png

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -382,5 +382,5 @@ def test_text_nonascii():
     fig.basemap(region=[0, 10, 0, 10], projection="X10c", frame=True)
     fig.text(position="TL", text="position-text:°α")
     fig.text(x=1, y=1, text="xytext:°α")
-    fig.text(x=[5, 5], y=[3, 5], text=["xytext1:°α", "xytext2:°α"])
+    fig.text(x=[5, 5], y=[3, 5], text=["xytext1:αζΔ❡", "xytext2:∑π∇✉"])
     return fig

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -371,3 +371,16 @@ def test_text_nonstr_text():
         text=[1, 2, 3.0, 4.0],
     )
     return fig
+
+
+@pytest.mark.mpl_image_compare
+def test_text_nonascii():
+    """
+    Test passing text strings with non-ascii characters.
+    """
+    fig = Figure()
+    fig.basemap(region=[0, 10, 0, 10], projection="X10c", frame=True)
+    fig.text(position="TL", text="position-text:°α")
+    fig.text(x=1, y=1, text="xytext:°α")
+    fig.text(x=[5, 5], y=[3, 5], text=["xytext1:°α", "xytext2:°α"])
+    return fig


### PR DESCRIPTION
**Description of proposed changes**

Address https://github.com/GenericMappingTools/pygmt/issues/2204 following #2584.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
