### PR TITLE
Pin Python to 3.12 in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
     - conda-forge
     - nodefaults
 dependencies:
+    - python=3.12
     # Required dependencies
     - gmt=6.4.0
     - numpy>=1.22


### PR DESCRIPTION
**Description of proposed changes**

Similar to https://github.com/GenericMappingTools/pygmt/pull/2824, `conda env create --file environment.yml` takes forever for me, and after pinning Python to a specific version, it works.

This PR pins Python to 3.12 in `environment.yml`.