### PR TITLE
Use beginning of first paragraph for "tooltip"  by Sphinx Gallery extension

### DIFF
--- a/examples/gallery/basemaps/ternary.py
+++ b/examples/gallery/basemaps/ternary.py
@@ -1,6 +1,7 @@
 """
 Ternary diagram
 ---------------
+
 The :meth:`pygmt.Figure.ternary` method can draw ternary diagrams. The example
 shows how to plot circles with a diameter of 0.1 centimeters
 (``style="c0.1c"``) on a 10-centimeter-wide (``width="10c"``) ternary diagram

--- a/examples/gallery/embellishments/colorbars_multiple.py
+++ b/examples/gallery/embellishments/colorbars_multiple.py
@@ -1,6 +1,7 @@
 """
 Multiple colormaps
 ------------------
+
 This gallery example shows how to create multiple colormaps for different
 subplots. To better understand how GMT modern mode maintains several levels of
 colormaps, please refer to

--- a/examples/gallery/embellishments/timestamp.py
+++ b/examples/gallery/embellishments/timestamp.py
@@ -1,6 +1,7 @@
 """
 Timestamp
 ---------
+
 The :meth:`pygmt.Figure.timestamp` method can draw the GMT timestamp logo on
 the plot. The timestamp will always be shown relative to the bottom-left corner
 of the plot. By default, the ``offset`` and ``justification`` parameters are

--- a/examples/gallery/histograms/blockm.py
+++ b/examples/gallery/histograms/blockm.py
@@ -1,6 +1,7 @@
 """
 Blockmean
 ---------
+
 The :func:`pygmt.blockmean` function calculates different quantities
 inside blocks/bins whose dimensions are defined via the ``spacing`` parameter.
 The following examples show how to calculate the averages of the given values

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -1,6 +1,7 @@
 """
 Histogram
 ---------
+
 The :meth:`pygmt.Figure.histogram` method can plot regular histograms.
 Using the ``series`` parameter allows to set the interval for the width of
 each bar. The type of the histogram (frequency count or percentage) can be

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -1,6 +1,7 @@
 """
 Scatter plot with histograms
 ----------------------------
+
 To create a scatter plot with histograms at the sides of the plot one
 can use :meth:`pygmt.Figure.plot` in combination with
 :meth:`pygmt.Figure.histogram`. The positions of the histograms are plotted

--- a/examples/gallery/images/contours.py
+++ b/examples/gallery/images/contours.py
@@ -1,6 +1,7 @@
 """
 Contours
 --------
+
 The :meth:`pygmt.Figure.contour` method can plot contour lines from a table of
 points by direct triangulation. The data for the triangulation can be provided
 using one of three methods:

--- a/examples/gallery/images/cross_section.py
+++ b/examples/gallery/images/cross_section.py
@@ -1,6 +1,7 @@
 """
 Cross-section along a transect
 ==============================
+
 :func:`pygmt.project` and :func:`pygmt.grdtrack` can be used to focus on
 a quantity and its variation along a desired survey line.
 In this example, the elevation is extracted from a grid provided via

--- a/examples/gallery/images/cross_section.py
+++ b/examples/gallery/images/cross_section.py
@@ -1,6 +1,6 @@
 """
 Cross-section along a transect
-------------------------------
+==============================
 
 :func:`pygmt.project` and :func:`pygmt.grdtrack` can be used to focus on
 a quantity and its variation along a desired survey line.

--- a/examples/gallery/images/cross_section.py
+++ b/examples/gallery/images/cross_section.py
@@ -1,6 +1,6 @@
 """
 Cross-section along a transect
-==============================
+------------------------------
 
 :func:`pygmt.project` and :func:`pygmt.grdtrack` can be used to focus on
 a quantity and its variation along a desired survey line.

