### PR TITLE
Remote datasets: Remove "Global" from dataset names

### DIFF
--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -1,6 +1,6 @@
 """
-Function to download the IGPP Earth Free-Air Anomaly dataset from the
-GMT data server, and load as :class:`xarray.DataArray`.
+Function to download the IGPP Earth Free-Air Anomaly dataset from the GMT data
+server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -1,5 +1,5 @@
 """
-Function to download the IGPP Global Earth Free-Air Anomaly dataset from the
+Function to download the IGPP Earth Free-Air Anomaly dataset from the
 GMT data server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
@@ -13,13 +13,13 @@ __doctest_skip__ = ["load_earth_free_air_anomaly"]
 @kwargs_to_strings(region="sequence")
 def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None):
     r"""
-    Load the IGPP Global Earth Free-Air Anomaly dataset in various resolutions.
+    Load the IGPP Earth Free-Air Anomaly dataset in various resolutions.
 
     .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_faa.jpg
        :width: 80 %
        :align: center
 
-       IGPP Global Earth Free-Air Anomaly dataset.
+       IGPP Earth Free-Air Anomaly dataset.
 
     The grids are downloaded to a user data directory
     (usually ``~/.gmt/server/earth/earth_faa/``) the first time you invoke

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -1,6 +1,6 @@
 """
-Function to download the EGM2008 Earth Geoid dataset from the GMT data
-server, and load as :class:`xarray.DataArray`.
+Function to download the EGM2008 Earth Geoid dataset from the GMT data server,
+and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -1,5 +1,5 @@
 """
-Function to download the EGM2008 Global Earth Geoid dataset from the GMT data
+Function to download the EGM2008 Earth Geoid dataset from the GMT data
 server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
@@ -13,13 +13,13 @@ __doctest_skip__ = ["load_earth_geoid"]
 @kwargs_to_strings(region="sequence")
 def load_earth_geoid(resolution="01d", region=None, registration=None):
     r"""
-    Load the EGM2008 Global Earth Geoid dataset in various resolutions.
+    Load the EGM2008 Earth Geoid dataset in various resolutions.
 
     .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_geoid.jpg
        :width: 80 %
        :align: center
 
