### PR TITLE
Enable the PDF format documentation in the ReadTheDocs site

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,8 +18,8 @@ sphinx:
    configuration: doc/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
-# formats:
-#    - pdf
+formats:
+   - pdf
 
 # Optionally declare the Python requirements required to build your docs
 conda:


### PR DESCRIPTION
**Description of proposed changes**

This PR enables the PDF documentation in the ReadTheDocs builds. This is the initial and simple effort to address the request in #1606.

After merging the changes into the main branch (PDFs are disabled in PR previews), we will see a PDF download link at the bottom of the sidebar on the ReadTheDocs site (https://pygmt-dev.readthedocs.io/), as shown below:

<img width="281" alt="image" src="https://github.com/GenericMappingTools/pygmt/assets/3974108/a288689d-f90e-4996-952d-4c28dc2ea0cb">

The screenshot above comes from the PyGMT documentation site built from my own PyGMT fork. The full URL of the site is https://pygmt-test.readthedocs.io/en/latest/, and the direct URL of PDF file is https://pygmt-test.readthedocs.io/_/downloads/en/latest/pdf/.

As you can see, the layout of the PDF documentation is not ideal, but at least it includes everything, and is still useful for offline use.

If approved and merged, I think we should post the link to the PDF documentation in issue #1606 so that users can easily find the PDF file.