### PR TITLE
CI: Test GMT dev version on Windows by building from source

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -14,7 +14,7 @@ name: GMT Dev Tests
 
 on:
   # push:
-  #  branches: [ main ]
+  #   branches: [ main ]
   pull_request:
     types: [ready_for_review]
     paths-ignore:

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -130,7 +130,12 @@ jobs:
           mkdir build
           cd build
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          cmake -G Ninja .. -DCMAKE_INSTALL_PREFIX=${{ env.GMT_INSTALL_DIR }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ env.MAMBA_ROOT_PREFIX }}\envs\pygmt\Library
+          cmake -G Ninja .. ^
+            -DCMAKE_INSTALL_PREFIX=${{ env.GMT_INSTALL_DIR }} ^
+            -DCMAKE_BUILD_TYPE=Release ^
+            -DCMAKE_PREFIX_PATH=${{ env.MAMBA_ROOT_PREFIX }}\envs\pygmt\Library ^
+            -DGMT_ENABLE_OPENMP=TRUE ^
+            -DGMT_USE_THREADS=TRUE
           cmake --build .
           cmake --build . --target install
         env:

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -3,10 +3,8 @@
 # This workflow runs regular PyGMT tests with the GMT dev version, and also
 # pre-release versions of several dependencies like NumPy, Pandas, Xarray, etc.
 # If any tests fail, it also uploads the diff images as workflow artifacts.
-# On Linux/macOS, GMT dev version is installed by fetching the latest source
-# codes from the GMT master branch and compiling.
-# On Windows, GMT dev version is installed from the conda-forge's dev channel
-# due to the complexity of building GMT source codes on Windows.
+# The GMT dev version is installed by fetching the latest source codes from
+# the GMT master branch and compiling.
 #
 # It is triggered when a pull request is marked as "ready as review", or using
 # the slash command `/test-gmt-dev`. It is also scheduled to run on Monday,
@@ -16,7 +14,7 @@ name: GMT Dev Tests
 
 on:
   # push:
-  #   branches: [ main ]
+  #  branches: [ main ]
   pull_request:
     types: [ready_for_review]
     paths-ignore:
@@ -116,6 +114,33 @@ jobs:
             pcre
             zlib
 
+      # Build and install latest GMT from GitHub
+      - name: Install GMT ${{ matrix.gmt_git_ref }} branch (Linux/macOS)
+        run: curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/build-gmt.sh | bash
+        env:
+          GMT_GIT_REF: ${{ matrix.gmt_git_ref }}
+          GMT_INSTALL_DIR: ${{ github.workspace }}/gmt-install-dir
+        if: runner.os != 'Windows'
+
+      - name: Install GMT ${{ matrix.gmt_git_ref }} branch (Windows)
+        shell: cmd
+        run: |
+          git clone --depth=1 --single-branch --branch ${{ env.GMT_GIT_REF }} https://github.com/GenericMappingTools/gmt
+          cd gmt/
+          mkdir build
+          cd build
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          cmake -G Ninja .. -DCMAKE_INSTALL_PREFIX=${{ env.GMT_INSTALL_DIR }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ env.MAMBA_ROOT_PREFIX }}\envs\pygmt\Library
+          cmake --build .
+          cmake --build . --target install
+        env:
+          GMT_GIT_REF: ${{ matrix.gmt_git_ref }}
+          GMT_INSTALL_DIR: ${{ github.workspace }}/gmt-install-dir
+        if: runner.os == 'Windows'
+
+      - name: Add GMT's bin to PATH
+        run: echo '${{ github.workspace }}/gmt-install-dir/bin' >> $GITHUB_PATH
+
       # Install dependencies from PyPI
       - name: Install dependencies
         run: |
@@ -135,18 +160,6 @@ jobs:
         run: |
           dvc pull
           ls -lhR pygmt/tests/baseline/
