### PR TITLE
Remove the invalid comment 'Choose how data will be passed ...'

### DIFF
--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -43,7 +43,6 @@ def _blockm(block_method, data, x, y, z, outfile, **kwargs):
     """
     with GMTTempFile(suffix=".csv") as tmpfile:
         with Session() as lib:
-            # Choose how data will be passed into the module
             table_context = lib.virtualfile_from_data(
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
             )

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -115,7 +115,6 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
 
     with Session() as lib:
-        # Choose how data will be passed into the module
         file_context = lib.virtualfile_from_data(
             check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
         )

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -493,7 +493,6 @@ def meca(
     # Assemble -S flag
     kwargs["S"] = f"{data_format}{scale}"
     with Session() as lib:
-        # Choose how data will be passed into the module
         file_context = lib.virtualfile_from_data(check_kind="vector", data=spec)
         with file_context as fname:
             lib.call_module(module="meca", args=build_arg_string(kwargs, infile=fname))

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -149,7 +149,6 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            # Choose how data will be passed into the module
             table_context = lib.virtualfile_from_data(
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
             )

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -258,7 +258,6 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
             kwargs[flag] = ""
 
     with Session() as lib:
-        # Choose how data will be passed in to the module
         file_context = lib.virtualfile_from_data(
             check_kind="vector", data=data, x=x, y=y, extra_arrays=extra_arrays
         )

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -228,7 +228,6 @@ def plot3d(
             kwargs[flag] = ""
 
     with Session() as lib:
-        # Choose how data will be passed in to the module
         file_context = lib.virtualfile_from_data(
             check_kind="vector",
             data=data,

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -227,7 +227,6 @@ def project(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
             outfile = tmpfile.name
         with Session() as lib:
             if kwargs.get("G") is None:
-                # Choose how data will be passed into the module
                 table_context = lib.virtualfile_from_data(
                     check_kind="vector", data=data, x=x, y=y, z=z, required_z=False
                 )

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -202,7 +202,6 @@ def rose(self, data=None, length=None, azimuth=None, **kwargs):
     kwargs = self._preprocess(**kwargs)  # pylint: disable=protected-access
 
     with Session() as lib:
-        # Choose how data will be passed into the module
         file_context = lib.virtualfile_from_data(
             check_kind="vector", data=data, x=length, y=azimuth
         )

--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -198,7 +198,6 @@ def select(data=None, outfile=None, **kwargs):
 
     with GMTTempFile(suffix=".csv") as tmpfile:
         with Session() as lib:
-            # Choose how data will be passed into the module
             table_context = lib.virtualfile_from_data(check_kind="vector", data=data)
             with table_context as infile:
                 if outfile is None:

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -164,7 +164,6 @@ def surface(data=None, x=None, y=None, z=None, **kwargs):
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            # Choose how data will be passed into the module
             file_context = lib.virtualfile_from_data(
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
             )

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -126,7 +126,6 @@ class triangulate:  # pylint: disable=invalid-name
               ``outgrid`` or ``outfile``)
         """
         with Session() as lib:
-            # Choose how data will be passed into the module
             table_context = lib.virtualfile_from_data(
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=False
             )

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -258,7 +258,6 @@ def velo(self, data=None, **kwargs):
         )
 
     with Session() as lib:
-        # Choose how data will be passed in to the module
         file_context = lib.virtualfile_from_data(check_kind="vector", data=data)
 
         with file_context as fname:

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -121,7 +121,6 @@ def wiggle(
             kwargs["G"].append(fillnegative + "+n")
 
     with Session() as lib:
-        # Choose how data will be passed in to the module
         file_context = lib.virtualfile_from_data(
             check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
         )


### PR DESCRIPTION
**Description of proposed changes**

The comment "Choose how data will be passed into the module" is invalid after we replace virtualfile_from_grid/matrix/vectors to virtualfile_from_data in https://github.com/GenericMappingTools/pygmt/issues/949, because we don't choose now (actually we still make choices but the logic is hidden in the virtualfile_from_data function).

Note: grdtrack.py is left intact because it will be addressed in PR https://github.com/GenericMappingTools/pygmt/pull/2708

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
