### PR TITLE
CI: List installed Python packages for easier debugging

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Install formatting tools
         run: |
           python -m pip install black blackdoc docformatter flakeheaven isort
+          python -m pip list
           sudo apt-get install dos2unix
 
       # Run "make format" and commit the change to the PR branch

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -35,6 +35,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install black blackdoc docformatter flakeheaven pylint isort
+          python -m pip list
           sudo apt-get install dos2unix
 
       - name: Formatting check (black, blackdoc, docformatter, flakeheaven and isort)


### PR DESCRIPTION
**Description of proposed changes**

Run `pip list` to show the installed packages so that we can easily find the versions of lining tools the CI is using.