### PR TITLE
clib: Fix the bug when passing multiple columns of strings with variable lengths to the GMT C API

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1291,9 +1291,7 @@ class Session:
             if len(string_arrays) == 1:
                 strings = string_arrays[0]
             elif len(string_arrays) > 1:
-                strings = np.apply_along_axis(
-                    func1d=" ".join, axis=0, arr=string_arrays
-                )
+                strings = np.array([" ".join(vals) for vals in zip(*string_arrays)])
             strings = np.asanyarray(a=strings, dtype=str)
             self.put_strings(
                 dataset, family="GMT_IS_VECTOR|GMT_IS_DUPLICATE", strings=strings

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -556,7 +556,8 @@ def test_virtualfile_from_vectors_two_string_or_object_columns(dtype):
     size = 5
     x = np.arange(size, dtype=np.int32)
     y = np.arange(size, size * 2, 1, dtype=np.int32)
-    strings1 = np.array(["a", "bc", "def", "ghij", "klmno"], dtype=dtype)
+    # Catch bug in https://github.com/GenericMappingTools/pygmt/pull/2719
+    strings1 = np.array(["a", "bc", "def", "ghij", "klmnolooong"], dtype=dtype)
     strings2 = np.array(["pqrst", "uvwx", "yz!", "@#", "$"], dtype=dtype)
     with clib.Session() as lib:
         with lib.virtualfile_from_vectors(x, y, strings1, strings2) as vfile:


### PR DESCRIPTION
**Description of proposed changes**

Found this bug when working on PR https://github.com/GenericMappingTools/pygmt/pull/2720.

The changed code is meant to element-wisely join two string arrays with a space, but it doesn't work if strings have different lengths.

Here is a simple example to reproduce the issue:
```python
>>> import numpy as np
>>> string_arrays = [np.array(["ABC", "DEF"]), np.array(["ABC", "DEFGHIJK"])]
>>> np.apply_along_axis(func1d=" ".join, axis=0, arr=string_arrays)
array(['ABC ABC', 'DEF DEF'], dtype='<U7')
```
Obvisouly the result is incorrect, although I don't fully understand why it doesn't work.

The new code works as expected.
```python
>>> np.array([" ".join(vals) for vals in zip(*string_arrays)])
array(['ABC ABC', 'DEF DEFGHIJK'], dtype='<U12')
```

BTW: a test related to this bug will be added in PR https://github.com/GenericMappingTools/pygmt/pull/2720.