### PR TITLE
Figure.inset: Fix typos in docstring of "box" parameter

### DIFF
--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -83,12 +83,12 @@ def inset(self, **kwargs):
         Append **+c**\ *clearance* where *clearance* is either
         *gap*, *xgap*\ /\ *ygap*, or *lgap*\ /\ *rgap*\ /\ *bgap*\ /\
         *tgap* where these items are uniform, separate in x- and
-        y-directions, or individual side spacings between map embellishment
-        and border. Append **+i** to draw a secondary, inner border as well.
-        We use a uniform *gap* between borders of 2p and the default pen
-        unless other values are specified. Append **+r** to draw rounded
-        rectangular borders instead, with a 6p corner radius. You
-        can override this radius by appending another value. Append
+        y-directions, or individual side spacings between the map
+        embellishment and border. Append **+i** to draw a secondary, inner
+        border as well. We use a uniform *gap* between borders of 2p and
+        the default pen unless other values are specified. Append **+r** to
+        draw rounded rectangular borders instead, with a 6p corner radius.
+        You can override this radius by appending another value. Append
         **+s** to draw an offset background shaded region. Here, *dx*/*dy*
         indicates the shift relative to the foreground frame [Default is
         ``"4p/-4p"``] and *shade* sets the fill style to use for

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -83,12 +83,12 @@ def inset(self, **kwargs):
         Append **+c**\ *clearance* where *clearance* is either
         *gap*, *xgap*\ /\ *ygap*, or *lgap*\ /\ *rgap*\ /\ *bgap*\ /\
         *tgap* where these items are uniform, separate in x- and
-        y-directions, or individual side spacings between the map
-        embellishment and border. Append **+i** to draw a secondary, inner
-        border as well. We use a uniform *gap* between borders of 2p and
-        the default pen unless other values are specified. Append **+r** to
-        draw rounded rectangular borders instead, with a 6p corner radius.
-        You can override this radius by appending another value. Append
+        y-directions, or individual side spacings between map embellishment
+        and border. Append **+i** to draw a secondary, inner border as well.
+        We use a uniform *gap* between borders of 2p and the default pen
+        unless other values are specified. Append **+r** to draw rounded
+        rectangular borders instead, with a 6p corner radius. You
+        can override this radius by appending another value. Append
         **+s** to draw an offset background shaded region. Here, *dx*/*dy*
         indicates the shift relative to the foreground frame [Default is
         ``"4p/-4p"``] and *shade* sets the fill style to use for

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -78,20 +78,20 @@ def inset(self, **kwargs):
         [[*dx*/*dy*/][*shade*]]].
         If set to ``True``, draw a rectangular box around the map
         inset using the default pen; specify a different pen
-        with **+p**\ *pen*. Add **+g**\ *fill* to fill the logo box
+        with **+p**\ *pen*. Add **+g**\ *fill* to fill the inset box
         [Default is no fill].
-        Append **+c**\ *clearance*  where *clearance* is either
+        Append **+c**\ *clearance* where *clearance* is either
         *gap*, *xgap*\ /\ *ygap*, or *lgap*\ /\ *rgap*\ /\ *bgap*\ /\
         *tgap* where these items are uniform, separate in x- and
-        y-direction, or individual side spacings between logo and border.
-        Append **+i** to draw a secondary, inner border as well. We use a
-        uniform *gap* between borders of 2\ **p** and the default pen
+        y-directions, or individual side spacings between map embellishment
+        and border. Append **+i** to draw a secondary, inner border as well.
+        We use a uniform *gap* between borders of 2p and the default pen
         unless other values are specified. Append **+r** to draw rounded
         rectangular borders instead, with a 6p corner radius. You
         can override this radius by appending another value. Append
         **+s** to draw an offset background shaded region. Here, *dx*/*dy*
         indicates the shift relative to the foreground frame [Default is
-        ``"4p/-4p"``] and ``shade`` sets the fill style to use for
+        ``"4p/-4p"``] and *shade* sets the fill style to use for
         shading [Default is ``"gray50"``].
     margin : float, str, or list
         This is clearance that is added around the inside of the inset.


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a few typos in the docstring of the `box` parameter of `Figure.inset`.

Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
