### PR TITLE
Switch away from Stamen basemaps

### DIFF
--- a/examples/gallery/maps/tilemaps.py
+++ b/examples/gallery/maps/tilemaps.py
@@ -37,8 +37,8 @@ fig = pygmt.Figure()
 fig.tilemap(
     region=[-157.84, -157.8, 21.255, 21.285],
     projection="M12c",
-    # Use the U.S. Geological Survey  Imagery Topo web tiles from contextily
-    source=contextily.providers.USGS.USImageryTopo,
+    # Use the CartoDB Positron option from contextily
+    source=contextily.providers.CartoDB.Positron,
     frame="afg",
 )
 

--- a/examples/gallery/maps/tilemaps.py
+++ b/examples/gallery/maps/tilemaps.py
@@ -37,8 +37,8 @@ fig = pygmt.Figure()
 fig.tilemap(
     region=[-157.84, -157.8, 21.255, 21.285],
     projection="M12c",
-    # Use the Stamen.Watercolor option from contextily
-    source=contextily.providers.Stamen.Watercolor,
+    # Use the U.S. Geological Survey  Imagery Topo web tiles from contextily
+    source=contextily.providers.USGS.USImageryTopo,
     frame="afg",
 )
 

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -50,8 +50,8 @@ def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_ret
           :class:`xyzservices.TileProvider` object. See
           :doc:`Contextily providers <contextily:providers_deepdive>` for a
           list of tile providers [Default is
-          ``xyzservices.providers.Stamen.Terrain``, i.e. Stamen Terrain web
-          tiles].
+          ``xyzservices.providers.OpenStreetMap.HOT``, i.e. OpenStreetMap
+          Humanitarian web tiles].
         - A web tile provider in the form of a URL. The placeholders for the
           XYZ in the URL need to be {x}, {y}, {z}, respectively. E.g.
           ``https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png``.
@@ -96,7 +96,7 @@ def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_ret
     >>> raster = load_tile_map(
     ...     region=[-180.0, 180.0, -90.0, 0.0],  # West, East, South, North
     ...     zoom=1,  # less detailed zoom level
-    ...     source=contextily.providers.Stamen.TerrainBackground,
+    ...     source=contextily.providers.OpenTopoMap,
     ...     lonlat=True,  # bounding box coordinates are longitude/latitude
     ... )
     >>> raster.sizes

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -74,8 +74,8 @@ def tilemap(
           :class:`xyzservices.TileProvider` object. See
           :doc:`Contextily providers <contextily:providers_deepdive>` for a
           list of tile providers [Default is
-          ``xyzservices.providers.Stamen.Terrain``, i.e. Stamen Terrain web
-          tiles].
+          ``xyzservices.providers.OpenStreetMap.HOT``, i.e. OpenStreetMap
+          Humanitarian web tiles].
         - A web tile provider in the form of a URL. The placeholders for the
           XYZ in the URL need to be {{x}}, {{y}}, {{z}}, respectively. E.g.
           ``https://{{s}}.tile.openstreetmap.org/{{z}}/{{x}}/{{y}}.png``.


### PR DESCRIPTION
**Description of proposed changes**

Stamen basemaps are being deprecated, so switching the default source to OpenStreetMap Humanitarian web tiles following contextily at https://github.com/geopandas/contextily/pull/221. Changed load_tile_map's inline example to use OpenTopoMap, and tilemap gallery example to use CartoDB's Positron basemap instead.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Preview** at https://pygmt-dev--2717.org.readthedocs.build/en/2717/gallery/maps/tilemaps.html

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #2716


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
