### PR TITLE
Figure.text: Support passing in a list of angle/font/justify values

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1291,9 +1291,7 @@ class Session:
             if len(string_arrays) == 1:
                 strings = string_arrays[0]
             elif len(string_arrays) > 1:
-                strings = np.apply_along_axis(
-                    func1d=" ".join, axis=0, arr=string_arrays
-                )
+                strings = np.array([" ".join(vals) for vals in zip(*string_arrays)])
             strings = np.asanyarray(a=strings, dtype=str)
             self.put_strings(
                 dataset, family="GMT_IS_VECTOR|GMT_IS_DUPLICATE", strings=strings

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1291,7 +1291,9 @@ class Session:
             if len(string_arrays) == 1:
                 strings = string_arrays[0]
             elif len(string_arrays) > 1:
-                strings = np.array([" ".join(vals) for vals in zip(*string_arrays)])
+                strings = np.apply_along_axis(
+                    func1d=" ".join, axis=0, arr=string_arrays
+                )
             strings = np.asanyarray(a=strings, dtype=str)
             self.put_strings(
                 dataset, family="GMT_IS_VECTOR|GMT_IS_DUPLICATE", strings=strings

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -167,7 +167,7 @@ def text_(
         ``x``/``y`` and ``text``.
     {wrap}
     """
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches,too-many-locals
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
 
     # Ensure inputs are either textfiles, x/y/text, or position/text

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -207,7 +207,7 @@ def text_(
         elif is_nonstr_iter(arg):
             kwargs["F"] += flag
             if flag == "+a":  # angle is numeric type
-                extra_arrays.append(np.atleast_1d(arg))  # numeric
+                extra_arrays.append(np.atleast_1d(arg))
             else:  # font or justify is str type
                 extra_arrays.append(np.atleast_1d(arg).astype(str))
         elif isinstance(arg, (int, float, str)):

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -39,9 +39,6 @@ from pygmt.helpers import (
 @kwargs_to_strings(
     R="sequence",
     textfiles="sequence_space",
-    angle="sequence_comma",
-    font="sequence_comma",
-    justify="sequence_comma",
     c="sequence_comma",
     p="sequence",
 )
@@ -203,25 +200,34 @@ def text_(
     ):
         kwargs.update({"F": ""})
 
+    extra_arrays = []
     if angle is True:
         kwargs["F"] += "+a"
+    elif is_nonstr_iter(angle):
+        kwargs["F"] += "+a"
+        extra_arrays.append(np.atleast_1d(angle))
     elif isinstance(angle, (int, float, str)):
         kwargs["F"] += f"+a{str(angle)}"
 
     if font is True:
         kwargs["F"] += "+f"
+    elif is_nonstr_iter(font):
+        kwargs["F"] += "+f"
+        extra_arrays.append(np.atleast_1d(font).astype(str))
     elif isinstance(font, str):
         kwargs["F"] += f"+f{font}"
 
     if justify is True:
         kwargs["F"] += "+j"
+    elif is_nonstr_iter(justify):
+        kwargs["F"] += "+j"
+        extra_arrays.append(np.atleast_1d(justify).astype(str))
     elif isinstance(justify, str):
         kwargs["F"] += f"+j{justify}"
 
     if isinstance(position, str):
         kwargs["F"] += f"+c{position}+t{text}"
 
-    extra_arrays = []
     # If an array of transparency is given, GMT will read it from
     # the last numerical column per data record.
     if kwargs.get("t") is not None and is_nonstr_iter(kwargs["t"]):

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -94,12 +94,12 @@ def text_(
         of the map.
     text : str or 1-D array
         The text string, or an array of strings to plot on the figure.
-    angle: int, float, str or bool
+    angle: int, float, str, bool or list
         Set the angle measured in degrees counter-clockwise from
         horizontal (e.g. 30 sets the text at 30 degrees). If no angle is
         explicitly given (i.e. ``angle=True``) then the input to ``textfiles``
         must have this as a column.
-    font : str or bool
+    font : str, bool or list of str
         Set the font specification with format *size*\ ,\ *font*\ ,\ *color*
         where *size* is text size in points, *font* is the font to use, and
         *color* sets the font color. For example,
@@ -107,7 +107,7 @@ def text_(
         font. If no font info is explicitly given (i.e. ``font=True``), then
         the input to ``textfiles`` must have this information in one of its
         columns.
-    justify : str or bool
+    justify : str, bool or list of str
         Set the alignment which refers to the part of the text string that
         will be mapped onto the (x, y) point. Choose a two-letter
         combination of **L**, **C**, **R** (for left, center, or right) and

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -201,29 +201,17 @@ def text_(
         kwargs.update({"F": ""})
 
     extra_arrays = []
-    if angle is True:
-        kwargs["F"] += "+a"
-    elif is_nonstr_iter(angle):
-        kwargs["F"] += "+a"
-        extra_arrays.append(np.atleast_1d(angle))
-    elif isinstance(angle, (int, float, str)):
-        kwargs["F"] += f"+a{str(angle)}"
-
-    if font is True:
-        kwargs["F"] += "+f"
-    elif is_nonstr_iter(font):
-        kwargs["F"] += "+f"
-        extra_arrays.append(np.atleast_1d(font).astype(str))
-    elif isinstance(font, str):
-        kwargs["F"] += f"+f{font}"
-
-    if justify is True:
-        kwargs["F"] += "+j"
-    elif is_nonstr_iter(justify):
-        kwargs["F"] += "+j"
-        extra_arrays.append(np.atleast_1d(justify).astype(str))
-    elif isinstance(justify, str):
-        kwargs["F"] += f"+j{justify}"
+    for arg, flag in [(angle, "+a"), (font, "+f"), (justify, "+j")]:
+        if arg is True:
+            kwargs["F"] += flag
+        elif is_nonstr_iter(arg):
+            kwargs["F"] += flag
+            if flag == "+a":  # angle is numeric type
+                extra_arrays.append(np.atleast_1d(arg))  # numeric
+            else:  # font or justify is str type
+                extra_arrays.append(np.atleast_1d(arg).astype(str))
+        elif isinstance(arg, (int, float, str)):
+            kwargs["F"] += f"{flag}{arg}"
 
     if isinstance(position, str):
         kwargs["F"] += f"+c{position}+t{text}"

--- a/pygmt/tests/baseline/test_text_angle_justify_font_arrays.png.dvc
+++ b/pygmt/tests/baseline/test_text_angle_justify_font_arrays.png.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: c111539b0b5966eee4305f9485c85bd0
+  size: 8208
+  hash: md5
+  path: test_text_angle_justify_font_arrays.png

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -330,6 +330,24 @@ def test_text_justify_array(region):
 
 
 @pytest.mark.mpl_image_compare
+def test_text_angle_justify_font_arrays(region):
+    """
+    Test passing arrays of angle, justify and font.
+    """
+    fig = Figure()
+    fig.basemap(region=region, projection="X5c/2.5c", frame=True)
+    fig.text(
+        x=[2.5, 2.5],
+        y=[1.0, 2.0],
+        angle=[30, 50],
+        justify=["TL", "BR"],
+        font=["15p,Helvetica-Bold,red", "5p,Times-Italic,blue"],
+        text=["TEXT1", "TEXT2 with spaces"],
+    )
+    return fig
+
+
+@pytest.mark.mpl_image_compare
 def test_text_transparency():
     """
     Add texts with a constant transparency.

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -311,6 +311,24 @@ def test_text_angle_font_justify_from_textfile():
     return fig
 
 
+@pytest.mark.mpl_image_compare(filename="test_text_position.png")
+def test_text_justify_array(region):
+    """
+    Test passing an array of justify codes.
+
+    Re-use the baseline image from test_text_position().
+    """
+    fig = Figure()
+    fig.basemap(region=region, projection="x1c", frame="a")
+    fig.text(
+        x=[0, 2.5, 5.0, 0, 2.5, 5.0, 0, 2.5, 5.0],
+        y=[0, 0, 0, 1.25, 1.25, 1.25, 2.5, 2.5, 2.5],
+        justify=["BL", "BC", "BR", "ML", "MC", "MR", "TL", "TC", "TR"],
+        text=["BL", "BC", "BR", "ML", "C M", "MR", "TL", "TC", "TR"],
+    )
+    return fig
+
+
 @pytest.mark.mpl_image_compare
 def test_text_transparency():
     """


### PR DESCRIPTION
**Description of proposed changes**

Address an old feature request https://github.com/GenericMappingTools/pygmt/issues/483.

**Example**:

``` python
import pygmt
fig = pygmt.Figure()
fig.basemap(region=[0, 5, 0., 2.5], projection="X5c/2.5c", frame=True)
fig.text(
    x=[2.5, 2.5],
    y=[1.0, 2.0],
    angle=[30, 50],
    justify=["TL", "BR"],
    font=["15p,Helvetica-Bold,red", "5p,Times-Italic,blue"],
    text=["TEXT1", "TEXT2 with spaces"],
)
fig.show()
```
**Preview**:
![image](https://github.com/GenericMappingTools/pygmt/assets/3974108/7b6467cf-5a47-4a6d-ad4a-10313ae6157c)

~~Note: Need to fix the bug in https://github.com/GenericMappingTools/pygmt/pull/2719 first.~~

Closes #483.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
