### PR TITLE
Merge dataset-independent tests into a separate test file

### DIFF
--- a/pygmt/tests/test_datasets_earth_age.py
+++ b/pygmt/tests/test_datasets_earth_age.py
@@ -8,14 +8,6 @@ from pygmt.datasets import load_earth_age
 from pygmt.exceptions import GMTInvalidInput
 
 
-def test_earth_age_incorrect_registration():
-    """
-    Test loading earth_age with incorrect registration type.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_age(registration="improper_type")
-
-
 def test_earth_age_01d():
     """
     Test some properties of the earth age 01d data.

--- a/pygmt/tests/test_datasets_earth_age.py
+++ b/pygmt/tests/test_datasets_earth_age.py
@@ -8,17 +8,6 @@ from pygmt.datasets import load_earth_age
 from pygmt.exceptions import GMTInvalidInput
 
 
-def test_earth_age_fails():
-    """
-    Make sure earth_age fails for invalid resolutions.
-    """
-    resolutions = "1m 1d bla 60d 001m 03".split()
-    resolutions.append(60)
-    for resolution in resolutions:
-        with pytest.raises(GMTInvalidInput):
-            load_earth_age(resolution=resolution)
-
-
 def test_earth_age_incorrect_registration():
     """
     Test loading earth_age with incorrect registration type.

--- a/pygmt/tests/test_datasets_earth_age.py
+++ b/pygmt/tests/test_datasets_earth_age.py
@@ -38,14 +38,6 @@ def test_earth_age_01d_with_region():
     npt.assert_allclose(data.max(), 125.12, atol=0.01)
 
 
-def test_earth_age_01m_without_region():
-    """
-    Test loading high-resolution earth age without passing 'region'.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_age("01m")
-
-
 def test_earth_age_incorrect_resolution_registration():
     """
     Test that an error is raised when trying to load a grid registration with

--- a/pygmt/tests/test_datasets_earth_age.py
+++ b/pygmt/tests/test_datasets_earth_age.py
@@ -3,9 +3,7 @@ Test basic functionality for loading Earth seafloor crust age datasets.
 """
 import numpy as np
 import numpy.testing as npt
-import pytest
 from pygmt.datasets import load_earth_age
-from pygmt.exceptions import GMTInvalidInput
 
 
 def test_earth_age_01d():
@@ -36,15 +34,6 @@ def test_earth_age_01d_with_region():
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), 11.29, atol=0.01)
     npt.assert_allclose(data.max(), 125.12, atol=0.01)
-
-
-def test_earth_age_incorrect_resolution_registration():
-    """
-    Test that an error is raised when trying to load a grid registration with
-    an unavailable resolution.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_age(resolution="01m", region=[0, 1, 3, 5], registration="pixel")
 
 
 def test_earth_age_01m_default_registration():

--- a/pygmt/tests/test_datasets_earth_free_air_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_free_air_anomaly.py
@@ -8,14 +8,6 @@ from pygmt.datasets import load_earth_free_air_anomaly
 from pygmt.exceptions import GMTInvalidInput
 
 
-def test_earth_faa_incorrect_registration():
-    """
-    Test loading earth_free_air_anomaly with incorrect registration type.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_free_air_anomaly(registration="improper_type")
-
-
 def test_earth_faa_01d():
     """
     Test some properties of the free air anomaly 01d data.

--- a/pygmt/tests/test_datasets_earth_free_air_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_free_air_anomaly.py
@@ -8,17 +8,6 @@ from pygmt.datasets import load_earth_free_air_anomaly
 from pygmt.exceptions import GMTInvalidInput
 
 
-def test_earth_faa_fails():
-    """
-    Make sure earth_free_air_anomaly fails for invalid resolutions.
-    """
-    resolutions = "1m 1d bla 60d 001m 03".split()
-    resolutions.append(60)
-    for resolution in resolutions:
-        with pytest.raises(GMTInvalidInput):
-            load_earth_free_air_anomaly(resolution=resolution)
-
-
 def test_earth_faa_incorrect_registration():
     """
     Test loading earth_free_air_anomaly with incorrect registration type.

--- a/pygmt/tests/test_datasets_earth_free_air_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_free_air_anomaly.py
@@ -3,9 +3,7 @@ Test basic functionality for loading Earth free air anomaly datasets.
 """
 import numpy as np
 import numpy.testing as npt
-import pytest
 from pygmt.datasets import load_earth_free_air_anomaly
-from pygmt.exceptions import GMTInvalidInput
 
 
 def test_earth_faa_01d():
@@ -36,15 +34,6 @@ def test_earth_faa_01d_with_region():
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -58.475, atol=0.025)
     npt.assert_allclose(data.max(), 69.975, atol=0.025)
-
-
-def test_earth_faa_01m_without_region():
-    """
-    Test loading high-resolution earth free air anomaly without passing
-    'region'.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_free_air_anomaly("01m")
 
 
 def test_earth_faa_01m_default_registration():

