### PR TITLE
Enable ruff's flake8-print (T20) rules

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -381,7 +381,7 @@ class Session:
             self._error_log.append(message)
             # flush to make sure the messages are printed even if we have a
             # crash.
-            print(message, file=sys.stderr, flush=True)
+            print(message, file=sys.stderr, flush=True)  # noqa: T201
             return 0
 
         # Need to store a copy of the function because ctypes doesn't and it

--- a/pygmt/tests/test_clib_virtualfiles.py
+++ b/pygmt/tests/test_clib_virtualfiles.py
@@ -80,7 +80,7 @@ def test_virtual_file_fails():
     with clib.Session() as lib, mock(lib, "GMT_Open_VirtualFile", returns=1):
         with pytest.raises(GMTCLibError):
             with lib.open_virtual_file(*vfargs):
-                print("Should not get to this code")
+                pass
 
     # Test the status check when closing the virtual file
     # Mock the opening to return 0 (success) so that we don't open a file that
@@ -91,7 +91,6 @@ def test_virtual_file_fails():
         with pytest.raises(GMTCLibError):
             with lib.open_virtual_file(*vfargs):
                 pass
-            print("Shouldn't get to this code either")
 
 
 def test_virtual_file_bad_direction():
@@ -107,7 +106,7 @@ def test_virtual_file_bad_direction():
         )
         with pytest.raises(GMTInvalidInput):
             with lib.open_virtual_file(*vfargs):
-                print("This should have failed")
+                pass
 
 
 @pytest.mark.parametrize(
@@ -280,7 +279,7 @@ def test_virtualfile_from_vectors_diff_size():
     with clib.Session() as lib:
         with pytest.raises(GMTInvalidInput):
             with lib.virtualfile_from_vectors(x, y):
-                print("This should have failed")
+                pass
 
 
 def test_virtualfile_from_matrix(dtypes):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ select = [
     "RSE",  # flake8-raise
     "S",    # flake8-bandit
     "SIM",  # flake8-simplify
+    "T20",  # flake8-print
     "TCH",  # flake8-type-checking
     "TID",  # flake8-tidy-imports
     "UP",   # pyupgrade
@@ -141,6 +142,7 @@ known-third-party = ["pygmt"]
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Ignore `F401` (unused-import) in all `__init__.py` files
 "*/tests/test_*.py" = ["S101"]  # Ignore `S101` (use of assert) in all tests files
+"examples/**/*.py" = ["T201"]  # Allow `print` in examples
 
 [tool.ruff.lint.pycodestyle]
 max-doc-length = 79


### PR DESCRIPTION
Changes:

- Enable ruff's [flake8-print (T20)](https://docs.astral.sh/ruff/rules/#flake8-print-t20) rules. 
- Fix a few violations
- Ignore the rules in all examples