### PR TITLE
Move variable __gmt_version__ to pygmt.clib to avoid cyclic-import errors

### DIFF
--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -21,13 +21,9 @@ import atexit as _atexit
 import sys
 from importlib.metadata import version
 
-from pygmt import clib
-
 # Get semantic version through setuptools-scm
 __version__ = f'v{version("pygmt")}'  # e.g. v0.1.2.dev3+g0ab3cd78
 __commit__ = __version__.split("+g")[-1] if "+g" in __version__ else ""  # 0ab3cd78
-with clib.Session() as lib:
-    __gmt_version__ = lib.info["version"]
 
 # Import modules to make the high-level GMT Python API
 from pygmt import datasets

--- a/pygmt/clib/__init__.py
+++ b/pygmt/clib/__init__.py
@@ -6,3 +6,6 @@ Pythonic interface. Access to the C library is done through ctypes.
 """
 
 from pygmt.clib.session import Session
+
+with Session() as lib:
+    __gmt_version__ = lib.info["version"]

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -3,8 +3,7 @@ ternary - Plot data on ternary diagrams.
 """
 import pandas as pd
 from packaging.version import Version
-from pygmt import __gmt_version__
-from pygmt.clib import Session
+from pygmt.clib import Session, __gmt_version__
 from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 

--- a/pygmt/src/timestamp.py
+++ b/pygmt/src/timestamp.py
@@ -4,8 +4,7 @@ timestamp - Plot the GMT timestamp logo.
 import warnings
 
 from packaging.version import Version
-from pygmt import __gmt_version__
-from pygmt.clib import Session
+from pygmt.clib import Session, __gmt_version__
 from pygmt.helpers import build_arg_string, is_nonstr_iter
 
 __doctest_skip__ = ["timestamp"]

--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -8,7 +8,8 @@ from pathlib import Path
 import pytest
 import xarray as xr
 from packaging.version import Version
-from pygmt import __gmt_version__, which
+from pygmt import which
+from pygmt.clib import __gmt_version__
 from pygmt.datasets import load_earth_relief
 from pygmt.exceptions import GMTInvalidInput
 

--- a/pygmt/tests/test_grdfill.py
+++ b/pygmt/tests/test_grdfill.py
@@ -7,7 +7,8 @@ import numpy as np
 import pytest
 import xarray as xr
 from packaging.version import Version
-from pygmt import __gmt_version__, grdfill, load_dataarray
+from pygmt import grdfill, load_dataarray
+from pygmt.clib import __gmt_version__
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import load_static_earth_relief

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -5,7 +5,8 @@ import numpy as np
 import pandas as pd
 import pytest
 from packaging.version import Version
-from pygmt import Figure, __gmt_version__
+from pygmt import Figure
+from pygmt.clib import __gmt_version__
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 


### PR DESCRIPTION
**Description of proposed changes**

Defining `__gmt_version__` in `pygmt/__init__.py` causes cyclic-import errors.
This PR fixes the issue by moving `__gmt_version__` from `pygmt/__init__.py`
to `pygmt/clib/__init__.py`.

Closes https://github.com/GenericMappingTools/pygmt/issues/2712.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
