### PR TITLE
Tests: Replace deprecated "np.random.seed()" with "np.random.Generator()" (NPY002 warning by ruff)

### DIFF
--- a/pygmt/tests/test_io.py
+++ b/pygmt/tests/test_io.py
@@ -14,8 +14,9 @@ def test_io_load_dataarray():
     GMTDataArrayAccessor information loaded.
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
+        rng = np.random.default_rng()
         grid = xr.DataArray(
-            data=np.random.rand(2, 2), coords=[[0.1, 0.2], [0.3, 0.4]], dims=("x", "y")
+            data=rng.random((2, 2)), coords=[[0.1, 0.2], [0.3, 0.4]], dims=("x", "y")
         )
         grid.to_netcdf(tmpfile.name)
         dataarray = load_dataarray(tmpfile.name)

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -110,8 +110,8 @@ def test_x2sys_cross_input_two_dataframes(mock_x2sys_home):
         # Create pandas.DataFrame track tables
         tracks = []
         for i in range(2):
-            np.random.seed(seed=i)
-            track = pd.DataFrame(data=np.random.rand(10, 3), columns=("x", "y", "z"))
+            rng = np.random.default_rng(seed=i)
+            track = pd.DataFrame(data=rng.random((10, 3)), columns=("x", "y", "z"))
             track["time"] = pd.date_range(start=f"2020-{i}1-01", periods=10, freq="min")
             tracks.append(track)
 
@@ -160,11 +160,11 @@ def test_x2sys_cross_input_two_filenames(mock_x2sys_home):
 
         # Create temporary xyz files
         for i in range(2):
-            np.random.seed(seed=i)
+            rng = np.random.default_rng(seed=i)
             with open(
                 os.path.join(os.getcwd(), f"track_{i}.xyz"), mode="w", encoding="utf8"
             ) as fname:
-                np.savetxt(fname=fname, X=np.random.rand(10, 3))
+                np.savetxt(fname=fname, X=rng.random((10, 3)))
 
         output = x2sys_cross(tracks=["track_0.xyz", "track_1.xyz"], tag=tag, coe="e")
 

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -118,7 +118,7 @@ def test_x2sys_cross_input_two_dataframes(mock_x2sys_home):
         output = x2sys_cross(tracks=tracks, tag=tag, coe="e")
 
         assert isinstance(output, pd.DataFrame)
-        assert output.shape == (30, 12)
+        assert output.shape == (26, 12)
         columns = list(output.columns)
         assert columns[:6] == ["x", "y", "t_1", "t_2", "dist_1", "dist_2"]
         assert columns[6:] == ["head_1", "head_2", "vel_1", "vel_2", "z_X", "z_M"]
@@ -169,7 +169,7 @@ def test_x2sys_cross_input_two_filenames(mock_x2sys_home):
         output = x2sys_cross(tracks=["track_0.xyz", "track_1.xyz"], tag=tag, coe="e")
 
         assert isinstance(output, pd.DataFrame)
-        assert output.shape == (24, 12)
+        assert output.shape == (18, 12)
         columns = list(output.columns)
         assert columns[:6] == ["x", "y", "i_1", "i_2", "dist_1", "dist_2"]
         assert columns[6:] == ["head_1", "head_2", "vel_1", "vel_2", "z_X", "z_M"]


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to update the tests to follow ruff's NumPy rules, especially it addresses the `NPY002` warning (please see https://docs.astral.sh/ruff/rules/numpy-legacy-random/):
```
NPY002 Replace legacy `np.random.seed` call with `np.random.Generator`
```
Example:
```
import numpy as np
np.random.seed(42)
np.random.normal()
```
is replaced by
```
rng = np.random.default_rng(seed=42)
rng.normal()
```
Affected tests
- [ ] test_io.py
- [ ] test_x2sys_cross (two times)

Please not the generated random numbers are not identical.

Related to the PRs
- #2782 
- #2781

Fixes #2779 partly


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
