### PR TITLE
Fix typos in documentations of datasets

### DIFF
--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -22,9 +22,9 @@ def load_earth_age(resolution="01d", region=None, registration=None):
 
     These grids can also be accessed by passing in the file name
     **@earth_age**\_\ *res*\[_\ *reg*] to any grid plotting/processing
-    function. *res* is the grid resolution (see below), and *reg* is grid
-    registration type (**p** for pixel registration or **g** for gridline
-    registration).
+    function. *res* is the grid resolution (see below), and *reg* is the
+    grid registration type (**p** for pixel registration or **g** for
+    gridline registration).
 
     The default color palette table (CPT) for this dataset is *@earth_age.cpt*.
     It's implicitly used when passing in the file name of the dataset to any

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -21,10 +21,10 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     So you'll need an internet connection the first time around.
 
     These grids can also be accessed by passing in the file name
-    **@earth_age**\_\ *res*\[_\ *reg*] to any grid plotting/processing
-    function. *res* is the grid resolution (see below), and *reg* is the
+    **@earth_age**\_\ *res*\[_\ *reg*] to any grid processing/plotting
+    function/method. *res* is the grid resolution (see below), and *reg* is
     grid registration type (**p** for pixel registration or **g** for
-    gridline registration).
+    the gridline registration).
 
     The default color palette table (CPT) for this dataset is *@earth_age.cpt*.
     It's implicitly used when passing in the file name of the dataset to any

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -30,7 +30,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     It's implicitly used when passing in the file name of the dataset to any
     grid plotting method if no CPT is explicitly specified. When the dataset
     is loaded and plotted as an :class:`xarray.DataArray` object, the default
-    CPT is ignored and GMT's default CPT (*turbo*) is used. To use the
+    CPT is ignored, and GMT's default CPT (*turbo*) is used. To use the
     dataset-specific CPT, you need to explicitly set ``cmap="@earth_age.cpt"``.
 
     Refer to :gmt-datasets:`earth-age.html` for more details.

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -1,6 +1,6 @@
 """
-Function to download the Earth seafloor crustal age dataset from the
-GMT data server, and load as :class:`xarray.DataArray`.
+Function to download the Earth seafloor crustal age dataset from the GMT data
+server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -33,7 +33,8 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     CPT is ignored, and GMT's default CPT (*turbo*) is used. To use the
     dataset-specific CPT, you need to explicitly set ``cmap="@earth_age.cpt"``.
 
-    Refer to :gmt-datasets:`earth-age.html` for more details.
+    Refer to :gmt-datasets:`earth-age.html` for more details about available
+    datasets, including version information and references.
 
     Parameters
     ----------

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -1,6 +1,6 @@
 """
