### PR TITLE
Enable ruff's flynt (FLY) rules

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -445,14 +445,7 @@ def fmt_docstring(module_func):
         filler_text["aliases"] = "\n".join(aliases)
 
     filler_text["table-like"] = (
-        ", ".join(
-            [
-                "numpy.ndarray",
-                "pandas.DataFrame",
-                "xarray.Dataset",
-            ]
-        )
-        + ", or geopandas.GeoDataFrame"
+        "numpy.ndarray, pandas.DataFrame, xarray.Dataset, " "or geopandas.GeoDataFrame"
     )
     filler_text["table-classes"] = (
         ":class:`numpy.ndarray`, a :class:`pandas.DataFrame`, an\n"

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -444,9 +444,9 @@ def fmt_docstring(module_func):
             aliases.append(f"- {arg} = {alias}")
         filler_text["aliases"] = "\n".join(aliases)
 
-    filler_text["table-like"] = (
-        "numpy.ndarray, pandas.DataFrame, xarray.Dataset, " "or geopandas.GeoDataFrame"
-    )
+    filler_text[
+        "table-like"
+    ] = "numpy.ndarray, pandas.DataFrame, xarray.Dataset, or geopandas.GeoDataFrame"
     filler_text["table-classes"] = (
         ":class:`numpy.ndarray`, a :class:`pandas.DataFrame`, an\n"
         "    :class:`xarray.Dataset` made up of 1-D :class:`xarray.DataArray`\n"

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -78,7 +78,7 @@ def ternary(self, data, alabel=None, blabel=None, clabel=None, **kwargs):
         alabel = str(alabel) if alabel is not None else "-"
         blabel = str(blabel) if blabel is not None else "-"
         clabel = str(clabel) if clabel is not None else "-"
-        kwargs["L"] = "/".join([alabel, blabel, clabel])
+        kwargs["L"] = f"{alabel}/{blabel}/{clabel}"
 
     # Patch for GMT < 6.5.0.
     # See https://github.com/GenericMappingTools/pygmt/pull/2138

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -203,7 +203,7 @@ def test_parse_constant_composite():
     lib = clib.Session()
     test_cases = ((family, via) for family in FAMILIES for via in VIAS)
     for family, via in test_cases:
-        composite = "|".join([family, via])
+        composite = f"{family}|{via}"
         expected = lib[family] + lib[via]
         parsed = lib._parse_constant(composite, valid=FAMILIES, valid_modifiers=VIAS)
         assert parsed == expected

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -83,7 +83,7 @@ def test_figure_savefig_exists():
     fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
     prefix = "test_figure_savefig_exists"
     for fmt in "bmp eps jpg jpeg pdf png ppm tif PNG JPG JPEG Png".split():
-        fname = ".".join([prefix, fmt])
+        fname = f"{prefix}.{fmt}"
         fig.savefig(fname)
 
         fname = Path(fname)
@@ -175,7 +175,7 @@ def test_figure_savefig_unknown_extension():
     fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
     prefix = "test_figure_savefig_unknown_extension"
     fmt = "test"
-    fname = ".".join([prefix, fmt])
+    fname = f"{prefix}.{fmt}"
     with pytest.raises(GMTInvalidInput, match="Unknown extension '.test'."):
         fig.savefig(fname)
 
@@ -199,11 +199,11 @@ def test_figure_savefig_transparent():
     fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
     prefix = "test_figure_savefig_transparent"
     for fmt in "pdf jpg bmp eps tif".split():
-        fname = ".".join([prefix, fmt])
+        fname = f"{prefix}.{fmt}"
         with pytest.raises(GMTInvalidInput):
             fig.savefig(fname, transparent=True)
     # png should not raise an error
-    fname = ".".join([prefix, "png"])
+    fname = f"{prefix}.png"
     fig.savefig(fname, transparent=True)
     assert os.path.exists(fname)
     os.remove(fname)
@@ -238,7 +238,7 @@ def test_figure_savefig():
 
     prefix = "test_figure_savefig"
 
-    fname = ".".join([prefix, "png"])
+    fname = f"{prefix}.png"
     fig.savefig(fname)
     assert kwargs_saved[-1] == {
         "prefix": prefix,
@@ -248,7 +248,7 @@ def test_figure_savefig():
         "Qg": 2,
     }
 
-    fname = ".".join([prefix, "pdf"])
+    fname = f"{prefix}.pdf"
     fig.savefig(fname)
     assert kwargs_saved[-1] == {
         "prefix": prefix,
@@ -258,7 +258,7 @@ def test_figure_savefig():
         "Qg": 2,
     }
 
-    fname = ".".join([prefix, "png"])
+    fname = f"{prefix}.png"
     fig.savefig(fname, transparent=True)
     assert kwargs_saved[-1] == {
         "prefix": prefix,
@@ -268,7 +268,7 @@ def test_figure_savefig():
         "Qg": 2,
     }
 
-    fname = ".".join([prefix, "eps"])
+    fname = f"{prefix}.eps"
     fig.savefig(fname)
     assert kwargs_saved[-1] == {
         "prefix": prefix,
@@ -278,7 +278,7 @@ def test_figure_savefig():
         "Qg": 2,
     }
 
-    fname = ".".join([prefix, "kml"])
+    fname = f"{prefix}.kml"
     fig.savefig(fname)
     assert kwargs_saved[-1] == {
         "prefix": prefix,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ select = [
     "B",    # flake8-bugbear
     "E",    # pycodestyle
     "F",    # pyflakes
+    "FLY",  # flynt
     "I",    # isort
     "NPY",  # numpy
     "PD",   # pandas-vet


### PR DESCRIPTION
**Description of proposed changes**

ruff's [FLY](https://docs.astral.sh/ruff/rules/#flynt-fly) linter only has one rule, which prefers `f"{foo} {bar}"`, not `" ".join((foo, bar))`. 

I personally also prefer f-strings.

Related to #2741.