--- a/pygmt/tests/test_datasets_earth_geoid.py
+++ b/pygmt/tests/test_datasets_earth_geoid.py
@@ -8,14 +8,6 @@ from pygmt.datasets import load_earth_geoid
 from pygmt.exceptions import GMTInvalidInput
 
 
-def test_earth_geoid_incorrect_registration():
-    """
-    Test loading load_earth_geoid with incorrect registration type.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_geoid(registration="improper_type")
-
-
 def test_earth_geoid_01d():
     """
     Test some properties of the earth geoid 01d data.

--- a/pygmt/tests/test_datasets_earth_geoid.py
+++ b/pygmt/tests/test_datasets_earth_geoid.py
@@ -8,17 +8,6 @@ from pygmt.datasets import load_earth_geoid
 from pygmt.exceptions import GMTInvalidInput
 
 
-def test_earth_geoid_fails():
-    """
-    Make sure load_earth_geoid fails for invalid resolutions.
-    """
-    resolutions = "1m 1d bla 60d 001m 03".split()
-    resolutions.append(60)
-    for resolution in resolutions:
-        with pytest.raises(GMTInvalidInput):
-            load_earth_geoid(resolution=resolution)
-
-
 def test_earth_geoid_incorrect_registration():
     """
     Test loading load_earth_geoid with incorrect registration type.

--- a/pygmt/tests/test_datasets_earth_geoid.py
+++ b/pygmt/tests/test_datasets_earth_geoid.py
@@ -3,9 +3,7 @@ Test basic functionality for loading Earth geoid datasets.
 """
 import numpy as np
 import numpy.testing as npt
-import pytest
 from pygmt.datasets import load_earth_geoid
-from pygmt.exceptions import GMTInvalidInput
 
 
 def test_earth_geoid_01d():
@@ -36,15 +34,6 @@ def test_earth_geoid_01d_with_region():
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), 4.87, atol=0.01)
     npt.assert_allclose(data.max(), 29.89, atol=0.01)
-
-
-def test_earth_geoid_incorrect_resolution_registration():
-    """
-    Test that an error is raised when trying to load a grid registration with
-    an unavailable resolution.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_geoid(resolution="01m", region=[0, 1, 3, 5], registration="pixel")
 
 
 def test_earth_geoid_01m_default_registration():

--- a/pygmt/tests/test_datasets_earth_geoid.py
+++ b/pygmt/tests/test_datasets_earth_geoid.py
@@ -38,14 +38,6 @@ def test_earth_geoid_01d_with_region():
     npt.assert_allclose(data.max(), 29.89, atol=0.01)
 
 
-def test_earth_geoid_01m_without_region():
-    """
-    Test loading high-resolution earth geoid without passing 'region'.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_geoid("01m")
-
-
 def test_earth_geoid_incorrect_resolution_registration():
     """
     Test that an error is raised when trying to load a grid registration with

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -8,14 +8,6 @@ from pygmt.datasets import load_earth_magnetic_anomaly
 from pygmt.exceptions import GMTInvalidInput
 
 
-def test_earth_mag_incorrect_registration():
-    """
-    Test loading earth_magnetic_anomaly with incorrect registration type.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_magnetic_anomaly(registration="improper_type")
-
-
 def test_earth_mag_01d():
     """
     Test some properties of the magnetic anomaly 01d data.

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -8,17 +8,6 @@ from pygmt.datasets import load_earth_magnetic_anomaly
 from pygmt.exceptions import GMTInvalidInput
 
 
-def test_earth_mag_fails():
-    """
-    Make sure earth_magnetic_anomaly fails for invalid resolutions.
-    """
-    resolutions = "1m 1d bla 60d 001m 03".split()
-    resolutions.append(60)
-    for resolution in resolutions:
-        with pytest.raises(GMTInvalidInput):
-            load_earth_magnetic_anomaly(resolution=resolution)
-
-
 def test_earth_mag_incorrect_registration():
     """
     Test loading earth_magnetic_anomaly with incorrect registration type.

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -38,15 +38,6 @@ def test_earth_mag_01d_with_region():
     npt.assert_allclose(data.max(), 127.4, atol=0.2)
 
 
