### PR TITLE
Figure.velo: Update docstrings related to "fill" and "uncertaintyfill"

### DIFF
--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -87,7 +87,7 @@ def velo(self, data=None, **kwargs):
           [Default is 9p,Helvetica,black]; give **+f**\ 0 to deactivate
           labeling. The arrow will be drawn with the pen attributes specified
           by the ``pen`` parameter and the arrow-head can be colored via
-          ``fill``. The ellipse will be filled with the color or shade
+          ``fill``. The ellipse will be filled with the color or pattern
           specified by the ``uncertaintyfill`` parameter [Default is
           transparent], and its outline will be drawn if ``line`` is selected
           using the pen selected (by ``pen`` if not given by ``line``).
@@ -120,7 +120,7 @@ def velo(self, data=None, **kwargs):
           [Default is 9p,Helvetica,black]; give **+f**\ 0 to deactivate
           labeling. The arrow will be drawn with the pen attributes specified
           by the ``pen`` parameter and the arrow-head can be colored via
-          ``fill``. The ellipse will be filled with the color or shade
+          ``fill``. The ellipse will be filled with the color or pattern
           specified by the ``uncertaintyfill`` parameter [Default is
           transparent], and its outline will be drawn if ``line`` is selected
           using the pen selected (by ``pen`` if not given by ``line``).
@@ -140,9 +140,9 @@ def velo(self, data=None, **kwargs):
           extra column. Rotation values are multiplied by *wedgemag* before
           plotting. For example, setting *wedgemag* to 1.e7 works well for
           rotations of the order of 100 nanoradians/yr. Use ``fill`` to set
-          the fill color or shade for the wedge, and ``uncertaintyfill`` to
-          set the color or shade for the uncertainty. Parameters are expected
-          to be in the following columns:
+          the fill color or pattern for the wedge, and ``uncertaintyfill`` to
+          set the color or pattern for the uncertainty. Parameters are
+          expected to be in the following columns:
 
             - **1**,\ **2**: longitude, latitude of station
             - **3**: rotation in radians


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to update the docstrings related to "fill" and "uncertaintyfill". It removes the term "shade" and adds the term "pattern". Related to
- the disccssion in https://github.com/GenericMappingTools/pygmt/pull/2345#discussion_r1094275882
- PR #2351

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