-Function to download the Earth seafloor age datasets from the GMT data server,
-and load as :class:`xarray.DataArray`.
+Function to download the Earth seafloor crustal age dataset from the
+GMT data server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
@@ -13,7 +13,7 @@ __doctest_skip__ = ["load_earth_age"]
 @kwargs_to_strings(region="sequence")
 def load_earth_age(resolution="01d", region=None, registration=None):
     r"""
-    Load Earth seafloor crustal ages in various resolutions.
+    Load the Earth seafloor crustal age dataset in various resolutions.
 
     The grids are downloaded to a user data directory
     (usually ``~/.gmt/server/earth/earth_age/``) the first time you invoke
@@ -23,7 +23,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     These grids can also be accessed by passing in the file name
     **@earth_age**\_\ *res*\[_\ *reg*] to any grid processing function or
     plotting method. *res* is the grid resolution (see below), and *reg* is
-    grid registration type (**p** for pixel registration or **g** for
+    the grid registration type (**p** for pixel registration or **g** for
     the gridline registration).
 
     The default color palette table (CPT) for this dataset is *@earth_age.cpt*.

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -21,8 +21,8 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     So you'll need an internet connection the first time around.
 
     These grids can also be accessed by passing in the file name
-    **@earth_age**\_\ *res*\[_\ *reg*] to any grid processing/plotting
-    function/method. *res* is the grid resolution (see below), and *reg* is
+    **@earth_age**\_\ *res*\[_\ *reg*] to any grid processing function or
+    plotting method. *res* is the grid resolution (see below), and *reg* is
     grid registration type (**p** for pixel registration or **g** for
     the gridline registration).
 

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -30,7 +30,7 @@ def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None
     It's implicitly used when passing in the file name of the dataset to any
     grid plotting method if no CPT is explicitly specified. When the dataset
     is loaded and plotted as an :class:`xarray.DataArray` object, the default
-    CPT is ignored and GMT's default CPT (*turbo*) is used. To use the
+    CPT is ignored, and GMT's default CPT (*turbo*) is used. To use the
     dataset-specific CPT, you need to explicitly set ``cmap="@earth_faa.cpt"``.
 
     Refer to :gmt-datasets:`earth-faa.html` for more details.

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -21,8 +21,8 @@ def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None
     So you'll need an internet connection the first time around.
 
     These grids can also be accessed by passing in the file name
-    **@earth_faa**\_\ *res*\[_\ *reg*] to any grid processing/plotting
-    function/method. *res* is the grid resolution (see below), and *reg* is
+    **@earth_faa**\_\ *res*\[_\ *reg*] to any grid processing function or
+    plotting method. *res* is the grid resolution (see below), and *reg* is
     the grid registration type (**p** for pixel registration or **g** for
     gridline registration).
 

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -22,9 +22,9 @@ def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None
 
     These grids can also be accessed by passing in the file name
     **@earth_faa**\_\ *res*\[_\ *reg*] to any grid plotting/processing
-    function. *res* is the grid resolution (see below), and *reg* is grid
-    registration type (**p** for pixel registration or **g** for gridline
-    registration).
+    function. *res* is the grid resolution (see below), and *reg* is the
+    grid registration type (**p** for pixel registration or **g** for
+    gridline registration).
 
     The default color palette table (CPT) for this dataset is *@earth_faa.cpt*.
     It's implicitly used when passing in the file name of the dataset to any

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -33,7 +33,8 @@ def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None
     CPT is ignored, and GMT's default CPT (*turbo*) is used. To use the
     dataset-specific CPT, you need to explicitly set ``cmap="@earth_faa.cpt"``.
 
-    Refer to :gmt-datasets:`earth-faa.html` for more details.
+    Refer to :gmt-datasets:`earth-faa.html` for more details about available
+    datasets, including version information and references.
 
     Parameters
     ----------

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -1,5 +1,5 @@
 """
-Function to download the IGPP Global Earth Free-Air Anomaly datasets from the
+Function to download the IGPP Global Earth Free-Air Anomaly dataset from the
 GMT data server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
@@ -13,7 +13,7 @@ __doctest_skip__ = ["load_earth_free_air_anomaly"]
 @kwargs_to_strings(region="sequence")
 def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None):
     r"""
-    Load an Earth Free-Air Anomaly grid in various resolutions.
+    Load the IGPP Global Earth Free-Air Anomaly datatset in various resolutions.
 
     The grids are downloaded to a user data directory
     (usually ``~/.gmt/server/earth/earth_faa/``) the first time you invoke

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -21,9 +21,9 @@ def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None
     So you'll need an internet connection the first time around.
 
     These grids can also be accessed by passing in the file name
-    **@earth_faa**\_\ *res*\[_\ *reg*] to any grid plotting/processing
-    function. *res* is the grid resolution (see below), and *reg* is the
-    grid registration type (**p** for pixel registration or **g** for
+    **@earth_faa**\_\ *res*\[_\ *reg*] to any grid processing/plotting
+    function/method. *res* is the grid resolution (see below), and *reg* is
+    the grid registration type (**p** for pixel registration or **g** for
     gridline registration).
 
     The default color palette table (CPT) for this dataset is *@earth_faa.cpt*.

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -13,7 +13,8 @@ __doctest_skip__ = ["load_earth_free_air_anomaly"]
 @kwargs_to_strings(region="sequence")
 def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None):
     r"""