-
-      # Build and install latest GMT from GitHub
-      - name: Install GMT ${{ matrix.gmt_git_ref }} branch (Linux/macOS)
-        run: curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/build-gmt.sh | bash
-        env:
-          GMT_GIT_REF: ${{ matrix.gmt_git_ref }}
-          GMT_INSTALL_DIR: ${{ github.workspace }}/gmt-install-dir
-        if: runner.os != 'Windows'
-
-      - name: Install GMT dev version from conda-forge (Windows)
-        run: micromamba install -c conda-forge/label/dev gmt
-        if: runner.os == 'Windows'
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub
@@ -170,21 +183,11 @@ jobs:
       - name: Install the package
         run: make install
 
-      - name: Add GMT's bin to PATH (Linux/macOS)
-        run: echo ${GITHUB_WORKSPACE}/gmt-install-dir/bin >> $GITHUB_PATH
-        if: runner.os != 'Windows'
-
       # Run the tests
-      - name: Test with pytest (Linux/macOS)
+      - name: Test with pytest
         run: make test PYTEST_EXTRA="-r P"
         env:
           GMT_LIBRARY_PATH: ${{ github.workspace }}/gmt-install-dir/lib
-        if: runner.os != 'Windows'
-
-      # Run the tests
-      - name: Test with pytest (Windows)
-        run: make test PYTEST_EXTRA="-r P"
-        if: runner.os == 'Windows'
 
       # Upload diff images on test failure
       - name: Upload diff images if any test fails

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -2,6 +2,7 @@
 Test the functions that load libgmt.
 """
 import ctypes
+import os
 import shutil
 import subprocess
 import sys
@@ -280,9 +281,8 @@ def test_clib_full_names_gmt_library_path_undefined_path_included(
     """
     with monkeypatch.context() as mpatch:
         mpatch.delenv("GMT_LIBRARY_PATH", raising=False)
-        mpatch.setenv("PATH", gmt_bin_dir)
+        mpatch.setenv("PATH", gmt_bin_dir, prepend=os.pathsep)
         lib_fullpaths = clib_full_names()
-
         assert isinstance(lib_fullpaths, types.GeneratorType)
         # Windows: find_library() searches the library in PATH, so one more
         npath = 2 if sys.platform == "win32" else 1
@@ -298,7 +298,7 @@ def test_clib_full_names_gmt_library_path_defined_path_included(
     """
     with monkeypatch.context() as mpatch:
         mpatch.setenv("GMT_LIBRARY_PATH", str(PurePath(gmt_lib_realpath).parent))
-        mpatch.setenv("PATH", gmt_bin_dir)
+        mpatch.setenv("PATH", gmt_bin_dir, prepend=os.pathsep)
         lib_fullpaths = clib_full_names()
 
         assert isinstance(lib_fullpaths, types.GeneratorType)
@@ -317,7 +317,7 @@ def test_clib_full_names_gmt_library_path_incorrect_path_included(
     """
     with monkeypatch.context() as mpatch:
         mpatch.setenv("GMT_LIBRARY_PATH", "/not/a/valid/library/path")
-        mpatch.setenv("PATH", gmt_bin_dir)
+        mpatch.setenv("PATH", gmt_bin_dir, prepend=os.pathsep)
         lib_fullpaths = clib_full_names()
 
         assert isinstance(lib_fullpaths, types.GeneratorType)


### PR DESCRIPTION
**Description of proposed changes**

In the "GMT Dev Tests" workflow, the way we get the GMT dev version is different on Linux/macOS and Windows. We build the GMT master branch source code on Linux/macOS, but on Windows, we install the dev version from the conda-forge/dev channel. The conda-forge/dev channel is updated every few weeks to months, so it's not always update-to-date. We choose to use the conda-forge/dev channel for Windows because building GMT on Windows is difficult.

However, it turns out that building GMT on Windows is much easier than I initially though, as long as we install all GMT dependencies via conda.

In this PR, I update the workflow to build GMT from source code on Windows, so that we're always using the same GMT dev version on all three platforms.

Supersedes https://github.com/GenericMappingTools/pygmt/pull/756

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
