### PR TITLE
Add Zenodo's GMT community to the maintainer's onboarding list

### DIFF
--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -28,7 +28,7 @@ communication tools we use.
 - Update the role on the {doc}`Team Gallery page <team>`
 - Added as moderator on the [GMT forum](https://forum.generic-mapping-tools.org) (to see mod-only discussions) [optional]
 - Added as a maintainer on [Readthedocs](https://readthedocs.org/projects/pygmt-dev) [optional]
-- Added as a Curator to the [GMT community](https://zenodo.org/communities/generic-mapping-tools/) on Zenodo (for making releases) [optional]
+- Added as a curator to the [GMT community](https://zenodo.org/communities/generic-mapping-tools/) on Zenodo (for making releases) [optional]
 
 ### As an Administrator
 

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -28,6 +28,7 @@ communication tools we use.
 - Update the role on the {doc}`Team Gallery page <team>`
 - Added as moderator on the [GMT forum](https://forum.generic-mapping-tools.org) (to see mod-only discussions) [optional]
 - Added as a maintainer on [Readthedocs](https://readthedocs.org/projects/pygmt-dev) [optional]
+- Added as a Curator to the [GMT community](https://zenodo.org/communities/generic-mapping-tools/) on Zenodo (for making releases) [optional]
 
 ### As an Administrator
 


### PR DESCRIPTION
**Description of proposed changes**

Now it's possible to invite people as members of the GMT community on Zenodo:

<img width="902" alt="image" src="https://github.com/GenericMappingTools/pygmt/assets/3974108/161430aa-ae0b-4e26-8f60-a003b5fb67c6">

Closes https://github.com/GenericMappingTools/pygmt/issues/601.