### PR TITLE
CI: Pin Python to 3.12 in the environment.yml file for ReadTheDocs

### DIFF
--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -4,6 +4,7 @@ channels:
     - nodefaults
 dependencies:
     # Required dependencies
+    - python=3.12
     - gmt=6.4.0
     - ghostscript=9.54.0
     - numpy>=1.22


### PR DESCRIPTION
**Description of proposed changes**

ReadTheDocs started to fail recently, with following errors:
```
mamba env create --quiet --name 2822 --file ci/requirements/docs.yml
Command killed due to timeout or excessive memory consumption
Command time: 1884s Return: 137
```
It seems mamba takes forever to resolve the package dependency. Pin python to a specific version can make mamba work again.