### PR TITLE
Enable ruff's flake8-bugbear (B) rules

### DIFF
--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -28,7 +28,7 @@ with rioxarray.open_rasterio(
     # Subset to area of Lāhainā in EPSG:32604 coordinates
     image = img.rio.clip_box(minx=738000, maxx=755000, miny=2300000, maxy=2318000)
     image = image.load()  # Force loading the DataArray into memory
-repr(image)
+image  # noqa: B018
 
 # %%
 # Plot the RGB imagery:

--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -28,7 +28,7 @@ with rioxarray.open_rasterio(
     # Subset to area of Lāhainā in EPSG:32604 coordinates
     image = img.rio.clip_box(minx=738000, maxx=755000, miny=2300000, maxy=2318000)
     image = image.load()  # Force loading the DataArray into memory
-image
+print(image)
 
 # %%
 # Plot the RGB imagery:

--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -28,7 +28,7 @@ with rioxarray.open_rasterio(
     # Subset to area of Lāhainā in EPSG:32604 coordinates
     image = img.rio.clip_box(minx=738000, maxx=755000, miny=2300000, maxy=2318000)
     image = image.load()  # Force loading the DataArray into memory
-print(image)
+repr(image)
 
 # %%
 # Plot the RGB imagery:

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -103,7 +103,7 @@ def dataarray_to_matrix(grid):
                 "but GMT only supports regular spacing. Calculated regular spacing "
                 f"{coord_inc} is assumed in the '{dim}' dimension."
             )
-            warnings.warn(msg, category=RuntimeWarning, stacklevel=1)
+            warnings.warn(msg, category=RuntimeWarning, stacklevel=2)
         if coord_inc == 0:
             raise GMTInvalidInput(
                 f"Grid has a zero increment in the '{dim}' dimension."

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -103,7 +103,7 @@ def dataarray_to_matrix(grid):
                 "but GMT only supports regular spacing. Calculated regular spacing "
                 f"{coord_inc} is assumed in the '{dim}' dimension."
             )
-            warnings.warn(msg, category=RuntimeWarning)
+            warnings.warn(msg, category=RuntimeWarning, stacklevel=1)
         if coord_inc == 0:
             raise GMTInvalidInput(
                 f"Grid has a zero increment in the '{dim}' dimension."

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -348,7 +348,7 @@ class Session:
         """
         try:
             # Won't raise an exception if there is a currently open session
-            self.session_pointer
+            _ = self.session_pointer
             # In this case, fail to create a new session until the old one is
             # destroyed
             raise GMTCLibError(

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -56,11 +56,11 @@ def mock(session, func, returns=None, mock_func=None):
             return mock_func
         return get_libgmt_func(name, argtypes, restype)
 
-    setattr(session, "get_libgmt_func", mock_get_libgmt_func)
+    session.get_libgmt_func = mock_get_libgmt_func
 
     yield
 
-    setattr(session, "get_libgmt_func", get_libgmt_func)
+    session.get_libgmt_func = get_libgmt_func
 
 
 def test_getitem():
@@ -94,12 +94,12 @@ def test_create_destroy_session():
     ses = clib.Session()
     for __ in range(2):
         with pytest.raises(GMTCLibNoSessionError):
-            ses.session_pointer
+            _ = ses.session_pointer
         ses.create("session1")
         assert ses.session_pointer is not None
         ses.destroy()
         with pytest.raises(GMTCLibNoSessionError):
-            ses.session_pointer
+            _ = ses.session_pointer
 
 
 def test_create_session_fails():
@@ -183,7 +183,7 @@ def test_method_no_session():
     with pytest.raises(GMTCLibNoSessionError):
         lib.call_module("gmtdefaults", "")
     with pytest.raises(GMTCLibNoSessionError):
-        lib.session_pointer
+        _ = lib.session_pointer
 
 
 def test_parse_constant_single():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ line-ending = "lf"  # Use UNIX `\n` line endings for all files
 
 [tool.ruff.lint]
 select = [
+    "B",    # flake8-bugbear
     "E",    # pycodestyle
     "F",    # pyflakes
     "I",    # isort


### PR DESCRIPTION
**Description of proposed changes**

Enabling [flake8-bugbear](https://docs.astral.sh/ruff/rules/#flake8-bugbear-b) rules result in following errors and they look good to me. Actually, some of the errors were reported by pylint but not by ruff's pylint rules (see https://github.com/GenericMappingTools/pygmt/pull/2815).
```
ruff check pygmt doc/conf.py examples
examples/gallery/images/rgb_image.py:31:1: B018 Found useless expression. Either assign it to a variable or remove it.
   |
29 |     image = img.rio.clip_box(minx=738000, maxx=755000, miny=2300000, maxy=2318000)
30 |     image = image.load()  # Force loading the DataArray into memory
31 | image
   | ^^^^^ B018
32 |
33 | # %%
   |

pygmt/clib/conversion.py:106:13: B028 No explicit `stacklevel` keyword argument found
    |
104 |                 f"{coord_inc} is assumed in the '{dim}' dimension."
105 |             )
106 |             warnings.warn(msg, category=RuntimeWarning)
    |             ^^^^^^^^^^^^^ B028
107 |         if coord_inc == 0:
108 |             raise GMTInvalidInput(
    |

pygmt/clib/session.py:351:13: B018 Found useless expression. Either assign it to a variable or remove it.
    |
349 |         try:
350 |             # Won't raise an exception if there is a currently open session
351 |             self.session_pointer
    |             ^^^^^^^^^^^^^^^^^^^^ B018
352 |             # In this case, fail to create a new session until the old one is
353 |             # destroyed
    |

pygmt/tests/test_clib.py:59:5: B010 [*] Do not call `setattr` with a constant attribute value. It is not any safer than normal property access.
   |
57 |         return get_libgmt_func(name, argtypes, restype)
58 |
59 |     setattr(session, "get_libgmt_func", mock_get_libgmt_func)
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B010
60 |
61 |     yield
   |
   = help: Replace `setattr` with assignment

pygmt/tests/test_clib.py:63:5: B010 [*] Do not call `setattr` with a constant attribute value. It is not any safer than normal property access.
   |
61 |     yield
62 |
63 |     setattr(session, "get_libgmt_func", get_libgmt_func)
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B010
   |
   = help: Replace `setattr` with assignment

pygmt/tests/test_clib.py:97:13: B018 Found useless expression. Either assign it to a variable or remove it.
   |
95 |     for __ in range(2):
96 |         with pytest.raises(GMTCLibNoSessionError):
97 |             ses.session_pointer
   |             ^^^^^^^^^^^^^^^^^^^ B018
98 |         ses.create("session1")
99 |         assert ses.session_pointer is not None
   |

pygmt/tests/test_clib.py:102:13: B018 Found useless expression. Either assign it to a variable or remove it.
    |
100 |         ses.destroy()
101 |         with pytest.raises(GMTCLibNoSessionError):
102 |             ses.session_pointer
    |             ^^^^^^^^^^^^^^^^^^^ B018
    |

pygmt/tests/test_clib.py:186:9: B018 Found useless expression. Either assign it to a variable or remove it.
    |
184 |         lib.call_module("gmtdefaults", "")
185 |     with pytest.raises(GMTCLibNoSessionError):
186 |         lib.session_pointer
    |         ^^^^^^^^^^^^^^^^^^^ B018
    |

Found 8 errors.
```


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
