### PR TITLE
Tutorial "Plotting data points": Change pen color for better contrast

### DIFF
--- a/examples/tutorials/basics/plot.py
+++ b/examples/tutorials/basics/plot.py
@@ -88,7 +88,7 @@ fig.plot(
     fill=data.depth_km,
     cmap=True,
     style="cc",
-    pen="black",
+    pen="white",
 )
 fig.colorbar(frame="af+lDepth (km)")
 fig.show()

--- a/examples/tutorials/basics/plot.py
+++ b/examples/tutorials/basics/plot.py
@@ -75,7 +75,6 @@ fig.show()
 # the earthquakes using :func:`pygmt.makecpt`, then set ``cmap=True`` in
 # :meth:`pygmt.Figure.plot` to use the colormap. At the end of the plot, we
 # also plot a colorbar showing the colormap used in the plot.
-#
 
 fig = pygmt.Figure()
 fig.basemap(region=region, projection="M15c", frame=True)


### PR DESCRIPTION
**Description of proposed changes**

This PR suggests to change the `pen` color to improve the contrast in the tutorial "Plotting data points":

| `pen="black"` | `pen="white"`
| --- | --- |
| ![black_outline](https://github.com/GenericMappingTools/pygmt/assets/94163266/9c4b517b-7933-4613-88cd-357ec6e19ece) | ![white_outline](https://github.com/GenericMappingTools/pygmt/assets/94163266/33da55c0-e80c-4060-8884-dd9f89747c69) |
**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
