### PR TITLE
Enable ruff's flake8-simplify (SIM) rules

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -4,11 +4,11 @@ access to the API functions.
 
 Uses ctypes to wrap most of the core functions from the C API.
 """
+import contextlib
 import ctypes as ctp
 import pathlib
 import sys
 import warnings
-from contextlib import contextmanager, nullcontext
 
 import numpy as np
 import pandas as pd
@@ -190,12 +190,10 @@ class Session:
             }
             # For GMT<6.4.0, API_IMAGE_LAYOUT is not defined if GMT is not
             # compiled with GDAL. Since GMT 6.4.0, GDAL is a required GMT
-            # dependency. The try-except block can be refactored after we bump
+            # dependency. The code block can be refactored after we bump
             # the minimum required GMT version to 6.4.0.
-            try:
+            with contextlib.suppress(GMTCLibError):
                 self._info["image layout"] = self.get_default("API_IMAGE_LAYOUT")
-            except GMTCLibError:
-                pass
             # API_BIN_VERSION is new in GMT 6.4.0.
             if Version(self._info["version"]) >= Version("6.4.0"):
                 self._info["binary version"] = self.get_default("API_BIN_VERSION")
@@ -732,10 +730,7 @@ class Session:
         """
         pad = kwargs.get("pad", None)
         if pad is None:
-            if "MATRIX" in family:
-                pad = 0
-            else:
-                pad = self["GMT_PAD_DEFAULT"]
+            pad = 0 if "MATRIX" in family else self["GMT_PAD_DEFAULT"]
         return pad
 
     def _parse_constant(self, constant, valid, valid_modifiers=None):
@@ -1089,7 +1084,7 @@ class Session:
         if status != 0:
             raise GMTCLibError(f"Failed to write dataset to '{output}'")
 
-    @contextmanager
+    @contextlib.contextmanager
     def open_virtual_file(self, family, geometry, direction, data):
         """
         Open a GMT virtual file to pass data to and from a module.
@@ -1196,7 +1191,7 @@ class Session:
             if status != 0:
                 raise GMTCLibError(f"Failed to close virtual file '{vfname}'.")
 
-    @contextmanager
+    @contextlib.contextmanager
     def virtualfile_from_vectors(self, *vectors):
         """
         Store 1-D arrays as columns of a table inside a virtual file.
@@ -1298,7 +1293,7 @@ class Session:
         ) as vfile:
             yield vfile
 
-    @contextmanager
+    @contextlib.contextmanager
     def virtualfile_from_matrix(self, matrix):
         """
         Store a 2-D array as a table inside a virtual file.
@@ -1379,7 +1374,7 @@ class Session:
         ) as vfile:
             yield vfile
 
-    @contextmanager
+    @contextlib.contextmanager
     def virtualfile_from_grid(self, grid):
         """
         Store a grid in a virtual file.
