### PR TITLE
Change create-or-update-comment@v3 parameter reaction-type to reactions

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -54,4 +54,4 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          reaction-type: hooray
+          reactions: hooray


### PR DESCRIPTION
**Description of proposed changes**

Parameter name 'reaction-type' is now 'reactions', see https://github.com/peter-evans/create-or-update-comment/pull/29

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes warning on running `/format` like `Unexpected input(s) 'reaction-type', valid inputs are ['token', 'repository', 'issue-number', 'comment-id', 'body', 'body-path', 'body-file', 'edit-mode', 'append-separator', 'reactions', 'reactions-edit-mode']`, see e.g. https://github.com/GenericMappingTools/pygmt/actions/runs/6006824531


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
