### PR TITLE
TYP: Add type hints for the 'registration' parameter in pygmt.datasets.load_* functions

### DIFF
--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -4,6 +4,8 @@ server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
+from typing import Literal
+
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
 from pygmt.helpers import kwargs_to_strings
 
@@ -11,7 +13,11 @@ __doctest_skip__ = ["load_earth_age"]
 
 
 @kwargs_to_strings(region="sequence")
-def load_earth_age(resolution="01d", region=None, registration=None):
+def load_earth_age(
+    resolution="01d",
+    region=None,
+    registration: Literal["gridline", "pixel"] = "gridline",
+):
     r"""
     Load the Earth seafloor crustal age dataset in various resolutions.
 
@@ -56,9 +62,9 @@ def load_earth_age(resolution="01d", region=None, registration=None):
         Required for grids with resolutions higher than 5
         arc-minutes (i.e., ``"05m"``).
 
-    registration : str
+    registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
-        ``"gridline"`` for gridline registration. Default is ``"gridline"``.
+        ``"gridline"`` for gridline registration.
 
     Returns
     -------

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -4,6 +4,8 @@ server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
+from typing import Literal
+
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
 from pygmt.helpers import kwargs_to_strings
 
@@ -11,7 +13,11 @@ __doctest_skip__ = ["load_earth_free_air_anomaly"]
 
 
 @kwargs_to_strings(region="sequence")
-def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None):
+def load_earth_free_air_anomaly(
+    resolution="01d",
+    region=None,
+    registration: Literal["gridline", "pixel", None] = None,
+):
     r"""
     Load the IGPP Earth Free-Air Anomaly dataset in various resolutions.
 
