### PR TITLE
CI: Change tilemap source from Stamen to OpenStreetMap

### DIFF
--- a/pygmt/tests/baseline/test_tilemap_no_clip_False.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_no_clip_False.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 03072b9a80791453d2e686bb11f2457e
-  size: 16486
+- md5: e2a9a57f61bdca0c21ddec3e1ae5d819
+  size: 16595
   path: test_tilemap_no_clip_False.png

--- a/pygmt/tests/baseline/test_tilemap_no_clip_False.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_no_clip_False.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 9317080021b0ce6f3b9ea6d17feece00
-  size: 23275
+- md5: 053bd9ad08c33c76a70fc6b426a31e34
+  size: 16475
+  hash: md5
   path: test_tilemap_no_clip_False.png

--- a/pygmt/tests/baseline/test_tilemap_no_clip_False.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_no_clip_False.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 053bd9ad08c33c76a70fc6b426a31e34
-  size: 16475
+- md5: 03072b9a80791453d2e686bb11f2457e
+  size: 16486
   path: test_tilemap_no_clip_False.png

--- a/pygmt/tests/baseline/test_tilemap_no_clip_False.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_no_clip_False.png.dvc
@@ -1,5 +1,4 @@
 outs:
 - md5: 053bd9ad08c33c76a70fc6b426a31e34
   size: 16475
-  hash: md5
   path: test_tilemap_no_clip_False.png

--- a/pygmt/tests/baseline/test_tilemap_no_clip_True.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_no_clip_True.png.dvc
@@ -1,5 +1,4 @@
 outs:
 - md5: 086b9d21e6634ceaa5ef0fc9954e820c
   size: 38892
-  hash: md5
   path: test_tilemap_no_clip_True.png

--- a/pygmt/tests/baseline/test_tilemap_no_clip_True.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_no_clip_True.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 83e6119b2351f9d472ca7e3cc45388c3
-  size: 60984
+- md5: 086b9d21e6634ceaa5ef0fc9954e820c
+  size: 38892
+  hash: md5
   path: test_tilemap_no_clip_True.png

--- a/pygmt/tests/baseline/test_tilemap_no_clip_True.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_no_clip_True.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 8ff34baa26dac9818cf1bc232b5ce056
-  size: 38824
+- md5: 86ce085faad17433dfabba675d0379ee
+  size: 38836
   path: test_tilemap_no_clip_True.png

--- a/pygmt/tests/baseline/test_tilemap_no_clip_True.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_no_clip_True.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 086b9d21e6634ceaa5ef0fc9954e820c
-  size: 38892
+- md5: 8ff34baa26dac9818cf1bc232b5ce056
+  size: 38824
   path: test_tilemap_no_clip_True.png

--- a/pygmt/tests/baseline/test_tilemap_ogc_wgs84.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_ogc_wgs84.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 3de0555d86aca49b92425c8d5272a934
-  size: 59286
+- md5: 367a3f11637b1be006a437c9f93d0317
+  size: 37289
+  hash: md5
   path: test_tilemap_ogc_wgs84.png

--- a/pygmt/tests/baseline/test_tilemap_ogc_wgs84.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_ogc_wgs84.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 367a3f11637b1be006a437c9f93d0317
-  size: 37289
+- md5: 9a076934efe119c318bd2ba311fb7c27
+  size: 37339
   path: test_tilemap_ogc_wgs84.png

--- a/pygmt/tests/baseline/test_tilemap_ogc_wgs84.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_ogc_wgs84.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 9a076934efe119c318bd2ba311fb7c27
-  size: 37339
+- md5: 6da0601f305a6c3391e4a1aa0aee6173
+  size: 37139
   path: test_tilemap_ogc_wgs84.png

--- a/pygmt/tests/baseline/test_tilemap_ogc_wgs84.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_ogc_wgs84.png.dvc
@@ -1,5 +1,4 @@
 outs:
 - md5: 367a3f11637b1be006a437c9f93d0317
   size: 37289
-  hash: md5
   path: test_tilemap_ogc_wgs84.png

--- a/pygmt/tests/baseline/test_tilemap_web_mercator.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_web_mercator.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 9b338dffe506f569769fa60f93ecee68
-  size: 62402
+- md5: 2965f6711c5878014491c7e6f791048e
+  size: 62077
   path: test_tilemap_web_mercator.png

--- a/pygmt/tests/baseline/test_tilemap_web_mercator.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_web_mercator.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 7362261406771b5cfe1bcfb7a292105a
-  size: 62463
+- md5: 9b338dffe506f569769fa60f93ecee68
+  size: 62402
   path: test_tilemap_web_mercator.png

--- a/pygmt/tests/baseline/test_tilemap_web_mercator.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_web_mercator.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: a76d9a9a1890d6b1345305eaea598bc3
-  size: 122195
+- md5: 7362261406771b5cfe1bcfb7a292105a
+  size: 62463
+  hash: md5
   path: test_tilemap_web_mercator.png

--- a/pygmt/tests/baseline/test_tilemap_web_mercator.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_web_mercator.png.dvc
@@ -1,5 +1,4 @@
 outs:
 - md5: 7362261406771b5cfe1bcfb7a292105a
   size: 62463
-  hash: md5
   path: test_tilemap_web_mercator.png

--- a/pygmt/tests/test_tilemap.py
+++ b/pygmt/tests/test_tilemap.py
@@ -17,6 +17,7 @@ def test_tilemap_web_mercator():
     fig.tilemap(
         region=[-20000000.0, 20000000.0, -20000000.0, 20000000.0],
         zoom=0,
+        source=contextily.providers.OpenStreetMap.Mapnik,
         lonlat=False,
         frame="afg",
     )
@@ -31,7 +32,11 @@ def test_tilemap_ogc_wgs84():
     """
     fig = Figure()
     fig.tilemap(
-        region=[-180.0, 180.0, -90, 90], zoom=0, frame="afg", projection="R180/5c"
+        region=[-180.0, 180.0, -90, 90],
+        zoom=0,
+        source=contextily.providers.OpenStreetMap.Mapnik,
+        frame="afg",
+        projection="R180/5c",
     )
     return fig
 
@@ -47,6 +52,7 @@ def test_tilemap_no_clip(no_clip):
     fig.tilemap(
         region=[-180.0, 180.0, -90, 0.6886],
         zoom=0,
+        source=contextily.providers.OpenStreetMap.Mapnik,
         frame="afg",
         projection="H180/5c",
         no_clip=no_clip,


### PR DESCRIPTION
**Description of proposed changes**

Change tilemap source from contextily's default Stamen Terrain to OpenStreetmap's Standard tile layer (osm-carto, see https://wiki.openstreetmap.org/wiki/Standard_tile_layer).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

References:
- https://contextily.readthedocs.io/en/latest/providers_deepdive.html
- https://wiki.openstreetmap.org/w/index.php?title=Standard_tile_layer&redirect=no
- https://operations.osmfoundation.org/policies/tiles/

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #2699


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
