### PR TITLE
Replace flakeheaven and isort with ruff

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -32,7 +32,7 @@ jobs:
       # Install formatting tools
       - name: Install formatting tools
         run: |
-          python -m pip install black blackdoc docformatter flakeheaven isort
+          python -m pip install black blackdoc docformatter ruff
           python -m pip list
           sudo apt-get install dos2unix
 

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -34,11 +34,11 @@ jobs:
 
       - name: Install packages
         run: |
-          python -m pip install black blackdoc docformatter flakeheaven pylint isort
+          python -m pip install black blackdoc docformatter pylint ruff
           python -m pip list
           sudo apt-get install dos2unix
 
-      - name: Formatting check (black, blackdoc, docformatter, flakeheaven and isort)
+      - name: Formatting check (black, blackdoc, docformatter, ruff)
         run: make check
 
       - name: Linting (pylint)

--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ MANIFEST
 .coverage
 coverage.xml
 htmlcov/
-.flakeheaven_cache/
 .pytest_cache/
+.ruff_cache/
 results/
 result_images/
 tmp-test-dir-with-unique-name/

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ help:
 	@echo "  fulltest       run the test suite (including all doctests)"
 	@echo "  doctest        run the doctests only"
 	@echo "  test_no_images run the test suite (including all doctests) but skip image comparisons"
-	@echo "  format         run black, blackdoc, docformatter and isort to automatically format the code"
-	@echo "  check          run code style and quality checks (black, blackdoc, docformatter, flakeheaven and isort)"
+	@echo "  format         run black, blackdoc, docformatter and ruff to automatically format the code"
+	@echo "  check          run code style and quality checks (black, blackdoc, docformatter, ruff)"
 	@echo "  codespell      run codespell to check common misspellings"
 	@echo "  lint           run pylint for a deeper (and slower) quality check"
 	@echo "  clean          clean up build and generated files"
@@ -60,17 +60,16 @@ test_no_images: PYTEST_ARGS=-o addopts="--verbose --durations=0 --durations-min=
 test_no_images: _runtest
 
 format:
-	isort .
 	docformatter --in-place $(FORMAT_FILES)
 	black $(FORMAT_FILES)
 	blackdoc $(FORMAT_FILES)
+	ruff check --fix $(FORMAT_FILES)
 
 check:
-	isort . --check
 	docformatter --check $(FORMAT_FILES)
 	black --check $(FORMAT_FILES)
 	blackdoc --check $(FORMAT_FILES)
-	FLAKEHEAVEN_CACHE_TIMEOUT=0 flakeheaven lint $(FORMAT_FILES)
+	ruff check $(FORMAT_FILES)
 
 codespell:
 	@codespell

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -7,7 +7,7 @@ Sphinx documentation configuration file.
 import datetime
 from importlib.metadata import metadata
 
