### PR TITLE
Use `====` as title unterline in the examples (gallery, tutorials, intro)

### DIFF
--- a/examples/gallery/3d_plots/grdview_surface.py
+++ b/examples/gallery/3d_plots/grdview_surface.py
@@ -1,6 +1,6 @@
 """
 Plotting a surface
-------------------
+==================
 
 The :meth:`pygmt.Figure.grdview()` method can plot 3-D surfaces with
 ``surftype="s"``. Here, we supply the data as an :class:`xarray.DataArray` with

--- a/examples/gallery/3d_plots/scatter3d.py
+++ b/examples/gallery/3d_plots/scatter3d.py
@@ -1,6 +1,6 @@
 """
 3-D Scatter plots
------------------
+=================
 
 The :meth:`pygmt.Figure.plot3d` method can be used to plot symbols in 3-D.
 In the example below, we show how the

--- a/examples/gallery/basemaps/double_y_axes.py
+++ b/examples/gallery/basemaps/double_y_axes.py
@@ -1,6 +1,6 @@
 """
 Double Y axes graph
--------------------
+===================
 
 The ``frame`` parameter of the plotting methods of the :class:`pygmt.Figure`
 class can control which axes should be plotted and optionally show annotations,

--- a/examples/gallery/basemaps/ternary.py
+++ b/examples/gallery/basemaps/ternary.py
@@ -1,6 +1,6 @@
 """
 Ternary diagram
----------------
+===============
 
 The :meth:`pygmt.Figure.ternary` method can draw ternary diagrams. The example
 shows how to plot circles with a diameter of 0.1 centimeters

--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -1,6 +1,6 @@
 r"""
 Colorbar
---------
+========
 
 The :meth:`pygmt.Figure.colorbar` method creates a color scalebar. We must
 specify the colormap via the ``cmap`` parameter, and optionally set the

--- a/examples/gallery/embellishments/colorbars_multiple.py
+++ b/examples/gallery/embellishments/colorbars_multiple.py
@@ -1,6 +1,6 @@
 """
 Multiple colormaps
-------------------
+==================
 
 This gallery example shows how to create multiple colormaps for different
 subplots. To better understand how GMT modern mode maintains several levels of

--- a/examples/gallery/embellishments/inset.py
+++ b/examples/gallery/embellishments/inset.py
@@ -1,6 +1,6 @@
 """
 Inset
------
+=====
 
 The :meth:`pygmt.Figure.inset` method adds an inset figure inside a larger
 figure. The method is called using a ``with`` statement, and its

--- a/examples/gallery/embellishments/inset_rectangle_region.py
+++ b/examples/gallery/embellishments/inset_rectangle_region.py
@@ -1,6 +1,6 @@
 """
 Inset map showing a rectangular region
---------------------------------------
+======================================
 
 The :meth:`pygmt.Figure.inset` method adds an inset figure inside a larger
 figure. The method is called using a ``with`` statement, and its

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -1,6 +1,6 @@
 """
 Legend
-------
+======
 
 The :meth:`pygmt.Figure.legend` method can automatically create a legend for
 symbols plotted using :meth:`pygmt.Figure.plot`. Legend entries are only

--- a/examples/gallery/embellishments/logo.py
+++ b/examples/gallery/embellishments/logo.py
@@ -1,6 +1,6 @@
 """
 Logo
-----
+====
 
 The :meth:`pygmt.Figure.logo` method allows to place the GMT logo on a map.
 """

--- a/examples/gallery/embellishments/solar.py
+++ b/examples/gallery/embellishments/solar.py
@@ -1,6 +1,6 @@
 """
 Day-night terminator line and twilights
----------------------------------------
+=======================================
 
 Use :meth:`pygmt.Figure.solar` to show the different transition stages between
 daytime and nighttime. The parameter ``terminator`` is used to set the twilight

--- a/examples/gallery/embellishments/timestamp.py
+++ b/examples/gallery/embellishments/timestamp.py
@@ -1,6 +1,6 @@
 """
 Timestamp
----------
+=========
 
 The :meth:`pygmt.Figure.timestamp` method can draw the GMT timestamp logo on
 the plot. The timestamp will always be shown relative to the bottom-left corner

--- a/examples/gallery/histograms/blockm.py
+++ b/examples/gallery/histograms/blockm.py
@@ -1,6 +1,6 @@
 """
 Blockmean
----------
+=========
 
 The :func:`pygmt.blockmean` function calculates different quantities
 inside blocks/bins whose dimensions are defined via the ``spacing`` parameter.

