### PR TITLE
Enable ruff's BLE/ICN/PGH/RSE/TCH/TID/YTT rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,19 +100,25 @@ line-ending = "lf"  # Use UNIX `\n` line endings for all files
 [tool.ruff.lint]
 select = [
     "B",    # flake8-bugbear
+    "BLE",  # flake8-blind-except
     "E",    # pycodestyle
     "F",    # pyflakes
     "FA",   # flake8-future-annotations
     "FLY",  # flynt
     "I",    # isort
+    "ICN",  # flake8-import-conventions
     "ISC",  # flake8-implicit-str-concat
     "NPY",  # numpy
     "PD",   # pandas-vet
+    "PGH",  # pygrep-hooks
     "PIE",  # flake8-pie
     "PL",   # pylint
+    "RSE",  # flake8-raise
     "SIM",  # flake8-simplify
+    "TID",  # flake8-tidy-imports
     "UP",   # pyupgrade
     "W",    # pycodestyle warnings
+    "YTT",  # flake8-2020
 ]
 ignore = [
     "E501", # Avoid enforcing line-length violations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ select = [
     "PL",   # pylint
     "RSE",  # flake8-raise
     "SIM",  # flake8-simplify
+    "TCH",  # flake8-type-checking
     "TID",  # flake8-tidy-imports
     "UP",   # pyupgrade
     "W",    # pycodestyle warnings


### PR DESCRIPTION
These rules all make sense to our project and there are no violations, so this PR enables them all:
- [BLE](https://docs.astral.sh/ruff/rules/#flake8-blind-except-ble): flake8-blind-except
- [ICN](https://docs.astral.sh/ruff/rules/#flake8-import-conventions-icn): flake8-import-conventions
- [PGH](https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh): pygrep-hooks
- [RSE](https://docs.astral.sh/ruff/rules/#flake8-raise-rse): flake8-raise
- [TCH](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch): flake8-type-checking
- [TID](https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid): flake8-tidy-imports
- [YTT](https://docs.astral.sh/ruff/rules/#flake8-2020-ytt): flake8-2020