### PR TITLE
Enable ruff's perflint (PERF) rules

### DIFF
--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -85,10 +85,9 @@ def print_clib_info(file=sys.stdout):
     """
     from pygmt.clib import Session
 
-    lines = ["GMT library information:"]
+    print("GMT library information:", file=file)
     with Session() as ses:
-        for key in sorted(ses.info):
-            lines.append(f"  {key}: {ses.info[key]}")
+        lines = [f"  {key}: {ses.info[key]}" for key in sorted(ses.info)]
     print("\n".join(lines), file=file)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ select = [
     "N",    # pep8-naming
     "NPY",  # numpy
     "PD",   # pandas-vet
+    "PERF", # perflint
     "PGH",  # pygrep-hooks
     "PIE",  # flake8-pie
     "PL",   # pylint


### PR DESCRIPTION
**Description of proposed changes**

Enable ruff's [perflint (PERF)](https://docs.astral.sh/ruff/rules/#perflint-perf) rules and also fix a violation.

```
pygmt/__init__.py:91:13: PERF401 Use a list comprehension to create a transformed list
   |
89 |     with Session() as ses:
90 |         for key in sorted(ses.info):
91 |             lines.append(f"  {key}: {ses.info[key]}")
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PERF401
92 |     print("\n".join(lines), file=file)
```

Address #2741.