### PR TITLE
POC: Implement the general BaseParams class for any class-like parameters

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -206,6 +206,15 @@ Miscellaneous
     print_clib_info
     show_versions
 
+Common Parameters
+-----------------
+
+.. autosummary::
+    :toctree: generated
+
+    params.Box
+
+
 .. currentmodule:: pygmt
 
 Datasets

--- a/pygmt/params/__init__.py
+++ b/pygmt/params/__init__.py
@@ -1,0 +1,5 @@
+"""
+Classes for common parameters.
+"""
+
+from pygmt.params.box import Box

--- a/pygmt/params/base.py
+++ b/pygmt/params/base.py
@@ -1,0 +1,75 @@
+"""
+General class for PyGMT parameters.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from pygmt.helpers import is_nonstr_iter
+
+
+class Alias(NamedTuple):
+    """
+    Alias PyGMT long-form parameter to GMT single-letter option flag.
+    """
+
+    name: str
+    modifier: str
+    separator: str | None = None
+
+
+class BaseParams:
+    """
+    Base class for PyGMT parameters.
+
+    Examples
+    --------
+    >>> import dataclasses
+    >>> from pygmt.params.base import BaseParams
+    >>>
+    >>> @dataclasses.dataclass(repr=False)
+    ... class Test(BaseParams):
+    ...     attr1: Any = None
+    ...     attr2: Any = None
+    ...     attr3: Any = None
+    ...
+    ...     __aliases__ = [
+    ...         Alias("attr1", ""),
+    ...         Alias("attr2", "+a"),
+    ...         Alias("attr3", "+b", "/"),
+    ...     ]
+    >>> var = Test(attr1="val1")
+    >>> str(var)
+    'val1'
+    >>> repr(var)
+    "Test(attr1='val1')"
+    """
+
+    def __str__(self):
+        """
+        String representation of the object that can be passed to GMT directly.
+        """
+        values = []
+        for alias in self.__aliases__:
+            value = getattr(self, alias.name)
+            if value in (None, False):
+                continue
+            if value is True:
+                value = ""
+            elif is_nonstr_iter(value):
+                value = alias.separator.join(map(str, value))
+            values.append(f"{alias.modifier}{value}")
+        return "".join(values)
+
+    def __repr__(self):
+        """
+        String representation of the object.
+        """
+        string = []
+        for alias in self.__aliases__:
+            value = getattr(self, alias.name)
+            if value is None or value is False:
+                continue
+            string.append(f"{alias.name}={value!r}")
+        return f"{self.__class__.__name__}({', '.join(string)})"

--- a/pygmt/params/box.py
+++ b/pygmt/params/box.py
@@ -1,0 +1,45 @@
+"""
+Class for the box around GMT embellishments.
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import ClassVar
+
+from pygmt.params.base import Alias, BaseParams
+
+
+@dataclass(repr=False)
+class Box(BaseParams):
+    """
+    Class for the box around GMT embellishments.
+
+    Attributes
+    ----------
+    clearance
+        Set clearances between the embellishment and the box border. Can be either a
+        scalar value or a list of two/four values.
+
+        - a scalar value means a uniform clearance in all four directions.
+        - a list of two values means separate clearances in x- and y- directions.
+        - a list of four values means separate clearances for left/right/bottom/top.
+    fill
+        Fill for the box. None means no fill.
+
+    """
+
+    clearance: float | str | Sequence[float | str] | None = None
+    fill: str | None = None
+    innerborder: str | Sequence | None = None
+    pen: str | None = None
+    radius: float | bool | None = False
+    shading: str | Sequence | None = None
+
+    __aliases__: ClassVar = [
+        Alias("clearance", "+c", "/"),
+        Alias("fill", "+g"),
+        Alias("innerborder", "+i", "/"),
+        Alias("pen", "+p"),
+        Alias("radius", "+r"),
+        Alias("shading", "+s", "/"),
+    ]

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -4,6 +4,7 @@ logo - Plot the GMT logo
 
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
+from pygmt.params import Box
 
 
 @fmt_docstring
@@ -18,7 +19,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
-def logo(self, **kwargs):
+def logo(self, box: bool | Box = False, **kwargs):  # noqa: ARG001
     r"""
     Plot the GMT logo.
 
@@ -39,7 +40,7 @@ def logo(self, **kwargs):
         [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\
         **+w**\ *width*\ [**+j**\ *justify*]\ [**+o**\ *dx*\ [/*dy*]].
         Set reference point on the map for the image.
-    box : bool or str
+    box
         If set to ``True``, draw a rectangular border around the
         GMT logo.
     style : str


### PR DESCRIPTION
This PR contains some experimental codes towards the Pythonic interface discussed in #1082. Generally speaking, this PR implements the base class `BaseParams` and any parameters that expect a class-like argument can inherit from it (a similar work is done in PR #1239).

In this PR, a `Box` class is implemented showing how the `BaseParams` can be used. The `Box` class can be passed to the `box` parameter in multiple modules (`image`, `logo`, `basemap`, `coast`, `inset`, `legend` and `colorbar`). The full syntax of the `box` parameter is (https://docs.generic-mapping-tools.org/dev/image.html#f):
```
-F[+cclearances][+gfill][+i[[gap/]pen]][+p[pen]][+r[radius]][+s[[dx/dy/][shade]]]
```
Here is an example showing how the `Box` class can be used:
```python
import pygmt
from pygmt import params

fig = pygmt.Figure()
for i, box in enumerate(
    [
        params.Box(fill="red@20"),
        params.Box(clearance=(0.2, 0.2), fill="red@20", pen="blue"),
        params.Box(clearance=(0.2, 0.2), pen="blue", radius=True),
        params.Box(clearance=(0.1, 0.2, 0.3, 0.4), pen="blue", radius="10p"),
        params.Box(
            clearance=0.2, pen="blue", radius="10p", shading=("5p", "5p", "lightred")
        ),
        params.Box(clearance=0.2, pen="blue", innerborder=("2p", "1p,red")),
    ]
):
    print("###", i)
    print(repr(box))
    print(str(box))
    print()
    fig.logo(position="x0/0+w3c", box=box)
    fig.shift_origin(xshift=4)
fig.show()
```
The console outputs are:
```
### 0
Box(fill='red@20')
+gred@20

### 1
Box(clearance=(0.2, 0.2), fill='red@20', pen='blue')
+c0.2/0.2+gred@20+pblue

### 2
Box(clearance=(0.2, 0.2), pen='blue', radius=True)
+c0.2/0.2+pblue+r

### 3
Box(clearance=(0.1, 0.2, 0.3, 0.4), pen='blue', radius='10p')
+c0.1/0.2/0.3/0.4+pblue+r10p

### 4
Box(clearance=0.2, pen='blue', radius='10p', shading=('5p', '5p', 'lightred'))
+c0.2+pblue+r10p+s5p/5p/lightred

### 5
Box(clearance=0.2, innerborder=('2p', '1p,red'), pen='blue')
+c0.2+i2p/1p,red+pblue
```
The generated image is:
![box](https://github.com/GenericMappingTools/pygmt/assets/3974108/9784a893-f1b7-4839-8647-c38b40e45a79)

Known limitations that should be addressed:

- [ ] `innerborder=('2p', '1p,red')` is not ideal. I expect to see `innergap="2p", innerpen="1p,red"` instead.
- [ ] `shading=('5p', '5p', 'lightred')` is not idea, `shading_offset=("5p", "5p")` and `shading_fill="lightred"` is better