### PR TITLE
Enable ruff's pep8-naming (N) rules

### DIFF
--- a/pygmt/exceptions.py
+++ b/pygmt/exceptions.py
@@ -35,7 +35,7 @@ class GMTCLibNoSessionError(GMTCLibError):
     """
 
 
-class GMTInvalidInput(GMTError):
+class GMTInvalidInput(GMTError):  # noqa: N818
     """
     Raised when the input of a function/method is invalid.
     """
@@ -47,7 +47,7 @@ class GMTVersionError(GMTError):
     """
 
 
-class GMTImageComparisonFailure(AssertionError):
+class GMTImageComparisonFailure(AssertionError):  # noqa: N818
     """
     Raised when a comparison between two images fails.
     """

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -73,8 +73,8 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
     ...
     >>> shutil.rmtree(path="tmp_result_images")  # cleanup folder if tests pass
     """
-    ALLOWED_CHARS = set(string.digits + string.ascii_letters + "_-[]()")
-    KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
+    allowed_chars = set(string.digits + string.ascii_letters + "_-[]()")
+    keyword_only = inspect.Parameter.KEYWORD_ONLY
 
     def decorator(func):
         import pytest
@@ -90,7 +90,7 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
             if "request" in old_sig.parameters:
                 kwargs["request"] = request
             try:
-                file_name = "".join(c for c in request.node.name if c in ALLOWED_CHARS)
+                file_name = "".join(c for c in request.node.name if c in allowed_chars)
             except AttributeError:  # 'NoneType' object has no attribute 'node'
                 file_name = func.__name__
             try:
@@ -129,9 +129,9 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
             if param.name not in {"fig_test", "fig_ref"}
         ]
         if "ext" not in old_sig.parameters:
-            parameters += [inspect.Parameter("ext", KEYWORD_ONLY)]
+            parameters += [inspect.Parameter("ext", keyword_only)]
         if "request" not in old_sig.parameters:
-            parameters += [inspect.Parameter("request", KEYWORD_ONLY)]
+            parameters += [inspect.Parameter("request", keyword_only)]
         new_sig = old_sig.replace(parameters=parameters)
         wrapper.__signature__ = new_sig
 

--- a/pygmt/src/config.py
+++ b/pygmt/src/config.py
@@ -6,7 +6,7 @@ from inspect import Parameter, Signature
 from pygmt.clib import Session
 
 
-class config:
+class config:  # noqa: N801
     """
     Set GMT defaults globally or locally.
 

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -19,7 +19,7 @@ from pygmt.io import load_dataarray
 __doctest_skip__ = ["grdhisteq.*"]
 
 
-class grdhisteq:
+class grdhisteq:  # noqa: N801
     r"""
     Perform histogram equalization for a grid.
 

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -17,7 +17,7 @@ from pygmt.helpers import (
 from pygmt.io import load_dataarray
 
 
-class triangulate:
+class triangulate:  # noqa: N801
     """
     Delaunay triangulation or Voronoi partitioning and gridding of Cartesian
     data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ select = [
     "I",    # isort
     "ICN",  # flake8-import-conventions
     "ISC",  # flake8-implicit-str-concat
+    "N",    # flake8-naming
     "NPY",  # numpy
     "PD",   # pandas-vet
     "PGH",  # pygrep-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ select = [
     "I",    # isort
     "ICN",  # flake8-import-conventions
     "ISC",  # flake8-implicit-str-concat
-    "N",    # flake8-naming
+    "N",    # pep8-naming
     "NPY",  # numpy
     "PD",   # pandas-vet
     "PGH",  # pygrep-hooks


### PR DESCRIPTION
**Description of proposed changes**
Enable [pep8-naming](https://docs.astral.sh/ruff/rules/#pep8-naming-n) rules to make sure that function/class/variable names follow the PEP8 conventions. This PR fixes the following errors.
```
ruff check pygmt examples --extend-select=N
pygmt/exceptions.py:38:7: N818 Exception name `GMTInvalidInput` should be named with an Error suffix
   |
38 | class GMTInvalidInput(GMTError):
   |       ^^^^^^^^^^^^^^^ N818
39 |     """
40 |     Raised when the input of a function/method is invalid.
   |

pygmt/exceptions.py:50:7: N818 Exception name `GMTImageComparisonFailure` should be named with an Error suffix
   |
50 | class GMTImageComparisonFailure(AssertionError):
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^ N818
51 |     """
52 |     Raised when a comparison between two images fails.
   |

pygmt/helpers/testing.py:76:5: N806 Variable `ALLOWED_CHARS` in function should be lowercase
   |
74 |     >>> shutil.rmtree(path="tmp_result_images")  # cleanup folder if tests pass
75 |     """
76 |     ALLOWED_CHARS = set(string.digits + string.ascii_letters + "_-[]()")
   |     ^^^^^^^^^^^^^ N806
77 |     KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
   |

pygmt/helpers/testing.py:77:5: N806 Variable `KEYWORD_ONLY` in function should be lowercase
   |
75 |     """
76 |     ALLOWED_CHARS = set(string.digits + string.ascii_letters + "_-[]()")
77 |     KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
   |     ^^^^^^^^^^^^ N806
78 | 
79 |     def decorator(func):
   |

pygmt/src/config.py:9:7: N801 Class name `config` should use CapWords convention 
   |
 9 | class config:
   |       ^^^^^^ N801
10 |     """
11 |     Set GMT defaults globally or locally.
   |

pygmt/src/grdhisteq.py:22:7: N801 Class name `grdhisteq` should use CapWords convention 
   |
22 | class grdhisteq:
   |       ^^^^^^^^^ N801
23 |     r"""
24 |     Perform histogram equalization for a grid.
   |

pygmt/src/triangulate.py:20:7: N801 Class name `triangulate` should use CapWords convention 
   |
20 | class triangulate:
   |       ^^^^^^^^^^^ N801
21 |     """
22 |     Delaunay triangulation or Voronoi partitioning and gridding of Cartesian
   |

Found 7 errors.

```