### PR TITLE
Enable ruff's flake8-future-annotations (FA) rules

### DIFF
--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -3,7 +3,7 @@ Internal function to load GMT remote datasets.
 """
 from __future__ import annotations
 
-from typing import NamedTuple, Union
+from typing import NamedTuple
 
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import kwargs_to_strings
@@ -60,7 +60,7 @@ class GMTRemoteDataset(NamedTuple):
     title: str
     name: str
     long_name: str
-    units: Union[str, None]
+    units: str | None
     resolutions: dict[str, Resolution]
     extra_attributes: dict
 

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -1,6 +1,8 @@
 """
 Internal function to load GMT remote datasets.
 """
+from __future__ import annotations
+
 from typing import NamedTuple, Union
 
 from pygmt.exceptions import GMTInvalidInput

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ select = [
     "B",    # flake8-bugbear
     "E",    # pycodestyle
     "F",    # pyflakes
+    "FA",   # flake8-future-annotations
     "FLY",  # flynt
     "I",    # isort
     "ISC",  # flake8-implicit-str-concat


### PR DESCRIPTION
**Description of proposed changes**

Enable ruff's [flake8-future annotations (FA)](https://docs.astral.sh/ruff/rules/#flake8-future-annotations-fa) rules. This rule set contains two rules, [FA100](https://docs.astral.sh/ruff/rules/future-rewritable-type-annotation/) and [FA102](https://docs.astral.sh/ruff/rules/future-required-type-annotation/).

Generally, these two rules recommend using `from __future__ import annotations` so that we can use some new type hinting syntax in old Python versions. For example, `Union[str, None]` can be rewritten as `str | None` for Python>=3.10 (introduced in [PEP 604](https://docs.astral.sh/ruff/rules/future-required-type-annotation/)). It won't work for Python 3.9 (PyGMT's minimum supported Python version) unless we use `from __future__ import annotations`.

For more details, please refer to:

- FA100: https://docs.astral.sh/ruff/rules/future-rewritable-type-annotation/
- FA102: https://docs.astral.sh/ruff/rules/future-required-type-annotation/
- PEP 563: https://peps.python.org/pep-0563/
- PEP 585: https://peps.python.org/pep-0585/
- PEP 604: https://peps.python.org/pep-0604/