### PR TITLE
Add gallery example for plotting an RGB image from an xarray.DataArray

### DIFF
--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -3,7 +3,7 @@ RGB Image
 ---------
 The :meth:`pygmt.Figure.grdimage` method can be used to plot Red, Green, Blue
 (RGB) images, or any 3-band false color combination. Here, we'll use
-:meth:`rioxarray.open_rasterio` to read a GeoTIFF file into an
+:py:func:`rioxarray.open_rasterio` to read a GeoTIFF file into an
 :class:`xarray.DataArray` format, and plot it on a map.
 
 The example below shows a Worldview 2 satellite image over
@@ -17,23 +17,24 @@ import pygmt
 import rioxarray
 
 ###############################################################################
-# Read 3-band data from GeoTIFF into an xarray.DataArray object
+# Read 3-band data from GeoTIFF into an xarray.DataArray object:
 with rioxarray.open_rasterio(
     filename="https://oin-hotosm.s3.us-east-1.amazonaws.com/64d6a49a19cb3a000147a65b/0/64d6a49a19cb3a000147a65c.tif",
     overview_level=5,
 ) as img:
     # Subset to area of Lāhainā in EPSG:32604 coordinates
     image = img.rio.clip_box(minx=738000, maxx=755000, miny=2300000, maxy=2318000)
-    image = image.load()  # force loading dataarray into memory
+    image = image.load()  # Force loading the DataArray into memory
 image
 
 ###############################################################################
-# Plot the RGB imagery
+# Plot the RGB imagery:
 fig = pygmt.Figure()
 with pygmt.config(FONT_TITLE="Times-Roman"):  # Set title font to Times-Roman
     fig.grdimage(
         grid=image,
-        projection="x1:100000",  # map scale where 1 cm on map equals 1 km on the ground
+        # Use a map scale where 1 cm on the map equals 1 km on the ground
+        projection="x1:100000", 
         frame=[r"WSne+tL@!a¯hain@!a¯, Hawai`i on 9 Aug 2023", "af"],
     )
 fig.show()

--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -1,0 +1,37 @@
+"""
+RGB Image
+---------
+The :meth:`pygmt.Figure.grdimage` method can be used to plot Red, Green, Blue
+(RGB) images, or any 3-band false color combination. Here, we'll use
+:meth:`rioxarray.open_rasterio` to read a GeoTIFF file into an
+:class:`xarray.DataArray` format, and plot it on a map.
+
+The example below shows a Worldview 2 satellite image over
+`Lāhainā, Hawai'i during the August 2023 wildfires
+<https://en.wikipedia.org/wiki/2023_Hawaii_wildfires#L%C4%81hain%C4%81>`_.
+Data is sourced from a Cloud-Optimized GeoTIFF file hosted on
+`OpenAerialMap <https://map.openaerialmap.org>`_ under a
+`CC BY-NC 4.0 <https://creativecommons.org/licenses/by-nc/4.0/>`_ license.
+"""
+import pygmt
+import rioxarray
+
+###############################################################################
+# Read 3-band data from GeoTIFF into an xarray.DataArray object
+image = rioxarray.open_rasterio(
+    filename="https://oin-hotosm.s3.us-east-1.amazonaws.com/64d6a49a19cb3a000147a65b/0/64d6a49a19cb3a000147a65c.tif",
+    overview_level=5,
+)
+# Subset to area of Lāhainā in EPSG:32604 coordinates
+image = image.rio.clip_box(minx=738000, maxx=755000, miny=2300000, maxy=2318000)
+image
+
+###############################################################################
+# Plot the RGB imagery
+fig = pygmt.Figure()
+fig.grdimage(
+    grid=image,
+    projection="x1:100000",
+    frame=[r"WSne+tL@!a\225hain@!a\225, Hawai\047i on 9 Aug 2023", "af"],
+)
+fig.show()

--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -32,7 +32,7 @@ fig = pygmt.Figure()
 with pygmt.config(FONT_TITLE="Times-Roman"):  # Set title font to Times-Roman
     fig.grdimage(
         grid=image,
-        projection="x1:100000",
+        projection="x1:100000",  # map scale where 1 cm on map equals 1 km on the ground
         frame=[r"WSne+tL@!a\225hain@!a\225, Hawai\140i on 9 Aug 2023", "af"],
     )
 fig.savefig("Lāhainā.png")

--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -29,9 +29,11 @@ image
 ###############################################################################
 # Plot the RGB imagery
 fig = pygmt.Figure()
-fig.grdimage(
-    grid=image,
-    projection="x1:100000",
-    frame=[r"WSne+tL@!a\225hain@!a\225, Hawai\047i on 9 Aug 2023", "af"],
-)
+with pygmt.config(FONT_TITLE="Times-Roman"):  # Set title font to Times-Roman
+    fig.grdimage(
+        grid=image,
+        projection="x1:100000",
+        frame=[r"WSne+tL@!a\225hain@!a\225, Hawai\047i on 9 Aug 2023", "af"],
+    )
+fig.savefig("Lāhainā.png")
 fig.show()

