### PR TITLE
Gallery example "Legend": Update regarding input data and multi-column legends

### DIFF
--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -38,7 +38,7 @@ fig.basemap(
 # -----------------------------------------------------------------------------
 # Top: Vertical legend (one column, default)
 
-# Use the label parameter to state to text label for the legend entry
+# Use the label parameter to state the text label for the legend entry
 fig.plot(x=x, y=y1, pen="1p,green3", label="Sine(x)+1.1")
 
 fig.plot(x=x, y=y2, style="c0.07c", fill="dodgerblue", label="Cosine(x)+1.1")

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -3,13 +3,17 @@ Legend
 ======
 
 The :meth:`pygmt.Figure.legend` method can automatically create a legend for
-symbols plotted using :meth:`pygmt.Figure.plot`. Legend entries are only
-created when the ``label`` parameter is used. For more complicated legends,
-including legends with multiple columns, users have to write an ASCII file
-with instructions for the layout of the legend items and pass it
-to the ``spec`` parameter of :meth:`pygmt.Figure.legend`. For details on
-how to set up such a file, please see the GMT documentation at
-:gmt-docs:`legend.html#legend-codes`.
+symbols plotted using :meth:`pygmt.Figure.plot`. A legend entry is only added
+when the ``label`` parameter is used to state the desired text. Optionally,
+to adjust the legend, users can append different modifiers. A list of all
+available modifiers can be found at :gmt-docs:`gmt.html#l-full`. To create a
+multiple-column legend **+N** is used with the desired number of columns.
+For more complicated legends, users may want to write an ASCII file with
+instructions for the layout of the legend items and pass it to the ``spec``
+parameter of :meth:`pygmt.Figure.legend`. For details on how to set up such a
+file, please see the GMT documentation at :gmt-docs:`legend.html#legend-codes`.
+In this example the same plot is created twice, first with a vertical (default)
+and then with a horizontal legend.
 """
 
 # %%
@@ -17,7 +21,9 @@ import pygmt
 
 fig = pygmt.Figure()
 
-fig.basemap(projection="x2c", region=[0, 7, 3, 7], frame=True)
+# -----------------------------------------------------------------------------
+# Left: Vertical legend (one column, default)
+fig.basemap(projection="x2c", region=[0, 7, 3, 7], frame=["WSne", "af"])
 
 fig.plot(
     data="@Table_5_11.txt",
@@ -30,5 +36,26 @@ fig.plot(data="@Table_5_11.txt", pen="1.5p,gray", label="My lines")
 fig.plot(data="@Table_5_11.txt", style="t0.40c", fill="orange", label="Oranges")
 
 fig.legend(position="JTR+jTR+o0.2c", box=True)
+
+fig.shift_origin(xshift="+w1c")
+
+# -----------------------------------------------------------------------------
+# Right: Horizontal legend (here three columns)
+fig.basemap(projection="x2c", region=[0, 7, 3, 7], frame=["wSne", "af"])
+
+fig.plot(
+    data="@Table_5_11.txt",
+    style="c0.40c",
+    fill="lightgreen",
+    pen="faint",
+    # +N sets the number of columns corresponding to the given number
+    label="Apples+N3",
+)
+fig.plot(data="@Table_5_11.txt", pen="1.5p,gray", label="My lines")
+fig.plot(data="@Table_5_11.txt", style="t0.40c", fill="orange", label="Oranges")
+
+# For multi-column legends users have to provide the width via +w, here it is
+# set to 6.5 centimeters
+fig.legend(position="JTR+jTR+o0.2c+w6.5c", box=True)
 
 fig.show()

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -19,7 +19,7 @@ import numpy as np
 import pygmt
 
 # Set up some test data
-x = np.arange(-10, 10, 0.2)
+x = np.arange(-10, 10.2, 0.2)
 y1 = np.sin(x) + 1.1
 y2 = np.cos(x) + 1.1
 y3 = np.sin(x / 2) - 1.1

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -39,9 +39,9 @@ fig.basemap(
 # Top: Vertical legend (one column, default)
 
 # Use the label parameter to state to text label for the legend entry
-fig.plot(x=x, y=y1, pen="1p,green3", label="Sine(x)")
+fig.plot(x=x, y=y1, pen="1p,green3", label="Sine(x)+1.1")
 
-fig.plot(x=x, y=y2, style="c0.07c", fill="dodgerblue", label="Cosine(x)")
+fig.plot(x=x, y=y2, style="c0.07c", fill="dodgerblue", label="Cosine(x)+1.1")
 
 # Add a legend to the plot; place it within the plot bounding box with both
 # reference ("J") and anchor ("+j") points being TopRight and with an offset
@@ -53,13 +53,13 @@ fig.legend(position="JTR+jTR+o0.2c", box=True)
 # Bottom: Horizontal legend (here two columns)
 
 # +N sets the number of columns corresponding to the given number, here 2
-fig.plot(x=x, y=y3, pen="1p,darkred,-", label="Sine(x/2)+N2")
+fig.plot(x=x, y=y3, pen="1p,darkred,-", label="Sine(x/2)-1.1+N2")
 
-fig.plot(x=x, y=y4, style="s0.07c", fill="orange", label="Cosine(x/2)")
+fig.plot(x=x, y=y4, style="s0.07c", fill="orange", label="Cosine(x/2)-1.1")
 
 # For a multi-column legend, users have to provide the width via "+w", here it
-# is set to 5 centimeters; reference and anchor points are set to BottomRight
-fig.legend(position="JBR+jBR+o0.2c+w5c", box=True)
+# is set to 6 centimeters; reference and anchor points are set to BottomRight
+fig.legend(position="JBR+jBR+o0.2c+w6c", box=True)
 
 
 fig.show()

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -33,14 +33,14 @@ fig = pygmt.Figure()
 # Left: Vertical legend (one column, default)
 fig.basemap(projection="X10c", region=[-10, 10, -1.5, 1.5], frame=True)
 
-# Use the label parameter to state to text label for the legend entery
+# Use the label parameter to state to text label for the legend entry
 fig.plot(x=x, y=y1, pen="1p,green3", label="Sine")
 
 fig.plot(x=x, y=y2, style="c0.1c", fill="dodgerblue", label="Cosine")
 
 # Add a legend to the plot; place it within the plot bounding box at position
 # ("J") TopRight with a anchor point ("j") TopRight and an offset of 0.2
-# centimeters in x and y directions; sourond the legend with a box
+# centimeters in x and y directions; surround the legend with a box
 fig.legend(position="JTR+jTR+o0.2c", box=True)
 
 fig.shift_origin(xshift="+w1c")

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -12,8 +12,6 @@ For more complicated legends, users may want to write an ASCII file with
 instructions for the layout of the legend items and pass it to the ``spec``
 parameter of :meth:`pygmt.Figure.legend`. For details on how to set up such a
 file, please see the GMT documentation at :gmt-docs:`legend.html#legend-codes`.
-In this example the same plot is created twice, first with a vertical (default)
-and then with a horizontal legend.
 """
 
 # %%
@@ -21,41 +19,47 @@ import numpy as np
 import pygmt
 
 # Set up some test data
-x = np.arange(-10, 10, 0.1)
-y1 = np.sin(x)
-y2 = np.cos(x)
+x = np.arange(-10, 10, 0.2)
+y1 = np.sin(x) + 1.1
+y2 = np.cos(x) + 1.1
+y3 = np.sin(x/2) - 1.1
+y4 = np.cos(x/2) - 1.1
 
 
 # Create new Figure() object
 fig = pygmt.Figure()
 
+fig.basemap(
+    projection="X10c/7c",
+    region=[-10, 10, -3.5, 3.5],
+    frame=["WSne", "xaf+lx", "ya1f0.5+ly"],
+)
+
 # -----------------------------------------------------------------------------
-# Left: Vertical legend (one column, default)
-fig.basemap(projection="X10c", region=[-10, 10, -1.5, 1.5], frame=True)
+# Top: Vertical legend (one column, default)
 
 # Use the label parameter to state to text label for the legend entry
-fig.plot(x=x, y=y1, pen="1p,green3", label="Sine")
+fig.plot(x=x, y=y1, pen="1p,green3", label="Sine(x)")
 
-fig.plot(x=x, y=y2, style="c0.1c", fill="dodgerblue", label="Cosine")
+fig.plot(x=x, y=y2, style="c0.07c", fill="dodgerblue", label="Cosine(x)")
 
 # Add a legend to the plot; place it within the plot bounding box at position
 # ("J") TopRight with a anchor point ("j") TopRight and an offset of 0.2
 # centimeters in x and y directions; surround the legend with a box
 fig.legend(position="JTR+jTR+o0.2c", box=True)
 
-fig.shift_origin(xshift="+w1c")
 
 # -----------------------------------------------------------------------------
-# Right: Horizontal legend (here two columns)
-fig.basemap(projection="X10c", region=[-10, 10, -1.5, 1.5], frame=["wStr", "af"])
+# Bottom: Horizontal legend (here two columns)
 
 # +N sets the number of columns corresponding to the given number, here two
-fig.plot(x=x, y=y1, pen="1p,green3", label="Sine+N2")
+fig.plot(x=x, y=y3, pen="1p,darkred,-", label="Sine(x/2)+N2")
 
-fig.plot(x=x, y=y2, style="c0.1c", fill="dodgerblue", label="Cosine")
+fig.plot(x=x, y=y4, style="s0.07c", fill="orange", label="Cosine(x/2)")
 
-# For multi-column legends users have to provide the width via +w, here it is
-# set to 4.5 centimeters
-fig.legend(position="JTR+jTR+o0.2c+w4.5c", box=True)
+# For multi-column legends, users have to provide the width via +w, here it is
+# set to 5 centimeters; position and anchor point are set to BottoRight
+fig.legend(position="JBR+jBR+o0.2c+w5c", box=True)
+
 
 fig.show()

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -39,9 +39,9 @@ fig.basemap(
 # Top: Vertical legend (one column, default)
 
 # Use the label parameter to state the text label for the legend entry
-fig.plot(x=x, y=y1, pen="1p,green3", label="Sine(x)+1.1")
+fig.plot(x=x, y=y1, pen="1p,green3", label="sin(x)+1.1")
 
-fig.plot(x=x, y=y2, style="c0.07c", fill="dodgerblue", label="Cosine(x)+1.1")
+fig.plot(x=x, y=y2, style="c0.07c", fill="dodgerblue", label="cos(x)+1.1")
 
 # Add a legend to the plot; place it within the plot bounding box with both
 # reference ("J") and anchor ("+j") points being TopRight and with an offset
@@ -53,9 +53,9 @@ fig.legend(position="JTR+jTR+o0.2c", box=True)
 # Bottom: Horizontal legend (here two columns)
 
 # +N sets the number of columns corresponding to the given number, here 2
-fig.plot(x=x, y=y3, pen="1p,darkred,-", label="Sine(x/2)-1.1+N2")
+fig.plot(x=x, y=y3, pen="1p,darkred,-", label="sin(x/2)-1.1+N2")
 
-fig.plot(x=x, y=y4, style="s0.07c", fill="orange", label="Cosine(x/2)-1.1")
+fig.plot(x=x, y=y4, style="s0.07c", fill="orange", label="cos(x/2)-1.1")
 
 # For a multi-column legend, users have to provide the width via "+w", here it
 # is set to 6 centimeters; reference and anchor points are set to BottomRight

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -25,7 +25,6 @@ y2 = np.cos(x) + 1.1
 y3 = np.sin(x / 2) - 1.1
 y4 = np.cos(x / 2) - 1.1
 
-
 # Create new Figure() object
 fig = pygmt.Figure()
 
@@ -48,7 +47,6 @@ fig.plot(x=x, y=y2, style="c0.07c", fill="dodgerblue", label="cos(x)+1.1")
 # of 0.2 centimeters in x and y directions; surround the legend with a box
 fig.legend(position="JTR+jTR+o0.2c", box=True)
 
-
 # -----------------------------------------------------------------------------
 # Bottom: Horizontal legend (here two columns)
 
@@ -60,6 +58,5 @@ fig.plot(x=x, y=y4, style="s0.07c", fill="orange", label="cos(x/2)-1.1")
 # For a multi-column legend, users have to provide the width via "+w", here it
 # is set to 6 centimeters; reference and anchor points are set to BottomRight
 fig.legend(position="JBR+jBR+o0.2c+w6c", box=True)
-
 
 fig.show()

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -43,22 +43,22 @@ fig.plot(x=x, y=y1, pen="1p,green3", label="Sine(x)")
 
 fig.plot(x=x, y=y2, style="c0.07c", fill="dodgerblue", label="Cosine(x)")
 
-# Add a legend to the plot; place it within the plot bounding box at position
-# ("J") TopRight with a anchor point ("j") TopRight and an offset of 0.2
-# centimeters in x and y directions; surround the legend with a box
+# Add a legend to the plot; place it within the plot bounding box with both
+# reference ("J") and anchor ("+j") points being TopRight and with an offset
+# of 0.2 centimeters in x and y directions; surround the legend with a box
 fig.legend(position="JTR+jTR+o0.2c", box=True)
 
 
 # -----------------------------------------------------------------------------
 # Bottom: Horizontal legend (here two columns)
 
-# +N sets the number of columns corresponding to the given number, here two
+# +N sets the number of columns corresponding to the given number, here 2
 fig.plot(x=x, y=y3, pen="1p,darkred,-", label="Sine(x/2)+N2")
 
 fig.plot(x=x, y=y4, style="s0.07c", fill="orange", label="Cosine(x/2)")
 
-# For a multi-column legend, users have to provide the width via +w, here it
-# is set to 5 centimeters; position and anchor point are set to BottomRight
+# For a multi-column legend, users have to provide the width via "+w", here it
+# is set to 5 centimeters; reference and anchor points are set to BottomRight
 fig.legend(position="JBR+jBR+o0.2c+w5c", box=True)
 
 

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -57,8 +57,8 @@ fig.plot(x=x, y=y3, pen="1p,darkred,-", label="Sine(x/2)+N2")
 
 fig.plot(x=x, y=y4, style="s0.07c", fill="orange", label="Cosine(x/2)")
 
-# For multi-column legends, users have to provide the width via +w, here it is
-# set to 5 centimeters; position and anchor point are set to BottoRight
+# For a multi-column legend, users have to provide the width via +w, here it
+# is set to 5 centimeters; position and anchor point are set to BottomRight
 fig.legend(position="JBR+jBR+o0.2c+w5c", box=True)
 
 

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -17,45 +17,45 @@ and then with a horizontal legend.
 """
 
 # %%
+import numpy as np
 import pygmt
 
+# Set up some test data
+x = np.arange(-10, 10, 0.1)
+y1 = np.sin(x)
+y2 = np.cos(x)
+
+
+# Create new Figure() object
 fig = pygmt.Figure()
 
 # -----------------------------------------------------------------------------
 # Left: Vertical legend (one column, default)
-fig.basemap(projection="x2c", region=[0, 7, 3, 7], frame=["WSne", "af"])
+fig.basemap(projection="X10c", region=[-10, 10, -1.5, 1.5], frame=True)
 
-fig.plot(
-    data="@Table_5_11.txt",
-    style="c0.40c",
-    fill="lightgreen",
-    pen="faint",
-    label="Apples",
-)
-fig.plot(data="@Table_5_11.txt", pen="1.5p,gray", label="My lines")
-fig.plot(data="@Table_5_11.txt", style="t0.40c", fill="orange", label="Oranges")
+# Use the label parameter to state to text label for the legend entery
+fig.plot(x=x, y=y1, pen="1p,green3", label="Sine")
 
+fig.plot(x=x, y=y2, style="c0.1c", fill="dodgerblue", label="Cosine")
+
+# Add a legend to the plot; place it within the plot bounding box at position
+# ("J") TopRight with a anchor point ("j") TopRight and an offset of 0.2
+# centimeters in x and y directions; sourond the legend with a box
 fig.legend(position="JTR+jTR+o0.2c", box=True)
 
 fig.shift_origin(xshift="+w1c")
 
 # -----------------------------------------------------------------------------
-# Right: Horizontal legend (here three columns)
-fig.basemap(projection="x2c", region=[0, 7, 3, 7], frame=["wSne", "af"])
+# Right: Horizontal legend (here two columns)
+fig.basemap(projection="X10c", region=[-10, 10, -1.5, 1.5], frame=["wStr", "af"])
 
-fig.plot(
-    data="@Table_5_11.txt",
-    style="c0.40c",
-    fill="lightgreen",
-    pen="faint",
-    # +N sets the number of columns corresponding to the given number
-    label="Apples+N3",
-)
-fig.plot(data="@Table_5_11.txt", pen="1.5p,gray", label="My lines")
-fig.plot(data="@Table_5_11.txt", style="t0.40c", fill="orange", label="Oranges")
+# +N sets the number of columns corresponding to the given number, here two
+fig.plot(x=x, y=y1, pen="1p,green3", label="Sine+N2")
+
+fig.plot(x=x, y=y2, style="c0.1c", fill="dodgerblue", label="Cosine")
 
 # For multi-column legends users have to provide the width via +w, here it is
-# set to 6.5 centimeters
-fig.legend(position="JTR+jTR+o0.2c+w6.5c", box=True)
+# set to 4.5 centimeters
+fig.legend(position="JTR+jTR+o0.2c+w4.5c", box=True)
 
 fig.show()

--- a/examples/gallery/embellishments/legend.py
+++ b/examples/gallery/embellishments/legend.py
@@ -22,8 +22,8 @@ import pygmt
 x = np.arange(-10, 10, 0.2)
 y1 = np.sin(x) + 1.1
 y2 = np.cos(x) + 1.1
-y3 = np.sin(x/2) - 1.1
-y4 = np.cos(x/2) - 1.1
+y3 = np.sin(x / 2) - 1.1
+y4 = np.cos(x / 2) - 1.1
 
 
 # Create new Figure() object


### PR DESCRIPTION
**Description of proposed changes**

In contrast to the change in PR #2606, it is actually possible to create a multi-column legend for a automatically created legend. This PR corrects the introduction text of the gallery example "Legend".

I feel it would be good to show how to create a horizontal legend, as this is done via the `label` parameter of `Figure.plot`, and not via a parameter of the `Figure.legend` method. For more complicated adjustments of a legend a tutorial seem to make sense. Currently, the same plot is created twice, first with a vertical legend (default) and then with a horizontal legend. However, I am not 100 % happy with this example. I do not like that we plot the same data twice above each other, just with different symbols. And maybe it is not optimal to simply repeat the same plot. Suggestions are welcome 🙂.

Related:
- PyGMT issue: #2603
- PyGMT PR: #2606
- GMT forum: https://forum.generic-mapping-tools.org/t/horizontal-legend/4362

**Preveiw**: https://pygmt-dev--2762.org.readthedocs.build/en/2762/gallery/embellishments/legend.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
