### PR TITLE
doc: Update the extlinks settings for Sphinx > 6

### DIFF
--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -24,7 +24,7 @@ dependencies:
     # Dev dependencies (building documentation)
     - myst-parser
     - panel
-    - sphinx
+    - sphinx=5
     - sphinx-copybutton
     - sphinx-design
     - sphinx-gallery

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -24,7 +24,7 @@ dependencies:
     # Dev dependencies (building documentation)
     - myst-parser
     - panel
-    - sphinx=7.1
+    - sphinx=7.0
     - sphinx-copybutton
     - sphinx-design
     - sphinx-gallery

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -24,7 +24,7 @@ dependencies:
     # Dev dependencies (building documentation)
     - myst-parser
     - panel
-    - sphinx=7.0
+    - sphinx
     - sphinx-copybutton
     - sphinx-design
     - sphinx-gallery

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -24,7 +24,7 @@ dependencies:
     # Dev dependencies (building documentation)
     - myst-parser
     - panel
-    - sphinx=5
+    - sphinx=6
     - sphinx-copybutton
     - sphinx-design
     - sphinx-gallery

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -24,7 +24,7 @@ dependencies:
     # Dev dependencies (building documentation)
     - myst-parser
     - panel
-    - sphinx=6
+    - sphinx=7.1
     - sphinx-copybutton
     - sphinx-design
     - sphinx-gallery

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,7 +44,7 @@ napoleon_use_ivar = True
 # configure links to GMT docs
 extlinks = {
     "gmt-docs": ("https://docs.generic-mapping-tools.org/6.4/%s", None),
-    "gmt-term": ("https://docs.generic-mapping-tools.org/6.4/gmt.conf#term-%s", ""),
+    "gmt-term": ("https://docs.generic-mapping-tools.org/6.4/gmt.conf#term-%s", "%s"),
     "gmt-datasets": ("https://www.generic-mapping-tools.org/remote-datasets/%s", None),
 }
 


### PR DESCRIPTION
**Description of proposed changes**

Solution from https://github.com/sphinx-doc/sphinx/issues/11094#issuecomment-1372994091.

Since Sphinx 6:

> If caption is a string, then it must contain %s exactly once. 


Address https://github.com/GenericMappingTools/pygmt/pull/2822#issuecomment-1833474416.