### PR TITLE
POC: Add Figure.choropleth to plot choropleth maps

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -520,6 +520,7 @@ class Figure:
 
     from pygmt.src import (  # pylint: disable=import-outside-toplevel
         basemap,
+        choropleth,
         coast,
         colorbar,
         contour,

--- a/pygmt/src/__init__.py
+++ b/pygmt/src/__init__.py
@@ -6,6 +6,7 @@ Source code for PyGMT methods.
 from pygmt.src.basemap import basemap
 from pygmt.src.binstats import binstats
 from pygmt.src.blockm import blockmean, blockmedian, blockmode
+from pygmt.src.choropleth import choropleth
 from pygmt.src.coast import coast
 from pygmt.src.colorbar import colorbar
 from pygmt.src.config import config

--- a/pygmt/src/choropleth.py
+++ b/pygmt/src/choropleth.py
@@ -1,0 +1,20 @@
+def choropleth(self, data, fillcol, cmap=True, **kwargs):
+    """
+    Plot a choropleth map from a :class:`geopandas.GeoDataFrame` object.
+
+    Parameters
+    ----------
+    data : :class:`geopandas.GeoDataFrame`
+        The geopandas dataframe containing the geometry and data to plot.
+    fillcol : str
+        The column name of the data to use for the fill.
+    cmap : str
+    """
+    self.plot(
+        data=data,
+        close=True,
+        fill="+z",
+        cmap=cmap,
+        aspatial=f"Z={fillcol}",
+        **kwargs,
+    )


### PR DESCRIPTION
**Description of proposed changes**

Add `Figure.choropleth` to plot choropleth maps, which can simplify #2796

```python
import geopandas as gpd
import pygmt

gdf = gpd.read_file("https://geodacenter.github.io/data-and-lab/data/airbnb.zip")

fig = pygmt.Figure()
pygmt.makecpt(
    cmap="acton",
    series=[gdf["population"].min(), gdf["population"].max(), 10],
    continuous=True,
    reverse=True,
)
fig.choropleth(gdf, fillcol="population", pen="0.3p,gray10")
fig.colorbar(frame=True)
fig.show()
```


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
