### PR TITLE
Fix several typos, detected by codespell

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -106,7 +106,7 @@ sphinx_gallery_conf = {
             "../examples/get_started",
         ]
     ),
-    # Patter to search for example files
+    # Pattern to search for example files
     "filename_pattern": r"\.py",
     # Remove the "Download all examples" button from the top level gallery
     "download_all_examples": False,

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -5,7 +5,7 @@ Scatter plot with histograms
 To create a scatter plot with histograms at the sides of the plot one
 can use :meth:`pygmt.Figure.plot` in combination with
 :meth:`pygmt.Figure.histogram`. The positions of the histograms are plotted
-by offseting them from the main scatter plot figure using
+by offsetting them from the main scatter plot figure using
 :meth:`pygmt.Figure.shift_origin`.
 """
 

--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -94,7 +94,7 @@ class GMTDataArrayAccessor:
     >>> grid2.gmt.registration, grid2.gmt.gtype
     (0, 1)
 
-    Accesing a :class:`xarray.DataArray` from a :class:`xarray.Dataset` always
+    Accessing a :class:`xarray.DataArray` from a :class:`xarray.Dataset` always
     creates new instances, so these properties are always lost. The workaround
     is to assign the :class:`xarray.DataArray` into a variable:
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -248,10 +248,10 @@ def meca(
 
         - *1-D array*: focal mechanism parameters of a single event.
           The meanings of columns are the same as above.
-        - *2-D array*: focal mechanim parameters of multiple events.
+        - *2-D array*: focal mechanism parameters of multiple events.
           The meanings of columns are the same as above.
         - *dictionary or pd.DataFrame*: The dictionary keys or pd.DataFrame
-          column names determine the focal mechanims convention. For
+          column names determine the focal mechanism convention. For
           different conventions, the following combination of keys are allowed:
 
           - ``"aki"``: *strike, dip, rake, magnitude*


### PR DESCRIPTION
These typos are detected by [codespell](https://github.com/codespell-project/codespell).

