### PR TITLE
Move pytest import inside of skip_if_no function

### DIFF
--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -6,7 +6,6 @@ import inspect
 import os
 import string
 
-import pytest
 from pygmt.exceptions import GMTImageComparisonFailure
 from pygmt.io import load_dataarray
 from pygmt.src import which
@@ -272,6 +271,8 @@ def skip_if_no(package):
         A pytest.mark.skipif to use as either a test decorator or a
         parametrization mark.
     """
+    import pytest
+
     try:
         _ = importlib.import_module(name=package)
         has_package = True


### PR DESCRIPTION
**Description of proposed changes**

To fix the `ModuleNotFoundError: No module named 'pytest'` error in the cache_data.yaml GitHub Action that was failing at https://github.com/GenericMappingTools/pygmt/actions/runs/7238500260/job/19719382772#step:5:13

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Patches #2883.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
