### PR TITLE
Enable ruff's pandas-vet (PD) rules

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -92,7 +92,7 @@ def dataarray_to_matrix(grid):
     # grids, this would be North-South, East-West. GMT's region and inc are
     # East-West, North-South.
     for dim in grid.dims[::-1]:
-        coord = grid.coords[dim].values
+        coord = grid.coords[dim].to_numpy()
         coord_incs = coord[1:] - coord[0:-1]
         coord_inc = coord_incs[0]
         if not np.allclose(coord_incs, coord_inc):
@@ -120,7 +120,7 @@ def dataarray_to_matrix(grid):
         inc = [abs(i) for i in inc]
         grid = grid.sortby(variables=list(grid.dims), ascending=True)
 
-    matrix = as_c_contiguous(grid[::-1].values)
+    matrix = as_c_contiguous(grid[::-1].to_numpy())
     return matrix, region, inc
 
 

--- a/pygmt/tests/test_blockmedian.py
+++ b/pygmt/tests/test_blockmedian.py
@@ -36,7 +36,7 @@ def test_blockmedian_input_table_matrix(dataframe):
     Run blockmedian using table input that is not a pandas.DataFrame but still
     a matrix.
     """
-    table = dataframe.values
+    table = dataframe.to_numpy()
     output = blockmedian(data=table, spacing="5m", region=[245, 255, 20, 30])
     assert isinstance(output, pd.DataFrame)
     assert output.shape == (5849, 3)

--- a/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
+++ b/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
@@ -21,7 +21,7 @@ def test_earth_vertical_gravity_gradient_01d():
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -137.125, atol=1 / 32)
     npt.assert_allclose(data.max(), 104.59375, atol=1 / 32)
-    assert data[1, 1].isna()
+    assert data[1, 1].isnull()  # noqa: PD003  # ruff's bug
 
 
 def test_earth_vertical_gravity_gradient_01d_with_region():

--- a/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
+++ b/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
@@ -21,7 +21,7 @@ def test_earth_vertical_gravity_gradient_01d():
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -137.125, atol=1 / 32)
     npt.assert_allclose(data.max(), 104.59375, atol=1 / 32)
-    assert data[1, 1].isnull()
+    assert data[1, 1].isna()
 
 
 def test_earth_vertical_gravity_gradient_01d_with_region():

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -189,7 +189,7 @@ def test_earth_relief_holes():
     npt.assert_allclose(grid.max(), 1601)
     npt.assert_allclose(grid.min(), -4929.5)
     # Test for the NaN values in the remote file
-    assert grid[2, 21].isnull()
+    assert grid[2, 21].isna()
 
 
 def test_maunaloa_co2():

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -189,7 +189,7 @@ def test_earth_relief_holes():
     npt.assert_allclose(grid.max(), 1601)
     npt.assert_allclose(grid.min(), -4929.5)
     # Test for the NaN values in the remote file
-    assert grid[2, 21].isna()
+    assert grid[2, 21].isnull()  # noqa: PD003  # ruff's bug
 
 
 def test_maunaloa_co2():

--- a/pygmt/tests/test_select.py
+++ b/pygmt/tests/test_select.py
@@ -37,7 +37,7 @@ def test_select_input_table_matrix(dataframe):
 
     Also testing the reverse (I) alias.
     """
-    data = dataframe.values
+    data = dataframe.to_numpy()
     output = select(data=data, region=[245.5, 254.5, 20.5, 29.5], reverse="r")
     assert isinstance(output, pd.DataFrame)
     assert output.shape == (9177, 3)

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -93,7 +93,7 @@ def test_surface_input_data_array(data, region, spacing, expected_grid):
     """
     Run surface by passing in a numpy array into data.
     """