@@ -56,10 +62,11 @@ def load_earth_free_air_anomaly(resolution="01d", region=None, registration=None
         Required for grids with resolutions higher than 5
         arc-minutes (i.e., ``"05m"``).
 
-    registration : str
+    registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
-        ``"gridline"`` for gridline registration. Default is ``"gridline"``
-        for all resolutions except ``"01m"`` which is ``"pixel"`` only.
+        ``"gridline"`` for gridline registration. Default is ``None``, means
+        ``"gridline"`` for all resolutions except ``"01m"`` which is
+        ``"pixel"`` only.
 
     Returns
     -------

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -4,6 +4,8 @@ and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
+from typing import Literal
+
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
 from pygmt.helpers import kwargs_to_strings
 
@@ -11,7 +13,11 @@ __doctest_skip__ = ["load_earth_geoid"]
 
 
 @kwargs_to_strings(region="sequence")
-def load_earth_geoid(resolution="01d", region=None, registration=None):
+def load_earth_geoid(
+    resolution="01d",
+    region=None,
+    registration: Literal["gridline", "pixel"] = "gridline",
+):
     r"""
     Load the EGM2008 Earth Geoid dataset in various resolutions.
 
@@ -49,9 +55,9 @@ def load_earth_geoid(resolution="01d", region=None, registration=None):
         Required for grids with resolutions higher than 5
         arc-minutes (i.e., ``"05m"``).
 
-    registration : str
+    registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
-        ``"gridline"`` for gridline registration. Default is ``"gridline"``.
+        ``"gridline"`` for gridline registration.
 
     Returns
     -------

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -17,7 +17,7 @@ __doctest_skip__ = ["load_earth_magnetic_anomaly"]
 def load_earth_magnetic_anomaly(
     resolution="01d",
     region=None,
-    registration=None,
+    registration: Literal["gridline", "pixel", None] = None,
     data_source: Literal["emag2", "emag2_4km", "wdmam"] = "emag2",
 ):
     r"""
@@ -76,11 +76,12 @@ def load_earth_magnetic_anomaly(
         Required for grids with resolutions higher than 5
         arc-minutes (i.e., ``"05m"``).
 
-    registration : str
+    registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
-        ``"gridline"`` for gridline registration. Default is ``"gridline"``
-        for all resolutions except ``"02m"`` for ``data_source="emag2"`` or
-        ``data_source="emag2_4km"``, which are ``"pixel"`` only.
+        ``"gridline"`` for gridline registration. Default is ``None``, means
+        ``"gridline"`` for all resolutions except ``"02m"`` for
+        ``data_source="emag2"`` or ``data_source="emag2_4km"``, which are
+        ``"pixel"`` only.
 
     data_source
         Select the source of the magnetic anomaly data. Available options are:

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -4,6 +4,8 @@ load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
+from typing import Literal
+
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
 from pygmt.helpers import kwargs_to_strings
 
@@ -11,7 +13,11 @@ __doctest_skip__ = ["load_earth_mask"]
 
 
 @kwargs_to_strings(region="sequence")
-def load_earth_mask(resolution="01d", region=None, registration=None):
+def load_earth_mask(
+    resolution="01d",
+    region=None,
+    registration: Literal["gridline", "pixel"] = "gridline",
+):
     r"""
     Load the GSHHG Earth Mask dataset in various resolutions.
 
@@ -47,9 +53,9 @@ def load_earth_mask(resolution="01d", region=None, registration=None):
         The subregion of the grid to load, in the form of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
 
-    registration : str
+    registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
-        ``"gridline"`` for gridline registration. Default is ``"gridline"``.
+        ``"gridline"`` for gridline registration.
 
     Returns
     -------

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -17,7 +17,7 @@ __doctest_skip__ = ["load_earth_relief"]
 def load_earth_relief(
     resolution="01d",
     region=None,
-    registration=None,
+    registration: Literal["gridline", "pixel", None] = None,
     data_source: Literal["igpp", "gebco", "gebcosi", "synbath"] = "igpp",
     use_srtm=False,
 ):
@@ -71,10 +71,11 @@ def load_earth_relief(
         Required for Earth relief grids with resolutions higher than 5
         arc-minutes (i.e., ``"05m"``).
 
-    registration : str
+    registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
-        ``"gridline"`` for gridline registration. Default is ``"gridline"``
-        for all resolutions except ``"15s"`` which is ``"pixel"`` only.
+        ``"gridline"`` for gridline registration. Default is ``None``, means
+        ``"gridline"`` for all resolutions except ``"15s"`` which is
+        ``"pixel"`` only.
 
     data_source
         Select the source for the Earth relief data. Available options are:

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -4,6 +4,8 @@ GMT data server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
+from typing import Literal
+
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
 from pygmt.helpers import kwargs_to_strings
 
@@ -12,7 +14,9 @@ __doctest_skip__ = ["load_earth_vertical_gravity_gradient"]
 
 @kwargs_to_strings(region="sequence")
 def load_earth_vertical_gravity_gradient(
-    resolution="01d", region=None, registration=None
+    resolution="01d",
+    region=None,
+    registration: Literal["gridline", "pixel", None] = None,
 ):
     r"""
     Load the IGPP Earth Vertical Gravity Gradient dataset in various
@@ -59,10 +63,11 @@ def load_earth_vertical_gravity_gradient(
         Required for grids with resolutions higher than 5
         arc-minutes (i.e., ``"05m"``).
 
-    registration : str
+    registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
-        ``"gridline"`` for gridline registration. Default is ``"gridline"``
-        for all resolutions except ``"01m"`` which is ``"pixel"`` only.
+        ``"gridline"`` for gridline registration. Default is ``None``, means
+        ``"gridline"`` for all resolutions except ``"01m"`` which is
+        ``"pixel"`` only.
 
     Returns
     -------


### PR DESCRIPTION
**Description of proposed changes**

Address #2812.

**Preview**: https://pygmt-dev--2867.org.readthedocs.build/en/2867/api/index.html#datasets

Changing `registration=None` to either
```
registration: Literal["gridline", "pixel", None] = None,
```
or 
```
registration: Literal["gridline", "pixel"] = "gridline",
```
For datasets like `earth_age`, `earth_geoid` and `earth_mask`, the `gridline`-registrated version exists for all resolutions, thus the default registration should always be `gridline`, rather than `None`.