### PR TITLE
Remote dataset "IGPP Global Earth Free-Air Anomaly": Fix typo in docs

### DIFF
--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -13,14 +13,14 @@ __doctest_skip__ = ["load_earth_free_air_anomaly"]
 @kwargs_to_strings(region="sequence")
 def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None):
     r"""
-    Load the IGPP Global Earth Free-Air Anomaly datatset in various
+    Load the IGPP Global Earth Free-Air Anomaly dataset in various
     resolutions.
 
     .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_faa.jpg
        :width: 80 %
        :align: center
 
-       IGPP Global Earth Free-Air Anomaly datatset.
+       IGPP Global Earth Free-Air Anomaly dataset.
 
     The grids are downloaded to a user data directory
     (usually ``~/.gmt/server/earth/earth_faa/``) the first time you invoke

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -13,8 +13,7 @@ __doctest_skip__ = ["load_earth_free_air_anomaly"]
 @kwargs_to_strings(region="sequence")
 def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None):
     r"""
-    Load the IGPP Global Earth Free-Air Anomaly dataset in various
-    resolutions.
+    Load the IGPP Global Earth Free-Air Anomaly dataset in various resolutions.
 
     .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_faa.jpg
        :width: 80 %


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a typo in the documentation of the remote dataset "IGPP Global Earth Free-Air Anomaly".

Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
