### PR TITLE
Figure.savefig: Add the 'worldfile' parameter to write a companion world file for raster images

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -296,13 +296,13 @@ class Figure:
             the arguments ``"t2"`` and ``"g2"`` to the ``anti_aliasing``
             parameter of :meth:`pygmt.Figure.psconvert`. Ignored if creating
             vector graphics.
-        show: bool
+        show : bool
             If ``True``, will open the figure in an external viewer.
-        worldfile: bool
+        worldfile : bool
             If ``True``, will create a companion
             `world file <https://en.wikipedia.org/wiki/World_file>`__ for the
             figure. The world file will have the same name as the figure file
-            but with different extension. See
+            but with different extension (e.g. tfw for tif). See
             https://en.wikipedia.org/wiki/World_file#Filename_extension
             for the convention of world file extensions.
             This parameter does not work for KML and GeoTIFF formats.
@@ -359,7 +359,7 @@ class Figure:
         if worldfile:
             if ext in ["kml", "tiff"]:
                 raise GMTInvalidInput(
-                    f"World file is not supported for '{ext}' format."
+                    f"Saving a world file is not supported for '{ext}' format."
                 )
             kwargs["W"] = True
 

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -304,8 +304,8 @@ class Figure:
             figure. The world file will have the same name as the figure file
             but with different extension (e.g. tfw for tif). See
             https://en.wikipedia.org/wiki/World_file#Filename_extension
-            for the convention of world file extensions.
-            This parameter does not work for KML and GeoTIFF formats.
+            for the convention of world file extensions. This parameter only
+            works for raster image formats.
         dpi : int
             Set raster resolution in dpi [Default is ``720`` for PDF, ``300``
             for others].

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -314,6 +314,7 @@ class Figure:
             :meth:`pygmt.Figure.psconvert`. Valid parameters are ``gs_path``,
             ``gs_option``, ``resize``, ``bb_style``, and ``verbose``.
         """
+        # pylint: disable=too-many-branches
         # All supported formats
         fmts = {
             "png": "g",

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -252,7 +252,14 @@ class Figure:
             )
 
     def savefig(
-        self, fname, transparent=False, crop=True, anti_alias=True, show=False, **kwargs
+        self,
+        fname,
+        transparent=False,
+        crop=True,
+        anti_alias=True,
+        show=False,
+        worldfile=False,
+        **kwargs,
     ):
         """
         Save the figure to a file.
@@ -291,6 +298,14 @@ class Figure:
             vector graphics.
         show: bool
             If ``True``, will open the figure in an external viewer.
+        worldfile: bool
+            If ``True``, will create a companion
+            `world file <https://en.wikipedia.org/wiki/World_file>`__ for the
+            figure. The world file will have the same name as the figure file
+            but with different extension. See
+            https://en.wikipedia.org/wiki/World_file#Filename_extension
+            for the convention of world file extensions.
+            This parameter does not work for KML and GeoTIFF formats.
         dpi : int
             Set raster resolution in dpi [Default is ``720`` for PDF, ``300``
             for others].
@@ -339,6 +354,13 @@ class Figure:
         if anti_alias:
             kwargs["Qt"] = 2
             kwargs["Qg"] = 2
+
+        if worldfile:
+            if ext in ["kml", "tiff"]:
+                raise GMTInvalidInput(
+                    f"World file is not supported for '{ext}' format."
+                )
+            kwargs["W"] = True
 
         self.psconvert(prefix=prefix, fmt=fmt, crop=crop, **kwargs)
 

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -311,7 +311,7 @@ class Figure:
             but with different extension (e.g. tfw for tif). See
             https://en.wikipedia.org/wiki/World_file#Filename_extension
             for the convention of world file extensions. This parameter only
-            works for raster image formats.
+            works for raster image formats (except GeoTIFF).
         dpi : int
             Set raster resolution in dpi [Default is ``720`` for PDF, ``300``
             for others].

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -357,7 +357,7 @@ class Figure:
             kwargs["Qg"] = 2
 
         if worldfile:
-            if ext in ["kml", "tiff"]:
+            if ext in ["eps", "kml", "pdf", "tiff"]:
                 raise GMTInvalidInput(
                     f"Saving a world file is not supported for '{ext}' format."
                 )

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -295,7 +295,7 @@ def test_figure_savefig():
 @pytest.mark.parametrize("fmt", [".png", ".pdf", ".jpg", ".tif"])
 def test_figure_savefig_worldfile(fmt):
     """
-    Check if worldfile is created when requested.
+    Check if a world file is created when requested.
     """
     fig = Figure()
     fig.basemap(region=[0, 1, 0, 1], projection="X1c/1c", frame=True)
@@ -309,8 +309,8 @@ def test_figure_savefig_worldfile(fmt):
 @pytest.mark.parametrize("fmt", [".tiff", ".kml"])
 def test_figure_savefig_worldfile_unsupported_format(fmt):
     """
-    Figure.savefig should raise an error when worldfile is requested for an
-    unsupported format.
+    Figure.savefig should raise an error when a world file is requested for
+    an unsupported format.
     """
     fig = Figure()
     fig.basemap(region=[0, 1, 0, 1], projection="X1c/1c", frame=True)

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -309,8 +309,8 @@ def test_figure_savefig_worldfile(fmt):
 @pytest.mark.parametrize("fmt", [".tiff", ".kml"])
 def test_figure_savefig_worldfile_unsupported_format(fmt):
     """
-    Figure.savefig should raise an error when a world file is requested for
-    an unsupported format.
+    Figure.savefig should raise an error when a world file is requested for an
+    unsupported format.
     """
     fig = Figure()
     fig.basemap(region=[0, 1, 0, 1], projection="X1c/1c", frame=True)

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -292,6 +292,33 @@ def test_figure_savefig():
     }
 
 