--- a/examples/gallery/images/grdclip.py
+++ b/examples/gallery/images/grdclip.py
@@ -1,6 +1,7 @@
 """
 Clipping grid values
 --------------------
+
 The :func:`pygmt.grdclip` function allows to clip defined ranges of grid
 values. In the example shown below we set all elevation values (grid points)
 smaller than 0 m (in general the bathymetric part of the grid) to a common

--- a/examples/gallery/images/grdgradient.py
+++ b/examples/gallery/images/grdgradient.py
@@ -1,6 +1,7 @@
 """
 Calculating grid gradient and radiance
 --------------------------------------
+
 The :func:`pygmt.grdgradient` function calculates the gradient of a grid file.
 In the example shown below we will see how to calculate a hillshade map based
 on a Data Elevation Model (DEM). As input :func:`pygmt.grdgradient` gets

--- a/examples/gallery/images/grdgradient_shading.py
+++ b/examples/gallery/images/grdgradient_shading.py
@@ -1,6 +1,7 @@
 """
 Calculating grid gradient with custom ``azimuth`` and ``normalize`` parameters
 ------------------------------------------------------------------------------
+
 The :func:`pygmt.grdgradient` function calculates the gradient of a grid file.
 As input, :func:`pygmt.grdgradient` gets a :class:`xarray.DataArray` object or
 a path string to a grid file. It then calculates the respective gradient and

--- a/examples/gallery/images/grdlandmask.py
+++ b/examples/gallery/images/grdlandmask.py
@@ -1,6 +1,7 @@
 """
 Create 'wet-dry' mask grid
 --------------------------
+
 The :func:`pygmt.grdlandmask` function allows setting
 all nodes on land or water to a specified value using
 the ``maskvalues`` parameter.

--- a/examples/gallery/images/image.py
+++ b/examples/gallery/images/image.py
@@ -1,6 +1,7 @@
 """
 Images on figures
 -----------------
+
 The :meth:`pygmt.Figure.image` method can be used to read and place an image
 file in many formats (e.g., png, jpg, eps, pdf) on a figure. We must specify
 the filename via the ``imagefile`` parameter or simply use the filename as

--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -1,6 +1,7 @@
 """
 RGB Image
 ---------
+
 The :meth:`pygmt.Figure.grdimage` method can be used to plot Red, Green, Blue
 (RGB) images, or any 3-band false color combination. Here, we'll use
 :py:func:`rioxarray.open_rasterio` to read a GeoTIFF file into an

--- a/examples/gallery/lines/decorated_lines.py
+++ b/examples/gallery/lines/decorated_lines.py
@@ -1,6 +1,7 @@
 """
 Decorated lines
 ---------------
+
 To draw a so-called *decorated line*, i.e., symbols along a line
 or curve, use the ``style`` parameter of the
 :meth:`pygmt.Figure.plot` method with the argument ``"~"`` and the

--- a/examples/gallery/lines/envelope.py
+++ b/examples/gallery/lines/envelope.py
@@ -1,6 +1,7 @@
 """
 Envelope
 --------
+
 The ``close`` parameter of the :meth:`pygmt.Figure.plot` method can be
 used to build a symmetrical or an asymmetrical envelope. The user can
 give either the deviations or the bounds in y-direction. For the first

--- a/examples/gallery/lines/quoted_lines.py
+++ b/examples/gallery/lines/quoted_lines.py
@@ -1,6 +1,7 @@
 """
 Quoted lines
 ------------
+
 To plot a so-called *quoted line*, i.e., labels along a line
 or curve, use the ``style`` parameter of the
 :meth:`pygmt.Figure.plot` method with the argument ``"q"`` and the

--- a/examples/gallery/lines/roads.py
+++ b/examples/gallery/lines/roads.py
@@ -1,6 +1,7 @@
 """
 Roads
 -----
+
 The :meth:`pygmt.Figure.plot` method allows us to plot geographical data such
 as lines which are stored in a :class:`geopandas.GeoDataFrame` object. Use
 :func:`geopandas.read_file` to load data from any supported OGR format such as

