### PR TITLE
CI: Pin ghostscript to 9.54.0 in Tests and Dev Tests workflows

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -106,6 +106,7 @@ jobs:
           create-args: >-
             python=${{ matrix.python-version }}${{ matrix.optional-packages }}
             gmt=6.4.0
+            ghostscript=9.54.0
             numpy=${{ matrix.numpy-version }}
             pandas
             xarray

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -106,7 +106,7 @@ jobs:
             ninja
             curl
             fftw
-            ghostscript
+            ghostscript=9.54.0
             hdf5
             libblas
             libcblas


### PR DESCRIPTION
**Description of proposed changes**

The latest gs version is 10.02.0 but our baseline images were generated with gs 9.54.0, thus we will have lots of failures if we use gs 10.02.0 (see PR #2694).

We should update our gs to 10.02.0 and update all baseline images, but we decided to wait for GMT 6.5 first (https://github.com/GenericMappingTools/pygmt/pull/2694#issuecomment-1724749593) so that we don't have to update baseline images twice in a short period.

In this PR, Ghostscript is pinned to 9.54.0 for the Tests and Dev Tests workflow, so that we don't have failures due to gs 10.02.0. Other workflows are not changed because they don't care about the gs version.

We will pin Ghostscript to 10.02.0 in PR https://github.com/GenericMappingTools/pygmt/pull/2694.