### PR TITLE
Simplify the use of is_nonstr_iter

### DIFF
--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -456,6 +456,8 @@ def is_nonstr_iter(value):
     False
     >>> is_nonstr_iter(10)
     False
+    >>> is_nonstr_iter(None)
+    False
     >>> is_nonstr_iter([1, 2, 3])
     True
     >>> is_nonstr_iter((1, 2, 3))

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -234,7 +234,7 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
                 kwargs["S"] = "s0.2c"
         except FileNotFoundError:
             pass
-    if kwargs.get("G") is not None and is_nonstr_iter(kwargs["G"]):
+    if is_nonstr_iter(kwargs.get("G")):
         if kind != "vectors":
             raise GMTInvalidInput(
                 "Can't use arrays for fill if data is matrix or file."
@@ -249,7 +249,7 @@ def plot(self, data=None, x=None, y=None, size=None, direction=None, **kwargs):
         extra_arrays.append(size)
 
     for flag in ["I", "t"]:
-        if kwargs.get(flag) is not None and is_nonstr_iter(kwargs[flag]):
+        if is_nonstr_iter(kwargs.get(flag)):
             if kind != "vectors":
                 raise GMTInvalidInput(
                     f"Can't use arrays for {plot.aliases[flag]} if data is matrix or file."

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -204,7 +204,7 @@ def plot3d(
                 kwargs["S"] = "u0.2c"
         except FileNotFoundError:
             pass
-    if kwargs.get("G") is not None and is_nonstr_iter(kwargs["G"]):
+    if is_nonstr_iter(kwargs.get("G")):
         if kind != "vectors":
             raise GMTInvalidInput(
                 "Can't use arrays for fill if data is matrix or file."
@@ -219,7 +219,7 @@ def plot3d(
         extra_arrays.append(size)
 
     for flag in ["I", "t"]:
-        if kwargs.get(flag) is not None and is_nonstr_iter(kwargs[flag]):
+        if is_nonstr_iter(kwargs.get(flag)):
             if kind != "vectors":
                 raise GMTInvalidInput(
                     f"Can't use arrays for {plot3d.aliases[flag]} if data is matrix or file."

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -216,7 +216,7 @@ def text_(
 
     # If an array of transparency is given, GMT will read it from
     # the last numerical column per data record.
-    if kwargs.get("t") is not None and is_nonstr_iter(kwargs["t"]):
+    if is_nonstr_iter(kwargs.get("t")):
         extra_arrays.append(kwargs["t"])
         kwargs["t"] = ""
 


### PR DESCRIPTION
**Description of proposed changes**

`is_nonstr_iter(None)` returns `False` because `None` is not iterable. 

So, `if x is not None and is_nonstr_iter(x)` is equivalent to `is_nonstr_iter(x)` thus can be simplified.