### PR TITLE
API reference: Shorten supported argument types in docstrings

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -416,7 +416,8 @@ def fmt_docstring(module_func):
     <BLANKLINE>
     Parameters
     ----------
-    data : str, numpy.ndarray, pandas.DataFrame, xarray.Dataset, or geopandas.GeoDataFrame
+    data : str, numpy.ndarray, pandas.DataFrame, xarray.Dataset, or
+           geopandas.GeoDataFrame
         Pass in either a file name to an ASCII data table, a 2-D
         :class:`numpy.ndarray`, a :class:`pandas.DataFrame`, an
         :class:`xarray.Dataset` made up of 1-D :class:`xarray.DataArray`

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -105,7 +105,9 @@ COMMON_DOCSTRINGS = {
             that do not match the pattern. Append **i** for case insensitive
             matching. This does not apply to headers or segment headers.""",
     "frame": r"""
-        frame : bool or str or list
+        frame : bool,
+
+		str or list
             Set map boundary
             :doc:`frame and axes attributes </tutorials/basics/frames>`. """,
     "gap": r"""
@@ -247,7 +249,7 @@ COMMON_DOCSTRINGS = {
               used then the columns given to ``outcols`` correspond to the
               order after the ``incols`` selection has taken place.""",
     "panel": r"""
-        panel : bool or int or list
+        panel : bool, int or list
             [*row,col*\|\ *index*].
             Select a specific subplot panel. Only allowed when in subplot
             mode. Use ``panel=True`` to advance to the next panel in the
@@ -450,7 +452,7 @@ def fmt_docstring(module_func):
             "pandas.DataFrame",
             "xarray.Dataset",
         ]
-    ) + " or geopandas.GeoDataFrame"
+    ) + ", or geopandas.GeoDataFrame"
     filler_text["table-classes"] = (
         ":class:`numpy.ndarray`, a :class:`pandas.DataFrame`, an\n"
         "    :class:`xarray.Dataset` made up of 1-D :class:`xarray.DataArray`\n"

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -416,8 +416,7 @@ def fmt_docstring(module_func):
     <BLANKLINE>
     Parameters
     ----------
-    data : str, numpy.ndarray, pandas.DataFrame, xarray.Dataset, or
-           geopandas.GeoDataFrame
+    data : str, numpy.ndarray, pandas.DataFrame, xarray.Dataset, or geo...
         Pass in either a file name to an ASCII data table, a 2-D
         :class:`numpy.ndarray`, a :class:`pandas.DataFrame`, an
         :class:`xarray.Dataset` made up of 1-D :class:`xarray.DataArray`

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -105,9 +105,7 @@ COMMON_DOCSTRINGS = {
             that do not match the pattern. Append **i** for case insensitive
             matching. This does not apply to headers or segment headers.""",
     "frame": r"""
-        frame : bool,
-
-		str or list
+        frame : bool, str, or list
             Set map boundary
             :doc:`frame and axes attributes </tutorials/basics/frames>`. """,
     "gap": r"""
@@ -249,7 +247,7 @@ COMMON_DOCSTRINGS = {
               used then the columns given to ``outcols`` correspond to the
               order after the ``incols`` selection has taken place.""",
     "panel": r"""
-        panel : bool, int or list
+        panel : bool, int, or list
             [*row,col*\|\ *index*].
             Select a specific subplot panel. Only allowed when in subplot
             mode. Use ``panel=True`` to advance to the next panel in the
@@ -300,7 +298,7 @@ COMMON_DOCSTRINGS = {
                   more of the columns equal NaN [Default skips record only
                   if values in all specified *cols* equal NaN].""",
     "spacing": r"""
-        spacing : float, str or list
+        spacing : float, str, or list
             *x_inc*\ [**+e**\|\ **n**][/\ *y_inc*\ [**+e**\|\ **n**]].
             *x_inc* [and optionally *y_inc*] is the grid spacing.
 

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -416,7 +416,7 @@ def fmt_docstring(module_func):
     <BLANKLINE>
     Parameters
     ----------
-    data : str or numpy.ndarray or pandas.DataFrame or xarray.Dataset or geo...
+    data : str, numpy.ndarray, pandas.DataFrame, xarray.Dataset, or geopandas.GeoDataFrame
         Pass in either a file name to an ASCII data table, a 2-D
         :class:`numpy.ndarray`, a :class:`pandas.DataFrame`, an
         :class:`xarray.Dataset` made up of 1-D :class:`xarray.DataArray`

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -400,7 +400,7 @@ def fmt_docstring(module_func):
     ...
     ...     Parameters
     ...     ----------
-    ...     data : str or {table-like}
+    ...     data : str, {table-like}
     ...         Pass in either a file name to an ASCII data table, a 2-D
     ...         {table-classes}.
     ...     {region}

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -16,7 +16,7 @@ from pygmt.helpers.utils import is_nonstr_iter
 
 COMMON_DOCSTRINGS = {
     "area_thresh": r"""
-        area_thresh : int or float or str
+        area_thresh : float or str
             *min_area*\ [/*min_level*/*max_level*][**+a**\[**g**\|\ **i**]\
             [**s**\|\ **S**]][**+l**\|\ **r**][**+p**\ *percent*].
             Features with an area smaller than *min_area* in km\ :sup:`2` or of
@@ -298,7 +298,7 @@ COMMON_DOCSTRINGS = {
                   more of the columns equal NaN [Default skips record only
                   if values in all specified *cols* equal NaN].""",
     "spacing": r"""
-        spacing : int or float or str or list or tuple
+        spacing : float, str or list
             *x_inc*\ [**+e**\|\ **n**][/\ *y_inc*\ [**+e**\|\ **n**]].
             *x_inc* [and optionally *y_inc*] is the grid spacing.
 
@@ -329,7 +329,7 @@ COMMON_DOCSTRINGS = {
             the registration have already been initialized; use ``spacing`` and
             ``registration`` to override these values.""",
     "transparency": r"""
-        transparency : int or float
+        transparency : float
             Set transparency level, in [0-100] percent range
             [Default is ``0``, i.e., opaque].
             Only visible when PDF or raster format output is selected.
@@ -444,14 +444,13 @@ def fmt_docstring(module_func):
             aliases.append(f"- {arg} = {alias}")
         filler_text["aliases"] = "\n".join(aliases)
 
-    filler_text["table-like"] = " or ".join(
+    filler_text["table-like"] = ", ".join(
         [
             "numpy.ndarray",
             "pandas.DataFrame",
             "xarray.Dataset",
-            "geopandas.GeoDataFrame",
         ]
-    )
+    ) + " or geopandas.GeoDataFrame"
     filler_text["table-classes"] = (
         ":class:`numpy.ndarray`, a :class:`pandas.DataFrame`, an\n"
         "    :class:`xarray.Dataset` made up of 1-D :class:`xarray.DataArray`\n"

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -444,13 +444,16 @@ def fmt_docstring(module_func):
             aliases.append(f"- {arg} = {alias}")
         filler_text["aliases"] = "\n".join(aliases)
 
-    filler_text["table-like"] = ", ".join(
-        [
-            "numpy.ndarray",
-            "pandas.DataFrame",
-            "xarray.Dataset",
-        ]
-    ) + ", or geopandas.GeoDataFrame"
+    filler_text["table-like"] = (
+        ", ".join(
+            [
+                "numpy.ndarray",
+                "pandas.DataFrame",
+                "xarray.Dataset",
+            ]
+        )
+        + ", or geopandas.GeoDataFrame"
+    )
     filler_text["table-classes"] = (
         ":class:`numpy.ndarray`, a :class:`pandas.DataFrame`, an\n"
         "    :class:`xarray.Dataset` made up of 1-D :class:`xarray.DataArray`\n"

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -48,7 +48,7 @@ def binstats(data, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         A file name of an ASCII data table or a 2-D
         {table-classes}.
     outgrid : str or None
@@ -78,7 +78,7 @@ def binstats(data, **kwargs):
         - **u** for maximum (upper)
         - **U** for maximum of negative values only
         - **z** for the sum
-    empty : float or int
+    empty : float
         Set the value assigned to empty nodes [Default is NaN].
     normalize : bool
         Normalize the resulting grid values by the area represented by the

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -105,7 +105,7 @@ def blockmean(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.
@@ -201,7 +201,7 @@ def blockmedian(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.
@@ -288,7 +288,7 @@ def blockmode(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -81,7 +81,7 @@ def coast(self, **kwargs):
         and (**c**\ )rude.
     land : str
         Select filling or clipping of "dry" areas.
-    rivers : int or str or list
+    rivers : int, str, or list
         *river*\ [/*pen*].
         Draw rivers. Specify the type of rivers and [optionally] append
         pen attributes [Default is ``"0.25p,black,solid"``].
@@ -128,7 +128,7 @@ def coast(self, **kwargs):
         [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\
         **+w**\ *length*.
         Draw a simple map scale centered on the reference point specified.
-    borders : int or str or list
+    borders : int, str, or list
         *border*\ [/*pen*].
         Draw political boundaries. Specify the type of boundary and
         [optionally] append pen attributes
@@ -146,7 +146,7 @@ def coast(self, **kwargs):
         a = All boundaries (1-3)
     water : str
         Select filling or clipping of "wet" areas.
-    shorelines : int or str or list
+    shorelines : int, str, or list
         [*level*\ /]\ *pen*.
         Draw shorelines [Default is no shorelines]. Append pen attributes
         [Default is ``"0.25p,black,solid"``] which

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -96,13 +96,13 @@ def colorbar(self, **kwargs):
     scale : float
         Multiply all z-values in the CPT by the provided scale. By default,
         the CPT is used as is.
-    shading : str or list or bool
+    shading : str, list, or bool
         Add illumination effects. Passing a single numerical value sets the
         range of intensities from -value to +value. If not specified, 1 is
         used. Alternatively, set ``shading=[low, high]`` to specify an
         asymmetric intensity range from *low* to *high*. [Default is no
         illumination].
-    equalsize : int or float or str
+    equalsize : float or str
         [**i**]\ [*gap*].
         Equal-sized color rectangles. By default, the rectangles are scaled
         according to the z-range in the CPT (see also ``zfile``). If *gap* is

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -46,7 +46,7 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -110,7 +110,7 @@ def grd2cpt(grid, **kwargs):
         *start*, where we automatically build monotonically increasing
         labels from *start* (a single letter or an integer). Additionally
         append **-** to build ranges *start*-*start+1* as labels instead.
-    nlevels : bool or int or str
+    nlevels : bool, int, or str
         Set to ``True`` to create a linear color table by using the grid
         z-range as the new limits in the CPT. Alternatively, set *nlevels*
         to resample the color table into *nlevels* equidistant slices.

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -56,16 +56,16 @@ def grdclip(grid, **kwargs):
         The name of the output netCDF file with extension .nc to store the grid
         in.
     {region}
-    above : str or list or tuple
+    above : str or list
         [*high*, *above*].
         Set all data[i] > *high* to *above*.
-    below : str or list or tuple
+    below : str or list
         [*low*, *below*].
         Set all data[i] < *low* to *below*.
-    between : str or list or tuple
+    between : str or list
         [*low*, *high*, *between*].
         Set all data[i] >= *low* and <= *high* to *between*.
-    new : str or list or tuple
+    new : str or list
         [*old*, *new*].
         Set all data[i] == *old* to *new*. This is mostly useful when
         your data are known to be integer values.

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -53,7 +53,7 @@ def grdcontour(self, grid, **kwargs):
           angle (col 3).
         - A fixed contour interval *cont_int* or a single contour with
           +\ *cont_int*.
-    annotation : str,  int, or list
+    annotation : str, int, or list
         Specify or disable annotated contour levels, modifies annotated
         contours specified in ``interval``.
 

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -53,7 +53,7 @@ def grdcut(grid, **kwargs):
         in.
     {projection}
     {region}
-    extend : bool or int or float
+    extend : bool or float
         Allow grid to be extended if new ``region`` exceeds existing
         boundaries. Give a value to initialize nodes outside current region.
     circ_subregion : str

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -53,7 +53,7 @@ def grdfill(grid, **kwargs):
         where (*X,Y*) are the node dimensions of the grid]), or
         **s** for bicubic spline (optionally append a *tension*
         parameter [Default is no tension]).
-    no_data : int or float
+    no_data : float
         Set the node value used to identify a point as a member of a hole
         [Default is NaN].
 

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -50,7 +50,7 @@ def grdgradient(grid, **kwargs):
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid
         in.
-    azimuth : int or float or str or list
+    azimuth : float, str, or list
         *azim*\ [/*azim2*].
         Azimuthal direction for a directional derivative; *azim* is the
         angle in the x,y plane measured in degrees positive clockwise from

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -80,7 +80,7 @@ class grdhisteq:  # pylint: disable=invalid-name
         outgrid : str or bool or None
             The name of the output netCDF file with extension .nc to store the
             grid in.
-        outfile : str, bool or None
+        outfile : str, bool, or None
             The name of the output ASCII file to store the results of the
             histogram equalization in.
         output_type: str

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -80,7 +80,7 @@ class grdhisteq:  # pylint: disable=invalid-name
         outgrid : str or bool or None
             The name of the output netCDF file with extension .nc to store the
             grid in.
-        outfile : str or bool or None
+        outfile : str, bool or None
             The name of the output ASCII file to store the results of the
             histogram equalization in.
         output_type: str

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -62,7 +62,7 @@ def grdlandmask(**kwargs):
         the coastlines differ in details a node in a mask file using one
         resolution is not guaranteed to remain inside [or outside] when a
         different resolution is selected.
-    bordervalues : bool or str or float or list
+    bordervalues : bool, str, float, or list
         Nodes that fall exactly on a polygon boundary should be
         considered to be outside the polygon [Default considers them to be
         inside]. Alternatively, append either a list of four values

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -71,7 +71,7 @@ def grdtrack(grid, points=None, newcolname=None, outfile=None, **kwargs):
         Gridded array from which to sample values from, or a file name (netCDF
         format).
 
-    points : str or {table-like}
+    points : str, {table-like}
         Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
 
@@ -228,7 +228,7 @@ def grdtrack(grid, points=None, newcolname=None, outfile=None, **kwargs):
            by deviations (**+d**) and finally residuals (**+r**). When more
            than one grid is sampled this sequence of 1-3 columns is repeated
            for each grid.
-    radius : bool or int or float or str
+    radius : bool, float, or str
         [*radius*][**+e**\|\ **p**].
         To be used with normal grid sampling, and limited to a single, non-IMG
         grid. If the nearest node to the input point is NaN, search outwards

--- a/pygmt/src/grdvolume.py
+++ b/pygmt/src/grdvolume.py
@@ -50,7 +50,7 @@ def grdvolume(grid, output_type="pandas", outfile=None, **kwargs):
             - ``file`` - ASCII file (requires ``outfile``)
     outfile : str
         The file name for the output ASCII file.
-    contour : str or int or float or list
+    contour : str, float, or list
         *cval*\|\ *low/high/delta*\|\ **r**\ *low/high*\|\ **r**\ *cval*.
         Find area, volume and mean height (volume/area) inside and above the
         *cval* contour. Alternatively, search using all contours from *low* to

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -48,7 +48,7 @@ def histogram(self, data, **kwargs):
 
     Parameters
     ----------
-    data : str or list or {table-like}
+    data : str, list, {table-like}
         Pass in either a file name to an ASCII data table, a Python list, a 2-D
         {table-classes}.
     {projection}
@@ -67,7 +67,7 @@ def histogram(self, data, **kwargs):
         annotation font; use **+o** to change the offset between bar and
         label [Default is ``"6p"``]; use **+r** to rotate the labels from
         horizontal to vertical.
-    barwidth : int or float or str
+    barwidth : float or str
         *width*\ [**+o**\ *offset*].
         Use an alternative histogram bar width than the default set via
         ``series``, and optionally shift all bars by an *offset*. Here
@@ -78,7 +78,7 @@ def histogram(self, data, **kwargs):
         plot dimension units by appending the relevant unit.
     center : bool
         Center bin on each value. [Default is left edge].
-    distribution : bool or int or float or str
+    distribution : bool, float, or str
         [*mode*][**+p**\ *pen*].
         Draw the equivalent normal distribution; append desired
         *pen* [Default is ``"0.25p,black,solid"``].
@@ -105,7 +105,7 @@ def histogram(self, data, **kwargs):
     horizontal : bool
         Plot the histogram using horizontal bars instead of the
         default vertical bars.
-    series : int or str or list
+    series : int, str, or list
         [*min*\ /*max*\ /]\ *inc*\ [**+n**\ ].
         Set the interval for the width of each bar in the histogram.
     histtype : int or str

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -47,7 +47,7 @@ def info(data, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in either a file name to an ASCII data table, a 1-D/2-D
         {table-classes}.
     per_column : bool

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -93,7 +93,7 @@ def inset(self, **kwargs):
         indicates the shift relative to the foreground frame [Default is
         ``"4p/-4p"``] and ``shade`` sets the fill style to use for
         shading [Default is ``"gray50"``].
-    margin : int or str or list
+    margin : float, str, or list
         This is clearance that is added around the inside of the inset.
         Plotting will take place within the inner region only. The margins
         can be a single value, a pair of values separated (for setting

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -227,7 +227,7 @@ def meca(
 
     Parameters
     ----------
-    spec : str, 1-D array, 2-D array, dict, or pd.DataFrame
+    spec : str, 1-D array, 2-D array, dict or pd.DataFrame
         Data that contain focal mechanism parameters.
 
         ``spec`` can be specified in either of the following types:
@@ -273,7 +273,7 @@ def meca(
         ``convention`` parameter is required so we know how to interpret the
         columns. If ``spec`` is a dictionary or a pd.DataFrame,
         ``convention`` is not needed and is ignored if specified.
-    scale : int, float, or str
+    scale : float or str
         *scale*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*]\
         [**+l**][**+m**][**+o**\ *dx*\ [/\ *dy*]][**+s**\ *reference*].
         Adjust scaling of the radius of the beachball, which is
@@ -307,27 +307,27 @@ def meca(
         - ``"dc"``: the closest double couple defined from the moment tensor
           (zero trace and zero determinant)
         - ``"deviatoric"``: deviatoric part of the moment tensor (zero trace)
-    longitude : int, float, list, or 1-D numpy array
+    longitude : float, list, or 1-D numpy array
         Longitude(s) of event location(s). Must be the same length as the
         number of events. Will override the ``longitude`` values
         in ``spec`` if ``spec`` is a dictionary or pd.DataFrame.
-    latitude : int, float, list, or 1-D numpy array
+    latitude : float, list, or 1-D numpy array
         Latitude(s) of event location(s). Must be the same length as the
         number of events. Will override the ``latitude`` values
         in ``spec`` if ``spec`` is a dictionary or pd.DataFrame.
-    depth : int, float, list, or 1-D numpy array
+    depth : float, list, or 1-D numpy array
         Depth(s) of event location(s) in kilometers. Must be the same length
         as the number of events. Will override the ``depth`` values in ``spec``
         if ``spec`` is a dictionary or pd.DataFrame.
-    plot_longitude : int, float, str, list, or 1-D numpy array
+    plot_longitude : float, str, list, or 1-D numpy array
         Longitude(s) at which to place beachball(s). Must be the same length
         as the number of events. Will override the ``plot_longitude`` values
         in ``spec`` if ``spec`` is a dictionary or pd.DataFrame.
-    plot_latitude : int, float, str, list, or 1-D numpy array
+    plot_latitude : float, str, list, or 1-D numpy array
         Latitude(s) at which to place beachball(s). List must be the same
         length as the number of events. Will override the ``plot_latitude``
         values in ``spec`` if ``spec`` is a dictionary or pd.DataFrame.
-    event_name : str or list of str, or 1-D numpy array
+    event_name : str, list of str, or 1-D numpy array
         Text string(s), e.g., event name(s) to appear near the beachball(s).
         List must be the same length as the number of events. Will override
         the ``event_name`` labels in ``spec`` if ``spec`` is a dictionary

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -227,7 +227,7 @@ def meca(
 
     Parameters
     ----------
-    spec : str, 1-D array, 2-D array, dict or pd.DataFrame
+    spec : str, 1-D array, 2-D array, dict, or pd.DataFrame
         Data that contain focal mechanism parameters.
 
         ``spec`` can be specified in either of the following types:

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -77,7 +77,7 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -154,7 +154,7 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
     {fill}
         *fill* can be a 1-D array, but it is only valid if using ``x``/``y``
         and ``cmap=True`` is also required.
-    intensity : float, bool or 1-D array
+    intensity : float, bool, or 1-D array
         Provide an *intensity* value (nominally in the -1 to +1 range) to
         modulate the fill color by simulating illumination. If using
         ``intensity=True``, we will instead read *intensity* from the first

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -77,7 +77,7 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
         Use parameter ``incols`` to choose which columns are x, y, fill, and
@@ -154,7 +154,7 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
     {fill}
         *fill* can be a 1-D array, but it is only valid if using ``x``/``y``
         and ``cmap=True`` is also required.
-    intensity : float or bool or 1-D array
+    intensity : float, bool or 1-D array
         Provide an *intensity* value (nominally in the -1 to +1 range) to
         modulate the fill color by simulating illumination. If using
         ``intensity=True``, we will instead read *intensity* from the first

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -120,7 +120,7 @@ def plot3d(
     {fill}
         *fill* can be a 1-D array, but it is only valid if using ``x``/``y``
         and ``cmap=True`` is also required.
-    intensity : float or bool or 1-D array
+    intensity : float, bool, or 1-D array
         Provide an *intensity* value (nominally in the -1 to +1 range) to
         modulate the fill color by simulating illumination. If using
         ``intensity=True``, we will instead read *intensity* from the first

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -80,7 +80,7 @@ def plot3d(
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Either a data file name, a 2-D {table-classes}.
         Optionally, use parameter ``incols`` to specify which columns are x, y,
         z, fill, and size, respectively.

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -100,7 +100,7 @@ def project(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -64,7 +64,7 @@ def rose(self, data=None, length=None, azimuth=None, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
         Use parameter ``incols`` to choose which columns are length and

--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -66,7 +66,7 @@ def select(data=None, outfile=None, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
     outfile : str

--- a/pygmt/src/sph2grd.py
+++ b/pygmt/src/sph2grd.py
@@ -41,7 +41,7 @@ def sph2grd(data, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in data with L, M, C[L,M], S[L,M] values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -46,7 +46,7 @@ def sphdistance(data=None, x=None, y=None, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in (x, y) or (longitude, latitude) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.
@@ -93,6 +93,7 @@ def sphdistance(data=None, x=None, y=None, **kwargs):
     voronoi : str
         Append the name of a file with pre-calculated Voronoi polygons
         [Default performs the Voronoi construction on input data].
+
     Returns
     -------
     ret: xarray.DataArray or None

--- a/pygmt/src/sphinterpolate.py
+++ b/pygmt/src/sphinterpolate.py
@@ -38,7 +38,7 @@ def sphinterpolate(data, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -51,10 +51,10 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
         Number of vertical rows of the subplot grid.
     ncols : int
         Number of horizontal columns of the subplot grid.
-    figsize : tuple
-        Specify the final figure dimensions as (*width*, *height*).
-    subsize : tuple
-        Specify the dimensions of each subplot directly as (*width*, *height*).
+    figsize : list
+        Specify the final figure dimensions as [*width*, *height*].
+    subsize : list
+        Specify the dimensions of each subplot directly as [*width*, *height*].
         Note that only one of ``figsize`` or ``subsize`` can be provided at
         once.
 

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -74,7 +74,7 @@ def surface(data=None, x=None, y=None, z=None, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -98,7 +98,7 @@ def surface(data=None, x=None, y=None, z=None, **kwargs):
         This is the final convergence limit at the desired grid spacing;
         for intermediate (coarser) grids the effective convergence limit is
         divided by the grid spacing multiplier.
-    maxradius : int or str
+    maxradius : float or str
         Optional. After solving for the surface, apply a mask so that nodes
         farther than ``maxradius`` away from a data constraint are set to NaN
         [Default is no masking]. Append a distance unit (see

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -40,7 +40,7 @@ def ternary(self, data, alabel=None, blabel=None, clabel=None, **kwargs):
 
     Parameters
     ----------
-    data : str or list or {table-like}
+    data : str, list, {table-like}
         Pass in either a file name to an ASCII data table, a Python list, a 2-D
         {table-classes}.
     width : str

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -97,7 +97,7 @@ def text_(
         of the map.
     text : str or 1-D array
         The text string, or an array of strings to plot on the figure.
-    angle: int, float, str or bool
+    angle: float, str, or bool
         Set the angle measured in degrees counter-clockwise from
         horizontal (e.g. 30 sets the text at 30 degrees). If no angle is
         explicitly given (i.e. ``angle=True``) then the input to ``textfiles``

--- a/pygmt/src/timestamp.py
+++ b/pygmt/src/timestamp.py
@@ -45,8 +45,8 @@ def timestamp(
         **M**\ (iddle), or **B**\ (ottom)) code. For example,
         ``justification="TL"`` means choosing the **T**\ op **L**\ eft point of
         the timestamp as the anchor point.
-    offset : str or tuple
-        *offset* or (*offset_x*, *offset_y*).
+    offset : str or list
+        *offset* or [*offset_x*, *offset_y*].
         Offset the anchor point of the timestamp box by *offset_x* and
         *offset_y*. If a single value *offset* is given, *offset_y* =
         *offset_x* = *offset*.

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -82,7 +82,7 @@ class triangulate:  # pylint: disable=invalid-name
         ----------
         x/y/z : np.ndarray
             Arrays of x and y coordinates and values z of the data points.
-        data : str or {table-like}
+        data : str, {table-like}
             Pass in (x, y, z) or (longitude, latitude, elevation) values by
             providing a file name to an ASCII data table, a 2-D
             {table-classes}.
@@ -96,7 +96,7 @@ class triangulate:  # pylint: disable=invalid-name
             better off projecting all data to a local coordinate system before
             using ``triangulate`` (this is true of all gridding routines) or
             instead select :gmt-docs:`sphtriangulate <sphtriangulate.html>`.
-        outfile : str or bool or None
+        outfile : str, bool or None
             The name of the output ASCII file to store the results of the
             histogram equalization in.
         output_type: str
@@ -197,7 +197,7 @@ class triangulate:  # pylint: disable=invalid-name
         ----------
         x/y/z : np.ndarray
             Arrays of x and y coordinates and values z of the data points.
-        data : str or {table-like}
+        data : str, {table-like}
             Pass in (x, y[, z]) or (longitude, latitude[, elevation]) values by
             providing a file name to an ASCII data table, a 2-D
             {table-classes}.
@@ -314,7 +314,7 @@ class triangulate:  # pylint: disable=invalid-name
         ----------
         x/y/z : np.ndarray
             Arrays of x and y coordinates and values z of the data points.
-        data : str or {table-like}
+        data : str, {table-like}
             Pass in (x, y, z) or (longitude, latitude, elevation) values by
             providing a file name to an ASCII data table, a 2-D
             {table-classes}.

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -64,7 +64,7 @@ def velo(self, data=None, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
         Note that text columns are only supported with file or

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -58,7 +58,7 @@ def wiggle(
     ----------
     x/y/z : 1-D arrays
         The arrays of x and y coordinates and z data points.
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
         Use parameter ``incols`` to choose which columns are x, y, z,

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -50,7 +50,7 @@ def xyz2grd(data=None, x=None, y=None, z=None, **kwargs):
 
     Parameters
     ----------
-    data : str or {table-like}
+    data : str, {table-like}
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D {table-classes}.
     x/y/z : 1-D arrays


### PR DESCRIPTION
**Description of proposed changes**

This PRs aims to shorten the supported argument types in docstrings:
- Change `int or float` to `float`
- Change `list or tuple` to `list`
- Change `type1 or typ2 or typ3` to `type1, typ2, or typ3`

Fixes #2718

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
