### PR TITLE
pygmt.grdtrack: Simplify the handling of optional virtual files

### DIFF
--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -283,7 +283,6 @@ def grdtrack(grid, points=None, newcolname=None, outfile=None, **kwargs):
     ...     points=points, grid=grid, newcolname="bathymetry"
     ... )
     """
-    # pylint: disable=too-many-branches
     if points is not None and kwargs.get("E") is not None:
         raise GMTInvalidInput("Can't set both 'points' and 'profile'.")
 


### PR DESCRIPTION
**Description of proposed changes**

The `pygmt.grdtrack` method also takes an optional virtual file, so it can be
greatly simplified after https://github.com/GenericMappingTools/pygmt/pull/2493.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
