### PR TITLE
pygmt.which: Fix the bug when passing multiple files

### DIFF
--- a/pygmt/src/which.py
+++ b/pygmt/src/which.py
@@ -6,14 +6,13 @@ from pygmt.helpers import (
     GMTTempFile,
     build_arg_string,
     fmt_docstring,
-    kwargs_to_strings,
+    is_nonstr_iter,
     use_alias,
 )
 
 
 @fmt_docstring
 @use_alias(G="download", V="verbose")
-@kwargs_to_strings(fname="sequence_space")
 def which(fname, **kwargs):
     r"""
     Find the full path to specified files.
@@ -63,6 +62,9 @@ def which(fname, **kwargs):
     FileNotFoundError
         If the file is not found.
     """
+    if is_nonstr_iter(fname):  # Got a list of files
+        fname = " ".join(fname)
+
     with GMTTempFile() as tmpfile:
         with Session() as lib:
             lib.call_module(

--- a/pygmt/tests/test_which.py
+++ b/pygmt/tests/test_which.py
@@ -1,7 +1,7 @@
 """
 Test pygmt.which.
 """
-import os
+from pathlib import Path
 
 import pytest
 from pygmt import which
@@ -14,8 +14,8 @@ def test_which():
     """
     for fname in ["tut_quakes.ngdc", "tut_bathy.nc"]:
         cached_file = which(f"@{fname}", download="c")
-        assert os.path.exists(cached_file)
-        assert os.path.basename(cached_file) == fname
+        assert Path(cached_file).exists()
+        assert Path(cached_file).name == fname
 
 
 def test_which_multiple():
@@ -23,10 +23,10 @@ def test_which_multiple():
     Make sure `which` returns file paths for multiple @files correctly.
     """
     filenames = ["ridge.txt", "tut_ship.xyz"]
-    cached_files = which(fname=[f"@{fname}" for fname in filenames], download="c")
+    cached_files = which([f"@{fname}" for fname in filenames], download="c")
     for cached_file in cached_files:
-        assert os.path.exists(cached_file)
-        assert os.path.basename(cached_file) in filenames
+        assert Path(cached_file).exists()
+        assert Path(cached_file).name in filenames
 
 
 def test_which_fails():

--- a/pygmt/tests/test_which.py
+++ b/pygmt/tests/test_which.py
@@ -13,7 +13,7 @@ def test_which():
     Make sure `which` returns file paths for @files correctly without errors.
     """
     for fname in ["tut_quakes.ngdc", "tut_bathy.nc"]:
-        cached_file = which(f"@{fname}", download="c")
+        cached_file = which(fname=f"@{fname}", download="c")
         assert Path(cached_file).exists()
         assert Path(cached_file).name == fname
 


### PR DESCRIPTION
**Description of proposed changes**

Issue first reported in https://github.com/GenericMappingTools/pygmt/issues/2361#issue-1581189232. See that issue for context.

To reproduce the issue:
```python
>>> from pygmt import which
>>> # doesn't work
>>> which(["@hotspots.txt", "@earth_relief_01d_g"])
gmtwhich [ERROR]: File ['@hotspots.txt', not found!
gmtwhich [ERROR]: File '@earth_relief_01d_g'] not found!
>>> # works
>>> which(fname=["@hotspots.txt", "@earth_relief_01d_g"])
```

Address #2361.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
