### PR TITLE
Correct the datum of the earth_relief dataset

### DIFF
--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -168,9 +168,9 @@ datasets = {
     "earth_relief": GMTRemoteDataset(
         title="Earth relief",
         name="elevation",
-        long_name="Earth elevation relative to the geoid",
+        long_name="Earth elevation relative to the WGS84 reference ellipsoid",
         units="meters",
-        extra_attributes={"vertical_datum": "EGM96", "horizontal_datum": "WGS84"},
+        extra_attributes={"datum": "WGS84"},
         resolutions={
             "01d": Resolution(["gridline", "pixel"], False),
             "30m": Resolution(["gridline", "pixel"], False),

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -30,9 +30,8 @@ def test_earth_relief_01d_igpp_synbath(data_source):
     data = load_earth_relief(resolution="01d", data_source=data_source)
     assert data.name == "elevation"
     assert data.attrs["units"] == "meters"
-    assert data.attrs["long_name"] == "Earth elevation relative to the geoid"
-    assert data.attrs["vertical_datum"] == "EGM96"
-    assert data.attrs["horizontal_datum"] == "WGS84"
+    assert data.attrs["long_name"] == "Earth elevation relative to the reference ellipsoid"
+    assert data.attrs["datum"] == "WGS84"
     assert data.gmt.registration == 0
     assert data.shape == (181, 361)
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
@@ -49,9 +48,8 @@ def test_earth_relief_01d_gebco(data_source):
     """
     data = load_earth_relief(resolution="01d", data_source=data_source)
     assert data.attrs["units"] == "meters"
-    assert data.attrs["long_name"] == "Earth elevation relative to the geoid"
-    assert data.attrs["vertical_datum"] == "EGM96"
-    assert data.attrs["horizontal_datum"] == "WGS84"
+    assert data.attrs["long_name"] == "Earth elevation relative to the reference ellipsoid"
+    assert data.attrs["datum"] == "WGS84"
     assert data.shape == (181, 361)
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))


### PR DESCRIPTION


earth elvation and bathymetry of earth_relief are relative to ellipsoid, ie. geodetic height or ellipsoidal height.




