### PR TITLE
ruff: Fix violations of ruff's S607 rule

### DIFF
--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -6,6 +6,7 @@ through the GMT_LIBRARY_PATH environment variable.
 """
 import ctypes
 import os
+import shutil
 import subprocess as sp
 import sys
 from ctypes.util import find_library
@@ -117,17 +118,17 @@ def clib_full_names(env=None):
 
     # 2. Search for the library returned by command "gmt --show-library"
     #    Use `str(Path(realpath))` to avoid mixture of separators "\\" and "/"
-    try:
-        libfullpath = Path(
-            sp.check_output(["gmt", "--show-library"], encoding="utf-8").rstrip("\n")
-        )
-        if libfullpath.exists():
-            yield str(libfullpath)
-    except (FileNotFoundError, sp.CalledProcessError):
-        # the 'gmt' executable  is not found
-        # the gmt library is not found
-        # the 'gmt' executable is broken
-        pass
+    if (gmtbin := shutil.which("gmt")) is not None:
+        try:
+            libfullpath = Path(
+                sp.check_output([gmtbin, "--show-library"], encoding="utf-8").rstrip(
+                    "\n"
+                )
+            )
+            if libfullpath.exists():
+                yield str(libfullpath)
+        except sp.CalledProcessError:  # the 'gmt' executable is broken
+            pass
 
     # 3. Search for DLLs in PATH by calling find_library() (Windows only)
     if sys.platform == "win32":

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -494,10 +494,12 @@ def launch_external_viewer(fname, waiting=0):
     # Open the file with the default viewer.
     # Fall back to the browser if can't recognize the operating system.
     os_name = sys.platform
-    if os_name.startswith(("linux", "freebsd")) and shutil.which("xdg-open"):
-        subprocess.run(["xdg-open", fname], check=False, **run_args)
+    if os_name.startswith(("linux", "freebsd")) and (
+        xdgopen := shutil.which("xdg-open")
+    ):
+        subprocess.run([xdgopen, fname], check=False, **run_args)
     elif os_name == "darwin":  # Darwin is macOS
-        subprocess.run(["open", fname], check=False, **run_args)
+        subprocess.run([shutil.which("open"), fname], check=False, **run_args)
     elif os_name == "win32":
         os.startfile(fname)
     else:

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -224,7 +224,7 @@ def fixture_gmt_lib_realpath():
     Return the real path of the GMT library.
     """
     lib_realpath = subprocess.check_output(
-        ["gmt", "--show-library"], encoding="utf-8"
+        [shutil.which("gmt"), "--show-library"], encoding="utf-8"
     ).rstrip("\n")
     # On Windows, clib_full_names() returns paths with separator "\\",
     # but "gmt --show-library" returns paths with separator "/".


### PR DESCRIPTION
**Description of proposed changes**

ruff's [S607](https://docs.astral.sh/ruff/rules/start-process-with-partial-path/) rule prefers to use full path to the command when calling `subprocess.check_output`/`subprocess.run`.

This PR fixes some violations in our codes.

Will enable the `S` ruleset in a follow-up PR.