### PR TITLE
Gallery example "choropleth map": Use code block separator "# %%"

### DIFF
--- a/examples/gallery/maps/choropleth_map.py
+++ b/examples/gallery/maps/choropleth_map.py
@@ -14,6 +14,7 @@ To fill the polygons based on a corresponding column you need to set
 parameter as shown in the example below.
 """
 
+# %%
 import geopandas as gpd
 import pygmt
 


### PR DESCRIPTION
**Description of proposed changes**

Related to PR #2662, this PR aims to use the code block separator `# %%` in the gallery example "Choropleth map".

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
