### PR TITLE
Figure.timestamp: Improve an existing test to check floating-point offset

### DIFF
--- a/pygmt/tests/baseline/test_timestamp_offset.png.dvc
+++ b/pygmt/tests/baseline/test_timestamp_offset.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: be0021731b881e32e3d8a46d6fa8abc3
-  size: 9450
+- md5: e80c5fe3218841aea80de48851b947ea
+  size: 12020
   path: test_timestamp_offset.png
+  hash: md5

--- a/pygmt/tests/baseline/test_timestamp_offset.png.dvc
+++ b/pygmt/tests/baseline/test_timestamp_offset.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: e80c5fe3218841aea80de48851b947ea
-  size: 12020
+- md5: c9274f7984b0c3f7228dd758d45d93b6
+  size: 12286
   path: test_timestamp_offset.png
   hash: md5

--- a/pygmt/tests/test_timestamp.py
+++ b/pygmt/tests/test_timestamp.py
@@ -56,7 +56,7 @@ def test_timestamp_offset():
     """
     fig = Figure()
     fig.basemap(projection="X10c/5c", region=[0, 10, 0, 5], frame="g1")
-    for offset in ["1c", "1c/2c", ("1c", "3c")]:
+    for offset in ["1c", "1c/2c", ("1c", "3c"), 4, (4, 1)]:
         fig.timestamp(offset=offset, timefmt=f"offset={offset}")
     return fig
 


### PR DESCRIPTION
**Description of proposed changes**

Modify an existing test to make sure that arguments like `offset=4`, `offset=(4, 1)` work as expected.