-    Load the IGPP Global Earth Free-Air Anomaly datatset in various resolutions.
+    Load the IGPP Global Earth Free-Air Anomaly datatset in various
+    resolutions.
 
     The grids are downloaded to a user data directory
     (usually ``~/.gmt/server/earth/earth_faa/``) the first time you invoke

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -1,6 +1,6 @@
 """
-Function to download the EGM2008 Global Earth Geoid dataset from the
-GMT data server, and load as :class:`xarray.DataArray`.
+Function to download the EGM2008 Global Earth Geoid dataset from the GMT data
+server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -22,9 +22,9 @@ def load_earth_geoid(resolution="01d", region=None, registration=None):
 
     These grids can also be accessed by passing in the file name
     **@earth_geoid**\_\ *res*\[_\ *reg*] to any grid plotting/processing
-    function. *res* is the grid resolution (see below), and *reg* is grid
-    registration type (**p** for pixel registration or **g** for gridline
-    registration).
+    function. *res* is the grid resolution (see below), and *reg* is the
+    grid registration type (**p** for pixel registration or **g** for
+    gridline registration).
 
     Refer to :gmt-datasets:`earth-geoid.html` for more details.
 

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -21,8 +21,8 @@ def load_earth_geoid(resolution="01d", region=None, registration=None):
     So you'll need an internet connection the first time around.
 
     These grids can also be accessed by passing in the file name
-    **@earth_geoid**\_\ *res*\[_\ *reg*] to any grid processing/plotting
-    function/method. *res* is the grid resolution (see below), and *reg* is
+    **@earth_geoid**\_\ *res*\[_\ *reg*] to any grid processing function or
+    plotting method. *res* is the grid resolution (see below), and *reg* is
     the grid registration type (**p** for pixel registration or **g** for
     gridline registration).
 

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -21,9 +21,9 @@ def load_earth_geoid(resolution="01d", region=None, registration=None):
     So you'll need an internet connection the first time around.
 
     These grids can also be accessed by passing in the file name
-    **@earth_geoid**\_\ *res*\[_\ *reg*] to any grid plotting/processing
-    function. *res* is the grid resolution (see below), and *reg* is the
-    grid registration type (**p** for pixel registration or **g** for
+    **@earth_geoid**\_\ *res*\[_\ *reg*] to any grid processing/plotting
+    function/method. *res* is the grid resolution (see below), and *reg* is
+    the grid registration type (**p** for pixel registration or **g** for
     gridline registration).
 
     Refer to :gmt-datasets:`earth-geoid.html` for more details.

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -1,6 +1,6 @@
 """
-Function to download the EGM2008 Global Earth Geoid from the GMT data server,
-and load as :class:`xarray.DataArray`.
+Function to download the EGM2008 Global Earth Geoid dataset from the
+GMT data server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
@@ -13,7 +13,7 @@ __doctest_skip__ = ["load_earth_geoid"]
 @kwargs_to_strings(region="sequence")
 def load_earth_geoid(resolution="01d", region=None, registration=None):
     r"""
-    Load the EGM2008 Global Earth Geoid in various resolutions.
+    Load the EGM2008 Global Earth Geoid dataset in various resolutions.
 
     The grids are downloaded to a user data directory
     (usually ``~/.gmt/server/earth/earth_geoid/``) the first time you invoke

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -26,7 +26,8 @@ def load_earth_geoid(resolution="01d", region=None, registration=None):
     the grid registration type (**p** for pixel registration or **g** for
     gridline registration).
 
-    Refer to :gmt-datasets:`earth-geoid.html` for more details.
+    Refer to :gmt-datasets:`earth-geoid.html` for more details about available
+    datasets, including version information and references.
 
     Parameters
     ----------

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -26,8 +26,8 @@ def load_earth_magnetic_anomaly(
     So you'll need an internet connection the first time around.
 
     These grids can also be accessed by passing in the file name
-    **@**\ *earth_mag_type*\_\ *res*\[_\ *reg*] to any grid plotting/processing
-    function. *earth_mag_type* is the GMT name
+    **@**\ *earth_mag_type*\_\ *res*\[_\ *reg*] to any grid processing/
+    plotting function/method. *earth_mag_type* is the GMT name
     for the dataset. The available options are **earth_mag**,
     **earth_mag4km**, and **earth_wdmam**. *res* is the grid resolution
     (see below), and *reg* is the grid registration type (**p** for pixel

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -1,6 +1,6 @@
 """
