### PR TITLE
Update link to GMT docs "Chart of Octal Codes for Characters" (cookbook to reference)

### DIFF
--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -288,7 +288,7 @@ def non_ascii_to_octal(argstr):
     # Adobe ISOLatin1+ charset (i.e., ISO-8859-1 with extensions)
     # References:
     # 1. https://en.wikipedia.org/wiki/ISO/IEC_8859-1
-    # 2. https://docs.generic-mapping-tools.org/dev/cookbook/octal-codes.html
+    # 2. https://docs.generic-mapping-tools.org/dev/reference/octal-codes.html
     # 3. https://www.adobe.com/jp/print/postscript/pdfs/PLRM.pdf
     mapping.update(
         {


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to update the link to the upstream GMT documentation "Chart of Octal Codes for Characters", as `cookbook` was renamed to `reference` in the GMT PR https://github.com/GenericMappingTools/gmt/pull/7786.

Fixes #2679 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