@@ -1550,8 +1545,8 @@ class Session:
 
         # Decide which virtualfile_from_ function to use
         _virtualfile_from = {
-            "file": nullcontext,
-            "arg": nullcontext,
+            "file": contextlib.nullcontext,
+            "arg": contextlib.nullcontext,
             "geojson": tempfile_from_geojson,
             "grid": self.virtualfile_from_grid,
             "image": tempfile_from_image,

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -144,10 +144,7 @@ def load_earth_magnetic_anomaly(
             "Valid values are 'emag2', 'emag2_4km', and 'wdmam'."
         )
     dataset_prefix = magnetic_anomaly_sources[data_source]
-    if data_source == "wdmam":
-        dataset_name = "earth_wdmam"
-    else:
-        dataset_name = "earth_magnetic_anomaly"
+    dataset_name = "earth_wdmam" if data_source == "wdmam" else "earth_magnetic_anomaly"
     grid = _load_remote_dataset(
         dataset_name=dataset_name,
         dataset_prefix=dataset_prefix,

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -273,7 +273,7 @@ def _load_remote_dataset(
     dataset = datasets[dataset_name]
 
     # check resolution
-    if resolution not in dataset.resolutions.keys():
+    if resolution not in dataset.resolutions:
         raise GMTInvalidInput(f"Invalid resolution '{resolution}'.")
 
     # check registration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ select = [
     "I",    # isort
     "NPY",  # numpy
     "PL",   # pylint
+    "SIM",  # flake8-simplify
     "UP",   # pyupgrade
     "W",    # pycodestyle warnings
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ select = [
 ignore = [
     "E501", # Avoid enforcing line-length violations
     "PLR2004",  # Allow any magic values
+    "SIM117",  # Allow nested `with` statements
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
**Description of proposed changes**

The following are the error messages after enabling flake8-simplify rules. The suggestions make sense to me but maybe we want to disable `SIM117` rule?

```
pygmt/clib/session.py:195:13: SIM105 Use `contextlib.suppress(GMTCLibError)` instead of `try`-`except`-`pass`
    |
193 |               # dependency. The try-except block can be refactored after we bump
194 |               # the minimum required GMT version to 6.4.0.
195 |               try:
    |  _____________^
196 | |                 self._info["image layout"] = self.get_default("API_IMAGE_LAYOUT")
197 | |             except GMTCLibError:
198 | |                 pass
    | |____________________^ SIM105
199 |               # API_BIN_VERSION is new in GMT 6.4.0.
200 |               if Version(self._info["version"]) >= Version("6.4.0"):
    |
    = help: Replace with `contextlib.suppress(GMTCLibError)`

pygmt/clib/session.py:735:13: SIM108 Use ternary operator `pad = 0 if "MATRIX" in family else self["GMT_PAD_DEFAULT"]` instead of `if`-`else`-block
    |
733 |           pad = kwargs.get("pad", None)
734 |           if pad is None:
735 |               if "MATRIX" in family:
    |  _____________^
736 | |                 pad = 0
737 | |             else:
738 | |                 pad = self["GMT_PAD_DEFAULT"]
    | |_____________________________________________^ SIM108
739 |           return pad
    |
    = help: Replace `if`-`else`-block with `pad = 0 if "MATRIX" in family else self["GMT_PAD_DEFAULT"]`

pygmt/datasets/earth_magnetic_anomaly.py:147:5: SIM108 Use ternary operator `dataset_name = "earth_wdmam" if data_source == "wdmam" else "earth_magnetic_anomaly"` instead of `if`-`else`-block
    |
145 |           )
146 |       dataset_prefix = magnetic_anomaly_sources[data_source]
147 |       if data_source == "wdmam":
    |  _____^
148 | |         dataset_name = "earth_wdmam"
149 | |     else:
150 | |         dataset_name = "earth_magnetic_anomaly"
    | |_______________________________________________^ SIM108
151 |       grid = _load_remote_dataset(
152 |           dataset_name=dataset_name,
    |
    = help: Replace `if`-`else`-block with `dataset_name = "earth_wdmam" if data_source == "wdmam" else "earth_magnetic_anomaly"`

pygmt/datasets/load_remote_dataset.py:276:8: SIM118 Use `key not in dict` instead of `key not in dict.keys()`
    |
275 |     # check resolution
276 |     if resolution not in dataset.resolutions.keys():
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM118
277 |         raise GMTInvalidInput(f"Invalid resolution '{resolution}'.")
    |
    = help: Remove `.keys()`

pygmt/src/grdimage.py:178:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
176 |       kwargs = self._preprocess(**kwargs)
177 |   
178 |       with Session() as lib:
    |  _____^
179 | |         with lib.virtualfile_from_data(
180 | |             check_kind="raster", data=grid
181 | |         ) as fname, lib.virtualfile_from_data(
182 | |             check_kind="raster", data=kwargs.get("I"), required_data=False
183 | |         ) as shadegrid:
    | |_______________________^ SIM117
184 |               kwargs["I"] = shadegrid
185 |               lib.call_module(
    |
    = help: Combine `with` statements

pygmt/src/grdtrack.py:296:9: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
295 |       with GMTTempFile(suffix=".csv") as tmpfile:
296 |           with Session() as lib:
    |  _________^
297 | |             with lib.virtualfile_from_data(
298 | |                 check_kind="raster", data=grid
299 | |             ) as grdfile, lib.virtualfile_from_data(
300 | |                 check_kind="vector", data=points, required_data=False
301 | |             ) as csvfile:
    | |_________________________^ SIM117
302 |                   kwargs["G"] = grdfile
303 |                   if outfile is None:  # Output to tmpfile if outfile is not set
    |
    = help: Combine `with` statements

pygmt/src/grdview.py:148:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
146 |       """
147 |       kwargs = self._preprocess(**kwargs)
148 |       with Session() as lib:
    |  _____^
149 | |         with lib.virtualfile_from_data(
150 | |             check_kind="raster", data=grid
151 | |         ) as fname, lib.virtualfile_from_data(
152 | |             check_kind="raster", data=kwargs.get("G"), required_data=False
153 | |         ) as drapegrid:
    | |_______________________^ SIM117
154 |               kwargs["G"] = drapegrid
155 |               lib.call_module(
    |
    = help: Combine `with` statements

pygmt/tests/test_clib.py:110:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
108 |       """
109 |       ses = clib.Session()
110 |       with mock(ses, "GMT_Create_Session", returns=None):
    |  _____^
111 | |         with pytest.raises(GMTCLibError):
    | |_________________________________________^ SIM117
112 |               ses.create("test-session-name")
113 |       # Should fail if trying to create a session before destroying the old one.
    |
    = help: Combine `with` statements

pygmt/tests/test_clib.py:127:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
125 |           ses.destroy()
126 |       ses.create("test-session")
127 |       with mock(ses, "GMT_Destroy_Session", returns=1):
    |  _____^
128 | |         with pytest.raises(GMTCLibError):
    | |_________________________________________^ SIM117
129 |               ses.destroy()
130 |       ses.destroy()
    |
    = help: Combine `with` statements

pygmt/tests/test_clib.py:139:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
137 |       data_fname = os.path.join(TEST_DATA_DIR, "points.txt")
138 |       out_fname = "test_call_module.txt"
139 |       with clib.Session() as lib:
    |  _____^
140 | |         with GMTTempFile() as out_fname:
    | |________________________________________^ SIM117
141 |               lib.call_module("info", f"{data_fname} -C ->{out_fname.name}")
142 |               assert Path(out_fname.name).stat().st_size > 0
    |
    = help: Combine `with` statements

pygmt/tests/test_clib.py:151:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
149 |       Fails for invalid module arguments.
150 |       """
151 |       with clib.Session() as lib:
    |  _____^
152 | |         with pytest.raises(GMTCLibError):
    | |_________________________________________^ SIM117
153 |               lib.call_module("info", "bogus-data.bla")
    |
    = help: Combine `with` statements

pygmt/tests/test_clib.py:160:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
158 |       Fails when given bad input.
159 |       """
160 |       with clib.Session() as lib:
    |  _____^
161 | |         with pytest.raises(GMTCLibError):
    | |_________________________________________^ SIM117
162 |               lib.call_module("meh", "")
    |
    = help: Combine `with` statements

pygmt/tests/test_clib.py:296:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
294 |       """
295 |       # Passing in invalid mode
296 |       with pytest.raises(GMTInvalidInput):
    |  _____^
297 | |         with clib.Session() as lib:
    | |___________________________________^ SIM117
298 |               lib.create_data(
299 |                   family="GMT_IS_DATASET",
    |
    = help: Combine `with` statements

pygmt/tests/test_clib.py:307:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
305 |               )
306 |       # Passing in invalid geometry
307 |       with pytest.raises(GMTInvalidInput):
    |  _____^
308 | |         with clib.Session() as lib:
    | |___________________________________^ SIM117
309 |               lib.create_data(
310 |                   family="GMT_IS_GRID",
    |
    = help: Combine `with` statements

pygmt/tests/test_clib.py:319:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
318 |       # If the data pointer returned is None (NULL pointer)
319 |       with pytest.raises(GMTCLibError):
    |  _____^
320 | |         with clib.Session() as lib:
    | |___________________________________^ SIM117
321 |               with mock(lib, "GMT_Create_Data", returns=None):
322 |                   lib.create_data(
    |
    = help: Combine `with` statements

pygmt/tests/test_clib.py:335:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
333 |       """
334 |       Figure()
335 |       with pytest.raises(GMTCLibError):
    |  _____^
336 | |         with clib.Session() as lib:
    | |___________________________________^ SIM117
337 |               lib.extract_region()
    |
    = help: Combine `with` statements

pygmt/tests/test_clib.py:377:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
375 |       # output=='', GMT will just write to stdout and spaces are valid file
376 |       # names. Use a mock instead just to exercise this part of the code.
377 |       with clib.Session() as lib:
    |  _____^
378 | |         with mock(lib, "GMT_Write_Data", returns=1):
    | |____________________________________________________^ SIM117
379 |               with pytest.raises(GMTCLibError):
380 |                   lib.write_data(
    |
    = help: Combine `with` statements

pygmt/tests/test_clib.py:510:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
508 |       Make sure get_default raises an exception for invalid names.
509 |       """
510 |       with clib.Session() as lib:
    |  _____^
511 | |         with pytest.raises(GMTCLibError):
    | |_________________________________________^ SIM117
512 |               lib.get_default("NOT_A_VALID_NAME")
    |
    = help: Combine `with` statements

pygmt/tests/test_clib.py:565:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
564 |       lib = clib.Session()
565 |       with mock(lib, "GMT_Get_Default", mock_func=mock_defaults):
    |  _____^
566 | |         with pytest.raises(GMTVersionError):
    | |____________________________________________^ SIM117
567 |               with lib:
568 |                   assert lib.info["version"] != "5.4.3"
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_put_matrix.py:61:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
   |
59 |       # checks on input arguments. Mock the C API function just to make sure it
60 |       # works.
61 |       with clib.Session() as lib:
   |  _____^
62 | |         with mock(lib, "GMT_Put_Matrix", returns=1):
   | |____________________________________________________^ SIM117
63 |               with pytest.raises(GMTCLibError):
64 |                   lib.put_matrix(dataset=None, matrix=np.empty((10, 2)), pad=0)
   |
   = help: Combine `with` statements

pygmt/tests/test_clib_put_strings.py:56:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
   |
54 |       Check that put_strings raises an exception if return code is not zero.
55 |       """
56 |       with clib.Session() as lib:
   |  _____^
57 | |         with pytest.raises(GMTCLibError):
   | |_________________________________________^ SIM117
58 |               lib.put_strings(
59 |                   dataset=None,
   |
   = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:55:13: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
   |
53 |               # Add the dataset to a virtual file and pass it along to gmt info
54 |               vfargs = (family, geometry, "GMT_IN|GMT_IS_REFERENCE", dataset)
55 |               with lib.open_virtual_file(*vfargs) as vfile:
   |  _____________^
56 | |                 with GMTTempFile() as outfile:
   | |______________________________________________^ SIM117
57 |                       lib.call_module("info", f"{vfile} ->{outfile.name}")
58 |                       output = outfile.read(keep_tabs=True)
   |
   = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:79:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
   |
77 |       # If the exception is raised, the code won't get to the closing of the
78 |       # virtual file.
79 |       with clib.Session() as lib, mock(lib, "GMT_Open_VirtualFile", returns=1):
   |  _____^
80 | |         with pytest.raises(GMTCLibError):
   | |_________________________________________^ SIM117
81 |               with lib.open_virtual_file(*vfargs):
82 |                   print("Should not get to this code")
   |
   = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:87:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
   |
85 |       # Mock the opening to return 0 (success) so that we don't open a file that
86 |       # we won't close later.
87 |       with clib.Session() as lib, mock(lib, "GMT_Open_VirtualFile", returns=0), mock(
   |  _____^
88 | |         lib, "GMT_Close_VirtualFile", returns=1
89 | |     ):
90 | |         with pytest.raises(GMTCLibError):
   | |_________________________________________^ SIM117
91 |               with lib.open_virtual_file(*vfargs):
92 |                   pass
   |
   = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:107:9: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
105 |               0,
106 |           )
107 |           with pytest.raises(GMTInvalidInput):
    |  _________^
108 | |             with lib.open_virtual_file(*vfargs):
    | |________________________________________________^ SIM117
109 |                   print("This should have failed")
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:127:9: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
125 |       data = array_func(dataframe)
126 |       with clib.Session() as lib:
127 |           with lib.virtualfile_from_data(
    |  _________^
128 | |             data=data, required_z=True, check_kind="vector"
129 | |         ) as vfile:
130 | |             with GMTTempFile() as outfile:
    | |__________________________________________^ SIM117
131 |                   lib.call_module("info", f"{vfile} ->{outfile.name}")
132 |                   output = outfile.read(keep_tabs=True)
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:149:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
147 |       """
148 |       data = np.ones((5, 2))
149 |       with clib.Session() as lib:
    |  _____^
150 | |         with pytest.raises(GMTInvalidInput):
    | |____________________________________________^ SIM117
151 |               with lib.virtualfile_from_data(
152 |                   data=data, required_z=True, check_kind="vector"
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:167:9: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
165 |           if not any(item is None for item in variable):
166 |               continue
167 |           with clib.Session() as lib:
    |  _________^
168 | |             with pytest.raises(GMTInvalidInput):
    | |________________________________________________^ SIM117
169 |                   lib.virtualfile_from_data(x=variable[0], y=variable[1])
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:177:9: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
175 |           if not any(item is None for item in variable):
176 |               continue
177 |           with clib.Session() as lib:
    |  _________^
178 | |             with pytest.raises(GMTInvalidInput):
    | |________________________________________________^ SIM117
179 |                   lib.virtualfile_from_data(
180 |                       x=variable[0], y=variable[1], z=variable[2], required_z=True
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:184:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
183 |       # Should also fail if given too much data
184 |       with clib.Session() as lib:
    |  _____^
185 | |         with pytest.raises(GMTInvalidInput):
    | |____________________________________________^ SIM117
186 |               lib.virtualfile_from_data(
187 |                   x=data[:, 0],
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:204:13: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
202 |           z = np.arange(size * 2, size * 3, 1, dtype=dtype)
203 |           with clib.Session() as lib:
204 |               with lib.virtualfile_from_vectors(x, y, z) as vfile:
    |  _____________^
205 | |                 with GMTTempFile() as outfile:
    | |______________________________________________^ SIM117
206 |                       lib.call_module("info", f"{vfile} ->{outfile.name}")
207 |                       output = outfile.read(keep_tabs=True)
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:224:9: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
222 |       strings = np.array(["a", "bc", "defg", "hijklmn", "opqrst"], dtype=dtype)
223 |       with clib.Session() as lib:
224 |           with lib.virtualfile_from_vectors(x, y, strings) as vfile:
    |  _________^
225 | |             with GMTTempFile() as outfile:
    | |__________________________________________^ SIM117
226 |                   lib.call_module("convert", f"{vfile} ->{outfile.name}")
227 |                   output = outfile.read(keep_tabs=True)
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:245:9: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
243 |       strings2 = np.array(["pqrst", "uvwx", "yz!", "@#", "$"], dtype=dtype)
244 |       with clib.Session() as lib:
245 |           with lib.virtualfile_from_vectors(x, y, strings1, strings2) as vfile:
    |  _________^
246 | |             with GMTTempFile() as outfile:
    | |__________________________________________^ SIM117
247 |                   lib.call_module("convert", f"{vfile} ->{outfile.name}")
248 |                   output = outfile.read(keep_tabs=True)
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:264:13: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
262 |           data = np.arange(shape[0] * shape[1], dtype=dtype).reshape(shape)
263 |           with clib.Session() as lib:
264 |               with lib.virtualfile_from_vectors(*data.T) as vfile:
    |  _____________^
265 | |                 with GMTTempFile() as outfile:
    | |______________________________________________^ SIM117
266 |                       lib.call_module("info", f"{vfile} -C ->{outfile.name}")
267 |                       output = outfile.read(keep_tabs=True)
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:279:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
277 |       x = np.arange(5)
278 |       y = np.arange(6)
279 |       with clib.Session() as lib:
    |  _____^
280 | |         with pytest.raises(GMTInvalidInput):
    | |____________________________________________^ SIM117
281 |               with lib.virtualfile_from_vectors(x, y):
282 |                   print("This should have failed")
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:293:13: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
291 |           data = np.arange(shape[0] * shape[1], dtype=dtype).reshape(shape)
292 |           with clib.Session() as lib:
293 |               with lib.virtualfile_from_matrix(data) as vfile:
    |  _____________^
294 | |                 with GMTTempFile() as outfile:
    | |______________________________________________^ SIM117
295 |                       lib.call_module("info", f"{vfile} ->{outfile.name}")
296 |                       output = outfile.read(keep_tabs=True)
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:313:13: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
311 |           data = full_data[:rows, :cols]
312 |           with clib.Session() as lib:
313 |               with lib.virtualfile_from_matrix(data) as vfile:
    |  _____________^
314 | |                 with GMTTempFile() as outfile:
    | |______________________________________________^ SIM117
315 |                       lib.call_module("info", f"{vfile} ->{outfile.name}")
316 |                       output = outfile.read(keep_tabs=True)
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:336:13: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
334 |           )
335 |           with clib.Session() as lib:
336 |               with lib.virtualfile_from_vectors(data.x, data.y, data.z) as vfile:
    |  _____________^
337 | |                 with GMTTempFile() as outfile:
    | |______________________________________________^ SIM117
338 |                       lib.call_module("info", f"{vfile} ->{outfile.name}")
339 |                       output = outfile.read(keep_tabs=True)
    |
    = help: Combine `with` statements

pygmt/tests/test_clib_virtualfiles.py:356:9: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
354 |       z = range(size * 2, size * 3, 1)
355 |       with clib.Session() as lib:
356 |           with lib.virtualfile_from_vectors(x, y, z) as vfile:
    |  _________^
357 | |             with GMTTempFile() as outfile:
    | |__________________________________________^ SIM117
358 |                   lib.call_module("info", f"{vfile} ->{outfile.name}")
359 |                   output = outfile.read(keep_tabs=True)
    |
    = help: Combine `with` statements

pygmt/tests/test_figure.py:309:9: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
307 |       # unsupported formats
308 |       for fmt in [".eps", ".kml", ".pdf", ".tiff"]:
309 |           with GMTTempFile(prefix="pygmt-worldfile", suffix=fmt) as imgfile:
    |  _________^
310 | |             with pytest.raises(GMTInvalidInput):
    | |________________________________________________^ SIM117
311 |                   fig.savefig(fname=imgfile.name, worldfile=True)
    |
    = help: Combine `with` statements

pygmt/tests/test_filter1d.py:73:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
   |
71 |       output_type is not set to 'file'.
72 |       """
73 |       with pytest.warns(RuntimeWarning):
   |  _____^
74 | |         with GMTTempFile(suffix=".txt") as tmpfile:
   | |___________________________________________________^ SIM117
75 |               result = filter1d(
76 |                   data=data, filter_type="g5", outfile=tmpfile.name, output_type="numpy"
   |
   = help: Combine `with` statements

pygmt/tests/test_grd2xyz.py:84:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
   |
82 |       output_type is not set to 'file'.
83 |       """
84 |       with pytest.warns(RuntimeWarning):
   |  _____^
85 | |         with GMTTempFile(suffix=".xyz") as tmpfile:
   | |___________________________________________________^ SIM117
86 |               result = grd2xyz(grid=grid, outfile=tmpfile.name, output_type="numpy")
87 |               assert result is None  # return value is None
   |
   = help: Combine `with` statements

pygmt/tests/test_helpers.py:101:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
 99 |       Check that generating multiple files creates unique names.
100 |       """
101 |       with GMTTempFile() as tmp1:
    |  _____^
102 | |         with GMTTempFile() as tmp2:
    | |___________________________________^ SIM117
103 |               with GMTTempFile() as tmp3:
104 |                   assert tmp1.name != tmp2.name != tmp3.name
    |
    = help: Combine `with` statements

pygmt/tests/test_subplot.py:90:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
   |
88 |       """
89 |       fig = Figure()
90 |       with pytest.raises(GMTInvalidInput):
   |  _____^
91 | |         with fig.subplot(figsize=("2c", "1c"), subsize=("2c", "1c")):
   | |_____________________________________________________________________^ SIM117
92 |               pass
   |
   = help: Combine `with` statements

pygmt/tests/test_subplot.py:100:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
 98 |       """
 99 |       fig = Figure()
100 |       with pytest.raises(GMTInvalidInput):
    |  _____^
101 | |         with fig.subplot(nrows=0, ncols=-1, figsize=("2c", "1c")):
    | |__________________________________________________________________^ SIM117
102 |               pass
    |
    = help: Combine `with` statements
```
