### PR TITLE
pygmt.filter1d: Fix the bug that the first line is read as headers

### DIFF
--- a/pygmt/src/filter1d.py
+++ b/pygmt/src/filter1d.py
@@ -130,7 +130,7 @@ def filter1d(data, output_type="pandas", outfile=None, **kwargs):
 
         # Read temporary csv output to a pandas table
         if outfile == tmpfile.name:  # if user did not set outfile, return pd.DataFrame
-            result = pd.read_csv(tmpfile.name, sep="\t", comment=">")
+            result = pd.read_csv(tmpfile.name, sep="\t", header=None, comment=">")
         elif outfile != tmpfile.name:  # return None if outfile set, output in outfile
             result = None
 

--- a/pygmt/tests/test_filter1d.py
+++ b/pygmt/tests/test_filter1d.py
@@ -25,7 +25,7 @@ def test_filter1d_no_outfile(data):
     Test filter1d with no set outgrid.
     """
     result = filter1d(data=data, filter_type="g5")
-    assert result.shape == (670, 2)
+    assert result.shape == (671, 2)
 
 
 def test_filter1d_file_output(data):


### PR DESCRIPTION
**Description of proposed changes**

The test `test_filter1d_no_outfile` should return a result with 671 lines, rather than 670 lines. This can be confirmed by the equivalent GMT CLI:
```
$ gmt filter1d @MaunaLoa_CO2.txt -Fg5  | gmt info
<Standard Input>: N = 671	<1960.7077/2016.7896>	<317.039650418/404.770728537>
```
The bug is because we forgot to set `header=None` when reading the result from the temporary CSV file.