### PR TITLE
Expand documentation for Cartesian projections

### DIFF
--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -2,8 +2,9 @@ r"""
 Cartesian linear
 ================
 
-**X**\ *width*[/*height*]: Give the *width* of the figure and the optional
-*height*.
+**X**\ *width*[/*height*] or **x**\ *x-scale*[/*y-scale*]
+
+Give the *width* of the figure and the optional *height*.
 """
 import pygmt
 

--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -11,10 +11,10 @@ an *x-scale* and an optional *y-scale*.
 The Cartesian linear projection is primarily designed for regular
 floating point data. To plot geographical data in a linear
 projection, see the upstream GMT documentation
-:gmt-docs:`Geographic coordinates </cookbook/coordinate-transformations.html#geographic-coordinates>`.
+:gmt-docs:`Geographic coordinates <cookbook/coordinate-transformations.html#geographic-coordinates>`.  # noqa:W505
 To make the linear plot using calendar date/time as the input
 coordinates, see the GMT documentation
-:gmt-docs:`Calendar time coordinates </cookbook/coordinate-transformations.html#calendar-time-coordinates>`.
+:gmt-docs:`Calendar time coordinates <cookbook/coordinate-transformations.html#calendar-time-coordinates>`.  # noqa:W505
 """
 import pygmt
 

--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -6,7 +6,15 @@ Cartesian linear
 
 Give the *width* of the figure and the optional *height*.
 The lower-case version **x** is similar to **X** but expects
-a *x-scale* and an optional *y-scale*.
+an *x-scale* and an optional *y-scale*.
+
+The Cartesian linear projection is primarily designed for regular
+floating point data. To plot geographical data in a linear
+projection, please see the upstream GMT docuemntation at
+https://docs.generic-mapping-tools.org/dev/cookbook/coordinate-transformations.html#geographic-coordinates
+To make the linear plot using calendar date/time as the input
+coordinates, please see the GMT docuemntation at
+https://docs.generic-mapping-tools.org/dev/cookbook/coordinate-transformations.html#calendar-time-coordinates
 """
 import pygmt
 

--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -2,7 +2,7 @@ r"""
 Cartesian linear
 ================
 
-**X**\ *width*[/*height*] or **x**\ *x-scale*[/*y-scale*]
+**X**\ *width*\ [/*height*] or **x**\ *x-scale*\ [/*y-scale*]
 
 Give the *width* of the figure and the optional *height*.
 The lower-case version **x** is similar to **X** but expects

--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -2,7 +2,7 @@ r"""
 Cartesian linear
 ================
 
