### PR TITLE
Fix typos in tutorials

### DIFF
--- a/examples/tutorials/advanced/3d_perspective_image.py
+++ b/examples/tutorials/advanced/3d_perspective_image.py
@@ -79,7 +79,7 @@ fig.show()
 # lines on the surface. :meth:`pygmt.Figure.colorbar` can be used to add a
 # color bar to the figure. The ``cmap`` parameter does not need to be passed
 # again. To keep the color bar's alignment similar to the figure, use ``True``
-# as the ``perspective`` parameter.
+# as argument for the ``perspective`` parameter.
 
 fig = pygmt.Figure()
 fig.grdview(

--- a/examples/tutorials/advanced/cartesian_histograms.py
+++ b/examples/tutorials/advanced/cartesian_histograms.py
@@ -231,7 +231,7 @@ fig.show()
 ###############################################################################
 # Overlaid bars
 # -------------
-# Overlaid or overlapping bars can be achieved by plotting two or serveral
+# Overlaid or overlapping bars can be achieved by plotting two or several
 # histograms, each for one data set, on top of each other. The legend entry
 # can be specified via the ``label`` parameter.
 #

--- a/examples/tutorials/advanced/date_time_charts.py
+++ b/examples/tutorials/advanced/date_time_charts.py
@@ -193,9 +193,9 @@ fig.show()
 # initialized as a list of :class:`xarray.DataArray` objects. This object
 # provides a wrapper around regular PyData formats. It also allows the data to
 # have labeled dimensions while supporting operations that use various pieces
-# of metadata.The following code uses :func:`pandas.date_range` object to fill
-# the DataArray with data, but this is not essential for the creation of a
-# valid DataArray.
+# of metadata. The following code uses :func:`pandas.date_range` object to
+# fill the DataArray with data, but this is not essential for the creation of
+# a valid DataArray.
 
 x = xr.DataArray(data=pd.date_range(start="2020-01-01", periods=4, freq="Q"))
 y = [4, 7, 5, 6]

--- a/examples/tutorials/advanced/grid_equalization.py
+++ b/examples/tutorials/advanced/grid_equalization.py
@@ -11,7 +11,7 @@ import pygmt
 ###############################################################################
 # Load sample data
 # ----------------
-# Load the sample Earth relief data for a region around Yosemite valley
+# Load the sample Earth relief data for a region around Yosemite Valley
 # and use :func:`pygmt.grd2xyz` to create a :class:`pandas.Series` with the
 # z-values.
 

--- a/examples/tutorials/advanced/subplots.py
+++ b/examples/tutorials/advanced/subplots.py
@@ -191,7 +191,7 @@ fig.show()
 # Advanced subplot layouts
 # ------------------------
 #
-# Nested subplot are currently not supported. If you want to create more
+# Nested subplots are currently not supported. If you want to create more
 # complex subplot layouts, some manual adjustments are needed.
 #
 # The following example draws three subplots in a 2-row, 2-column layout, with

--- a/examples/tutorials/advanced/subplots.py
+++ b/examples/tutorials/advanced/subplots.py
@@ -124,8 +124,7 @@ fig.show()
 # Notice that each subplot was set to use a linear projection ``"X?"``.
 # Usually, we need to specify the width and height of the map frame, but it is
 # also possible to use a question mark ``"?"`` to let GMT decide automatically
-# on what is the most appropriate width/height for the each subplot's map
-# frame.
+# on what is the most appropriate width/height for each subplot's map frame.
 
 ###############################################################################
 # .. tip::

--- a/examples/tutorials/advanced/vectors.py
+++ b/examples/tutorials/advanced/vectors.py
@@ -13,7 +13,7 @@ import pygmt
 # Plot Cartesian Vectors
 # ----------------------
 #
-# Create a simple Cartesian vector using a starting point through
+# Create a simple Cartesian vector using a start point through
 # ``x``, ``y``, and ``direction`` parameters.
 # On the shown figure, the plot is projected on a 10cm X 10cm region,
 # which is specified by the ``projection`` parameter.
@@ -356,7 +356,7 @@ fig.show()
 # Other styling features such as vector stem thickness and head color
 # can be passed into the ``pen`` and ``fill`` parameters.
 #
-# Note that the **+s** is added to use a startpoint and an endpoint
+# Note that the **+s** is added to use a start point and an end point
 # to represent the vector instead of input angle and length.
 
 point_1 = [-114.7420, 44.0682]
@@ -382,8 +382,8 @@ fig.show()
 
 ###############################################################################
 # Using the same technique shown in the previous example,
-# multiple vectors can be plotted in a chain where the endpoint
-# of one is the starting point of another. This can be done
+# multiple vectors can be plotted in a chain where the end point
+# of one is the start point of another. This can be done
 # by adding the coordinate lists together to create this structure:
 # ``[[start_latitude, start_longitude, end_latitude, end_longitude]]``.
 # Each list within the 2-D list contains the start and end information
@@ -418,7 +418,7 @@ fig.plot(
 fig.show()
 
 ###############################################################################
-# This example plots vectors over a Mercator projection. The starting points
+# This example plots vectors over a Mercator projection. The start points
 # are located at SA which is South Africa and going to four different
 # locations.
 

--- a/examples/tutorials/advanced/vectors.py
+++ b/examples/tutorials/advanced/vectors.py
@@ -112,7 +112,7 @@ fig.show()
 # ``[x_start, y_start, direction_degrees, length]``.
 #
 # If this approach is chosen, the ``data`` parameter must be
-# used instead of ``x``, ``y`` and  ``direction``.
+# used instead of ``x``, ``y``, and ``direction``.
 
 # Create a list of lists that include each vector information
 vectors = [[2, 3, 45, 4]]

--- a/examples/tutorials/advanced/working_with_panel.py
+++ b/examples/tutorials/advanced/working_with_panel.py
@@ -63,7 +63,7 @@ fig.show()
 # To generate a rotation of the Earth around the vertical axis, the central
 # longitude of the Orthographic projection is varied iteratively in steps of
 # 10 degrees. The library ``Panel`` is used to create an interactive dashboard
-# with a slider (works only in a notebook environment, e.g. Jupyter notebook).
+# with a slider (works only in a notebook environment, e.g., Jupyter notebook).
 
 # Create a slider
 slider_lon = pn.widgets.DiscreteSlider(

--- a/examples/tutorials/basics/plot.py
+++ b/examples/tutorials/basics/plot.py
@@ -42,9 +42,9 @@ fig.plot(x=data.longitude, y=data.latitude, style="c0.3c", fill="white", pen="bl
 fig.show()
 
 ###############################################################################
-# We used the style ``c0.3c`` which means "circles of 0.3 centimeters size".
-# The ``pen`` parameter controls the outline of the symbols and the ``fill``
-# parameter controls the fill.
+# We used the style ``c0.3c`` which means "circles with a diameter of 0.3
+# centimeters". The ``pen`` parameter controls the outline of the symbols and
+# the ``fill`` parameter controls the fill.
 #
 # We can map the size of the circles to the earthquake magnitude by passing an
 # array to the ``size`` parameter. Because the magnitude is on a logarithmic

--- a/examples/tutorials/basics/regions.py
+++ b/examples/tutorials/basics/regions.py
@@ -82,7 +82,7 @@ fig.show()
 # the region to the entire globe. The range is 180W to 180E (-180, 180) and 90S
 # to 90N (-90 to 90). With no parameters set for the projection, the figure
 # defaults to be centered at the mid-point of both x- and y-axes. Using
-# **d**\ , the figure is centered at (0, 0), or the intersection of the equator
+# **d**, the figure is centered at (0, 0), or the intersection of the equator
 # and prime meridian.
 
 fig = pygmt.Figure()


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a few typos in several tutorials.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
