### PR TITLE
Remote datasets: Use "gmt-datasets" to link to images

### DIFF
--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -15,7 +15,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     r"""
     Load the Earth seafloor crustal age dataset in various resolutions.
 
-    .. figure:: :gmt-datasets:`earth-age.html`
+    .. figure:: :gmt-datasets:`_images/GMT_earth_age.png`
        :width: 80 %
        :align: center
 

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -15,7 +15,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     r"""
     Load the Earth seafloor crustal age dataset in various resolutions.
 
-    .. figure:: :gmt-dataset:`_images/GMT_earth_age.pn`
+    .. figure:: :gmt-dataset:`_images/GMT_earth_age.png`
        :width: 80 %
        :align: center
 

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -15,7 +15,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     r"""
     Load the Earth seafloor crustal age dataset in various resolutions.
 
-    .. figure:: :gmt-dataset:`_images/GMT_earth_age.png`
+    .. figure:: :gmt-datasets:`_images/GMT_earth_age.png`
        :width: 80 %
        :align: center
 

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -15,7 +15,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     r"""
     Load the Earth seafloor crustal age dataset in various resolutions.
 
-    .. figure:: :gmt-datasets:`_images/GMT_earth_age.png`
+    .. figure:: :gmt-datasets:`earth-age.html`
        :width: 80 %
        :align: center
 

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -15,7 +15,7 @@ def load_earth_age(resolution="01d", region=None, registration=None):
     r"""
     Load the Earth seafloor crustal age dataset in various resolutions.
 
-    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_age.png
+    .. figure:: :gmt-dataset:`_images/GMT_earth_age.pn`
        :width: 80 %
        :align: center
 

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -15,7 +15,7 @@ def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None
     r"""
     Load the IGPP Global Earth Free-Air Anomaly dataset in various resolutions.
 
-    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_faa.jpg
+    .. figure:: :gmt-datasets:`_images/GMT_earth_faa.jpg`
        :width: 80 %
        :align: center
 

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -15,7 +15,7 @@ def load_earth_geoid(resolution="01d", region=None, registration=None):
     r"""
     Load the EGM2008 Global Earth Geoid dataset in various resolutions.
 
-    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_geoid.jpg
+    .. figure:: :gmt-datasets:`_images/GMT_earth_geoid.jpg`
        :width: 80 %
        :align: center
 

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -24,8 +24,8 @@ def load_earth_magnetic_anomaly(
 
        * - Global Earth Magnetic Anomaly Model (EMAG2)
          - World Digital Magnetic Anomaly Map (WDMAM)
-       * - .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_mag4km.jpg
-         - .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_wdmam.jpg
+       * - .. figure:: :gmt-datasets:`_images/GMT_earth_mag4km.jpg`
+         - .. figure:: :gmt-datasets:`_images/GMT_earth_wdmam.jpg`
 
     The grids are downloaded to a user data directory
     (usually ``~/.gmt/server/earth/earth_mag/``,

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -15,7 +15,7 @@ def load_earth_mask(resolution="01d", region=None, registration=None):
     r"""
     Load the GSHHG Global Earth Mask dataset in various resolutions.
 
-    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_mask.png
+    .. figure:: :gmt-datasets:`_images/GMT_earth_mask.png`
        :width: 80 %
        :align: center
 

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -23,7 +23,7 @@ def load_earth_relief(
     Load the Earth relief datasets (topography and bathymetry) in various
     resolutions.
 
-    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_gebcosi.jpg
+    .. figure:: :gmt-datasets:`_images/GMT_earth_gebcosi.jpg`
        :width: 80 %
        :align: center
 

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -18,7 +18,7 @@ def load_earth_vertical_gravity_gradient(
     Load the IGPP Global Earth Vertical Gravity Gradient dataset in various
     resolutions.
 
-    .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_vgg.jpg
+    .. figure:: :gmt-datasets:`_images/GMT_earth_vgg.jpg`
        :width: 80 %
        :align: center
 


### PR DESCRIPTION
**Description of proposed changes**

I just realized that we actually defined a link to the GMT remote datasets in the `config.py` file:
```
# configure links to GMT docs
extlinks = {
    "gmt-docs": ("https://docs.generic-mapping-tools.org/6.4/%s", None),
    "gmt-term": ("https://docs.generic-mapping-tools.org/6.4/gmt.conf#term-%s", ""),
    "gmt-datasets": ("https://www.generic-mapping-tools.org/remote-datasets/%s", None),
}
```
Thus, this PR aims to use `gmt-datasets` for linking to the remote dataset images instead of adding the complete URL.

**Preview**: https://pygmt-dev--2750.org.readthedocs.build/en/2750/api/index.html#datasets

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