--- a/examples/gallery/maps/country_polygons.py
+++ b/examples/gallery/maps/country_polygons.py
@@ -1,6 +1,7 @@
 """
 Highlight country, continent and state polygons
 -----------------------------------------------
+
 The :meth:`pygmt.Figure.coast` method can highlight country polygons
 via the ``dcw`` parameter. It accepts the country code or full
 country name and can draw its borders and add a color to its landmass.

--- a/examples/gallery/maps/tilemaps.py
+++ b/examples/gallery/maps/tilemaps.py
@@ -1,6 +1,7 @@
 """
 Tile maps
 ---------
+
 The :meth:`pygmt.Figure.tilemap` method allows to plot
 tiles from a tile server or local file as a basemap or overlay.
 """

--- a/examples/gallery/symbols/bars.py
+++ b/examples/gallery/symbols/bars.py
@@ -1,6 +1,7 @@
 r"""
 Vertical or horizontal bars
 ---------------------------
+
 The :meth:`pygmt.Figure.plot` method can plot vertical (**b**) or
 horizontal (**B**) bars by passing the corresponding shortcut to
 the ``style`` parameter. By default, *base* = 0 meaning that the

--- a/examples/gallery/symbols/points_categorical.py
+++ b/examples/gallery/symbols/points_categorical.py
@@ -1,6 +1,7 @@
 """
 Color points by categories
 ---------------------------
+
 The :meth:`pygmt.Figure.plot` method can be used to plot symbols which are
 color-coded by categories. In the example below, we show how the
 `Palmer Penguins dataset <https://github.com/allisonhorst/palmerpenguins>`__

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -1,6 +1,7 @@
 r"""
 Text symbols
 ------------
+
 The :meth:`pygmt.Figure.plot` method allows to plot text symbols. Text is
 normally placed with the :meth:`pygmt.Figure.text` method but there are times
 we wish to treat a character or even a string as a plottable symbol.

