### PR TITLE
CI: Require at least one code block separator for example files in the Style Checks workflow

### DIFF
--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Ensure example scripts have at least one code block separator
         run: |
-          grep -L '# %%' $(find 'examples' -name '*.py') > output.txt
-          nfiles=$(wc -l output.txt | awk '{print $1}')
+          grep --files-without-match '# %%' $(find 'examples' -name '*.py') > output.txt
+          nfiles=$(wc --lines output.txt | awk '{print $1}')
           if [[ $nfiles > 0 ]]; then
             echo "Code block separator '# %%' is required in following example files:"
             cat output.txt

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -49,3 +49,14 @@ jobs:
           find . -type f -not -path '*/\.git/*' -exec grep -Iq . {} \; -exec dos2unix --quiet {} \;
           find . -type f -not -path '*/\.git/*' -exec grep -Iq . {} \; -exec chmod 644 {} \;
           if [[ $(git ls-files -m) ]]; then git --no-pager diff HEAD; exit 1; fi
+
+      - name: Ensure example scripts have at least one code block separator
+        run: |
+          grep -L '# %%' $(find 'examples' -name '*.py') > output.txt
+          nfiles=$(wc -l output.txt | awk '{print $1}')
+          if [[ $nfiles > 0 ]]; then
+            echo "Code block separator '# %%' is required in following example files:"
+            cat output.txt
+            rm output.txt
+            exit $nfiles
+          fi

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -499,6 +499,13 @@ words bridged only by consonants, such as `distcalc`, and `crossprofile`. This
 convention is not applied by the code checking tools, but the PyGMT maintainers
 will comment on any pull requests as needed.
 
+When working on a tutorial or a gallery plot, it's a good practice to use code
+block separators to split a long script into multiple blocks. The separators also
+make it possible to run the script like a Jupyter Notebook in some modern text
+editors or IDEs. We consistenly use `# %%` as our code block separators (please
+refer to [issue #2660](https://github.com/GenericMappingTools/pygmt/issues/2660)
+for the discussions). We also require at least one separator in all example files.
+
 We also use [ruff](https://docs.astral.sh/ruff) and
 [pylint](https://pylint.pycqa.org/) to check the quality of the code and quickly catch
 common errors.

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -499,7 +499,7 @@ words bridged only by consonants, such as `distcalc`, and `crossprofile`. This
 convention is not applied by the code checking tools, but the PyGMT maintainers
 will comment on any pull requests as needed.
 
-When working on a tutorial or a gallery plot, it's a good practice to use code
+When working on a tutorial or a gallery plot, it is good practice to use code
 block separators to split a long script into multiple blocks. The separators also
 make it possible to run the script like a Jupyter Notebook in some modern text
 editors or IDEs. We consistenly use `# %%` as our code block separators (please

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -501,10 +501,10 @@ will comment on any pull requests as needed.
 
 When working on a tutorial or a gallery plot, it is good practice to use code
 block separators to split a long script into multiple blocks. The separators also
-make it possible to run the script like a Jupyter Notebook in some modern text
-editors or IDEs. We consistenly use `# %%` as our code block separators (please
+make it possible to run the script like a Jupyter notebook in some modern text
+editors or IDEs. We consistently use `# %%` as code block separators (please
 refer to [issue #2660](https://github.com/GenericMappingTools/pygmt/issues/2660)
-for the discussions). We also require at least one separator in all example files.
+for the discussions) and require at least one separator in all example files.
 
 We also use [ruff](https://docs.astral.sh/ruff) and
 [pylint](https://pylint.pycqa.org/) to check the quality of the code and quickly catch

--- a/examples/gallery/maps/choropleth_map.py
+++ b/examples/gallery/maps/choropleth_map.py
@@ -14,6 +14,7 @@ To fill the polygons based on a corresponding column you need to set
 parameter as shown in the example below.
 """
 
+# %%
 import geopandas as gpd
 import pygmt
 

--- a/examples/gallery/maps/choropleth_map.py
+++ b/examples/gallery/maps/choropleth_map.py
@@ -14,7 +14,6 @@ To fill the polygons based on a corresponding column you need to set
 parameter as shown in the example below.
 """
 
-# %%
 import geopandas as gpd
 import pygmt
 


### PR DESCRIPTION
**Description of proposed changes**

Add a step in the Style Checks workflow, to ensure all example files have at least one code block separator `# %%`.

Address https://github.com/GenericMappingTools/pygmt/pull/2805#issuecomment-1807232746.

See https://github.com/GenericMappingTools/pygmt/actions/runs/6864172516/job/18665360359?pr=2810. If I revert the changes in PR #2805, the workflow fails with the following error:
```
Code block separator '# %%' is required in following example files:
examples/gallery/maps/choropleth_map.py
```
which means the added step works as expected.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
