### PR TITLE
Improve the error messages for unsupported numpy dtypes

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -834,8 +834,11 @@ class Session:
         # Check that the array has a valid/known data type
         if array.dtype.type not in DTYPES:
             try:
-                # Try to convert any unknown numpy data types to np.datetime64
-                array = array_to_datetime(array)
+                if array.dtype.type is np.object_:
+                    # Try to convert unknown object type to np.datetime64
+                    array = array_to_datetime(array)
+                else:
+                    raise ValueError
             except ValueError as e:
                 raise GMTInvalidInput(
                     f"Unsupported numpy data type '{array.dtype.type}'."

--- a/pygmt/tests/test_clib_put_vector.py
+++ b/pygmt/tests/test_clib_put_vector.py
@@ -170,16 +170,24 @@ def test_put_vector_invalid_dtype():
     """
     Check that it fails with an exception for invalid data types.
     """
-    with clib.Session() as lib:
-        dataset = lib.create_data(
-            family="GMT_IS_DATASET|GMT_VIA_VECTOR",
-            geometry="GMT_IS_POINT",
-            mode="GMT_CONTAINER_ONLY",
-            dim=[2, 3, 1, 0],  # columns, rows, layers, dtype
-        )
-        data = np.array([37, 12, 556], dtype="object")
-        with pytest.raises(GMTInvalidInput):
-            lib.put_vector(dataset, column=1, vector=data)
+    for dtype in [
+        np.float16,
+        np.object_,
+        np.bool_,
+        np.csingle,
+        np.complex_,
+        np.clongfloat,
+    ]:
+        with clib.Session() as lib:
+            dataset = lib.create_data(
+                family="GMT_IS_DATASET|GMT_VIA_VECTOR",
+                geometry="GMT_IS_POINT",
+                mode="GMT_CONTAINER_ONLY",
+                dim=[2, 3, 1, 0],  # columns, rows, layers, dtype
+            )
+            data = np.array([37, 12, 556], dtype=dtype)
+            with pytest.raises(GMTInvalidInput, match="Unsupported numpy data type"):
+                lib.put_vector(dataset, column=1, vector=data)
 
 
 def test_put_vector_wrong_column():


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
