### PR TITLE
Enable ruff's flake8-executable (EXE) rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ select = [
     "BLE",  # flake8-blind-except
     "C4",   # flake8-comprehensions
     "E",    # pycodestyle
+    "EXE",  # flake8-executable
     "F",    # pyflakes
     "FA",   # flake8-future-annotations
     "FLY",  # flynt


### PR DESCRIPTION
Enable [flake8-executable (EXE)](https://docs.astral.sh/ruff/rules/#flake8-executable-exe) rules.

Please note that we don't have shebang in any Python scripts and our "Style Checks" workflow checks that all files (not only Python files) have 644 permissions (no execute permissions).

So, the "Style Checkes" workflow and the "EXE" ruleset help us make sure that:

1. All files have 644 permission, so not executable
2. All Python files have no shebang