--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -18,12 +18,13 @@ import rioxarray
 
 ###############################################################################
 # Read 3-band data from GeoTIFF into an xarray.DataArray object
-image = rioxarray.open_rasterio(
+with rioxarray.open_rasterio(
     filename="https://oin-hotosm.s3.us-east-1.amazonaws.com/64d6a49a19cb3a000147a65b/0/64d6a49a19cb3a000147a65c.tif",
     overview_level=5,
-)
-# Subset to area of Lāhainā in EPSG:32604 coordinates
-image = image.rio.clip_box(minx=738000, maxx=755000, miny=2300000, maxy=2318000)
+) as img:
+    # Subset to area of Lāhainā in EPSG:32604 coordinates
+    image = img.rio.clip_box(minx=738000, maxx=755000, miny=2300000, maxy=2318000)
+    image = image.load()  # force loading dataarray into memory
 image
 
 ###############################################################################

--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -7,7 +7,7 @@ The :meth:`pygmt.Figure.grdimage` method can be used to plot Red, Green, Blue
 :class:`xarray.DataArray` format, and plot it on a map.
 
 The example below shows a Worldview 2 satellite image over
-`Lāhainā, Hawai'i during the August 2023 wildfires
+`Lāhainā, Hawaiʻi during the August 2023 wildfires
 <https://en.wikipedia.org/wiki/2023_Hawaii_wildfires#L%C4%81hain%C4%81>`_.
 Data is sourced from a Cloud-Optimized GeoTIFF (COG) file hosted on
 `OpenAerialMap <https://map.openaerialmap.org>`_ under a
@@ -33,7 +33,7 @@ with pygmt.config(FONT_TITLE="Times-Roman"):  # Set title font to Times-Roman
     fig.grdimage(
         grid=image,
         projection="x1:100000",
-        frame=[r"WSne+tL@!a\225hain@!a\225, Hawai\047i on 9 Aug 2023", "af"],
+        frame=[r"WSne+tL@!a\225hain@!a\225, Hawai\140i on 9 Aug 2023", "af"],
     )
 fig.savefig("Lāhainā.png")
 fig.show()

--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -9,7 +9,7 @@ The :meth:`pygmt.Figure.grdimage` method can be used to plot Red, Green, Blue
 The example below shows a Worldview 2 satellite image over
 `Lāhainā, Hawai'i during the August 2023 wildfires
 <https://en.wikipedia.org/wiki/2023_Hawaii_wildfires#L%C4%81hain%C4%81>`_.
-Data is sourced from a Cloud-Optimized GeoTIFF file hosted on
+Data is sourced from a Cloud-Optimized GeoTIFF (COG) file hosted on
 `OpenAerialMap <https://map.openaerialmap.org>`_ under a
 `CC BY-NC 4.0 <https://creativecommons.org/licenses/by-nc/4.0/>`_ license.
 """

--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -33,7 +33,6 @@ with pygmt.config(FONT_TITLE="Times-Roman"):  # Set title font to Times-Roman
     fig.grdimage(
         grid=image,
         projection="x1:100000",  # map scale where 1 cm on map equals 1 km on the ground
-        frame=[r"WSne+tL@!a\225hain@!a\225, Hawai\140i on 9 Aug 2023", "af"],
+        frame=[r"WSne+tL@!a¯hain@!a¯, Hawai`i on 9 Aug 2023", "af"],
     )
-fig.savefig("Lāhainā.png")
 fig.show()

--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -34,7 +34,7 @@ with pygmt.config(FONT_TITLE="Times-Roman"):  # Set title font to Times-Roman
     fig.grdimage(
         grid=image,
         # Use a map scale where 1 cm on the map equals 1 km on the ground
-        projection="x1:100000", 
+        projection="x1:100000",
         frame=[r"WSne+tL@!a¯hain@!a¯, Hawai`i on 9 Aug 2023", "af"],
     )
 fig.show()


### PR DESCRIPTION
**Description of proposed changes**

Gallery example using `pygmt.Figure.grdimage` to plot an RGB image from a 3-band GeoTIFF loaded into an `xarray.DataArray` via `rioxarray.open_rasterio`. Example is over Lāhainā, Hawai'i on 9 Aug 2023.

**Preview** at https://pygmt-dev--2641.org.readthedocs.build/en/2641/gallery/images/rgb_image.html

![Worldview 2 satellite image over Lāhainā, Hawai'i on 9 Aug 2023.](https://github.com/GenericMappingTools/pygmt/assets/23487320/3320a0fa-2198-48a5-8901-7604db0e2e70)

Image is sourced from https://map.openaerialmap.org/#/-156.64478302001953,20.89666397351934,11/square/022300003203/64d6ae6619cb3a000147a65f?resolution=high&_k=nh7cia

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Followup from #2590.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [x] If adding new functionality, add an example to docstrings or tutorials.
- [x] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
