### PR TITLE
Simplify checks like "x is not None or y is not None or z is not None"

### DIFF
--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -180,7 +180,7 @@ def text_(
         if kind == "vectors" and text is None:
             raise GMTInvalidInput("Must provide text with x/y pairs")
     else:
-        if x is not None or y is not None or textfiles is not None:
+        if any(v is not None for v in (x, y, textfiles)):
             raise GMTInvalidInput(
                 "Provide either position only, or x/y pairs, or textfiles."
             )

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -189,8 +189,8 @@ def text_(  # noqa: PLR0912
         textfiles = ""
 
     # Build the -F option in gmt text.
-    if kwargs.get("F") is None and 
-        any(v is not None for v in (position, angle, font, justify)
+    if kwargs.get("F") is None and any(
+        v is not None for v in (position, angle, font, justify)
     ):
         kwargs.update({"F": ""})
 

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -190,11 +190,8 @@ def text_(
         textfiles = ""
 
     # Build the -F option in gmt text.
-    if kwargs.get("F") is None and (
-        position is not None
-        or angle is not None
-        or font is not None
-        or justify is not None
+    if kwargs.get("F") is None and 
+        any(v is not None for v in (position, angle, font, justify))
     ):
         kwargs.update({"F": ""})
 

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -191,7 +191,7 @@ def text_(
 
     # Build the -F option in gmt text.
     if kwargs.get("F") is None and 
-        any(v is not None for v in (position, angle, font, justify))
+        any(v is not None for v in (position, angle, font, justify)
     ):
         kwargs.update({"F": ""})
 


### PR DESCRIPTION
**Description of proposed changes**

Related to #2757 

- [x] text.py


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
