### PR TITLE
Refactor the kwargs_to_strings decorator to avoid try-except in loops

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -757,15 +757,12 @@ def kwargs_to_strings(**conversions):
                 else:
                     continue
 
-                issequence = fmt in separators
-                if issequence and is_nonstr_iter(value):
+                if fmt in separators and is_nonstr_iter(value):
                     for index, item in enumerate(value):
-                        try:
+                        if " " in str(item):
                             # Check if there is a space " " when converting
                             # a pandas.Timestamp/xr.DataArray to a string.
                             # If so, use np.datetime_as_string instead.
-                            assert " " not in str(item)
-                        except AssertionError:
                             # Convert datetime-like item to ISO 8601
                             # string format like YYYY-MM-DDThh:mm:ss.ffffff.
                             value[index] = np.datetime_as_string(


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
