### PR TITLE
Use ruff to format codes so remove black

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -32,7 +32,7 @@ jobs:
       # Install formatting tools
       - name: Install formatting tools
         run: |
-          python -m pip install black blackdoc docformatter ruff
+          python -m pip install blackdoc docformatter ruff
           python -m pip list
           sudo apt-get install dos2unix
 

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -34,11 +34,11 @@ jobs:
 
       - name: Install packages
         run: |
-          python -m pip install black blackdoc docformatter pylint ruff
+          python -m pip install blackdoc docformatter pylint ruff
           python -m pip list
           sudo apt-get install dos2unix
 
-      - name: Formatting check (black, blackdoc, docformatter, ruff)
+      - name: Formatting check (blackdoc, docformatter, ruff)
         run: make check
 
       - name: Linting (pylint)

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ help:
 	@echo "  fulltest       run the test suite (including all doctests)"
 	@echo "  doctest        run the doctests only"
 	@echo "  test_no_images run the test suite (including all doctests) but skip image comparisons"
-	@echo "  format         run black, blackdoc, docformatter and ruff to automatically format the code"
-	@echo "  check          run code style and quality checks (black, blackdoc, docformatter, ruff)"
+	@echo "  format         run blackdoc, docformatter and ruff to automatically format the code"
+	@echo "  check          run code style and quality checks (blackdoc, docformatter, ruff)"
 	@echo "  codespell      run codespell to check common misspellings"
 	@echo "  lint           run pylint for a deeper (and slower) quality check"
 	@echo "  clean          clean up build and generated files"
@@ -61,14 +61,12 @@ test_no_images: _runtest
 
 format:
 	docformatter --in-place $(FORMAT_FILES)
-	black $(FORMAT_FILES)
 	blackdoc $(FORMAT_FILES)
 	ruff check --fix $(FORMAT_FILES)
 	ruff format $(FORMAT_FILES)
 
 check:
 	docformatter --check $(FORMAT_FILES)
-	black --check $(FORMAT_FILES)
 	blackdoc --check $(FORMAT_FILES)
 	ruff check $(FORMAT_FILES)
 	ruff format --check $(FORMAT_FILES)

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -404,7 +404,7 @@ the `pygmt/src/` and `pygmt/datasets/` folders. **All docstrings** should follow
 All functions/classes/methods should have docstrings with a full description of all
 arguments and return values.
 
-While the maximum line length for code is automatically set by Black, docstrings
+While the maximum line length for code is automatically set by ruff, docstrings
 must be formatted manually. To play nicely with Jupyter and IPython, **keep docstrings
 limited to 79 characters** per line.
 
@@ -473,12 +473,11 @@ code, be sure to follow the general guidelines in the
 
 We use some tools to format the code so we don't have to think about it:
 
-- [Black](https://github.com/psf/black)
 - [blackdoc](https://github.com/keewis/blackdoc)
 - [docformatter](https://github.com/myint/docformatter)
 - [ruff](https://docs.astral.sh/ruff)
 
-Black and blackdoc loosely follows the [PEP8](http://pep8.org) guide but with a few
+Blackdoc loosely follows the [PEP8](http://pep8.org) guide but with a few
 differences. Regardless, you won't have to worry about formatting the code yourself.
 Before committing, run it to automatically format your code:
 
@@ -513,7 +512,7 @@ The [`Makefile`](https://github.com/GenericMappingTools/pygmt/blob/main/Makefile
 contains rules for running both checks:
 
 ```bash
-make check   # Runs black, blackdoc, docformatter, ruff (in check mode)
+make check   # Runs blackdoc, docformatter, ruff (in check mode)
 make lint    # Runs pylint, which is a bit slower
 ```
 

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -477,7 +477,7 @@ We use some tools to format the code so we don't have to think about it:
 - [docformatter](https://github.com/myint/docformatter)
 - [ruff](https://docs.astral.sh/ruff)
 
-Blackdoc loosely follows the [PEP8](http://pep8.org) guide but with a few
+These tools loosely follow the [PEP8](http://pep8.org) guide but with a few
 differences. Regardless, you won't have to worry about formatting the code yourself.
 Before committing, run it to automatically format your code:
 

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,6 @@ dependencies:
     - make
     - pip
     # Dev dependencies (style checks)
-    - black
     - blackdoc
     - codespell
     - docformatter>=1.7.2


### PR DESCRIPTION
**Description of proposed changes**

Address https://github.com/GenericMappingTools/pygmt/pull/2770#issuecomment-1813758399.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
