### PR TITLE
Recommend Miniforge instead of Mambaforge

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -186,7 +186,7 @@ These steps for setting up your environment are necessary for
 [contributing code](contributing.md#contributing-code). A local PyGMT development environment
 is not needed for [editing the documentation on GitHub](contributing.md#editing-the-documentation-on-github).
 
-We highly recommend using [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge/)
+We highly recommend using [Miniforge](https://github.com/conda-forge/miniforge#miniforge3)
 and the `mamba` package manager to install and manage your Python packages.
 It will make your life a lot easier!
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -66,10 +66,10 @@ Which Python?
 
 PyGMT is tested to run on Python |requires_python|.
 
-We recommend using the `Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`__
+We recommend using the `Miniforge <https://github.com/conda-forge/miniforge#miniforge3>`__
 Python distribution to ensure you have all dependencies installed and the
 `mamba <https://mamba.readthedocs.io/en/stable/user_guide/mamba.html>`__
-package manager in the base environment. Installing Mambaforge does not require
+package manager in the base environment. Installing Miniforge does not require
 administrative rights to your computer and doesn't interfere with any other Python
 installations on your system.
 
@@ -264,13 +264,13 @@ respectively.
 For Linux/macOS, add the following line to your shell configuration file
 (usually ``~/.bashrc`` for Bash on Linux and ``~/.zshrc`` for Zsh on macOS)::
 
-    export GMT_LIBRARY_PATH=$HOME/mambaforge/envs/pygmt/lib
+    export GMT_LIBRARY_PATH=$HOME/miniforge3/envs/pygmt/lib
 
 For Windows, add the ``GMT_LIBRARY_PATH`` environment variable following these
 `instructions <https://www.wikihow.com/Create-an-Environment-Variable-in-Windows-10>`__
 and set its value to a path like::
 
-    C:\Users\USERNAME\Mambaforge\envs\pygmt\Library\bin\
+    C:\Users\USERNAME\Miniforge3\envs\pygmt\Library\bin\
 
 Notes for Jupyter users
 -----------------------


### PR DESCRIPTION
Mambaforge is discouraged. Use Miniforge instead.

See https://github.com/conda-forge/miniforge#miniforge-pypy3:

> With the [release](https://github.com/conda-forge/miniforge/releases/tag/23.3.1-0) of Miniforge3-23.3.1-0, that incorporated the changes in https://github.com/conda-forge/miniforge/pull/277, the packages and configuration of Mambaforge and Miniforge3 are now identical. The only difference between the two is the name of the installer and, subsequently, the default installation directory.

> Given its wide usage, there are no plans to deprecate Mambaforge. If at some point we decide to deprecate Mambaforge, it will be appropriately announced and communicated with sufficient time in advance.

> As of September 2023, the new usage of Mambaforge is thus discouraged. Bug reports specific to Mambaforge will be closed as won't fix.

