### PR TITLE
Enable ruff's flake8-return (RET) rules and ignore RET504

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ select = [
     "PGH",  # pygrep-hooks
     "PIE",  # flake8-pie
     "PL",   # pylint
+    "RET",  # flake8-return
     "RSE",  # flake8-raise
     "S",    # flake8-bandit
     "SIM",  # flake8-simplify
@@ -132,6 +133,7 @@ ignore = [
     "ISC001",   # Single-line-implicit-string-concatenation, conflict with formatter
     "PD901",    # Allow using the generic variable name `df` for DataFrames
     "PLR2004",  # Allow any magic values
+    "RET504",   # Allow variable assignment and return immediately for readability
     "S603",     # Allow method calls that initiate a subprocess without a shell
     "SIM117",   # Allow nested `with` statements
 ]


### PR DESCRIPTION
Enable ruff's [flake8-return](https://docs.astral.sh/ruff/rules/#flake8-return-ret) rules and ignore RET504.