### PR TITLE
CI: Add glib as a dependency in GMT Dev Tests to build GMT source codes

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -105,6 +105,7 @@ jobs:
             curl
             fftw
             ghostscript=9.54.0
+            glib
             hdf5
             libblas
             libcblas


### PR DESCRIPTION
**Description of proposed changes**

The "GMT Dev Tests" workflow fails to build GMT source code on Windows because the `glib` package is missing, which is required if `GMT_USE_THREADS` is set to `True`.

Patches https://github.com/GenericMappingTools/pygmt/pull/2773.