### PR TITLE
Refactor the _get_ghostscript_version function to avoid try-except in loops

### DIFF
--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -107,6 +107,7 @@ def show_versions(file=sys.stdout):
 
     import importlib
     import platform
+    import shutil
     import subprocess
 
     from packaging.requirements import Requirement
@@ -141,12 +142,10 @@ def show_versions(file=sys.stdout):
             return None
 
         for gs_cmd in cmds:
-            try:
+            if (gsfullpath := shutil.which(gs_cmd)) is not None:
                 return subprocess.check_output(
-                    [gs_cmd, "--version"], universal_newlines=True
+                    [gsfullpath, "--version"], universal_newlines=True
                 ).strip()
-            except FileNotFoundError:
-                continue
         return None
 
     sys_info = {


### PR DESCRIPTION
**Description of proposed changes**

Rule [PERF203](https://docs.astral.sh/ruff/rules/try-except-in-loop/) says:

> Exception handling via try-except blocks incurs some performance overhead, regardless of whether an exception is raised.
> 
> When possible, refactor your code to put the entire loop into the try-except block, rather than wrapping each iteration in a separate try-except block.
> 
> This rule is only enforced for Python versions prior to 3.11, which introduced "zero cost" exception handling.
> 
> Note that, as with all perflint rules, this is only intended as a micro-optimization, and will have a negligible impact on performance in most cases.

```
$ ruff check pygmt doc/conf.py examples --extend-select=PERF
pygmt/__init__.py:148:13: PERF203 `try`-`except` within a loop incurs performance overhead
    |
146 |                       [gs_cmd, "--version"], universal_newlines=True
147 |                   ).strip()
148 |               except FileNotFoundError:
    |  _____________^
149 | |                 continue
    | |________________________^ PERF203
150 |           return None

```
Instead of using `try`-`except` in a for loop, we can check if the gs command exists using `shutil.which` method.