### PR TITLE
Gallery example "Clipping grid values": Add annotations to frames

### DIFF
--- a/examples/gallery/images/grdclip.py
+++ b/examples/gallery/images/grdclip.py
@@ -20,7 +20,11 @@ region = [-28, -10, 62, 68]
 grid = pygmt.datasets.load_earth_relief(resolution="03m", region=region)
 
 # Plot original grid
-fig.basemap(region=region, projection="M12c", frame=["f", "+toriginal grid"])
+fig.basemap(
+    region=region,
+    projection="M12c",
+    frame=["WSne+toriginal grid", "xa5f1", "ya2f1"],
+)
 fig.grdimage(grid=grid, cmap="oleron")
 
 # Shift plot origin of the second map by "width of the first map + 0.5 cm"
@@ -31,7 +35,11 @@ fig.shift_origin(xshift="w+0.5c")
 grid = pygmt.grdclip(grid, below=[0, -2000])
 
 # Plot clipped grid
-fig.basemap(region=region, projection="M12c", frame=["f", "+tclipped grid"])
+fig.basemap(
+    region=region,
+    projection="M12c",
+    frame=["wSne+tclipped grid", "xa5f1", "ya2f1"],
+)
 fig.grdimage(grid=grid)
 fig.colorbar(frame=["x+lElevation", "y+lm"], position="JMR+o0.5c/0c+w8c")
 


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to add annotations to the frames of the maps in the gallery example `Clipping grid values`:

| without annotations | with annotations |
| --- | --- |
|  ![grdclip_WITHOUT_Baf](https://github.com/GenericMappingTools/pygmt/assets/94163266/22aa1561-7c4d-4af9-ad10-ece32f86f5cc) | ![grdclip_WITH_Baf](https://github.com/GenericMappingTools/pygmt/assets/94163266/5d744397-7faa-47c2-8ffd-3401d6335e58) |


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
