### PR TITLE
pygmt.grdinfo: Fix typo in docstring of the "geographic" parameter

### DIFF
--- a/pygmt/src/grdinfo.py
+++ b/pygmt/src/grdinfo.py
@@ -63,7 +63,7 @@ def grdinfo(grid, **kwargs):
         xmin xmax ymin ymax per tile, or use ``per_column="t"`` to also have
         the region string appended as trailing text.
     geographic : bool
-        Report grid domain and x/y-increments in world mapping format
+        Report grid domain and x/y-increments in world mapping format.
         The default value is ``False``. This cannot be called if
         ``per_column`` is also set.
     spacing : str or list


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a tiny typo in the  docstring of the `geographic` parameter of `pygmt.grdinfo`.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
