### PR TITLE
Fix typos in "Figure.meca"

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -228,7 +228,7 @@ def meca(
     Parameters
     ----------
     spec : str, 1-D array, 2-D array, dict, or pd.DataFrame
-        Data that contains focal mechanism parameters.
+        Data that contain focal mechanism parameters.
 
         ``spec`` can be specified in either of the following types:
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -269,10 +269,10 @@ def meca(
           keys/column names: ``latitude``, ``longitude``, ``depth``,
           ``plot_longitude``, ``plot_latitude``, and/or ``event_name``.
 
-          If ``spec`` is either a str, a 1-D array or a 2-D array, the
-          ``convention`` parameter is required so we know how to interpret the
-          columns. If ``spec`` is a dictionary or a pd.DataFrame,
-          ``convention`` is not needed and is ignored if specified.
+        If ``spec`` is either a str, a 1-D array or a 2-D array, the
+        ``convention`` parameter is required so we know how to interpret the
+        columns. If ``spec`` is a dictionary or a pd.DataFrame,
+        ``convention`` is not needed and is ignored if specified.
     scale : int, float, or str
         *scale*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*]\
         [**+l**][**+m**][**+o**\ *dx*\ [/\ *dy*]][**+s**\ *reference*].


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix some typos in the docstrings for `Figure.meca`.

**Preview**:

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