--- a/examples/get_started/03_figure_element.py
+++ b/examples/get_started/03_figure_element.py
@@ -1,6 +1,7 @@
 """
 3. Figure elements
 ==================
+
 The figure below shows the naming of figure elements in PyGMT.
 
 - :meth:`pygmt.Figure()`: having a number of plotting methods. Every new

--- a/examples/tutorials/advanced/cartesian_histograms.py
+++ b/examples/tutorials/advanced/cartesian_histograms.py
@@ -39,6 +39,7 @@ data02 = np.random.normal(mean, stddev * 2, 42)
 ###############################################################################
 # Vertical and horizontal bars
 # ----------------------------
+#
 # To define the width of the bins, the ``series`` parameter has to be
 # specified. The bars can be filled via the ``fill`` parameter with either a
 # color or a pattern (see later in this tutorial). Use the ``pen`` parameter
@@ -95,6 +96,7 @@ fig.show()
 ###############################################################################
 # Stair-steps
 # -----------
+#
 # A stair-step diagram can be created by setting ``stairs=True``. Then only
 # the outer outlines of the bars are drawn, and no internal bars are visible.
 
@@ -137,6 +139,7 @@ fig.show()
 ###############################################################################
 # Counts and frequency percent
 # ----------------------------
+#
 # By default, a histogram showing the counts in each bin is created
 # (``histtype=0``). To show the frequency percent set the ``histtpye``
 # parameter to ``1``. For further options please have a look at the
@@ -181,6 +184,7 @@ fig.show()
 ###############################################################################
 # Cumulative values
 # -----------------
+#
 # To create a histogram showing the cumulative values set ``cumulative=True``.
 # Here, the bars of the cumulative histogram are filled with a pattern via
 # the ``fill`` parameter. Annotate each bar with the counts it represents
@@ -231,6 +235,7 @@ fig.show()
 ###############################################################################
 # Overlaid bars
 # -------------
+#
 # Overlaid or overlapping bars can be achieved by plotting two or serveral
 # histograms, each for one data set, on top of each other. The legend entry
 # can be specified via the ``label`` parameter.
@@ -279,6 +284,7 @@ fig.show()
 ###############################################################################
 # Stacked bars
 # ------------
+#
 # Histograms with stacked bars are not directly supported by PyGMT. Thus,
 # before plotting, combined data sets have to be created from the single data
 # sets. Then, stacked bars can be achieved similar to overlaid bars via
@@ -330,6 +336,7 @@ fig.show()
 ###############################################################################
 # Grouped bars
 # ------------
+#
 # By setting the ``barwidth`` parameter in respect to the values passed to the
 # ``series`` parameter histograms with grouped bars can be created.
 #

--- a/examples/tutorials/advanced/date_time_charts.py
+++ b/examples/tutorials/advanced/date_time_charts.py
@@ -216,6 +216,7 @@ fig.show()
 ###############################################################################
 # Using :class:`numpy.datetime64`
 # -------------------------------
+#
 # In this example, instead of using a :func:`pd.date_range`, ``x`` is
 # initialized as an ``np.array`` object. Similar to :class:`xarray.DataArray`
 # this wraps the dataset before passing it as a parameter. However,

--- a/examples/tutorials/advanced/grid_equalization.py
+++ b/examples/tutorials/advanced/grid_equalization.py
@@ -12,6 +12,7 @@ import pygmt
 ###############################################################################
 # Load sample data
 # ----------------
+#
 # Load the sample Earth relief data for a region around Yosemite valley
 # and use :func:`pygmt.grd2xyz` to create a :class:`pandas.Series` with the
 # z-values.
@@ -24,6 +25,7 @@ grid_dist = pygmt.grd2xyz(grid=grid, output_type="pandas")["elevation"]
 ###############################################################################
 # Plot the original digital elevation model and data distribution
 # ---------------------------------------------------------------
+#
 # For comparison, we will create a map of the original digital elevation
 # model and a histogram showing the distribution of elevation data values.
 
@@ -59,6 +61,7 @@ fig.show()
 ###############################################################################
 # Equalize grid based on a linear distribution
 # --------------------------------------------
+#
 # The :meth:`pygmt.grdhisteq.equalize_grid` method creates a new grid with the
 # z-values representing the position of the original z-values in a given
 # cumulative distribution. By default, it computes the position in a linear
@@ -73,6 +76,7 @@ linear_dist = pygmt.grd2xyz(grid=linear, output_type="pandas")["z"]
 ###############################################################################
 # Calculate the bins used for data transformation
 # -----------------------------------------------
+#
 # The :meth:`pygmt.grdhisteq.compute_bins` method reports statistics about the
 # grid equalization. Here, we report the bins that would linearly divide the
 # original data into 9 divisions with equal area. In our new grid produced by
@@ -85,7 +89,8 @@ pygmt.grdhisteq.compute_bins(grid=grid, divisions=divisions)
 
 ###############################################################################
 # Plot the equally distributed data
-# ---------------------------------------------------------------
+# ---------------------------------
+#
 # Here we create a map showing the grid that has been transformed to
 # have a linear distribution with nine divisions and a histogram of the data
 # values.
@@ -122,6 +127,7 @@ fig.show()
 ###############################################################################
 # Transform grid based on a normal distribution
 # ---------------------------------------------
+#
 # The ``gaussian`` parameter of :meth:`pygmt.grdhisteq.equalize_grid` can be
 # used to transform the z-values relative to their position in a normal
 # distribution rather than a linear distribution. In this case, the output
@@ -133,6 +139,7 @@ normal_dist = pygmt.grd2xyz(grid=normal, output_type="pandas")["z"]
 ###############################################################################
 # Plot the normally distributed data
 # ----------------------------------
+#
 # Here we create a map showing the grid that has been transformed to have
 # a normal distribution and a histogram of the data values.
 
@@ -167,6 +174,7 @@ fig.show()
 ###############################################################################
 # Equalize grid based on a quadratic distribution
 # -----------------------------------------------
+#
 # The ``quadratic`` parameter of :meth:`pygmt.grdhisteq.equalize_grid` can be
 # used to transform the z-values relative to their position in a quadratic
 # distribution rather than a linear distribution. Here, we equalize the grid
@@ -181,6 +189,7 @@ quadratic_dist = pygmt.grd2xyz(grid=quadratic, output_type="pandas")["z"]
 ###############################################################################
 # Calculate the bins used for data transformation
 # -----------------------------------------------
+#
 # We can also use the ``quadratic`` parameter of
 # :meth:`pygmt.grdhisteq.compute_bins` to report the bins used for dividing
 # the grid into 9 divisions based on their position in a quadratic
@@ -191,6 +200,7 @@ pygmt.grdhisteq.compute_bins(grid=grid, divisions=divisions, quadratic=True)
 ###############################################################################
 # Plot the quadratic distribution of data
 # ---------------------------------------
+#
 # Here we create a map showing the grid that has been transformed to have
 # a quadratic distribution and a histogram of the data values.
 

--- a/examples/tutorials/advanced/grid_equalization.py
+++ b/examples/tutorials/advanced/grid_equalization.py
@@ -1,6 +1,7 @@
 """
 Performing grid histogram equalization
 ======================================