-    data = data.values  # convert pandas.DataFrame to numpy.ndarray
+    data = data.to_numpy()  # convert pandas.DataFrame to numpy.ndarray
     output = surface(
         data=data,
         spacing=spacing,
@@ -132,7 +132,7 @@ def test_surface_with_outgrid_param(data, region, spacing, expected_grid):
     """
     Run surface with the -Goutputfile.nc parameter.
     """
-    data = data.values  # convert pandas.DataFrame to numpy.ndarray
+    data = data.to_numpy()  # convert pandas.DataFrame to numpy.ndarray
     with GMTTempFile(suffix=".nc") as tmpfile:
         output = surface(
             data=data,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ select = [
 ]
 ignore = [
     "E501", # Avoid enforcing line-length violations
+    "PD901",  # Allow using the generic variable name `df` for DataFrames
     "PLR2004",  # Allow any magic values
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ select = [
     "F",    # pyflakes
     "I",    # isort
     "NPY",  # numpy
+    "PD",   # pandas-vet
     "PL",   # pylint
     "UP",   # pyupgrade
     "W",    # pycodestyle warnings


### PR DESCRIPTION
Errors after enabling ruff's pandas-vet rules. Looks good to me but maybe we should ignore `PD901`?
```
examples/gallery/3d_plots/scatter3d.py:22:1: PD901 Avoid using the generic variable name `df` for DataFrames
   |
21 | # Load sample iris data
22 | df = pd.read_csv("https://github.com/mwaskom/seaborn-data/raw/master/iris.csv")
   | ^^ PD901
23 | 
24 | # Convert 'species' column to categorical dtype
   |

examples/gallery/histograms/blockm.py:28:1: PD901 Avoid using the generic variable name `df` for DataFrames
   |
26 | # Calculate mean depth in kilometers from all events within
27 | # 150x150 arc-minute bins using blockmean
28 | df = pygmt.blockmean(data=data, region=region, spacing=spacing)
   | ^^ PD901
29 | # Convert to grid
30 | grd = pygmt.xyz2grd(data=df, region=region, spacing=spacing)
   |

examples/gallery/histograms/blockm.py:48:1: PD901 Avoid using the generic variable name `df` for DataFrames
   |
46 | # Calculate number of total locations within 150x150 arc-minute bins
47 | # with blockmean's summary parameter
48 | df = pygmt.blockmean(data=data, region=region, spacing=spacing, summary="n")
   | ^^ PD901
49 | grd = pygmt.xyz2grd(data=df, region=region, spacing=spacing)
   |

examples/gallery/seismology/velo_arrow_ellipse.py:18:1: PD901 Avoid using the generic variable name `df` for DataFrames
   |
17 | fig = pygmt.Figure()
18 | df = pd.DataFrame(
   | ^^ PD901
19 |     data={
20 |         "x": [0, -8, 0, -5, 5, 0],
   |

examples/gallery/symbols/points_categorical.py:20:1: PD901 Avoid using the generic variable name `df` for DataFrames
   |
19 | # Load sample penguins data
20 | df = pd.read_csv("https://github.com/mwaskom/seaborn-data/raw/master/penguins.csv")
   | ^^ PD901
21 | 
22 | # Convert 'species' column to categorical dtype
   |

examples/tutorials/advanced/date_time_charts.py:268:1: PD901 Avoid using the generic variable name `df` for DataFrames
    |
266 |     ["20200729", 1634],
267 | ]
268 | df = pd.DataFrame(data, columns=["Date", "Score"])
    | ^^ PD901
269 | df.Date = pd.to_datetime(df["Date"], format="%Y%m%d")
    |

pygmt/clib/conversion.py:95:17: PD011 Use `.to_numpy()` instead of `.values`
   |
93 |     # East-West, North-South.
94 |     for dim in grid.dims[::-1]:
95 |         coord = grid.coords[dim].values
   |                 ^^^^^^^^^^^^^^^^^^^^^^^ PD011
96 |         coord_incs = coord[1:] - coord[0:-1]
97 |         coord_inc = coord_incs[0]
   |

pygmt/tests/test_blockmedian.py:39:13: PD011 Use `.to_numpy()` instead of `.values`
   |
37 |     a matrix.
38 |     """
39 |     table = dataframe.values
   |             ^^^^^^^^^^^^^^^^ PD011
40 |     output = blockmedian(data=table, spacing="5m", region=[245, 255, 20, 30])
41 |     assert isinstance(output, pd.DataFrame)
   |

pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py:24:12: PD003 `.isna` is preferred to `.isnull`; functionality is equivalent
   |
22 |     npt.assert_allclose(data.min(), -137.125, atol=1 / 32)
23 |     npt.assert_allclose(data.max(), 104.59375, atol=1 / 32)
24 |     assert data[1, 1].isnull()
   |            ^^^^^^^^^^^^^^^^^ PD003
   |

pygmt/tests/test_datasets_samples.py:192:12: PD003 `.isna` is preferred to `.isnull`; functionality is equivalent
    |
190 |     npt.assert_allclose(grid.min(), -4929.5)
191 |     # Test for the NaN values in the remote file
192 |     assert grid[2, 21].isnull()
    |            ^^^^^^^^^^^^^^^^^^ PD003
    |

pygmt/tests/test_select.py:40:12: PD011 Use `.to_numpy()` instead of `.values`
   |
38 |     Also testing the reverse (I) alias.
39 |     """
40 |     data = dataframe.values
   |            ^^^^^^^^^^^^^^^^ PD011
41 |     output = select(data=data, region=[245.5, 254.5, 20.5, 29.5], reverse="r")
42 |     assert isinstance(output, pd.DataFrame)
   |

pygmt/tests/test_surface.py:96:12: PD011 Use `.to_numpy()` instead of `.values`
   |
94 |     Run surface by passing in a numpy array into data.
95 |     """
96 |     data = data.values  # convert pandas.DataFrame to numpy.ndarray
   |            ^^^^^^^^^^^ PD011
97 |     output = surface(
98 |         data=data,
   |

pygmt/tests/test_surface.py:135:12: PD011 Use `.to_numpy()` instead of `.values`
    |
133 |     Run surface with the -Goutputfile.nc parameter.
134 |     """
135 |     data = data.values  # convert pandas.DataFrame to numpy.ndarray
    |            ^^^^^^^^^^^ PD011
136 |     with GMTTempFile(suffix=".nc") as tmpfile:
137 |         output = surface(
    |

Found 13 errors.
```