### PR TITLE
Use consistent descriptions for the grid parameter

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -149,6 +149,13 @@ COMMON_DOCSTRINGS = {
                   column value must exceed *gap* for a break to be imposed.
                 - **+p** - specify that the current value minus the previous
                   value must exceed *gap* for a break to be imposed.""",
+    "grid": r"""
+        grid : str or xarray.DataArray
+            Name of the input grid file or the grid loaded as a
+            :class:`xarray.DataArray` object.
+
+            For name of the input grid file, see
+            :gmt-docs:`gmt.html#grd-inout-full` for available modifiers.""",
     "header": r"""
         header : str
             [**i**\|\ **o**][*n*][**+c**][**+d**][**+m**\ *segheader*][**+r**\

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -154,8 +154,8 @@ COMMON_DOCSTRINGS = {
             Name of the input grid file or the grid loaded as a
             :class:`xarray.DataArray` object.
 
-            For name of the input grid file, see
-            :gmt-docs:`gmt.html#grd-inout-full` for available modifiers.""",
+            For reading a specific grid file format or applying basic data operations,
+            see :gmt-docs:`gmt.html#grd-inout-full` for the available modifiers.""",
     "header": r"""
         header : str
             [**i**\|\ **o**][*n*][**+c**][**+d**][**+m**\ *segheader*][**+r**\

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -53,8 +53,7 @@ def dimfilter(grid, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name of the input grid or the grid loaded as a DataArray.
+    {grid}
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid
         in.

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -79,8 +79,7 @@ def grd2cpt(grid, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name of the input grid or the grid loaded as a DataArray.
+    {grid}
     transparency : int or float or str
         Set a constant level of transparency (0-100) for all color slices.
         Append **+a** to also affect the foreground, background, and NaN

--- a/pygmt/src/grd2xyz.py
+++ b/pygmt/src/grd2xyz.py
@@ -46,9 +46,7 @@ def grd2xyz(grid, output_type="pandas", outfile=None, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name of the input grid or the grid loaded as a
-        :class:`xarray.DataArray`. This is the only required parameter.
+    {grid}
     output_type : str
         Determine the format the xyz data will be returned in [Default is
         ``pandas``]:

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -50,8 +50,7 @@ def grdclip(grid, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name of the input grid or the grid loaded as a DataArray.
+    {grid}
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid
         in.

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -41,8 +41,7 @@ def grdcontour(self, grid, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name of the input grid or the grid loaded as a DataArray.
+    {grid}
     interval : str or int
         Specify the contour lines to generate.
 

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -46,8 +46,7 @@ def grdcut(grid, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name of the input grid or the grid loaded as a DataArray.
+    {grid}
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid
         in.

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -40,8 +40,7 @@ def grdfill(grid, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name of the input grid or the grid loaded as a DataArray.
+    {grid}
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid
         in.

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -48,9 +48,7 @@ def grdfilter(grid, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name of the input grid or the grid loaded as a
-        :class:`xarray.DataArray`.
+    {grid}
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid
         in.

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -45,8 +45,7 @@ def grdgradient(grid, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name of the input grid or the grid loaded as a DataArray.
+    {grid}
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid
         in.

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -75,8 +75,7 @@ class grdhisteq:
 
         Parameters
         ----------
-        grid : str or xarray.DataArray
-            The file name of the input grid or the grid loaded as a DataArray.
+        {grid}
         outgrid : str or bool or None
             The name of the output netCDF file with extension .nc to store the
             grid in.
@@ -162,8 +161,7 @@ class grdhisteq:
 
         Parameters
         ----------
-        grid : str or xarray.DataArray
-            The file name of the input grid or the grid loaded as a DataArray.
+        {grid}
         outgrid : str or None
             The name of the output netCDF file with extension .nc to store the
             grid in.
@@ -262,8 +260,7 @@ class grdhisteq:
 
         Parameters
         ----------
-        grid : str or xarray.DataArray
-            The file name of the input grid or the grid loaded as a DataArray.
+        {grid}
         outfile : str or bool or None
             The name of the output ASCII file to store the results of the
             histogram equalization in.

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -75,10 +75,7 @@ def grdimage(self, grid, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name or a DataArray containing the input 2-D gridded data
-        set or image to be plotted (See GRID FILE FORMATS at
-        :gmt-docs:`grdimage.html#grid-file-formats`).
+    {grid}
     img_out : str
         *out_img*\[=\ *driver*].
         Save an image in a raster format instead of PostScript. Append

--- a/pygmt/src/grdinfo.py
+++ b/pygmt/src/grdinfo.py
@@ -37,9 +37,7 @@ def grdinfo(grid, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name of the input grid or the grid loaded as a DataArray.
-        This is the only required parameter.
+    {grid}
     {region}
     per_column : str or bool
         **n**\|\ **t**.

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -56,8 +56,7 @@ def grdproject(grid, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name of the input grid or the grid loaded as a DataArray.
+    {grid}
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid
         in.

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -51,8 +51,7 @@ def grdsample(grid, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name of the input grid or the grid loaded as a DataArray.
+    {grid}
     outgrid : str or None
         The name of the output netCDF file with extension .nc to store the grid
         in.

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -67,9 +67,7 @@ def grdtrack(grid, points=None, newcolname=None, outfile=None, **kwargs):
 
     Parameters
     ----------
-    grid : xarray.DataArray or str
-        Gridded array from which to sample values from, or a file name (netCDF
-        format).
+    {grid}
 
     points : str, {table-like}
         Pass in either a file name to an ASCII data table, a 2-D

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -47,9 +47,7 @@ def grdview(self, grid, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name of the input relief grid or the grid loaded as a
-        DataArray.
+    {grid}
     region : str or list
         *xmin/xmax/ymin/ymax*\ [**+r**][**+u**\ *unit*].
         Specify the :doc:`region </tutorials/basics/regions>` of interest.

--- a/pygmt/src/grdvolume.py
+++ b/pygmt/src/grdvolume.py
@@ -39,8 +39,7 @@ def grdvolume(grid, output_type="pandas", outfile=None, **kwargs):
 
     Parameters
     ----------
-    grid : str or xarray.DataArray
-        The file name of the input grid or the grid loaded as a DataArray.
+    {grid}
     output_type : str
         Determine the format the output data will be returned in [Default is
         ``pandas``]:


### PR DESCRIPTION
**Description of proposed changes**

First PR to address #2695.

This PR adds the `grid` placeholder to `COMMON_DOCSTRINGS` so that the `grid` docstring can be consistently used in many modules.

**Preview**: https://pygmt-dev--2861.org.readthedocs.build/en/2861/api/generated/pygmt.grdcut.html#pygmt.grdcut

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