+
 The :meth:`pygmt.grdhisteq.equalize_grid` method creates a grid using
 statistics based on a cumulative distribution function.
 """

--- a/examples/tutorials/advanced/subplots.py
+++ b/examples/tutorials/advanced/subplots.py
@@ -90,6 +90,7 @@ fig.show()
 ###############################################################################
 # Making your first subplot
 # -------------------------
+#
 # Next, let's use what we learned above to make a 2 row by 2 column subplot
 # figure. We'll also pick up on some new parameters to configure our subplot.
 
@@ -155,6 +156,7 @@ fig.show()
 ###############################################################################
 # Shared x- and y-axes
 # --------------------
+#
 # In the example above with the four subplots, the two subplots for each row
 # have the same y-axis range, and the two subplots for each column have the
 # same x-axis range. You can use the ``sharex``/``sharey`` parameters to set a

--- a/examples/tutorials/advanced/vectors.py
+++ b/examples/tutorials/advanced/vectors.py
@@ -347,6 +347,7 @@ fig.show()
 ###############################################################################
 # Plot Geographic Vectors
 # -----------------------
+#
 # On this map,
 # ``point_1`` and ``point_2`` are coordinate pairs used to set the
 # start and end points of the geographic vector.

--- a/examples/tutorials/advanced/working_with_panel.py
+++ b/examples/tutorials/advanced/working_with_panel.py
@@ -34,6 +34,7 @@ pn.extension()
 ###############################################################################
 # Make a static map
 # -----------------
+#
 # The `Orthographic projection
 # <https://www.pygmt.org/dev/projections/azim/azim_orthographic.html>`__
 # can be used to show the Earth as a globe. Land and water masses are
@@ -60,6 +61,7 @@ fig.show()
 ###############################################################################
 # Make an interactive map
 # -----------------------
+#
 # To generate a rotation of the Earth around the vertical axis, the central
 # longitude of the Orthographic projection is varied iteratively in steps of
 # 10 degrees. The library ``Panel`` is used to create an interactive dashboard
@@ -97,6 +99,7 @@ pn.Column(slider_lon, view)
 ###############################################################################
 # Add a grid for Earth relief
 # ---------------------------
+#
 # Instead of using colors as fill for the land and water masses a grid can be
 # displayed. Here, the Earth relief is shown by color-coding the elevation.
 

--- a/examples/tutorials/basics/plot.py
+++ b/examples/tutorials/basics/plot.py
@@ -1,6 +1,6 @@
 """
 Plotting data points
-====================
+--------------------
 
 GMT shines when it comes to plotting data on a map. We can use some sample data
 that is packaged with GMT to try this out. PyGMT provides access to these

