### PR TITLE
Disable pylint's line-length checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,4 +133,8 @@ max-module-lines=2000
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=["duplicate-code", "import-error"]
+disable=[
+    "duplicate-code",
+    "import-error",
+    "line-too-long",  # Already checked by flakeheaven/pycodestyle
+]


### PR DESCRIPTION
**Description of proposed changes**

flakeheaven/pycodestyle already set the line-length limit to 79, so it makes no sense to check line-length again by pylint.

This PR disables pylint's line-length checking.

Address https://github.com/GenericMappingTools/pygmt/pull/2728#issuecomment-1755357356.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
