### PR TITLE
NEP29: Test PyGMT on NumPy 1.26

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -63,14 +63,14 @@ jobs:
             isDraft: true
           - os: windows-latest
             isDraft: true
-        # Pair Python 3.9 with NumPy 1.22 and Python 3.11 with NumPy 1.25
-        # Only install optional packages on Python 3.11/NumPy 1.25
+        # Pair Python 3.9 with NumPy 1.22 and Python 3.11 with NumPy 1.26
+        # Only install optional packages on Python 3.11/NumPy 1.26
         include:
           - python-version: '3.9'
             numpy-version: '1.22'
             optional-packages: ''
           - python-version: '3.11'
-            numpy-version: '1.25'
+            numpy-version: '1.26'
             optional-packages: ' contextily geopandas ipython rioxarray sphinx-gallery'
 
     timeout-minutes: 30


### PR DESCRIPTION
**Description of proposed changes**

Bumps [numpy](https://github.com/numpy/numpy) from 1.25 to 1.26. [NumPy 1.26.0](https://github.com/numpy/numpy/releases/tag/v1.26.0) was released on 18 Jun 2023.
- [Release notes](https://github.com/numpy/numpy/releases)
- [Changelog](https://numpy.org/doc/1.26/release/1.26.0-notes.html)
- [Commits](https://github.com/numpy/numpy/compare/v1.25.0...v1.26.0)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This is in line with PyGMT's policy on [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) at https://www.pygmt.org/v0.9.0/maintenance.html#dependencies-policy, xref #1074.

Note that the branch protection rules at [GenericMappingTools/pygmt/settings/branches](https://github.com/GenericMappingTools/pygmt/settings/branches) will need to be changed to use Python 3.11/Numpy 1.26 instead of Python 3.11/Numpy 1.25 before this Pull Request is merged.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Supersedes #2581

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