-def test_earth_mag_02m_without_region():
-    """
-    Test loading high-resolution earth magnetic anomaly without passing
-    'region'.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_magnetic_anomaly("02m")
-
-
 def test_earth_mag_incorrect_resolution_registration():
     """
     Test that an error is raised when trying to load a EMAG2 grid registration
@@ -181,16 +172,6 @@ def test_earth_mag_03m_wdmam_with_region():
     assert data.lon.max() == 13
     npt.assert_allclose(data.min(), -790.2, atol=0.2)
     npt.assert_allclose(data.max(), 528.0, atol=0.2)
-
-
-def test_earth_mag_03m_wdmam_without_region():
-    """
-    Test loading a high-resolution WDMAM grid without passing 'region'.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_magnetic_anomaly(
-            resolution="03m", registration="gridline", data_source="wdmam"
-        )
 
 
 def test_earth_mag_wdmam_incorrect_resolution_registration():

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -38,20 +38,6 @@ def test_earth_mag_01d_with_region():
     npt.assert_allclose(data.max(), 127.4, atol=0.2)
 
 
-def test_earth_mag_incorrect_resolution_registration():
-    """
-    Test that an error is raised when trying to load a EMAG2 grid registration
-    with an unavailable resolution.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_magnetic_anomaly(
-            resolution="02m",
-            region=[0, 1, 3, 5],
-            registration="gridline",
-            data_source="emag2_4km",
-        )
-
-
 def test_earth_mag_02m_default_registration():
     """
     Test that the grid returned by default for the 2 arc-minute resolution has
@@ -172,20 +158,6 @@ def test_earth_mag_03m_wdmam_with_region():
     assert data.lon.max() == 13
     npt.assert_allclose(data.min(), -790.2, atol=0.2)
     npt.assert_allclose(data.max(), 528.0, atol=0.2)
-
-
-def test_earth_mag_wdmam_incorrect_resolution_registration():
-    """
-    Test that an error is raised when trying to load a WDMAM grid registration
-    with an unavailable resolution.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_magnetic_anomaly(
-            resolution="03m",
-            region=[0, 1, 3, 5],
-            registration="pixel",
-            data_source="wdmam",
-        )
 
 
 def test_earth_mag_data_source_error():

--- a/pygmt/tests/test_datasets_earth_mask.py
+++ b/pygmt/tests/test_datasets_earth_mask.py
@@ -8,14 +8,6 @@ from pygmt.datasets import load_earth_mask
 from pygmt.exceptions import GMTInvalidInput
 
 
-def test_earth_mask_incorrect_registration():
-    """
-    Test loading load_earth_mask with incorrect registration type.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_mask(registration="improper_type")
-
-
 def test_earth_mask_01d():
     """
     Test some properties of the Earth mask 01d data.

--- a/pygmt/tests/test_datasets_earth_mask.py
+++ b/pygmt/tests/test_datasets_earth_mask.py
@@ -8,17 +8,6 @@ from pygmt.datasets import load_earth_mask
 from pygmt.exceptions import GMTInvalidInput
 
 
-def test_earth_mask_fails():
-    """
-    Make sure load_earth_mask fails for invalid resolutions.
-    """
-    resolutions = "1m 1d bla 60d 001m 03".split()
-    resolutions.append(60)
-    for resolution in resolutions:
-        with pytest.raises(GMTInvalidInput):
-            load_earth_mask(resolution=resolution)
-
-
 def test_earth_mask_incorrect_registration():
     """
     Test loading load_earth_mask with incorrect registration type.

--- a/pygmt/tests/test_datasets_earth_mask.py
+++ b/pygmt/tests/test_datasets_earth_mask.py
@@ -3,9 +3,7 @@ Test basic functionality for loading Earth mask datasets.
 """
 import numpy as np
 import numpy.testing as npt
-import pytest
 from pygmt.datasets import load_earth_mask
-from pygmt.exceptions import GMTInvalidInput
 
 
 def test_earth_mask_01d():

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -128,14 +128,6 @@ def test_earth_relief_30s_synbath():
     npt.assert_allclose(data.max(), -2257.5, atol=0.5)
 
 
-def test_earth_relief_01m_without_region():
-    """
-    Test loading high-resolution earth relief without passing 'region'.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_relief("01m")
-
-
 def test_earth_relief_03s_landonly_srtm():
     """
     Test loading original 3 arc-seconds land-only SRTM tiles.

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -8,18 +8,6 @@ from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 
 
