### PR TITLE
RUF005: Use the unpacking operator to concatenate collections

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -482,8 +482,8 @@ def _insert_alias(module_func, default_value=None):
             new_param = Parameter(
                 alias, kind=Parameter.KEYWORD_ONLY, default=default_value
             )
-            wrapped_params = wrapped_params + [new_param]
-    all_params = wrapped_params + [kwargs_param]
+            wrapped_params = [*wrapped_params, new_param]
+    all_params = [*wrapped_params, kwargs_param]
     # Update method signature
     sig_new = sig.replace(parameters=all_params)
     module_func.__signature__ = sig_new

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -429,7 +429,7 @@ def build_arg_string(kwdict, confdict=None, infile=None, outfile=None):
         gmt_args.extend(f'--{key}="{value}"' for key, value in confdict.items())
 
     if infile:
-        gmt_args = [str(infile)] + gmt_args
+        gmt_args = [str(infile), *gmt_args]
     if outfile:
         gmt_args.append("->" + str(outfile))
     return non_ascii_to_octal(" ".join(gmt_args))

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -310,7 +310,7 @@ def grdtrack(grid, points=None, newcolname=None, outfile=None, **kwargs):
         # Read temporary csv output to a pandas table
         if outfile == tmpfile.name:  # if user did not set outfile, return pd.DataFrame
             try:
-                column_names = points.columns.to_list() + [newcolname]
+                column_names = [*points.columns.to_list(), newcolname]
                 result = pd.read_csv(tmpfile.name, sep="\t", names=column_names)
             except AttributeError:  # 'str' object has no attribute 'columns'
                 result = pd.read_csv(tmpfile.name, sep="\t", header=None, comment=">")

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -429,7 +429,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
 
         # Convert array to pd.DataFrame and assign column names
         spec = pd.DataFrame(np.atleast_2d(spec))
-        colnames = ["longitude", "latitude", "depth"] + convention_params(convention)
+        colnames = ["longitude", "latitude", "depth", *convention_params(convention)]
         # check if spec has the expected number of columns
         ncolsdiff = len(spec.columns) - len(colnames)
         if ncolsdiff == 0:
@@ -472,7 +472,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
         # expected columns are:
         # longitude, latitude, depth, focal_parameters,
         #   [plot_longitude, plot_latitude] [event_name]
-        newcols = ["longitude", "latitude", "depth"] + convention_params(convention)
+        newcols = ["longitude", "latitude", "depth", *convention_params(convention)]
         if "plot_longitude" in spec.columns and "plot_latitude" in spec.columns:
             newcols += ["plot_longitude", "plot_latitude"]
             if kwargs.get("A") is None:

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -261,7 +261,7 @@ def test_clib_full_names_gmt_library_path_defined_path_empty(
         lib_fullpaths = clib_full_names()
 
         assert isinstance(lib_fullpaths, types.GeneratorType)
-        assert list(lib_fullpaths) == [gmt_lib_realpath] + gmt_lib_names
+        assert list(lib_fullpaths) == [gmt_lib_realpath, *gmt_lib_names]
 
 
 def test_clib_full_names_gmt_library_path_undefined_path_included(


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes some errors reported by ruff's RUF005 rule. See https://docs.astral.sh/ruff/rules/collection-literal-concatenation/ for the explanations about RUF005.

The changes in this PR are made by running the following command:
```
ruff check pygmt examples --extend-select=RUF005 --unsafe-fixes --fix
```