--- a/examples/tutorials/basics/plot.py
+++ b/examples/tutorials/basics/plot.py
@@ -1,6 +1,6 @@
 """
 Plotting data points
---------------------
+====================
 
 GMT shines when it comes to plotting data on a map. We can use some sample data
 that is packaged with GMT to try this out. PyGMT provides access to these

--- a/examples/tutorials/basics/text.py
+++ b/examples/tutorials/basics/text.py
@@ -39,6 +39,7 @@ fig.show()
 ###############################################################################
 # Changing font style
 # -------------------
+#
 # The size, family/weight, and color of an annotation can be specified using
 # the ``font`` parameter.
 #
@@ -117,6 +118,7 @@ fig.show()
 ###############################################################################
 # ``angle`` parameter
 # -------------------
+#
 # ``angle`` is an optional parameter used to specify the counter-clockwise
 # rotation in degrees of the text from the horizontal.
 


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix an error regarding the link to the GMT China documentation in the gallery example "Cross-section along a transect".

It seems like empty lines within the introduction part of a gallery example impact on what is used by the Sphinx-Gallery extension as text for `tooltip`.
Adding an empty line after the heading changes the text used for `tooltip` to the beginning of the first paragraph. Without any empty line within the introduction part the heading of the gallery example is used for `tooltip`.

_(0) Main branch_  -  `view-source:https://www.pygmt.org/dev/gallery/index.html`
```
</div><div class="sphx-glr-thumbcontainer" tooltip="This example is orientated on an example in the GMT/China documentation: https://docs.gmt-china..."><img alt="" src="../_images/sphx_glr_cross_section_thumb.png" />
<p><a class="reference internal" href="images/cross_section.html#sphx-glr-gallery-images-cross-section-py"><span class="std std-ref">Cross-section along a transect</span></a></p>
  <div class="sphx-glr-thumbnail-title">Cross-section along a transect</div>
```

_(1) Empty line after heading_ 
```
</div><div class="sphx-glr-thumbcontainer" tooltip="pygmt.project and pygmt.grdtrack can be used to focus on a quantity and its variation along a d..."><img alt="Cross-section along a transect" src="../_images/sphx_glr_cross_section_thumb.png" />
<p><a class="reference internal" href="images/cross_section.html#sphx-glr-gallery-images-cross-section-py"><span class="std std-ref">Cross-section along a transect</span></a></p>
  <div class="sphx-glr-thumbnail-title">Cross-section along a transect</div>
```

_(2) No empty lines_
```
</div><div class="sphx-glr-thumbcontainer" tooltip="Cross-section along a transect"><img alt="Cross-section along a transect" src="../_images/sphx_glr_cross_section_thumb.png" />
<p><a class="reference internal" href="images/cross_section.html#sphx-glr-gallery-images-cross-section-py"><span class="std std-ref">Cross-section along a transect</span></a></p>
  <div class="sphx-glr-thumbnail-title">Cross-section along a transect</div>
```

_Output_
| (0) main branch | (1) empty line after heading | (2) no empty lines |
|---|---|---|
| ![crosssection_tooltip_bug](https://github.com/GenericMappingTools/pygmt/assets/94163266/d82d8373-9897-4871-8440-dbb4ed28440d) | ![crosssection_tooltip_fix](https://github.com/GenericMappingTools/pygmt/assets/94163266/2b6d97ce-5734-4057-ad12-1ec17d9fdd4d) | ![crosssection_tooltip_heading](https://github.com/GenericMappingTools/pygmt/assets/94163266/126903bc-7709-417c-969c-dfff0232e0ff) |
| ![crosssection_intro_bug](https://github.com/GenericMappingTools/pygmt/assets/94163266/29b0040f-670f-4bbc-9c4c-47278781f241) | ![crosssection_intro_fix](https://github.com/GenericMappingTools/pygmt/assets/94163266/504e6fc4-bdc1-46fd-a237-93d058192bbf) | ![crosssection_intro_heading](https://github.com/GenericMappingTools/pygmt/assets/94163266/80ae44f3-0593-4e18-ac76-650cc2ce3302) |

So far, this PR contains version (1). Maybe/ if possible we should choose one version and update all gallery examples corresponding to it?

**Fixes**: #2657

**Preview**: 
- [x] Gallery examples: view-source:https://pygmt-dev--2659.org.readthedocs.build/en/2659/gallery/index.html
- [x] Tutorials: view-source:https://pygmt-dev--2659.org.readthedocs.build/en/2659/tutorials/index.html
- [x] Intros: view-source:https://pygmt-dev--2659.org.readthedocs.build/en/2659/get_started/index.html
- [x] Projections: no changes needed

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version