--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -1,6 +1,6 @@
 """
 Histogram
----------
+=========
 
 The :meth:`pygmt.Figure.histogram` method can plot regular histograms.
 Using the ``series`` parameter allows to set the interval for the width of

--- a/examples/gallery/histograms/rose.py
+++ b/examples/gallery/histograms/rose.py
@@ -1,6 +1,6 @@
 """
 Rose diagram
-------------
+============
 
 The :meth:`pygmt.Figure.rose` method can plot windrose diagrams or polar
 histograms.

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -1,6 +1,6 @@
 """
 Scatter plot with histograms
-----------------------------
+============================
 
 To create a scatter plot with histograms at the sides of the plot one
 can use :meth:`pygmt.Figure.plot` in combination with

--- a/examples/gallery/images/contours.py
+++ b/examples/gallery/images/contours.py
@@ -1,6 +1,6 @@
 """
 Contours
---------
+========
 
 The :meth:`pygmt.Figure.contour` method can plot contour lines from a table of
 points by direct triangulation. The data for the triangulation can be provided

--- a/examples/gallery/images/grdclip.py
+++ b/examples/gallery/images/grdclip.py
@@ -1,6 +1,6 @@
 """
 Clipping grid values
---------------------
+====================
 
 The :func:`pygmt.grdclip` function allows to clip defined ranges of grid
 values. In the example shown below we set all elevation values (grid points)

--- a/examples/gallery/images/grdgradient.py
+++ b/examples/gallery/images/grdgradient.py
@@ -1,6 +1,6 @@
 """
 Calculating grid gradient and radiance
---------------------------------------
+======================================
 
 The :func:`pygmt.grdgradient` function calculates the gradient of a grid file.
 In the example shown below we will see how to calculate a hillshade map based

--- a/examples/gallery/images/grdgradient_shading.py
+++ b/examples/gallery/images/grdgradient_shading.py
@@ -1,6 +1,6 @@
 """
 Calculating grid gradient with custom ``azimuth`` and ``normalize`` parameters
-------------------------------------------------------------------------------
+==============================================================================
 
 The :func:`pygmt.grdgradient` function calculates the gradient of a grid file.
 As input, :func:`pygmt.grdgradient` gets an :class:`xarray.DataArray` object

--- a/examples/gallery/images/grdlandmask.py
+++ b/examples/gallery/images/grdlandmask.py
@@ -1,6 +1,6 @@
 """
 Create 'wet-dry' mask grid
---------------------------
+==========================
 
 The :func:`pygmt.grdlandmask` function allows setting
 all nodes on land or water to a specified value using

--- a/examples/gallery/images/image.py
+++ b/examples/gallery/images/image.py
@@ -1,6 +1,6 @@
 """
 Images on figures
------------------
+=================
 
 The :meth:`pygmt.Figure.image` method can be used to read and place an image
 file in many formats (e.g., png, jpg, eps, pdf) on a figure. We must specify

--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -1,6 +1,6 @@
 """
 RGB Image
----------
+=========
 
 The :meth:`pygmt.Figure.grdimage` method can be used to plot Red, Green, Blue
 (RGB) images, or any 3-band false color combination. Here, we'll use

--- a/examples/gallery/images/track_sampling.py
+++ b/examples/gallery/images/track_sampling.py
@@ -1,6 +1,6 @@
 """
 Sampling along tracks
----------------------
+=====================
 
 The :func:`pygmt.grdtrack` function samples a raster grid's value along
 specified points. We will need to input a 2-D raster to ``grid`` which can be

--- a/examples/gallery/lines/decorated_lines.py
+++ b/examples/gallery/lines/decorated_lines.py
@@ -1,6 +1,6 @@
 """
 Decorated lines
----------------
+===============
 
 To draw a so-called *decorated line*, i.e., symbols along a line
 or curve, use the ``style`` parameter of the

--- a/examples/gallery/lines/envelope.py
+++ b/examples/gallery/lines/envelope.py
@@ -1,6 +1,6 @@
 """
 Envelope
---------
+========
 
 The ``close`` parameter of the :meth:`pygmt.Figure.plot` method can be
 used to build a symmetrical or an asymmetrical envelope. The user can

--- a/examples/gallery/lines/great_circles.py
+++ b/examples/gallery/lines/great_circles.py
@@ -1,6 +1,6 @@
 """
 Generate points along great circles
------------------------------------
+===================================
 
 The :func:`pygmt.project` function can generate points along a great circle
 whose center and end points can be defined via the ``center`` and ``endpoint``

