### PR TITLE
Intro "2. Create a contour map": Correct explanation of "pen" parameter

### DIFF
--- a/examples/get_started/02_contour_map.py
+++ b/examples/get_started/02_contour_map.py
@@ -87,9 +87,9 @@ fig.show()
 # ``annotation`` parameter annotates the contour lines corresponding to the
 # given interval (in this case, 1,000 meters) with the related values, here
 # elevation or bathymetry. By default, these contour lines are drawn thicker.
-# Optionally, the appearance (thickness, color, style) of the contour lines
-# can be adjusted by specifying a desired ``pen``, which then applies to all
-# contour lines.
+# Optionally, the appearance (thickness, color, style) of the annotated and
+# the not annotated contour lines can be adjusted by specifying a desired
+# ``pen``.
 
 fig = pygmt.Figure()
 fig.grdimage(grid=grid, frame="a", projection="M10c", cmap="oleron")

--- a/examples/get_started/02_contour_map.py
+++ b/examples/get_started/02_contour_map.py
@@ -88,8 +88,8 @@ fig.show()
 # given interval (in this case, 1,000 meters) with the related values, here
 # elevation or bathymetry. By default, these contour lines are drawn thicker.
 # Optionally, the appearance (thickness, color, style) of the annotated and
-# the not annotated contour lines can be adjusted by specifying a desired
-# ``pen``.
+# the not-annotated contour lines can be (separately) adjusted by specifying
+# a desired ``pen``.
 
 fig = pygmt.Figure()
 fig.grdimage(grid=grid, frame="a", projection="M10c", cmap="oleron")

--- a/examples/get_started/02_contour_map.py
+++ b/examples/get_started/02_contour_map.py
@@ -88,8 +88,8 @@ fig.show()
 # given interval (in this case, 1,000 meters) with the related values, here
 # elevation or bathymetry. By default, these contour lines are drawn thicker.
 # Optionally, the appearance (thickness, color, style) of the annotated and
-# the not-annotated contour lines can be (separately) adjusted by specifying
-# a desired ``pen``.
+# the not-annotated contour lines can be adjusted (separately) by specifying
+# the desired ``pen``.
 
 fig = pygmt.Figure()
 fig.grdimage(grid=grid, frame="a", projection="M10c", cmap="oleron")


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to correct a formulation in the intro "2. Create a contour map". Unfortunately, I did not know about the possibility to separately specify the `pen` used for annotated and non-annotated contour lines by prepending **a** and **c** when working on PR #2654.

**Preview**: https://pygmt-dev--2705.org.readthedocs.build/en/2705/get_started/02_contour_map.html#adding-contour-lines

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