-@pytest.mark.parametrize("data_source", ["igpp", "gebco", "gebcosi", "synbath"])
-def test_earth_relief_fails(data_source):
-    """
-    Make sure earth relief fails for invalid resolutions.
-    """
-    resolutions = "1m 1d bla 60d 001m 03".split()
-    resolutions.append(60)
-    for resolution in resolutions:
-        with pytest.raises(GMTInvalidInput):
-            load_earth_relief(resolution=resolution, data_source=data_source)
-
-
 # Only test 01d and 30m to avoid downloading large datasets in CI
 @pytest.mark.parametrize("data_source", ["igpp", "synbath"])
 def test_earth_relief_01d_igpp_synbath(data_source):

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -147,20 +147,6 @@ def test_earth_relief_03s_landonly_srtm():
     assert data.sizes["lon"] == 1201
 
 
-def test_earth_relief_invalid_resolution_registration_combination():
-    """
-    Test loading earth relief with invalid combination of resolution and
-    registration.
-    """
-    for resolution, registration in [
-        ("15s", "gridline"),
-        ("03s", "pixel"),
-        ("01s", "pixel"),
-    ]:
-        with pytest.raises(GMTInvalidInput):
-            load_earth_relief(resolution=resolution, registration=registration)
-
-
 def test_earth_relief_invalid_data_source():
     """
     Test loading earth relief with invalid data_source argument.
@@ -183,28 +169,6 @@ def test_earth_relief_invalid_data_source_with_use_srtm():
             registration="gridline",
             use_srtm=True,
             data_source="gebco",
-        )
-
-
-@pytest.mark.parametrize("data_source", ["igpp", "gebco", "gebcosi", "synbath"])
-def test_earth_relief_incorrect_resolution_registration(data_source):
-    """
-    Test that an error is raised when trying to load a grid registration with
-    an unavailable resolution.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_relief(
-            resolution="03s",
-            region=[0, 1, 3, 5],
-            registration="pixel",
-            data_source=data_source,
-        )
-    with pytest.raises(GMTInvalidInput):
-        load_earth_relief(
-            resolution="15s",
-            region=[0, 1, 3, 5],
-            registration="gridline",
-            data_source=data_source,
         )
 
 

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -155,14 +155,6 @@ def test_earth_relief_03s_landonly_srtm():
     assert data.sizes["lon"] == 1201
 
 
-def test_earth_relief_incorrect_registration():
-    """
-    Test loading earth relief with incorrect registration type.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_relief(registration="improper_type")
-
-
 def test_earth_relief_invalid_resolution_registration_combination():
     """
     Test loading earth relief with invalid combination of resolution and

--- a/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
+++ b/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
@@ -8,18 +8,6 @@ from pygmt.datasets import load_earth_vertical_gravity_gradient
 from pygmt.exceptions import GMTInvalidInput
 
 
-def test_earth_vertical_gravity_gradient_fails():
-    """
-    Make sure load_earth_vertical_gravity_gradient fails for invalid
-    resolutions.
-    """
-    resolutions = "1m 1d bla 60d 001m 03".split()
-    resolutions.append(60)
-    for resolution in resolutions:
-        with pytest.raises(GMTInvalidInput):
-            load_earth_vertical_gravity_gradient(resolution=resolution)
-
-
 def test_earth_vertical_gravity_gradient_incorrect_registration():
     """
     Test loading load_earth_vertical_gravity_gradient with incorrect

--- a/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
+++ b/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
@@ -41,14 +41,6 @@ def test_earth_vertical_gravity_gradient_01d_with_region():
     npt.assert_allclose(data.max(), 19.875, atol=1 / 32)
 
 
-def test_earth_vertical_gravity_gradient_01m_without_region():
-    """
-    Test loading high-resolution earth vgg without passing 'region'.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_vertical_gravity_gradient("01m")
-
-
 def test_earth_vertical_gravity_gradient_incorrect_resolution_registration():
     """
     Test that an error is raised when trying to load a grid registration with

--- a/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
+++ b/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
@@ -3,9 +3,7 @@ Test basic functionality for loading Earth vertical gravity gradient datasets.
 """
 import numpy as np
 import numpy.testing as npt
-import pytest
 from pygmt.datasets import load_earth_vertical_gravity_gradient
-from pygmt.exceptions import GMTInvalidInput
 
 
 def test_earth_vertical_gravity_gradient_01d():
@@ -39,17 +37,6 @@ def test_earth_vertical_gravity_gradient_01d_with_region():
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -15.6875, atol=1 / 32)
     npt.assert_allclose(data.max(), 19.875, atol=1 / 32)