--- a/examples/gallery/lines/line_custom_cpt.py
+++ b/examples/gallery/lines/line_custom_cpt.py
@@ -1,6 +1,6 @@
 """
 Line colors with a custom CPT
------------------------------
+=============================
 
 The color of the lines made by :meth:`pygmt.Figure.plot` can be set according
 to a custom CPT and assigned with the ``pen`` parameter.

--- a/examples/gallery/lines/linefronts.py
+++ b/examples/gallery/lines/linefronts.py
@@ -1,6 +1,6 @@
 r"""
 Line fronts
------------
+===========
 
 Using the :meth:`pygmt.Figure.plot` method you can draw a so-called
 *front* which allows to plot specific symbols distributed along a line

--- a/examples/gallery/lines/linestyles.py
+++ b/examples/gallery/lines/linestyles.py
@@ -1,6 +1,6 @@
 """
 Line styles
------------
+===========
 
 The :meth:`pygmt.Figure.plot` method can plot lines in different styles.
 The default line style is a 0.25-point wide, black, solid line, and can be

--- a/examples/gallery/lines/quoted_lines.py
+++ b/examples/gallery/lines/quoted_lines.py
@@ -1,6 +1,6 @@
 """
 Quoted lines
-------------
+============
 
 To plot a so-called *quoted line*, i.e., labels along a line
 or curve, use the ``style`` parameter of the

--- a/examples/gallery/lines/roads.py
+++ b/examples/gallery/lines/roads.py
@@ -1,6 +1,6 @@
 """
 Roads
------
+=====
 
 The :meth:`pygmt.Figure.plot` method allows us to plot geographical data such
 as lines which are stored in a :class:`geopandas.GeoDataFrame` object. Use

--- a/examples/gallery/lines/vector_heads_tails.py
+++ b/examples/gallery/lines/vector_heads_tails.py
@@ -1,6 +1,6 @@
 r"""
 Vector heads and tails
-----------------------
+======================
 
 Many methods in PyGMT allow plotting vectors with individual
 heads and tails. For this purpose, several modifiers may be appended to

--- a/examples/gallery/lines/vector_styles.py
+++ b/examples/gallery/lines/vector_styles.py
@@ -1,6 +1,6 @@
 """
 Cartesian, circular, and geographic vectors
--------------------------------------------
+===========================================
 
 The :meth:`pygmt.Figure.plot` method can plot Cartesian, circular, and
 geographic vectors. The ``style`` parameter controls vector attributes.

--- a/examples/gallery/lines/wiggle.py
+++ b/examples/gallery/lines/wiggle.py
@@ -1,6 +1,6 @@
 """
 Wiggle along tracks
--------------------
+===================
 
 The :meth:`pygmt.Figure.wiggle` method can plot z = f(x,y) anomalies along
 tracks. ``x``, ``y``, ``z`` can be specified as 1-D arrays or within a

--- a/examples/gallery/maps/borders.py
+++ b/examples/gallery/maps/borders.py
@@ -1,6 +1,6 @@
 """
 Political Boundaries
---------------------
+====================
 
 The ``borders`` parameter of :meth:`pygmt.Figure.coast` specifies levels of
 political boundaries to plot and the pen used to draw them. Choose from the

--- a/examples/gallery/maps/country_polygons.py
+++ b/examples/gallery/maps/country_polygons.py
@@ -1,6 +1,6 @@
 """
 Highlight country, continent and state polygons
------------------------------------------------
+===============================================
 
 The :meth:`pygmt.Figure.coast` method can highlight country polygons
 via the ``dcw`` parameter. It accepts the country code or full

--- a/examples/gallery/maps/land_and_water.py
+++ b/examples/gallery/maps/land_and_water.py
@@ -1,6 +1,6 @@
 """
 Color land and water
---------------------
+====================
 
 The ``land`` and ``water`` parameters of :meth:`pygmt.Figure.coast` specify
 a color to fill in the land and water masses, respectively. There are many

--- a/examples/gallery/maps/shorelines.py
+++ b/examples/gallery/maps/shorelines.py
@@ -1,6 +1,6 @@
 """
 Shorelines
-----------
+==========
 
 Use :meth:`pygmt.Figure.coast` to display shorelines as black lines.
 """

--- a/examples/gallery/maps/tilemaps.py
+++ b/examples/gallery/maps/tilemaps.py
@@ -1,6 +1,6 @@
 """
 Tile maps
----------
+=========
 
 The :meth:`pygmt.Figure.tilemap` method allows to plot
 tiles from a tile server or local file as a basemap or overlay.

--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -1,6 +1,6 @@
 """
 Focal mechanisms
-----------------
+================
 
 The :meth:`pygmt.Figure.meca` method can plot focal mechanisms or beachballs.
 We can specify the focal mechanism nodal planes or moment tensor components

--- a/examples/gallery/seismology/velo_arrow_ellipse.py
+++ b/examples/gallery/seismology/velo_arrow_ellipse.py
@@ -1,6 +1,6 @@
 """
 Velocity arrows and confidence ellipses