-**X**\ *width*/[*height*]: Give the *width* of the figure and the optional
+**X**\ *width*[/*height*]: Give the *width* of the figure and the optional
 *height*.
 """
 import pygmt

--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -13,7 +13,7 @@ floating point data. To plot geographical data in a linear
 projection, see the upstream GMT documentation
 :gmt-docs:`Geographic coordinates
 <cookbook/coordinate-transformations.html#geographic-coordinates>`.
-To make the linear plot using calendar date/time as the input
+To make the linear plot using calendar date/time as input
 coordinates, see the GMT documentation
 :gmt-docs:`Calendar time coordinates
 <cookbook/coordinate-transformations.html#calendar-time-coordinates>`.

--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -10,11 +10,11 @@ an *x-scale* and an optional *y-scale*.
 
 The Cartesian linear projection is primarily designed for regular
 floating point data. To plot geographical data in a linear
-projection, please see the upstream GMT docuemntation at
-https://docs.generic-mapping-tools.org/dev/cookbook/coordinate-transformations.html#geographic-coordinates
+projection, see the upstream GMT documentation
+:gmt-docs:`Geographic coordinates </cookbook/coordinate-transformations.html#geographic-coordinates>`.
 To make the linear plot using calendar date/time as the input
-coordinates, please see the GMT docuemntation at
-https://docs.generic-mapping-tools.org/dev/cookbook/coordinate-transformations.html#calendar-time-coordinates
+coordinates, see the GMT documentation
+:gmt-docs:`Calendar time coordinates </cookbook/coordinate-transformations.html#calendar-time-coordinates>`.
 """
 import pygmt
 

--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -11,10 +11,12 @@ an *x-scale* and an optional *y-scale*.
 The Cartesian linear projection is primarily designed for regular
 floating point data. To plot geographical data in a linear
 projection, see the upstream GMT documentation
-:gmt-docs:`Geographic coordinates <cookbook/coordinate-transformations.html#geographic-coordinates>`.  # noqa:W505
+:gmt-docs:`Geographic coordinates
+<cookbook/coordinate-transformations.html#geographic-coordinates>`.
 To make the linear plot using calendar date/time as the input
 coordinates, see the GMT documentation
-:gmt-docs:`Calendar time coordinates <cookbook/coordinate-transformations.html#calendar-time-coordinates>`.  # noqa:W505
+:gmt-docs:`Calendar time coordinates
+<cookbook/coordinate-transformations.html#calendar-time-coordinates>`.
 """
 import pygmt
 

--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -5,6 +5,8 @@ Cartesian linear
 **X**\ *width*[/*height*] or **x**\ *x-scale*[/*y-scale*]
 
 Give the *width* of the figure and the optional *height*.
+The lower-case version **x** is similar to **X** but expects
+a *x-scale* and an optional *y-scale*.
 """
 import pygmt
 

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -7,7 +7,7 @@ Cartesian logarithmic
 
 Give the *width* of the figure and the optional *height*.
 The lower-case version **x** is similar to **X** but expects
-a *x-scale* and an optional *y-scale*.
+an *x-scale* and an optional *y-scale*.
 Each axis with a logarithmic transformation requires **l** after
 its size argument.
 """

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -2,9 +2,12 @@ r"""
 Cartesian logarithmic
 =====================
 
-**X**\ *width*\ [**l**][/*height*\ [**l**]]: Give the *width* of the figure and
-the optional *height*. Each axis with a logarithmic transformation
-requires **l** after its size argument.
+**X**\ *width*\ [**l**][/*height*\ [**l**]] or
+**x**\ *x-scale*\ [**l**][/*y-scale*\ [**l**]]
+
+Give the *width* of the figure and the optional *height*.
+Each axis with a logarithmic transformation requires **l** after
+its size argument.
 """
 import numpy as np
 import pygmt

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -2,7 +2,7 @@ r"""
 Cartesian logarithmic
 =====================
 
-**X**\ *width*\ [**l**]/[*height*\ [**l**]]: Give the *width* of the figure and
+**X**\ *width*\ [**l**][/*height*\ [**l**]]: Give the *width* of the figure and
 the optional *height*. Each axis with a logarithmic transformation
 requires **l** after its size argument.
 """

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -6,6 +6,8 @@ Cartesian logarithmic
 **x**\ *x-scale*\ [**l**][/*y-scale*\ [**l**]]
 
 Give the *width* of the figure and the optional *height*.
+The lower-case version **x** is similar to **X** but expects
+a *x-scale* and an optional *y-scale*.
 Each axis with a logarithmic transformation requires **l** after
 its size argument.
 """

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -2,10 +2,12 @@ r"""
 Cartesian power
 ===============
 
-**X**\ *width*\ [**p**\ *pvalue*][/*height*\ [**p**\ *pvalue*]]: Give the
-*width* of the figure and the optional argument *height*. Each axis with
-a power transformation requires **p** and the exponent for that axis
-after its size argument.
+**X**\ *width*\ [**p**\ *pvalue*][/*height*\ [**p**\ *pvalue*]] or
+**x**\ *x-scale*\ [**p**\ *pvalue*][/*y-scale*\ [**p**\ *pvalue*]]
+
+Give the *width* of the figure and the optional argument *height*.
+Each axis with a power transformation requires **p** and the exponent
+for that axis after its size argument.
 """
 import numpy as np
 import pygmt

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -7,7 +7,7 @@ Cartesian power
 
 Give the *width* of the figure and the optional argument *height*.
 The lower-case version **x** is similar to **X** but expects
-a *x-scale* and an optional *y-scale*.
+an *x-scale* and an optional *y-scale*.
 Each axis with a power transformation requires **p** and the exponent
 for that axis after its size argument.
 """

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -2,7 +2,7 @@ r"""
 Cartesian power
 ===============
 
-**X**\ *width*\ [**p**\ *pvalue*]/[*height*\ [**p**\ *pvalue*]]: Give the
+**X**\ *width*\ [**p**\ *pvalue*][/*height*\ [**p**\ *pvalue*]]: Give the
 *width* of the figure and the optional argument *height*. Each axis with
 a power transformation requires **p** and the exponent for that axis
 after its size argument.

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -6,6 +6,8 @@ Cartesian power
 **x**\ *x-scale*\ [**p**\ *pvalue*][/*y-scale*\ [**p**\ *pvalue*]]
 
 Give the *width* of the figure and the optional argument *height*.
+The lower-case version **x** is similar to **X** but expects
+a *x-scale* and an optional *y-scale*.
 Each axis with a power transformation requires **p** and the exponent
 for that axis after its size argument.
 """


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to expand the documentations of the Cartesian [linear](https://www.pygmt.org/dev/projections/nongeo/cartesian_linear.html), [logarithmic](https://www.pygmt.org/dev/projections/nongeo/cartesian_logarithmic.html), and [power](https://www.pygmt.org/dev/projections/nongeo/cartesian_power.html) projections regarding the scale option.

Currently, the general syntax is repeated for the scale option (lower-case letter version), as we have it for nearly all other projections. Or do we only want to state the width-height version (upper-case letter version), as is currently done for the [polar projection](https://www.pygmt.org/dev/projections/nongeo/polar.html)?

**For context / first mentioned**: https://github.com/GenericMappingTools/pygmt/pull/2641#discussion_r1305791567

**Preview**:
- Cartesian [linear](https://pygmt-dev--2643.org.readthedocs.build/en/2643/projections/nongeo/cartesian_linear.html)
- Cartesian [logarithmic](https://pygmt-dev--2643.org.readthedocs.build/en/2643/projections/nongeo/cartesian_logarithmic.html)
- Cartesian [power](https://pygmt-dev--2643.org.readthedocs.build/en/2643/projections/nongeo/cartesian_power.html)

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
