### PR TITLE
Update README to clarify official and non-official GMT-related projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,11 +236,13 @@ The development of PyGMT has been supported by NSF grants
 Related projects
 ----------------
 
+Other official wrappers for GMT:
+
 * `GMT.jl <https://github.com/GenericMappingTools/GMT.jl>`__: A Julia wrapper for GMT.
 * `gmtmex <https://github.com/GenericMappingTools/gmtmex>`__: A Matlab/Octave wrapper
   for GMT.
 
-Other Python wrappers for GMT (not maintained):
+Other non-official Python wrappers for GMT (not maintained):
 
 * `gmtpy <https://github.com/emolch/gmtpy>`__ by `Sebastian Heimann <https://github.com/emolch>`__
 * `pygmt <https://github.com/ian-r-rose/pygmt>`__ by `Ian Rose <https://github.com/ian-r-rose>`__


### PR DESCRIPTION
Just minor changes to clarify that GMT.jl and gmtmex are official projects and other Python wrappers are non-official.