### PR TITLE
Add the full changelog link to the release drafter template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -53,6 +53,8 @@ template: |
 
   $CHANGES
 
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
   ### Contributors
 
   $CONTRIBUTORS


### PR DESCRIPTION
**Description of proposed changes**

Add the link to the full changelog between the current version and previous version at the end of the Changes section. 

An example link is https://github.com/GenericMappingTools/pygmt/compare/v0.9.0...v0.10.0. So for the next release, it will be:

**Full changelog**: https://github.com/GenericMappingTools/pygmt/compare/v0.10.0...v0.11.0 

Need to note that the link is invalid for draft releases, because the tag v0.11.0 doesn't exist until we make the release.

The template is from https://github.com/release-drafter/release-drafter/blob/3bc19058001dbbdd774f09eb627a189c88e7336e/.github/release-drafter.yml#L8