-Function to download the Earth magnetic anomaly datasets from the
-GMT data server, and load as :class:`xarray.DataArray`.
+Function to download the Earth magnetic anomaly datasets from the GMT data
+server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -26,8 +26,8 @@ def load_earth_magnetic_anomaly(
     So you'll need an internet connection the first time around.
 
     These grids can also be accessed by passing in the file name
-    **@**\ *earth_mag_type*\_\ *res*\[_\ *reg*] to any grid processing/
-    plotting function/method. *earth_mag_type* is the GMT name
+    **@**\ *earth_mag_type*\_\ *res*\[_\ *reg*] to any grid processing
+    function or plotting method. *earth_mag_type* is the GMT name
     for the dataset. The available options are **earth_mag**,
     **earth_mag4km**, and **earth_wdmam**. *res* is the grid resolution
     (see below), and *reg* is the grid registration type (**p** for pixel

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -39,7 +39,7 @@ def load_earth_magnetic_anomaly(
     ``data_source="wdmam"``. The dataset-specific CPT is implicitly used when
     passing in the file name of the dataset to any grid plotting method if no
     CPT is explicitly specified. When the dataset is loaded and plotted as an
-    :class:`xarray.DataArray` object, the default CPT is ignored and GMT's
+    :class:`xarray.DataArray` object, the default CPT is ignored, and GMT's
     default CPT (*turbo*) is used. To use the dataset-specific CPT, you need to
     explicitly set ``cmap="@earth_mag.cpt"`` or ``cmap="@earth_wdmam.cpt"``.
 

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -44,7 +44,8 @@ def load_earth_magnetic_anomaly(
     explicitly set ``cmap="@earth_mag.cpt"`` or ``cmap="@earth_wdmam.cpt"``.
 
     Refer to :gmt-datasets:`earth-mag.html`
-    and :gmt-datasets:`earth-wdmam.html` for more details.
+    and :gmt-datasets:`earth-wdmam.html` for more details about available
+    datasets, including version information and references.
 
     Parameters
     ----------

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -30,7 +30,7 @@ def load_earth_magnetic_anomaly(
     function. *earth_mag_type* is the GMT name
     for the dataset. The available options are **earth_mag**,
     **earth_mag4km**, and **earth_wdmam**. *res* is the grid resolution
-    (see below), and *reg* is grid registration type (**p** for pixel
+    (see below), and *reg* is the grid registration type (**p** for pixel
     registration or **g** for gridline registration).
 
     The default color palette tables (CPTs) for this dataset are

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -1,6 +1,6 @@
 """
-Function to download the Earth magnetic anomaly datasets from the GMT data
-server, and load as :class:`xarray.DataArray`.
+Function to download the Earth magnetic anomaly datasets from the
+GMT data server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
@@ -16,7 +16,7 @@ def load_earth_magnetic_anomaly(
     resolution="01d", region=None, registration=None, data_source="emag2"
 ):
     r"""
-    Load an Earth magnetic anomaly grid in various resolutions.
+    Load the Earth magnetic anomaly datasets in various resolutions.
 
     The grids are downloaded to a user data directory
     (usually ``~/.gmt/server/earth/earth_mag/``,

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -1,6 +1,6 @@
 """
-Function to download the GSHHG Global Earth Mask dataset from the
-GMT data server, and load as :class:`xarray.DataArray`.
+Function to download the GSHHG Global Earth Mask dataset from the GMT data
+server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -21,8 +21,8 @@ def load_earth_mask(resolution="01d", region=None, registration=None):
     So you'll need an internet connection the first time around.
 
     These grids can also be accessed by passing in the file name
-    **@earth_mask**\_\ *res*\[_\ *reg*] to any grid processing/plotting
-    function/method. *res* is the grid resolution (see below), and *reg* is
+    **@earth_mask**\_\ *res*\[_\ *reg*] to any grid processing function or
+    plotting method. *res* is the grid resolution (see below), and *reg* is
     the grid registration type (**p** for pixel registration or **g** for
     gridline registration).
 

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -22,9 +22,9 @@ def load_earth_mask(resolution="01d", region=None, registration=None):
 
     These grids can also be accessed by passing in the file name
     **@earth_mask**\_\ *res*\[_\ *reg*] to any grid plotting/processing
-    function. *res* is the grid resolution (see below), and *reg* is grid
-    registration type (**p** for pixel registration or **g** for gridline
-    registration).
+    function. *res* is the grid resolution (see below), and *reg* is the
+    grid registration type (**p** for pixel registration or **g** for
+    gridline registration).
 
     Refer to :gmt-datasets:`earth-mask.html` for more details.
 

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -1,6 +1,6 @@
 """
-Function to download the GSHHG Global Earth Mask from the GMT data server, and
-load as :class:`xarray.DataArray`.
+Function to download the GSHHG Global Earth Mask dataset from the
+GMT data server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
@@ -13,7 +13,7 @@ __doctest_skip__ = ["load_earth_mask"]
 @kwargs_to_strings(region="sequence")
 def load_earth_mask(resolution="01d", region=None, registration=None):
     r"""
-    Load the GSHHG Global Earth Mask in various resolutions.
+    Load the GSHHG Global Earth Mask dataset in various resolutions.
 
     The grids are downloaded to a user data directory
     (usually ``~/.gmt/server/earth/earth_mask/``) the first time you invoke

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -21,9 +21,9 @@ def load_earth_mask(resolution="01d", region=None, registration=None):
     So you'll need an internet connection the first time around.
 
     These grids can also be accessed by passing in the file name
-    **@earth_mask**\_\ *res*\[_\ *reg*] to any grid plotting/processing
-    function. *res* is the grid resolution (see below), and *reg* is the
-    grid registration type (**p** for pixel registration or **g** for
+    **@earth_mask**\_\ *res*\[_\ *reg*] to any grid processing/plotting
+    function/method. *res* is the grid resolution (see below), and *reg* is
+    the grid registration type (**p** for pixel registration or **g** for
     gridline registration).
 
     Refer to :gmt-datasets:`earth-mask.html` for more details.

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -26,7 +26,8 @@ def load_earth_mask(resolution="01d", region=None, registration=None):
     the grid registration type (**p** for pixel registration or **g** for
     gridline registration).
 
-    Refer to :gmt-datasets:`earth-mask.html` for more details.
+    Refer to :gmt-datasets:`earth-mask.html` for more details about available
+    datasets, including version information and references.
 
     Parameters
     ----------

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -31,8 +31,8 @@ def load_earth_relief(
 
     This module downloads the grids that can also be accessed by
     passing in the file name **@**\ *earth_relief_type*\_\ *res*\[_\ *reg*] to
-    any grid plotting/processing function. *earth_relief_type* is the GMT name
-    for the dataset. The available options are **earth_relief**\,
+    any grid processing/plotting function/method. *earth_relief_type* is the
+    GMT name for the dataset. The available options are **earth_relief**\,
     **earth_gebco**\, **earth_gebcosi**\, and **earth_synbath**\. *res* is the
     grid resolution (see below), and *reg* is the grid registration type
     (**p** for pixel registration or **g** for gridline registration).

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -1,6 +1,6 @@
 """
-Function to download the Earth relief dataset from the GMT data server, and
-load as :class:`xarray.DataArray`.
+Function to download the Earth relief datasets from the GMT data server,
+and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
@@ -20,7 +20,7 @@ def load_earth_relief(
     use_srtm=False,
 ):
     r"""
-    Load the Earth relief dataset (topography and bathymetry) in various
+    Load the Earth relief datasets (topography and bathymetry) in various
     resolutions.
 
     The grids are downloaded to a user data directory

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -31,8 +31,8 @@ def load_earth_relief(
 
     This module downloads the grids that can also be accessed by
     passing in the file name **@**\ *earth_relief_type*\_\ *res*\[_\ *reg*] to
-    any grid processing/plotting function/method. *earth_relief_type* is the
-    GMT name for the dataset. The available options are **earth_relief**\,
+    any grid processing function or plotting method. *earth_relief_type* is
+    the GMT name for the dataset. The available options are **earth_relief**\,
     **earth_gebco**\, **earth_gebcosi**\, and **earth_synbath**\. *res* is the
     grid resolution (see below), and *reg* is the grid registration type
     (**p** for pixel registration or **g** for gridline registration).

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -1,6 +1,6 @@
 """
-Function to download the Earth relief datasets from the GMT data server, and
-load as :class:`xarray.DataArray`.
+Function to download the Earth relief dataset from the
+GMT data server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
@@ -20,7 +20,8 @@ def load_earth_relief(
     use_srtm=False,
 ):
     r"""
-    Load Earth relief grids (topography and bathymetry) in various resolutions.
+    Load the Earth relief dataset (topography and bathymetry) in various
+    resolutions.
 
     The grids are downloaded to a user data directory
     (usually ``~/.gmt/server/earth/earth_relief``,

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -34,7 +34,7 @@ def load_earth_relief(
     any grid plotting/processing function. *earth_relief_type* is the GMT name
     for the dataset. The available options are **earth_relief**\,
     **earth_gebco**\, **earth_gebcosi**\, and **earth_synbath**\. *res* is the
-    grid resolution (see below), and *reg* is grid registration type
+    grid resolution (see below), and *reg* is the grid registration type
     (**p** for pixel registration or **g** for gridline registration).
 
     The default color palette table (CPT) for this dataset is *geo*.

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -1,6 +1,6 @@
 """
-Function to download the Earth relief datasets from the GMT data server,
-and load as :class:`xarray.DataArray`.
+Function to download the Earth relief datasets from the GMT data server, and
+load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -1,6 +1,6 @@
 """
-Function to download the Earth relief dataset from the
-GMT data server, and load as :class:`xarray.DataArray`.
+Function to download the Earth relief dataset from the GMT data server, and
+load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -41,7 +41,7 @@ def load_earth_relief(
     It's implicitly used when passing in the file name of the dataset to any
     grid plotting method if no CPT is explicitly specified. When the dataset
     is loaded and plotted as an :class:`xarray.DataArray` object, the default
-    CPT is ignored and GMT's default CPT (*turbo*) is used. To use the
+    CPT is ignored, and GMT's default CPT (*turbo*) is used. To use the
     dataset-specific CPT, you need to explicitly set ``cmap="geo"``.
 
     Refer to :gmt-datasets:`earth-relief.html` for more details about available

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -24,9 +24,9 @@ def load_earth_vertical_gravity_gradient(
     So you'll need an internet connection the first time around.
 
     These grids can also be accessed by passing in the file name
-    **@earth_vgg**\_\ *res*\[_\ *reg*] to any grid plotting/processing
-    function. *res* is the grid resolution (see below), and *reg* is the
-    grid registration type (**p** for pixel registration or **g** for
+    **@earth_vgg**\_\ *res*\[_\ *reg*] to any grid processing/plotting
+    function/method. *res* is the grid resolution (see below), and *reg* is
+    the grid registration type (**p** for pixel registration or **g** for
     gridline registration).
 
     The default color palette table (CPT) for this dataset is *@earth_vgg.cpt*.

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -24,8 +24,8 @@ def load_earth_vertical_gravity_gradient(
     So you'll need an internet connection the first time around.
 
     These grids can also be accessed by passing in the file name
-    **@earth_vgg**\_\ *res*\[_\ *reg*] to any grid processing/plotting
-    function/method. *res* is the grid resolution (see below), and *reg* is
+    **@earth_vgg**\_\ *res*\[_\ *reg*] to any grid processing function or
+    plotting method. *res* is the grid resolution (see below), and *reg* is
     the grid registration type (**p** for pixel registration or **g** for
     gridline registration).
 

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -1,6 +1,6 @@
 """
-Function to download the IGPP Global Earth Vertical Gravity Gradient from the
-GMT data server, and load as :class:`xarray.DataArray`.
+Function to download the IGPP Global Earth Vertical Gravity Gradient dataset
+from the GMT data server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
@@ -15,7 +15,7 @@ def load_earth_vertical_gravity_gradient(
     resolution="01d", region=None, registration=None
 ):
     r"""
-    Load the IGPP Global Earth Vertical Gravity Gradient in various
+    Load the IGPP Global Earth Vertical Gravity Gradient dataset in various
     resolutions.
 
     The grids are downloaded to a user data directory

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -36,7 +36,8 @@ def load_earth_vertical_gravity_gradient(
     CPT is ignored, and GMT's default CPT (*turbo*) is used. To use the
     dataset-specific CPT, you need to explicitly set ``cmap="@earth_vgg.cpt"``.
 
-    Refer to :gmt-datasets:`earth-vgg.html` for more details.
+    Refer to :gmt-datasets:`earth-vgg.html` for more details about available
+    datasets, including version information and references.
 
     Parameters
     ----------

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -33,7 +33,7 @@ def load_earth_vertical_gravity_gradient(
     It's implicitly used when passing in the file name of the dataset to any
     grid plotting method if no CPT is explicitly specified. When the dataset
     is loaded and plotted as an :class:`xarray.DataArray` object, the default
-    CPT is ignored and GMT's default CPT (*turbo*) is used. To use the
+    CPT is ignored, and GMT's default CPT (*turbo*) is used. To use the
     dataset-specific CPT, you need to explicitly set ``cmap="@earth_vgg.cpt"``.
 
     Refer to :gmt-datasets:`earth-vgg.html` for more details.

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -25,9 +25,9 @@ def load_earth_vertical_gravity_gradient(
 
     These grids can also be accessed by passing in the file name
     **@earth_vgg**\_\ *res*\[_\ *reg*] to any grid plotting/processing
-    function. *res* is the grid resolution (see below), and *reg* is grid
-    registration type (**p** for pixel registration or **g** for gridline
-    registration).
+    function. *res* is the grid resolution (see below), and *reg* is the
+    grid registration type (**p** for pixel registration or **g** for
+    gridline registration).
 
     The default color palette table (CPT) for this dataset is *@earth_vgg.cpt*.
     It's implicitly used when passing in the file name of the dataset to any


### PR DESCRIPTION
**Description of proposed changes**

Related to @michaelgrund's review at https://github.com/GenericMappingTools/pygmt/pull/2674#discussion_r1324094315, this PR aims to update the documenations of the other datasets in the same way. Eventually TODO: Add comma related to review at https://github.com/GenericMappingTools/pygmt/pull/2674#discussion_r1324095302. DONE: See commit https://github.com/GenericMappingTools/pygmt/pull/2688/commits/ee8ab66cd05736ab60270efdcc85ed0d3f95efbb.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
