### PR TITLE
Get the list of dependencies from package metadata

### DIFF
--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -109,6 +109,8 @@ def show_versions(file=sys.stdout):
     import platform
     import subprocess
 
+    from packaging.requirements import Requirement
+
     def _get_module_version(modname):
         """
         Get version information of a Python module.
@@ -153,17 +155,7 @@ def show_versions(file=sys.stdout):
         "machine": platform.platform(),
     }
 
-    deps = [
-        "numpy",
-        "pandas",
-        "xarray",
-        "netCDF4",
-        "packaging",
-        "contextily",
-        "geopandas",
-        "IPython",
-        "rioxarray",
-    ]
+    deps = [Requirement(v).name for v in importlib.metadata.requires("pygmt")]
 
     print("PyGMT information:", file=file)
     print(f"  version: {__version__}", file=file)


### PR DESCRIPTION
**Description of proposed changes**

Get the list of PyGMT dependencies from package metadata automatically
so that we don't have to maintain the list manually.

```python
>>> from importlib.metadata import requires
>>> from packaging.requirements import Requirement
>>> requires("pygmt")
['numpy>=1.22',
 'pandas',
 'xarray',
 'netCDF4',
 'packaging',
 'contextily; extra == "all"',
 'geopandas; extra == "all"',
 'ipython; extra == "all"',
 'rioxarray; extra == "all"']
>>> [Requirement(v).name for v in requires("pygmt")]
['numpy',
 'pandas',
 'xarray',
 'netCDF4',
 'packaging',
 'contextily',
 'geopandas',
 'ipython',
 'rioxarray']
```

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
