### PR TITLE
CI: Remove the setup-node workaround from the dvc-diff workflow

### DIFF
--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -70,7 +70,7 @@ jobs:
         cp pygmt/tests/baseline/*.png pygmt/tests/baseline-new/
         # Pull images in the main branch from cloud storage
         git checkout main
-        dvc pull --remote upstream
+        dvc pull --remote upstream --force
 
         # Append each image to the markdown report
         echo -e "## Image diff(s)\n" >> report.md

--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -32,12 +32,6 @@ jobs:
     - name: Setup continuous machine learning (CML)
       uses: iterative/setup-cml@v2.0.0
 
-    # workaround from https://github.com/iterative/cml/issues/1377
-    - name: Setup NodeJS
-      uses: actions/setup-node@v3.8.1
-      with:
-        node-version: '16'
-
     # Produce the markdown diff report, which should look like:
     # ## Summary of changed images
     #

--- a/pygmt/tests/baseline/test_basemap.png.dvc
+++ b/pygmt/tests/baseline/test_basemap.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 3cf01816fa5dd3fbc1adc602557bb032
-  size: 6187
+- md5: f7e2465d57ddd21c0b274f3e109f0f28
+  size: 16994
   path: test_basemap.png
+  hash: md5

--- a/pygmt/tests/baseline/test_basemap.png.dvc
+++ b/pygmt/tests/baseline/test_basemap.png.dvc
@@ -1,5 +1,4 @@
 outs:
-- md5: f7e2465d57ddd21c0b274f3e109f0f28
-  size: 16994
+- md5: 3cf01816fa5dd3fbc1adc602557bb032
+  size: 6187
   path: test_basemap.png
-  hash: md5


### PR DESCRIPTION
**Description of proposed changes**

The workaround added in https://github.com/GenericMappingTools/pygmt/pull/2549 is no longer necessary.

After removing the `setup-node` step, the dvc-diff workflow runs successfully (see https://github.com/GenericMappingTools/pygmt/pull/2776#issuecomment-1784133391).

Closes https://github.com/GenericMappingTools/pygmt/pull/2769.