### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -43,7 +43,7 @@ jobs:
               - conda-forge
               - nodefaults
           create-args: >-
-            python=3.11
+            python=3.12
             gmt=6.4.0
             numpy
             pandas

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -44,7 +44,7 @@ jobs:
         # Is it a draft Pull Request (true or false)?
         isDraft:
           - ${{ github.event.pull_request.draft }}
-        # Only run one job (Ubuntu + Python 3.11) for draft PRs
+        # Only run one job (Ubuntu + Python 3.12) for draft PRs
         exclude:
           - os: macos-latest
             isDraft: true
@@ -75,7 +75,7 @@ jobs:
           cache-downloads: true
           cache-environment: true
           create-args: >-
-            python=3.11
+            python=3.12
             gmt=6.4.0
             numpy
             pandas

--- a/.github/workflows/ci_doctests.yaml
+++ b/.github/workflows/ci_doctests.yaml
@@ -48,7 +48,7 @@ jobs:
               - conda-forge
               - nodefaults
           create-args: >-
-            python=3.11
+            python=3.12
             gmt=6.4.0
             numpy
             pandas

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -52,24 +52,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.11']
+        python-version: ['3.9', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
         # Is it a draft Pull Request (true or false)?
         isDraft:
           - ${{ github.event.pull_request.draft }}
-        # Only run two jobs (Ubuntu + Python 3.9/3.11) for draft PRs
+        # Only run two jobs (Ubuntu + Python 3.9/3.12) for draft PRs
         exclude:
           - os: macos-latest
             isDraft: true
           - os: windows-latest
             isDraft: true
-        # Pair Python 3.9 with NumPy 1.22 and Python 3.11 with NumPy 1.25
-        # Only install optional packages on Python 3.11/NumPy 1.25
+        # Pair Python 3.9 with NumPy 1.22 and Python 3.12 with NumPy 1.25
+        # Only install optional packages on Python 3.12/NumPy 1.25
         include:
           - python-version: '3.9'
             numpy-version: '1.22'
             optional-packages: ''
-          - python-version: '3.11'
+          - python-version: '3.12'
             numpy-version: '1.25'
             optional-packages: ' contextily geopandas ipython rioxarray sphinx-gallery'
 

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -100,7 +100,7 @@ jobs:
           cache-downloads: true
           cache-environment: true
           create-args: >-
-            python=3.11
+            python=3.12
             cmake
             make
             ninja

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -27,7 +27,7 @@ jobs:
       # Setup Python environment
       - uses: actions/setup-python@v4.7.0
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       # Install formatting tools
       - name: Install formatting tools

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4.7.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install dependencies
       run: python -m pip install build

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4.7.0
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install packages
         run: |

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -132,14 +132,14 @@ want):
 
         ::
 
-            mamba create --name pygmt python=3.11 numpy pandas xarray netcdf4 packaging gmt
+            mamba create --name pygmt python=3.12 numpy pandas xarray netcdf4 packaging gmt
 
     .. tab-item:: conda
         :sync: conda
 
         ::
 
-            conda create --name pygmt python=3.11 numpy pandas xarray netcdf4 packaging gmt
+            conda create --name pygmt python=3.12 numpy pandas xarray netcdf4 packaging gmt
 
 Activate the environment by running the following (**do not forget this step!**):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: BSD License",
 ]
 dependencies = [


### PR DESCRIPTION
**Description of proposed changes**

Python 3.12 has been released on 2 Oct 2023, changelog is at https://docs.python.org/3.12/whatsnew/3.12.html

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Previous PR for Python 3.11 at #2172

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
