### PR TITLE
CI: Pin GMT to a specific build on RTD

### DIFF
--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -4,7 +4,7 @@ channels:
     - nodefaults
 dependencies:
     # Required dependencies
-    - gmt=6.4.0
+    - gmt=6.4.0=h4733502_10
     - numpy>=1.22
     - pandas
     - xarray


### PR DESCRIPTION
**Description of proposed changes**

The ReadTheDocs build started to fail recently. For example, in https://github.com/GenericMappingTools/pygmt/pull/2678, build https://readthedocs.org/projects/pygmt-dev/builds/21875786/ succeed but the next build https://readthedocs.org/projects/pygmt-dev/builds/21881327/ failed with the following errors:
```
gmt: error while loading shared libraries: libabsl_cord.so.2301.0.0: cannot open shared object file: No such file or directory
```

Comparing these two builds:
```diff
>   + gtest                                1.14.0  h00ab1b0_1               conda-forge/linux-64     395 KB
85c86
<   + libabseil                        20230125.3  cxx17_h59595ed_0         conda-forge/linux-64       1 MB
---
>   + libabseil                        20230802.0  cxx17_h59595ed_3         conda-forge/linux-64       1 MB
100c101
<   + libgcc-ng                            13.1.0  he5830b7_0               conda-forge/linux-64     758 KB
---
>   + libgcc-ng                            13.2.0  h807b86a_0               conda-forge/linux-64     753 KB
102,107c103,108
<   + libgfortran-ng                       13.1.0  h69a702a_0               conda-forge/linux-64      23 KB
<   + libgfortran5                         13.1.0  h15d22d2_0               conda-forge/linux-64       1 MB
<   + libglib                              2.76.4  hebfc3b9_0               conda-forge/linux-64       3 MB
<   + libgomp                              13.1.0  he5830b7_0               conda-forge/linux-64     409 KB
<   + libgoogle-cloud                      2.12.0  h840a212_1               conda-forge/linux-64      44 MB
<   + libgrpc                              1.56.2  h3905398_1               conda-forge/linux-64       6 MB
---
>   + libgfortran-ng                       13.2.0  h69a702a_0               conda-forge/linux-64      23 KB
>   + libgfortran5                         13.2.0  ha4646dd_0               conda-forge/linux-64       1 MB
>   + libglib                              2.78.0  hebfc3b9_0               conda-forge/linux-64       3 MB
>   + libgomp                              13.2.0  h807b86a_0               conda-forge/linux-64     412 KB
>   + libgoogle-cloud                      2.12.0  h8d7e28b_2               conda-forge/linux-64      44 MB
>   + libgrpc                              1.57.0  ha4d0f93_1               conda-forge/linux-64       6 MB
118c119
<   + libprotobuf                          4.23.3  hd1fb520_1               conda-forge/linux-64       2 MB
---
>   + libprotobuf                          4.23.4  hf27288f_5               conda-forge/linux-64       2 MB
124c125
<   + libstdcxx-ng                         13.1.0  hfd8a6a1_0               conda-forge/linux-64       4 MB
---
>   + libstdcxx-ng                         13.2.0  h7e041cc_0               conda-forge/linux-64       4 MB
254c255
<   + zstd                                  1.5.5  hfc55251_0               conda-forge/linux-64     532 KB
\ No newline at end of file
---
>   + zstd                                  1.5.5  hfc55251_0               conda-forge/linux-64     532 K
```
The main difference is libabseil (20230125.3->20230802.0), which is likely due to the ongoing conda-forge migration https://conda-forge.org/status/#libabseil20230802_libgrpc157_libprotobuf4234.

For unknown reasons, the ReadTheDocs CI is using gmt-6.4.0_hf1dbac9_15 (the latest build) while  the Docs workflow is using gmt-6.4.0_h4733502_10, which still works. Thus, in this PR, we can temporarily pin GMT to the specific build `h4733502_10` to make the RTD CI work again.