-
-
-def test_earth_vertical_gravity_gradient_incorrect_resolution_registration():
-    """
-    Test that an error is raised when trying to load a grid registration with
-    an unavailable resolution.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_vertical_gravity_gradient(
-            resolution="01m", region=[0, 1, 3, 5], registration="gridline"
-        )
 
 
 def test_earth_vertical_gravity_gradient_01m_default_registration():

--- a/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
+++ b/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
@@ -8,15 +8,6 @@ from pygmt.datasets import load_earth_vertical_gravity_gradient
 from pygmt.exceptions import GMTInvalidInput
 
 
-def test_earth_vertical_gravity_gradient_incorrect_registration():
-    """
-    Test loading load_earth_vertical_gravity_gradient with incorrect
-    registration type.
-    """
-    with pytest.raises(GMTInvalidInput):
-        load_earth_vertical_gravity_gradient(registration="improper_type")
-
-
 def test_earth_vertical_gravity_gradient_01d():
     """
     Test some properties of the earth vgg 01d data.

--- a/pygmt/tests/test_datasets_load_remote_datasets.py
+++ b/pygmt/tests/test_datasets_load_remote_datasets.py
@@ -1,0 +1,30 @@
+"""
+Test the _load_remote_dataset function.
+"""
+import pytest
+from pygmt.datasets.load_remote_dataset import _load_remote_dataset
+from pygmt.exceptions import GMTInvalidInput
+
+
+def load_remote_dataset_wrapper(resolution="01d", region=None, registration=None):
+    """
+    Wrapper for _load_remote_dataset using the earth age dataset as an example.
+    """
+    return _load_remote_dataset(
+        dataset_name="earth_age",
+        dataset_prefix="earth_age_",
+        resolution=resolution,
+        region=region,
+        registration=registration,
+    )
+
+
+def test_load_remote_dataset_invalid_resolutions():
+    """
+    Make sure _load_remote_dataset fails for invalid resolutions.
+    """
+    resolutions = "1m 1d bla 60d 001m 03".split()
+    resolutions.append(60)
+    for resolution in resolutions:
+        with pytest.raises(GMTInvalidInput):
+            load_remote_dataset_wrapper(resolution=resolution)

--- a/pygmt/tests/test_datasets_load_remote_datasets.py
+++ b/pygmt/tests/test_datasets_load_remote_datasets.py
@@ -28,3 +28,11 @@ def test_load_remote_dataset_invalid_resolutions():
     for resolution in resolutions:
         with pytest.raises(GMTInvalidInput):
             load_remote_dataset_wrapper(resolution=resolution)
+
+
+def test_load_remote_dataset_invalid_registration():
+    """
+    Make sure _load_remote_dataset fails for invalid registrations.
+    """
+    with pytest.raises(GMTInvalidInput):
+        load_remote_dataset_wrapper(registration="improper_type")

--- a/pygmt/tests/test_datasets_load_remote_datasets.py
+++ b/pygmt/tests/test_datasets_load_remote_datasets.py
@@ -45,3 +45,14 @@ def test_load_remote_dataset_tiled_grid_without_region():
     """
     with pytest.raises(GMTInvalidInput):
         load_remote_dataset_wrapper(resolution="01m")
+
+
+def test_load_remote_dataset_incorrect_resolution_registration():
+    """
+    Make sure _load_remote_dataset fails when trying to load a grid
+    registration with an unavailable resolution.
+    """
+    with pytest.raises(GMTInvalidInput):
+        load_remote_dataset_wrapper(
+            resolution="01m", region=[0, 1, 3, 5], registration="pixel"
+        )

--- a/pygmt/tests/test_datasets_load_remote_datasets.py
+++ b/pygmt/tests/test_datasets_load_remote_datasets.py
@@ -36,3 +36,12 @@ def test_load_remote_dataset_invalid_registration():
     """
     with pytest.raises(GMTInvalidInput):
         load_remote_dataset_wrapper(registration="improper_type")
+
+
+def test_load_remote_dataset_tiled_grid_without_region():
+    """
+    Make sure _load_remote_dataset fails when trying to load a tiled grid
+    without specifying a region.
+    """
+    with pytest.raises(GMTInvalidInput):
+        load_remote_dataset_wrapper(resolution="01m")


### PR DESCRIPTION
**Description of proposed changes**

For each dataset, we have tests that check invalid resolutions (like `60d`) and invalid registrations. These tests are dataset-independent, so better to have these tests in a single test file to reduce test redundancy. 