### PR TITLE
CI: Pin ghostscript to 9.54.0 for docs

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -77,6 +77,7 @@ jobs:
           create-args: >-
             python=3.11
             gmt=6.4.0
+            ghostscript=9.54.0
             numpy
             pandas
             xarray

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
     # Required dependencies
     - gmt=6.4.0
+    - ghostscript=9.54.0
     - numpy>=1.22
     - pandas
     - xarray


### PR DESCRIPTION
**Description of proposed changes**

Transparency doesn't work for the GMT 6.4 + Ghostscript 10.02.0 combination (see a broken figure at https://www.pygmt.org/dev/gallery/symbols/scatter.html). Thus, we need to pin ghostscript to 9.54.0 for docs until GMT 6.5 is the default (which works well with gs 10.02.0)

Patches https://github.com/GenericMappingTools/pygmt/pull/2754.