### PR TITLE
ruff: Enable the UP (pyupgrade) rules and upgrade to new syntax

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Sphinx documentation configuration file.
 """

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -908,10 +908,8 @@ class Session:
         )
         if status != 0:
             raise GMTCLibError(
-                (
-                    f"Failed to put vector of type {vector.dtype} "
-                    f"in column {column} of dataset."
-                )
+                f"Failed to put vector of type {vector.dtype} "
+                f"in column {column} of dataset."
             )
 
     def put_strings(self, dataset, family, strings):

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -1,7 +1,7 @@
 """
 Internal function to load GMT remote datasets.
 """
-from typing import Dict, NamedTuple
+from typing import NamedTuple
 
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import kwargs_to_strings
@@ -59,7 +59,7 @@ class GMTRemoteDataset(NamedTuple):
     name: str
     long_name: str
     units: str
-    resolutions: Dict[str, Resolution]
+    resolutions: dict[str, Resolution]
     extra_attributes: dict
 
 

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -402,20 +402,16 @@ class Figure:
 
         if method not in ["external", "notebook", "none"]:
             raise GMTInvalidInput(
-                (
-                    f"Invalid display method '{method}', "
-                    "should be either 'notebook', 'external', or 'none'."
-                )
+                f"Invalid display method '{method}', "
+                "should be either 'notebook', 'external', or 'none'."
             )
 
         if method == "notebook":
             if IPython is None:
                 raise GMTError(
-                    (
-                        "Notebook display is selected, but IPython is not available. "
-                        "Make sure you have IPython installed, "
-                        "or run the script in a Jupyter notebook."
-                    )
+                    "Notebook display is selected, but IPython is not available. "
+                    "Make sure you have IPython installed, "
+                    "or run the script in a Jupyter notebook."
                 )
             png = self._preview(
                 fmt="png", dpi=dpi, anti_alias=True, as_bytes=True, **kwargs
@@ -549,8 +545,6 @@ def set_display(method=None):
         SHOW_CONFIG["method"] = method
     elif method is not None:
         raise GMTInvalidInput(
-            (
-                f"Invalid display mode '{method}', "
-                "should be either 'notebook', 'external', 'none' or None."
-            )
+            f"Invalid display mode '{method}', "
+            "should be either 'notebook', 'external', 'none' or None."
         )

--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -83,7 +83,7 @@ class GMTTempFile:
         content : str
             Content of the temporary file as a Unicode string.
         """
-        with open(self.name, mode="r", encoding="utf8") as tmpfile:
+        with open(self.name, encoding="utf8") as tmpfile:
             content = tmpfile.read()
             if not keep_tabs:
                 content = content.replace("\t", " ")

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -227,7 +227,7 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
     elif kwargs.get("S") is None and kind == "file" and str(data).endswith(".gmt"):
         # checking that the data is a file path to set default style
         try:
-            with open(which(data), mode="r", encoding="utf8") as file:
+            with open(which(data), encoding="utf8") as file:
                 line = file.readline()
             if "@GMULTIPOINT" in line or "@GPOINT" in line:
                 # if the file is gmt style and geometry is set to Point

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -197,7 +197,7 @@ def plot3d(
     elif kwargs.get("S") is None and kind == "file" and str(data).endswith(".gmt"):
         # checking that the data is a file path to set default style
         try:
-            with open(which(data), mode="r", encoding="utf8") as file:
+            with open(which(data), encoding="utf8") as file:
                 line = file.readline()
             if "@GMULTIPOINT" in line or "@GPOINT" in line:
                 # if the file is gmt style and geometry is set to Point

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -194,12 +194,10 @@ def text_(
 
     # Build the -F option in gmt text.
     if kwargs.get("F") is None and (
-        (
-            position is not None
-            or angle is not None
-            or font is not None
-            or justify is not None
-        )
+        position is not None
+        or angle is not None
+        or font is not None
+        or justify is not None
     ):
         kwargs.update({"F": ""})
 

--- a/pygmt/tests/test_x2sys_init.py
+++ b/pygmt/tests/test_x2sys_init.py
@@ -29,7 +29,7 @@ def test_x2sys_init_region_spacing(mock_x2sys_home):
             tag=tag, fmtfile="xyz", force=True, region=[0, 10, 20, 30], spacing=[5, 5]
         )
 
-        with open(os.path.join(tmpdir, f"{tag}.tag"), "r", encoding="utf8") as tagpath:
+        with open(os.path.join(tmpdir, f"{tag}.tag"), encoding="utf8") as tagpath:
             tail_line = tagpath.readlines()[-1]
             assert "-R0/10/20/30" in tail_line
             assert "-I5/5" in tail_line
@@ -50,7 +50,7 @@ def test_x2sys_init_units_gap(mock_x2sys_home):
             gap=["tseconds", "de"],
         )
 
-        with open(os.path.join(tmpdir, f"{tag}.tag"), "r", encoding="utf8") as tagpath:
+        with open(os.path.join(tmpdir, f"{tag}.tag"), encoding="utf8") as tagpath:
             tail_line = tagpath.readlines()[-1]
             assert "-Nse -Nde" in tail_line
             assert "-Wtseconds -Wde" in tail_line

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ select = [
     "E",    # pycodestyle
     "F",    # pyflakes
     "I",    # isort
+    "UP",   # pyupgrade
     "W",    # pycodestyle warnings
 ]
 ignore = ["E501"]  # Avoid enforcing line-length violations


### PR DESCRIPTION
**Description of proposed changes**

Enable the [UP (pygrade)](https://docs.astral.sh/ruff/rules/#pyupgrade-up) rules, and run `make format` twice to automatically upgrade the syntax.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