-# isort: off
+# ruff: isort: off
 from sphinx_gallery.sorting import (  # pylint: disable=no-name-in-module
     ExplicitOrder,
     ExampleTitleSortKey,
@@ -16,7 +16,7 @@ import pygmt
 from pygmt import __commit__, __version__
 from pygmt.sphinx_gallery import PyGMTScraper
 
-# isort: on
+# ruff: isort: on
 
 extensions = [
     "myst_parser",

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -476,7 +476,7 @@ We use some tools to format the code so we don't have to think about it:
 - [Black](https://github.com/psf/black)
 - [blackdoc](https://github.com/keewis/blackdoc)
 - [docformatter](https://github.com/myint/docformatter)
-- [isort](https://pycqa.github.io/isort/)
+- [ruff](https://docs.astral.sh/ruff)
 
 Black and blackdoc loosely follows the [PEP8](http://pep8.org) guide but with a few
 differences. Regardless, you won't have to worry about formatting the code yourself.
@@ -499,14 +499,14 @@ words bridged only by consonants, such as `distcalc`, and `crossprofile`. This
 convention is not applied by the code checking tools, but the PyGMT maintainers
 will comment on any pull requests as needed.
 
-We also use [flakeheaven](https://flakeheaven.readthedocs.io) and
+We also use [ruff](https://docs.astral.sh/ruff) and
 [pylint](https://pylint.pycqa.org/) to check the quality of the code and quickly catch
 common errors.
 The [`Makefile`](https://github.com/GenericMappingTools/pygmt/blob/main/Makefile)
 contains rules for running both checks:
 
 ```bash
-make check   # Runs black, blackdoc, docformatter, flakeheaven and isort (in check mode)
+make check   # Runs black, blackdoc, docformatter, ruff (in check mode)
 make lint    # Runs pylint, which is a bit slower
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -26,9 +26,8 @@ dependencies:
     - blackdoc
     - codespell
     - docformatter>=1.7.2
-    - flakeheaven>=3
-    - isort>=5
     - pylint
+    - ruff
     # Dev dependencies (unit testing)
     - matplotlib
     - pytest-cov

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -34,7 +34,7 @@ conformal latitude in the general spherical formulae instead.
 
 The projection is set with **u** or **U**. *zone* sets the zone for the figure,
 and the figure size is set with *scale* or *width*.
-"""  # noqa: W505
+"""
 
 # %%
 import pygmt

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -14,7 +14,7 @@ not needed to specify the projection for most cases. See Figure
 
 .. _GMT_utm_zones:
 
-.. figure:: https://docs.generic-mapping-tools.org/latest/_images/GMT_utm_zones.png # noqa: W505
+.. figure:: https://docs.generic-mapping-tools.org/latest/_images/GMT_utm_zones.png
    :width: 700 px
    :align: center
 
@@ -34,7 +34,7 @@ conformal latitude in the general spherical formulae instead.
 
 The projection is set with **u** or **U**. *zone* sets the zone for the figure,
 and the figure size is set with *scale* or *width*.
-"""
+"""  # noqa: W505
 
 # %%
 import pygmt

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -72,8 +72,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     :class:`xarray.DataArray` grid can be accessed via the GMT accessors
     (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
     However, these properties may be lost after specific grid operations (such
-    as slicing) and will need to be manually set before passing the grid to any
-    PyGMT data processing or plotting functions. Refer to
+    as slicing) and will need to be manually set before passing the grid to any PyGMT data processing or plotting functions. Refer to
     :class:`pygmt.GMTDataArrayAccessor` for detailed explanations and
     workarounds.
 
@@ -91,7 +90,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     ...     region=[120, 160, 30, 60],
     ...     registration="gridline",
     ... )
-    """  # noqa: W505
+    """
     grid = _load_remote_dataset(
         dataset_name="earth_age",
         dataset_prefix="earth_age_",

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -15,7 +15,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     r"""
     Load the Earth seafloor crustal age dataset in various resolutions.
 
-    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_age.png # noqa: W505
+    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_age.png
        :width: 80 %
        :align: center
 
@@ -91,7 +91,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     ...     region=[120, 160, 30, 60],
     ...     registration="gridline",
     ... )
-    """
+    """  # noqa: W505
     grid = _load_remote_dataset(
         dataset_name="earth_age",
         dataset_prefix="earth_age_",

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -72,7 +72,8 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     :class:`xarray.DataArray` grid can be accessed via the GMT accessors
     (i.e., ``grid.gmt.registration`` and ``grid.gmt.gtype`` respectively).
     However, these properties may be lost after specific grid operations (such
-    as slicing) and will need to be manually set before passing the grid to any PyGMT data processing or plotting functions. Refer to
+    as slicing) and will need to be manually set before passing the grid to any
+    PyGMT data processing or plotting functions. Refer to
     :class:`pygmt.GMTDataArrayAccessor` for detailed explanations and
     workarounds.
 

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -95,7 +95,7 @@ def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None
     ...     region=[120, 160, 30, 60],
     ...     registration="gridline",
     ... )
-    """  # noqa: W505
+    """
     grid = _load_remote_dataset(
         dataset_name="earth_free_air_anomaly",
         dataset_prefix="earth_faa_",

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -16,7 +16,7 @@ def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None
     Load the IGPP Global Earth Free-Air Anomaly datatset in various
     resolutions.
 
-    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_faa.jpg # noqa: W505
+    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_faa.jpg
        :width: 80 %
        :align: center
 
@@ -95,7 +95,7 @@ def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None
     ...     region=[120, 160, 30, 60],
     ...     registration="gridline",
     ... )
-    """
+    """  # noqa: W505
     grid = _load_remote_dataset(
         dataset_name="earth_free_air_anomaly",
         dataset_prefix="earth_faa_",

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -84,7 +84,7 @@ def load_earth_geoid(resolution="01d", region=None, registration=None):
     ...     region=[120, 160, 30, 60],
     ...     registration="gridline",
     ... )
-    """  # noqa: W505
+    """
     grid = _load_remote_dataset(
         dataset_name="earth_geoid",
         dataset_prefix="earth_geoid_",

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -15,7 +15,7 @@ def load_earth_geoid(resolution="01d", region=None, registration=None):
     r"""
     Load the EGM2008 Global Earth Geoid dataset in various resolutions.
 
-    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_geoid.jpg # noqa: W505
+    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_geoid.jpg
        :width: 80 %
        :align: center
 
@@ -84,7 +84,7 @@ def load_earth_geoid(resolution="01d", region=None, registration=None):
     ...     region=[120, 160, 30, 60],
     ...     registration="gridline",
     ... )
-    """
+    """  # noqa: W505
     grid = _load_remote_dataset(
         dataset_name="earth_geoid",
         dataset_prefix="earth_geoid_",

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -132,7 +132,7 @@ def load_earth_magnetic_anomaly(
     >>> grid = load_earth_magnetic_anomaly(
     ...     resolution="20m", registration="gridline", data_source="wdmam"
     ... )
-    """  # noqa: W505
+    """
     magnetic_anomaly_sources = {
         "emag2": "earth_mag_",
         "emag2_4km": "earth_mag4km_",

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -24,8 +24,8 @@ def load_earth_magnetic_anomaly(
 
        * - Global Earth Magnetic Anomaly Model (EMAG2)
          - World Digital Magnetic Anomaly Map (WDMAM)
-       * - .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_mag4km.jpg # noqa: W505
-         - .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_wdmam.jpg # noqa: W505
+       * - .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_mag4km.jpg
+         - .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_wdmam.jpg
 
     The grids are downloaded to a user data directory
     (usually ``~/.gmt/server/earth/earth_mag/``,
@@ -132,7 +132,7 @@ def load_earth_magnetic_anomaly(
     >>> grid = load_earth_magnetic_anomaly(
     ...     resolution="20m", registration="gridline", data_source="wdmam"
     ... )
-    """
+    """  # noqa: W505
     magnetic_anomaly_sources = {
         "emag2": "earth_mag_",
         "emag2_4km": "earth_mag4km_",

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -15,7 +15,7 @@ def load_earth_mask(resolution="01d", region=None, registration=None):
     r"""
     Load the GSHHG Global Earth Mask dataset in various resolutions.
 
-    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_mask.png # noqa: W505
+    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_mask.png
        :width: 80 %
        :align: center
 
@@ -88,7 +88,7 @@ def load_earth_mask(resolution="01d", region=None, registration=None):
     >>> # location (170°E, 50°N) is in oceanic area (0)
     >>> grid.sel(lon=170, lat=50).values
     array(0, dtype=int8)
-    """
+    """  # noqa: W505
     grid = _load_remote_dataset(
         dataset_name="earth_mask",
         dataset_prefix="earth_mask_",

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -88,7 +88,7 @@ def load_earth_mask(resolution="01d", region=None, registration=None):
     >>> # location (170°E, 50°N) is in oceanic area (0)
     >>> grid.sel(lon=170, lat=50).values
     array(0, dtype=int8)
-    """  # noqa: W505
+    """
     grid = _load_remote_dataset(
         dataset_name="earth_mask",
         dataset_prefix="earth_mask_",

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -136,7 +136,7 @@ def load_earth_relief(
     ...     registration="gridline",
     ...     use_srtm=True,
     ... )
-    """  # noqa: W505
+    """
     # resolutions of original land-only SRTM tiles from NASA
     land_only_srtm_resolutions = ["03s", "01s"]
 

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -23,7 +23,7 @@ def load_earth_relief(
     Load the Earth relief datasets (topography and bathymetry) in various
     resolutions.
 
-    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_gebcosi.jpg # noqa: W505
+    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_gebcosi.jpg
        :width: 80 %
        :align: center
 
@@ -136,7 +136,7 @@ def load_earth_relief(
     ...     registration="gridline",
     ...     use_srtm=True,
     ... )
-    """
+    """  # noqa: W505
     # resolutions of original land-only SRTM tiles from NASA
     land_only_srtm_resolutions = ["03s", "01s"]
 

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -97,7 +97,7 @@ def load_earth_vertical_gravity_gradient(
     ...     region=[120, 160, 30, 60],
     ...     registration="gridline",
     ... )
-    """  # noqa: W505
+    """
     grid = _load_remote_dataset(
         dataset_name="earth_vgg",
         dataset_prefix="earth_vgg_",

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -18,7 +18,7 @@ def load_earth_vertical_gravity_gradient(
     Load the IGPP Global Earth Vertical Gravity Gradient dataset in various
     resolutions.
 
-    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_vgg.jpg # noqa: W505
+    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_vgg.jpg
        :width: 80 %
        :align: center
 
@@ -97,7 +97,7 @@ def load_earth_vertical_gravity_gradient(
     ...     region=[120, 160, 30, 60],
     ...     registration="gridline",
     ... )
-    """
+    """  # noqa: W505
     grid = _load_remote_dataset(
         dataset_name="earth_vgg",
         dataset_prefix="earth_vgg_",

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -344,7 +344,7 @@ def load_sample_data(name):
      'usgs_quakes': 'Table of earthquakes from the USGS'}
     >>> # load the sample bathymetry dataset
     >>> data = load_sample_data("bathymetry")
-    """
+    """  # noqa: W505
     if name not in datasets:
         raise GMTInvalidInput(f"Invalid dataset name '{name}'.")
     return datasets[name].func()

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -330,7 +330,7 @@ def load_sample_data(name):
     >>> from pprint import pprint
     >>> from pygmt.datasets import list_sample_data, load_sample_data
     >>> # use list_sample_data to see the available datasets
-    >>> pprint(list_sample_data(), width=120)  # noqa: W505
+    >>> pprint(list_sample_data(), width=120)
     {'bathymetry': 'Table of ship bathymetric observations off Baja California',
      'earth_relief_holes': 'Regional 20 arc-minutes Earth relief grid with holes',
      'fractures': 'Table of hypothetical fracture lengths and azimuths',
@@ -344,7 +344,7 @@ def load_sample_data(name):
      'usgs_quakes': 'Table of earthquakes from the USGS'}
     >>> # load the sample bathymetry dataset
     >>> data = load_sample_data("bathymetry")
-    """  # noqa: W505
+    """
     if name not in datasets:
         raise GMTInvalidInput(f"Invalid dataset name '{name}'.")
     return datasets[name].func()

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -301,7 +301,6 @@ def list_sample_data():
 
 
 def load_sample_data(name):
-    # pylint: disable=line-too-long
     """
     Load an example dataset from the GMT server.
 
@@ -317,8 +316,8 @@ def load_sample_data(name):
     Returns
     -------
     :class:`pandas.DataFrame` or :class:`xarray.DataArray`
-        Sample dataset loaded as a :class:`pandas.DataFrame` for tabular data or
-        :class:`xarray.DataArray` for raster data.
+        Sample dataset loaded as a :class:`pandas.DataFrame` for tabular data
+        or :class:`xarray.DataArray` for raster data.
 
     See Also
     --------
@@ -345,7 +344,7 @@ def load_sample_data(name):
      'usgs_quakes': 'Table of earthquakes from the USGS'}
     >>> # load the sample bathymetry dataset
     >>> data = load_sample_data("bathymetry")
-    """
+    """  # noqa: W505
     if name not in datasets:
         raise GMTInvalidInput(f"Invalid dataset name '{name}'.")
     return datasets[name].func()

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -40,11 +40,11 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
     r"""
     Grid table data using a "Nearest neighbor" algorithm.
 
-    **nearneighbor** reads arbitrarily located (*x*, *y*, *z*\ [, *w*]) triplets
-    [quadruplets] and uses a nearest neighbor algorithm to assign a weighted
-    average value to each node that has one or more data points within a search
-    radius centered on the node with adequate coverage across a subset of the
-    chosen sectors. The node value is computed as a weighted mean of the
+    **nearneighbor** reads arbitrarily located (*x*, *y*, *z*\ [, *w*])
+    triplets [quadruplets] and uses a nearest neighbor algorithm to assign a
+    weighted average value to each node that has one or more data points within
+    a search radius centered on the node with adequate coverage across a subset
+    of the chosen sectors. The node value is computed as a weighted mean of the
     nearest point from each sector inside the search radius. The weighting
     function and the averaging used is given by:
 
@@ -139,7 +139,7 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
     >>> # Load a sample dataset of bathymetric x, y, and z values
     >>> data = pygmt.datasets.load_sample_data(name="bathymetry")
     >>> # Create a new grid with 5 arc-minutes spacing in the designated region
-    >>> # Set search_radius to only consider points within 10 arc-minutes of a node
+    >>> # Set search_radius to only take points within 10 arc-minutes of a node
     >>> output = pygmt.nearneighbor(
     ...     data=data,
     ...     spacing="5m",

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -57,7 +57,7 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
     criteria and :math:`r_i` is the distance from the node to the *i*'th data
     point. If no data weights are supplied then :math:`w_i = 1`.
 
-    .. figure:: https://docs.generic-mapping-tools.org/dev/_images/GMT_nearneighbor.png # noqa: W505
+    .. figure:: https://docs.generic-mapping-tools.org/dev/_images/GMT_nearneighbor.png
        :width: 300 px
        :align: center
 
@@ -146,7 +146,7 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
     ...     region=[245, 255, 20, 30],
     ...     search_radius="10m",
     ... )
-    """
+    """  # noqa: W505
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
             table_context = lib.virtualfile_from_data(

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -146,7 +146,7 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
     ...     region=[245, 255, 20, 30],
     ...     search_radius="10m",
     ... )
-    """  # noqa: W505
+    """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
             table_context = lib.virtualfile_from_data(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,26 +85,29 @@ make-summary-multi-line = true
 wrap-summaries = 79
 wrap-descriptions = 79
 
-[tool.flakeheaven]
-max_line_length = 88
-max_doc_length = 79
-show_source = true
+[tool.ruff]
+line-length = 88  # E501 (line-too-long)
+show-source = true
+select = [
+    "E",    # pycodestyle
+    "F",    # pyflakes
+    "I",    # isort
+    "W",    # pycodestyle warnings
+]
+ignore = ["E501"]  # Avoid enforcing line-length violations
 
-[tool.flakeheaven.plugins]
-pycodestyle = ["+*", "-E501", "-W503"]
-pyflakes = ["+*"]
+[tool.ruff.pycodestyle]
+max-doc-length = 79
 
-[tool.flakeheaven.exceptions."**/__init__.py"]
-pyflakes = ["-F401"]
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]  # Ignore `F401` (unused-import) in all `__init__.py` files
+
+[tool.ruff.isort]
+known-third-party = ["pygmt"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "--verbose --durations=0 --durations-min=0.2 --doctest-modules --mpl --mpl-results-path=results"
-
-[tool.isort]
-profile = "black"
-skip_gitignore = true
-known_third_party = "pygmt"
 
 [tool.pylint.MASTER]
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
@@ -136,5 +139,5 @@ max-module-lines=2000
 disable=[
     "duplicate-code",
     "import-error",
-    "line-too-long",  # Already checked by flakeheaven/pycodestyle
+    "line-too-long",  # Already checked by ruff's pycodestyle
 ]


### PR DESCRIPTION
**Description of proposed changes**

Use ruff to replace both `flakeheaven` (including `pycodestyle` and `pyflakes` rules) and `isort`, because it is much faster, and will help with Python 3.12 support (xref #2711).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Rulesets we are applying from https://docs.astral.sh/ruff/rules:
- [pycodestyle (E, W)](https://docs.astral.sh/ruff/rules/#pycodestyle-e-w)
- [Pyflakes (F)](https://docs.astral.sh/ruff/rules/#pyflakes-f)
- [isort (I)](https://docs.astral.sh/ruff/rules/#isort-i)

Ignoring:
- [E501 (line-too-long)](https://docs.astral.sh/ruff/rules/line-too-long) - a bit complicated, see inline comment below
- [F401 (unused-import)](https://docs.astral.sh/ruff/rules/unused-import) - only for `__init__.py` files

TODO
- [x] Update the documentation in `doc/contributing.md`
- [x] Update Makefile's `format` and `check` commands.
- [x] GitHub Actions CI `format-command.yml` and `style_checks.yml` now installs ruff instead of flakeheaven/isort
- [x] Gitignoring `.ruff_cache/` instead of `.flakeheaven_cache/`
- [x] Update files for [W505 (doc-line-too-long)](https://docs.astral.sh/ruff/rules/doc-line-too-long)


<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Supersedes https://github.com/GenericMappingTools/pygmt/pull/1847, addresses #2741.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
