### PR TITLE
pyarrow: Check compatibility of pyarrow array objects with numeric and timestamp dtypes

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -71,7 +71,7 @@ jobs:
             optional-packages: ''
           - python-version: '3.12'
             numpy-version: '1.26'
-            optional-packages: ' contextily geopandas ipython rioxarray sphinx-gallery'
+            optional-packages: ' contextily geopandas ipython pyarrow rioxarray sphinx-gallery'
 
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
**Description of proposed changes**

Check that [`pyarrow.array`](https://arrow.apache.org/docs/13.0/python/generated/pyarrow.array.html) objects of various types can be passed to PyGMT modules/functions.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

TODO:
- [ ] Initial compatibility check by adding parametrized tests to `pygmt.info`
- [ ] Add `pyarrow.array` to unit tests that already have the `@pytest.mark.parametrize("array_func", ...)`
- [ ] Document that `pyarrow.array` objects can be used in place of `numpy.array`
- [ ] etc

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses https://github.com/GenericMappingTools/pygmt/issues/2800#issuecomment-1844400954, part of #2800.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
