### PR TITLE
POC: pygmt.grdtrack: pygmt.grdtrack: Support consistent table-like outputs

### DIFF
--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -328,7 +328,7 @@ def grdtrack(
 
         if output_type == "file":
             return None
-        vectors = lib.gmtdataset_to_vectors(outvfile)
+        vectors = lib.read_virtualfile(outvfile, kind="dataset").contents.to_vectors()
         if output_type == "numpy":
             return np.array(vectors).T
         return pd.DataFrame(np.array(vectors).T, columns=column_names)

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -1,16 +1,13 @@
 """
 grdtrack - Sample grids at specified (x,y) locations.
 """
+import warnings
+
+import numpy as np
 import pandas as pd
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import (
-    GMTTempFile,
-    build_arg_string,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
+from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["grdtrack"]
 
@@ -43,7 +40,9 @@ __doctest_skip__ = ["grdtrack"]
     w="wrap",
 )
 @kwargs_to_strings(R="sequence", S="sequence", i="sequence_comma", o="sequence_comma")
-def grdtrack(grid, points=None, newcolname=None, outfile=None, **kwargs):
+def grdtrack(
+    grid, points=None, output_type="pandas", outfile=None, newcolname=None, **kwargs
+):
     r"""
     Sample grids at specified (x,y) locations.
 
@@ -292,29 +291,45 @@ def grdtrack(grid, points=None, newcolname=None, outfile=None, **kwargs):
     if hasattr(points, "columns") and newcolname is None:
         raise GMTInvalidInput("Please pass in a str to 'newcolname'")
 
-    with GMTTempFile(suffix=".csv") as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_from_data(
-                check_kind="raster", data=grid
-            ) as grdfile, lib.virtualfile_from_data(
-                check_kind="vector", data=points, required_data=False
-            ) as csvfile:
-                kwargs["G"] = grdfile
-                if outfile is None:  # Output to tmpfile if outfile is not set
-                    outfile = tmpfile.name
-                lib.call_module(
-                    module="grdtrack",
-                    args=build_arg_string(kwargs, infile=csvfile, outfile=outfile),
-                )
+    if output_type not in ["numpy", "pandas", "file"]:
+        raise GMTInvalidInput(
+            "Must specify 'output_type' either as 'numpy', 'pandas' or 'file'."
+        )
 
-        # Read temporary csv output to a pandas table
-        if outfile == tmpfile.name:  # if user did not set outfile, return pd.DataFrame
-            try:
-                column_names = points.columns.to_list() + [newcolname]
-                result = pd.read_csv(tmpfile.name, sep="\t", names=column_names)
-            except AttributeError:  # 'str' object has no attribute 'columns'
-                result = pd.read_csv(tmpfile.name, sep="\t", header=None, comment=">")
-        elif outfile != tmpfile.name:  # return None if outfile set, output in outfile
-            result = None
+    if outfile is not None and output_type != "file":
+        msg = (
+            f"Changing 'output_type'  from '{output_type}' to 'file' "
+            "since 'outfile' parameter is set. Please use output_type='file' "
+            "to silence this warning."
+        )
+        warnings.warn(message=msg, category=RuntimeWarning, stacklevel=2)
+        output_type = "file"
+    elif outfile is None and output_type == "file":
+        raise GMTInvalidInput("Must specify 'outfile' for ASCII output.")
 
-    return result
+    with Session() as lib:
+        with lib.virtualfile_from_data(
+            check_kind="raster", data=grid
+        ) as ingrid, lib.virtualfile_from_data(
+            check_kind="vector", data=points, required_data=False
+        ) as infile, lib.virtualfile_to_gmtdataset() as outvfile:
+            kwargs["G"] = ingrid
+            lib.call_module(
+                module="grdtrack",
+                args=build_arg_string(kwargs, infile=infile, outfile=outvfile),
+            )
+
+        if output_type == "file":
+            lib.call_module("write", f"{outvfile} {outfile} -Td")
+            return None
+
+        vectors = lib.gmtdataset_to_vectors(outvfile)
+        if output_type == "numpy":
+            return np.array(vectors).T
+
+        if isinstance(points, pd.DataFrame):
+            column_names = points.columns.to_list() + [newcolname]
+        else:
+            column_names = None
+
+        return pd.DataFrame(np.array(vectors).T, columns=column_names)

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -312,7 +312,7 @@ def grdtrack(
             check_kind="raster", data=grid
         ) as ingrid, lib.virtualfile_from_data(
             check_kind="vector", data=points, required_data=False
-        ) as infile, lib.virtualfile_to_gmtdataset() as outvfile:
+        ) as infile, lib.virtualfile_to_data(kind="dataset") as outvfile:
             kwargs["G"] = ingrid
             lib.call_module(
                 module="grdtrack",


### PR DESCRIPTION
**Description of proposed changes**

This PR is based on the feature implemented in PR #2729, so we need to merge #2729 first and change the base branch to "main" before reviewing this PR seriously. This PR is opened so that we can better verify the implementation in PR #2729 is correct and can be applied to multiple methods/functions.

Changes in this PR:

- Get rid of temporary files by writing the table output to a `GMT_DATASET` object (xref #2730)
- Add `output_type` parameter to have consistent behavior for table-like output (xref #1318)

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