-       EGM2008 Global Earth Geoid dataset.
+       EGM2008 Earth Geoid dataset.
 
     The grids are downloaded to a user data directory
     (usually ``~/.gmt/server/earth/earth_geoid/``) the first time you invoke

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -22,7 +22,7 @@ def load_earth_magnetic_anomaly(
        :widths: 50 50
        :header-rows: 1
 
-       * - Global Earth Magnetic Anomaly Model (EMAG2)
+       * - Earth Magnetic Anomaly Model (EMAG2)
          - World Digital Magnetic Anomaly Map (WDMAM)
        * - .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_mag4km.jpg
          - .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_wdmam.jpg
@@ -80,7 +80,7 @@ def load_earth_magnetic_anomaly(
     data_source : str
         Select the source of the magnetic anomaly data. Available options are:
 
-        - ``"emag2"``: EMAG2 Global Earth Magnetic Anomaly Model [Default
+        - ``"emag2"``: EMAG2 Earth Magnetic Anomaly Model [Default
           option]. It only includes data observed at sea level over
           oceanic regions. See :gmt-datasets:`earth-mag.html`.
 

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -1,6 +1,6 @@
 """
-Function to download the GSHHG Earth Mask dataset from the GMT data
-server, and load as :class:`xarray.DataArray`.
+Function to download the GSHHG Earth Mask dataset from the GMT data server, and
+load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -1,5 +1,5 @@
 """
-Function to download the GSHHG Global Earth Mask dataset from the GMT data
+Function to download the GSHHG Earth Mask dataset from the GMT data
 server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
@@ -13,13 +13,13 @@ __doctest_skip__ = ["load_earth_mask"]
 @kwargs_to_strings(region="sequence")
 def load_earth_mask(resolution="01d", region=None, registration=None):
     r"""
-    Load the GSHHG Global Earth Mask dataset in various resolutions.
+    Load the GSHHG Earth Mask dataset in various resolutions.
 
     .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_mask.png
        :width: 80 %
        :align: center
 
-       GSHHG Global Earth Mask dataset.
+       GSHHG Earth Mask dataset.
 
     The grids are downloaded to a user data directory
     (usually ``~/.gmt/server/earth/earth_mask/``) the first time you invoke

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -77,18 +77,18 @@ def load_earth_relief(
     data_source : str
         Select the source for the Earth relief data. Available options are:
 
-        - ``"igpp"``: IGPP Global Earth Relief [Default option]. See
+        - ``"igpp"``: IGPP Earth Relief [Default option]. See
           :gmt-datasets:`earth-relief.html`.
 
-        - ``"synbath"``: IGPP Global Earth Relief dataset that uses
+        - ``"synbath"``: IGPP Earth Relief dataset that uses
           stastical properties of young seafloor to provide a more realistic
           relief of young areas with small seamounts.
 
-        - ``"gebco"``: GEBCO Global Earth Relief with only observed relief and
+        - ``"gebco"``: GEBCO Earth Relief with only observed relief and
           inferred relief via altimetric gravity. See
           :gmt-datasets:`earth-gebco.html`.
 
-        - ``"gebcosi"``: GEBCO Global Earth Relief that gives sub-ice (si)
+        - ``"gebcosi"``: GEBCO Earth Relief that gives sub-ice (si)
           elevations.
 
     use_srtm : bool

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -1,5 +1,5 @@
 """
-Function to download the IGPP Global Earth Vertical Gravity Gradient dataset
+Function to download the IGPP Earth Vertical Gravity Gradient dataset
 from the GMT data server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
@@ -15,14 +15,14 @@ def load_earth_vertical_gravity_gradient(
     resolution="01d", region=None, registration=None
 ):
     r"""
-    Load the IGPP Global Earth Vertical Gravity Gradient dataset in various
+    Load the IGPP Earth Vertical Gravity Gradient dataset in various
     resolutions.
 
     .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_vgg.jpg
        :width: 80 %
        :align: center
 
-       IGPP Global Earth Vertical Gravity Gradient dataset.
+       IGPP Earth Vertical Gravity Gradient dataset.
 
     The grids are downloaded to a user data directory
     (usually ``~/.gmt/server/earth/earth_vgg/``) the first time you invoke

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -1,6 +1,6 @@
 """
-Function to download the IGPP Earth Vertical Gravity Gradient dataset
-from the GMT data server, and load as :class:`xarray.DataArray`.
+Function to download the IGPP Earth Vertical Gravity Gradient dataset from the
+GMT data server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -87,7 +87,7 @@ datasets = {
     "earth_free_air_anomaly": GMTRemoteDataset(
         title="free air anomaly",
         name="free_air_anomaly",
-        long_name="IGPP Global Earth Free-Air Anomaly",
+        long_name="IGPP Earth Free-Air Anomaly",
         units="mGal",
         extra_attributes={"horizontal_datum": "WGS84"},
         resolutions={
@@ -107,7 +107,7 @@ datasets = {
     "earth_geoid": GMTRemoteDataset(
         title="Earth geoid",
         name="earth_geoid",
-        long_name="EGM2008 Global Earth Geoid",
+        long_name="EGM2008 Earth Geoid",
         units="m",
         extra_attributes={"horizontal_datum": "WGS84"},
         resolutions={
@@ -192,7 +192,7 @@ datasets = {
     "earth_vgg": GMTRemoteDataset(
         title="Earth vertical gravity gradient",
         name="earth_vgg",
-        long_name="IGPP Global Earth Vertical Gravity Gradient",
+        long_name="IGPP Earth Vertical Gravity Gradient",
         units="Eotvos",
         extra_attributes={"horizontal_datum": "WGS84"},
         resolutions={

--- a/pygmt/tests/test_datasets_earth_free_air_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_free_air_anomaly.py
@@ -12,7 +12,7 @@ def test_earth_faa_01d():
     """
     data = load_earth_free_air_anomaly(resolution="01d")
     assert data.name == "free_air_anomaly"
-    assert data.attrs["long_name"] == "IGPP Global Earth Free-Air Anomaly"
+    assert data.attrs["long_name"] == "IGPP Earth Free-Air Anomaly"
     assert data.attrs["units"] == "mGal"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)

--- a/pygmt/tests/test_datasets_earth_geoid.py
+++ b/pygmt/tests/test_datasets_earth_geoid.py
@@ -13,7 +13,7 @@ def test_earth_geoid_01d():
     data = load_earth_geoid(resolution="01d")
     assert data.name == "earth_geoid"
     assert data.attrs["units"] == "m"
-    assert data.attrs["long_name"] == "EGM2008 Global Earth Geoid"
+    assert data.attrs["long_name"] == "EGM2008 Earth Geoid"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
     assert data.gmt.registration == 0

--- a/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
+++ b/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
@@ -13,7 +13,7 @@ def test_earth_vertical_gravity_gradient_01d():
     data = load_earth_vertical_gravity_gradient(resolution="01d")
     assert data.name == "earth_vgg"
     assert data.attrs["units"] == "Eotvos"
-    assert data.attrs["long_name"] == "IGPP Global Earth Vertical Gravity Gradient"
+    assert data.attrs["long_name"] == "IGPP Earth Vertical Gravity Gradient"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
     assert data.gmt.registration == 0


### PR DESCRIPTION
**Description of proposed changes**

Related to PR https://github.com/GenericMappingTools/remote-datasets/pull/98#issuecomment-1770516419, this PR aims to remove "Global" from the dataset names of the remote datasets in the PyGMT:
- [x] API reference
- [x] Tests
- [ ] Examples (gallery, tutorials, intros)

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