+@pytest.mark.parametrize("fmt", [".png", ".pdf", ".jpg", ".tif"])
+def test_figure_savefig_worldfile(fmt):
+    """
+    Check if worldfile is created when requested.
+    """
+    fig = Figure()
+    fig.basemap(region=[0, 1, 0, 1], projection="X1c/1c", frame=True)
+    with GMTTempFile(prefix="pygmt-worldfile", suffix=fmt) as imgfile:
+        fig.savefig(fname=imgfile.name, worldfile=True)
+        assert Path(imgfile.name).stat().st_size > 0
+        worldfile_suffix = "." + fmt[1] + fmt[3] + "w"
+        assert Path(imgfile.name).with_suffix(worldfile_suffix).stat().st_size > 0
+
+
+@pytest.mark.parametrize("fmt", [".tiff", ".kml"])
+def test_figure_savefig_worldfile_unsupported_format(fmt):
+    """
+    Figure.savefig should raise an error when worldfile is requested for an
+    unsupported format.
+    """
+    fig = Figure()
+    fig.basemap(region=[0, 1, 0, 1], projection="X1c/1c", frame=True)
+    with GMTTempFile(prefix="pygmt-worldfile", suffix=fmt) as imgfile:
+        with pytest.raises(GMTInvalidInput):
+            fig.savefig(fname=imgfile.name, worldfile=True)
+
+
 @pytest.mark.skipif(IPython is None, reason="run when IPython is installed")
 def test_figure_show():
     """

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -300,7 +300,7 @@ def test_figure_savefig_worldfile():
     fig = Figure()
     fig.basemap(region=[0, 1, 0, 1], projection="X1c/1c", frame=True)
     # supported formats
-    for fmt in [".bmp", ".jpg", ".png", ".tif"]:
+    for fmt in [".bmp", ".jpg", ".png", ".ppm", ".tif"]:
         with GMTTempFile(prefix="pygmt-worldfile", suffix=fmt) as imgfile:
             fig.savefig(fname=imgfile.name, worldfile=True)
             assert Path(imgfile.name).stat().st_size > 0

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -292,7 +292,7 @@ def test_figure_savefig():
     }
 
 
-@pytest.mark.parametrize("fmt", [".png", ".pdf", ".jpg", ".tif"])
+@pytest.mark.parametrize("fmt", ["bmp", ".jpg", ".pdf", ".png", ".tif"])
 def test_figure_savefig_worldfile(fmt):
     """
     Check if a world file is created when requested.

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -292,31 +292,25 @@ def test_figure_savefig():
     }
 
 
-@pytest.mark.parametrize("fmt", [".bmp", ".jpg", ".pdf", ".png", ".tif"])
-def test_figure_savefig_worldfile(fmt):
+def test_figure_savefig_worldfile():
     """
-    Check if a world file is created when requested.
-    """
-    fig = Figure()
-    fig.basemap(region=[0, 1, 0, 1], projection="X1c/1c", frame=True)
-    with GMTTempFile(prefix="pygmt-worldfile", suffix=fmt) as imgfile:
-        fig.savefig(fname=imgfile.name, worldfile=True)
-        assert Path(imgfile.name).stat().st_size > 0
-        worldfile_suffix = "." + fmt[1] + fmt[3] + "w"
-        assert Path(imgfile.name).with_suffix(worldfile_suffix).stat().st_size > 0
-
-
-@pytest.mark.parametrize("fmt", [".tiff", ".kml"])
-def test_figure_savefig_worldfile_unsupported_format(fmt):
-    """
-    Figure.savefig should raise an error when a world file is requested for an
-    unsupported format.
+    Check if a world file is created for supported formats and raise an error
+    for unsupported formats.
     """
     fig = Figure()
     fig.basemap(region=[0, 1, 0, 1], projection="X1c/1c", frame=True)
-    with GMTTempFile(prefix="pygmt-worldfile", suffix=fmt) as imgfile:
-        with pytest.raises(GMTInvalidInput):
+    # supported formats
+    for fmt in [".bmp", ".jpg", ".png", ".tif"]:
+        with GMTTempFile(prefix="pygmt-worldfile", suffix=fmt) as imgfile:
             fig.savefig(fname=imgfile.name, worldfile=True)
+            assert Path(imgfile.name).stat().st_size > 0
+            worldfile_suffix = "." + fmt[1] + fmt[3] + "w"
+            assert Path(imgfile.name).with_suffix(worldfile_suffix).stat().st_size > 0
+    # unsupported formats
+    for fmt in [".eps", ".kml", ".pdf", ".tiff"]:
+        with GMTTempFile(prefix="pygmt-worldfile", suffix=fmt) as imgfile:
+            with pytest.raises(GMTInvalidInput):
+                fig.savefig(fname=imgfile.name, worldfile=True)
 
 
 @pytest.mark.skipif(IPython is None, reason="run when IPython is installed")

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -292,7 +292,7 @@ def test_figure_savefig():
     }
 
 
-@pytest.mark.parametrize("fmt", ["bmp", ".jpg", ".pdf", ".png", ".tif"])
+@pytest.mark.parametrize("fmt", [".bmp", ".jpg", ".pdf", ".png", ".tif"])
 def test_figure_savefig_worldfile(fmt):
     """
     Check if a world file is created when requested.


### PR DESCRIPTION
**Description of proposed changes**

Address https://github.com/GenericMappingTools/pygmt/pull/2698#discussion_r1335316532.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