----------------------------------------
+=======================================
 
 The :meth:`pygmt.Figure.velo` method can be used to plot mean velocity arrows
 and confidence ellipses. The example below plots red velocity arrows with

--- a/examples/gallery/symbols/bars.py
+++ b/examples/gallery/symbols/bars.py
@@ -1,6 +1,6 @@
 r"""
 Vertical or horizontal bars
----------------------------
+===========================
 
 The :meth:`pygmt.Figure.plot` method can plot vertical (**b**) or
 horizontal (**B**) bars by passing the corresponding shortcut to

--- a/examples/gallery/symbols/basic_symbols.py
+++ b/examples/gallery/symbols/basic_symbols.py
@@ -1,6 +1,6 @@
 """
 Basic geometric symbols
------------------------
+=======================
 
 The :meth:`pygmt.Figure.plot` method can plot individual geometric symbols
 by passing the corresponding shortcuts to the ``style`` parameter. The 14 basic

--- a/examples/gallery/symbols/custom_symbols.py
+++ b/examples/gallery/symbols/custom_symbols.py
@@ -1,6 +1,6 @@
 """
 Custom symbols
---------------
+==============
 
 The :meth:`pygmt.Figure.plot` method can plot individual custom symbols
 by passing the corresponding symbol name together with the **k** shortcut to

--- a/examples/gallery/symbols/datetime_inputs.py
+++ b/examples/gallery/symbols/datetime_inputs.py
@@ -1,6 +1,6 @@
 """
 Datetime inputs
----------------
+===============
 
 Datetime inputs of the following types are supported in PyGMT:
 

--- a/examples/gallery/symbols/multi_parameter_symbols.py
+++ b/examples/gallery/symbols/multi_parameter_symbols.py
@@ -1,6 +1,6 @@
 """
 Multi-parameter symbols
--------------------------
+=======================
 
 The :meth:`pygmt.Figure.plot` method can plot individual multi-parameter
 symbols by passing the corresponding shortcuts (**e**, **j**, **r**, **R**,

--- a/examples/gallery/symbols/patterns.py
+++ b/examples/gallery/symbols/patterns.py
@@ -1,6 +1,6 @@
 r"""
 Bit and Hachure Patterns
-------------------------
+========================
 
 PyGMT allows using bit or hachure patterns via the ``fill`` parameter
 or similar parameters:

--- a/examples/gallery/symbols/points.py
+++ b/examples/gallery/symbols/points.py
@@ -1,6 +1,6 @@
 """
 Points
-------
+======
 
 The :meth:`pygmt.Figure.plot` method can plot points. The plot symbol and size
 is set with the ``style`` parameter.

--- a/examples/gallery/symbols/points_categorical.py
+++ b/examples/gallery/symbols/points_categorical.py
@@ -1,6 +1,6 @@
 """
 Color points by categories
----------------------------
+==========================
 
 The :meth:`pygmt.Figure.plot` method can be used to plot symbols which are
 color-coded by categories. In the example below, we show how the

--- a/examples/gallery/symbols/points_transparency.py
+++ b/examples/gallery/symbols/points_transparency.py
@@ -1,6 +1,6 @@
 """
 Points with varying transparency
---------------------------------
+================================
 
 Points can be plotted with different transparency levels by passing in an array
 argument to the ``transparency`` parameter of :meth:`pygmt.Figure.plot`.

--- a/examples/gallery/symbols/scatter.py
+++ b/examples/gallery/symbols/scatter.py
@@ -1,6 +1,6 @@
 """
 Scatter plots with a legend
----------------------------
+===========================
 
 To create a scatter plot with a legend one may use a loop and create one
 scatter plot per item to appear in the legend and set the label accordingly.

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -1,6 +1,6 @@
 r"""
 Text symbols
-------------
+============
 
 The :meth:`pygmt.Figure.plot` method allows to plot text symbols. Text is
 normally placed with the :meth:`pygmt.Figure.text` method but there are times

--- a/examples/tutorials/basics/plot.py
+++ b/examples/tutorials/basics/plot.py
@@ -1,6 +1,6 @@
 """
 Plotting data points
---------------------
+====================
 
 GMT shines when it comes to plotting data on a map. We can use some sample data
 that is packaged with GMT to try this out. PyGMT provides access to these


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to use consistently `====` as title underline in the examples of the gallery, tutorials, and intro.

Fixes #2672


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
