### PR TITLE
Figure.savefig: Support .jpeg as JPEG image extension

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -260,7 +260,7 @@ class Figure:
         This method implements a matplotlib-like interface for
         :meth:`pygmt.Figure.psconvert`.
 
-        Supported formats: PNG (``.png``), JPEG (``.jpg`` or ``.jpeg),
+        Supported formats: PNG (``.png``), JPEG (``.jpg`` or ``.jpeg``),
         PDF (``.pdf``), BMP (``.bmp``), TIFF (``.tif``), EPS (``.eps``), and
         KML (``.kml``). The KML output generates a companion PNG file.
 

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -306,7 +306,7 @@ class Figure:
 
         fname = Path(fname)
         prefix, suffix = fname.with_suffix("").as_posix(), fname.suffix
-        ext = suffix[1:]
+        ext = suffix[1:]  # Remove the .
         # alias jpeg to jpg
         if ext == "jpeg":
             ext = "jpg"

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -305,7 +305,7 @@ class Figure:
             "kml": "g",
         }
 
-        prefix = Path(fname).with_suffix("")
+        prefix = Path(fname).with_suffix("").as_posix()
         ext = Path(fname).suffix[1:]  # suffix without .
         if ext not in fmts:
             if ext == "ps":

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -260,9 +260,9 @@ class Figure:
         This method implements a matplotlib-like interface for
         :meth:`pygmt.Figure.psconvert`.
 
-        Supported formats: PNG (``.png``), JPEG (``.jpg``), PDF (``.pdf``),
-        BMP (``.bmp``), TIFF (``.tif``), EPS (``.eps``), and KML (``.kml``).
-        The KML output generates a companion PNG file.
+        Supported formats: PNG (``.png``), JPEG (``.jpg`` or ``.jpeg),
+        PDF (``.pdf``), BMP (``.bmp``), TIFF (``.tif``), EPS (``.eps``), and
+        KML (``.kml``). The KML output generates a companion PNG file.
 
         You can pass in any keyword arguments that
         :meth:`pygmt.Figure.psconvert` accepts.
@@ -298,14 +298,15 @@ class Figure:
             "png": "g",
             "pdf": "f",
             "jpg": "j",
+            "jpeg": "j",
             "bmp": "b",
             "eps": "e",
             "tif": "t",
             "kml": "g",
         }
 
-        prefix, ext = os.path.splitext(fname)
-        ext = ext[1:]  # Remove the .
+        prefix = Path(fname).with_suffix("")
+        ext = Path(fname).suffix[1:]  # suffix without .
         if ext not in fmts:
             if ext == "ps":
                 raise GMTInvalidInput(
@@ -327,6 +328,11 @@ class Figure:
             kwargs["W"] = "+k"
 
         self.psconvert(prefix=prefix, fmt=fmt, crop=crop, **kwargs)
+
+        # rename .jpg to .jpeg
+        if ext == "jpeg":
+            Path(fname).with_suffix(".jpg").rename(fname)
+
         if show:
             launch_external_viewer(fname)
 

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -298,15 +298,19 @@ class Figure:
             "png": "g",
             "pdf": "f",
             "jpg": "j",
-            "jpeg": "j",
             "bmp": "b",
             "eps": "e",
             "tif": "t",
             "kml": "g",
         }
 
-        prefix = Path(fname).with_suffix("").as_posix()
-        ext = Path(fname).suffix[1:]  # suffix without .
+        fname = Path(fname)
+        prefix, suffix = fname.with_suffix("").as_posix(), fname.suffix
+        ext = suffix[1:]
+        # alias jpeg to jpg
+        if ext == "jpeg":
+            ext = "jpg"
+
         if ext not in fmts:
             if ext == "ps":
                 raise GMTInvalidInput(
@@ -329,9 +333,9 @@ class Figure:
 
         self.psconvert(prefix=prefix, fmt=fmt, crop=crop, **kwargs)
 
-        # rename .jpg to .jpeg
-        if ext == "jpeg":
-            Path(fname).with_suffix(".jpg").rename(fname)
+        # Rename if file extension doesn't match the input file suffix
+        if ext != suffix[1:]:
+            fname.with_suffix("." + ext).rename(fname)
 
         if show:
             launch_external_viewer(fname)

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -83,7 +83,7 @@ def test_figure_savefig_exists():
     fig = Figure()
     fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
     prefix = "test_figure_savefig_exists"
-    for fmt in "png pdf jpg bmp eps tif".split():
+    for fmt in "png pdf jpg jpeg bmp eps tif".split():
         fname = ".".join([prefix, fmt])
         fig.savefig(fname)
         assert os.path.exists(fname)


### PR DESCRIPTION
Support `.jpeg` as file extension. Please note that `gmt psconvert -Tj` always produces images with the `.jpg` extension. It has two downsides:

1. Users may be surprised that they give `.jpeg` but get `.jpg`
2. `show=True` won't work unless we change the codes

I feel it's better to rename the files to have the file extension that users expect. 

Closes https://github.com/GenericMappingTools/pygmt/issues/2689.