### PR TITLE
Add a 'Common installation issues' section to the install guides

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -248,9 +248,14 @@ following in your Python interpreter::
 
 If you see a global map with shorelines, then you're all set.
 
+Common installation issues
+--------------------------
 
-Finding the GMT shared library
-------------------------------
+If you have any issues with the installation, please check the following
+common problems and solutions.
+
+"Error loading GMT shared library at ..."
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Sometimes, PyGMT will be unable to find the correct version of the GMT shared
 library (``libgmt``).
@@ -272,8 +277,8 @@ and set its value to a path like::
 
     C:\Users\USERNAME\Miniforge3\envs\pygmt\Library\bin\
 
-Notes for Jupyter users
------------------------
+``ModuleNotFoundError`` in Jupyter notebook environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you can successfully import pygmt in a Python interpreter or IPython, but
 get a ``ModuleNotFoundError`` when importing pygmt in Jupyter, you may need to

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -251,7 +251,7 @@ If you see a global map with shorelines, then you're all set.
 Common installation issues
 --------------------------
 
-If you have any issues with the installation, please check the following
+If you have any issues with the installation, please check out the following
 common problems and solutions.
 
 "Error loading GMT shared library at ..."


### PR DESCRIPTION
Add "Common installation issues" section and move the current "Finding the GMT shared library" and "Notes for Jupyter users" sections to this new section. 

This is just my personal preferences, so open to comments and suggestions.

**Preview**: https://pygmt-dev--2868.org.readthedocs.build/en/2868/install.html#common-installation-issues