### PR TITLE
Enable ruff's ruff-specific (RUF) rules

### DIFF
--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -13,7 +13,7 @@ The example below shows a Worldview 2 satellite image over
 Data is sourced from a Cloud-Optimized GeoTIFF (COG) file hosted on
 `OpenAerialMap <https://map.openaerialmap.org>`_ under a
 `CC BY-NC 4.0 <https://creativecommons.org/licenses/by-nc/4.0/>`_ license.
-"""
+"""  # noqa: RUF002
 
 # %%
 import pygmt

--- a/examples/gallery/lines/roads.py
+++ b/examples/gallery/lines/roads.py
@@ -9,6 +9,7 @@ a shapefile (.shp), GeoJSON (.geojson), geopackage (.gpkg), etc. Then, pass the
 :class:`geopandas.GeoDataFrame` as an argument to the ``data`` parameter of
 :meth:`pygmt.Figure.plot`, and style the geometry using the ``pen`` parameter.
 """
+# ruff: noqa: RUF003
 
 # %%
 import geopandas as gpd

--- a/examples/projections/conic/conic_lambert.py
+++ b/examples/projections/conic/conic_lambert.py
@@ -5,7 +5,7 @@ Lambert Conic Conformal Projection
 This conic projection was designed by the Alsatian mathematician Johann
 Heinrich Lambert (1772) and has been used extensively for mapping of regions
 with predominantly east-west orientation, just like the Albers projection.
-Unlike the Albers projection, Lambert’s conformal projection is not equal-area.
+Unlike the Albers projection, Lambert's conformal projection is not equal-area.
 The parallels are arcs of circles with a common origin, and meridians are the
 equally spaced radii of these circles. As with Albers projection, it is only
 the two standard parallels that are distortion-free.

--- a/examples/projections/conic/polyconic.py
+++ b/examples/projections/conic/polyconic.py
@@ -4,7 +4,7 @@ Polyconic Projection
 
 The polyconic projection, in Europe usually referred to as the American
 polyconic projection, was introduced shortly before 1820 by the Swiss-American
-cartographer Ferdinand Rodulph Hassler (1770–1843). As head of the Survey of
+cartographer Ferdinand Rodulph Hassler (1770-1843). As head of the Survey of
 the Coast, he was looking for a projection that would give the least distortion
 for mapping the coast of the United States. The projection acquired its name
 from the construction of each parallel, which is achieved by projecting the

--- a/examples/projections/cyl/cyl_miller.py
+++ b/examples/projections/cyl/cyl_miller.py
@@ -6,7 +6,7 @@ This cylindrical projection, presented by Osborn Maitland Miller of the
 American Geographic Society in 1942, is neither equal nor conformal. All
 meridians and parallels are straight lines. The projection was designed to be a
 compromise between Mercator and other cylindrical projections. Specifically,
-Miller spaced the parallels by using Mercator’s formula with 0.8 times the
+Miller spaced the parallels by using Mercator's formula with 0.8 times the
 actual latitude, thus avoiding the singular poles; the result was then divided
 by 0.8.
 

--- a/examples/projections/misc/misc_eckertIV.py
+++ b/examples/projections/misc/misc_eckertIV.py
@@ -5,7 +5,7 @@ Eckert IV
 The Eckert IV projection, presented by the German cartographer Max
 Eckert-Greiffendorff in 1906, is a pseudo-cylindrical equal-area projection.
 Central meridian and all parallels are straight lines; other meridians are
-equally spaced elliptical arcs. The scale is true along latitude 40°30’.
+equally spaced elliptical arcs. The scale is true along latitude 40°30'.
 
 **kf**\ [*lon0/*]\ *scale* or **Kf**\ [*lon0/*]\ *width*
 

--- a/examples/projections/misc/misc_eckertVI.py
+++ b/examples/projections/misc/misc_eckertVI.py
@@ -5,7 +5,7 @@ Eckert VI
 The Eckert VI projections, presented by the German cartographer Max
 Eckert-Greiffendorff in 1906, is a pseudo-cylindrical equal-area projection.
 Central meridian and all parallels are straight lines; other meridians are
-equally spaced sinusoids. The scale is true along latitude 49°16’.
+equally spaced sinusoids. The scale is true along latitude 49°16'.
 
 
 **ks**\ [*lon0/*]\ *scale* or **Ks**\ [*lon0/*]\ *width*

--- a/examples/projections/misc/misc_mollweide.py
+++ b/examples/projections/misc/misc_mollweide.py
@@ -5,7 +5,7 @@ Mollweide
 This pseudo-cylindrical, equal-area projection was developed by the German
 mathematician and astronomer Karl Brandan Mollweide in 1805. Parallels are
 unequally spaced straight lines with the meridians being equally spaced
-elliptical arcs. The scale is only true along latitudes 40°44’ north and south.
+elliptical arcs. The scale is only true along latitudes 40°44' north and south.
 The projection is used mainly for global maps showing data distributions. It is
 occasionally referenced under the name homalographic projection.
 

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1653,7 +1653,7 @@ class Session:
         ...
         >>> print(", ".join([f"{x:.2f}" for x in wesn]))
         -165.00, -150.00, 15.00, 25.00
-        """
+        """  # noqa: RUF002
         c_extract_region = self.get_libgmt_func(
             "GMT_Extract_Region",
             argtypes=[ctp.c_void_p, ctp.c_char_p, ctp.POINTER(ctp.c_double)],

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -1,6 +1,7 @@
 """
 Utilities and common tasks for wrapping the GMT modules.
 """
+# ruff: noqa: RUF001
 import os
 import pathlib
 import shutil
@@ -224,7 +225,7 @@ def non_ascii_to_octal(argstr):
     '@%34%\\41@%%@%34%\\176@%%@%34%\\241@%%@%34%\\376@%%'
     >>> non_ascii_to_octal("ABC ±120° DEF α ♥")
     'ABC \\261120\\260 DEF @~\\141@~ @%34%\\252@%%'
-    """
+    """  # noqa: RUF002
     # Dictionary mapping non-ASCII characters to octal codes
     mapping = {}
 

--- a/pygmt/src/config.py
+++ b/pygmt/src/config.py
@@ -2,6 +2,7 @@
 config - set GMT defaults globally or locally.
 """
 from inspect import Parameter, Signature
+from typing import ClassVar
 
 from pygmt.clib import Session
 
@@ -23,7 +24,7 @@ class config:  # noqa: N801
     """
 
     # Manually set the __signature__ attribute to enable tab autocompletion
-    _keywords = [
+    _keywords: ClassVar = [
         "COLOR_BACKGROUND",
         "COLOR_FOREGROUND",
         "COLOR_CPT",
@@ -154,7 +155,7 @@ class config:  # noqa: N801
         "TIME_Y2K_OFFSET_YEAR",
     ]
 
-    _special_keywords = {
+    _special_keywords: ClassVar = {
         "FONT": [
             "FONT_ANNOT_PRIMARY",
             "FONT_ANNOT_SECONDARY",

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -416,7 +416,7 @@ def test_text_nonascii():
     """
     fig = Figure()
     fig.basemap(region=[0, 10, 0, 10], projection="X10c", frame=True)
-    fig.text(position="TL", text="position-text:°α")
-    fig.text(x=1, y=1, text="xytext:°α")
+    fig.text(position="TL", text="position-text:°α")  # noqa: RUF001
+    fig.text(x=1, y=1, text="xytext:°α")  # noqa: RUF001
     fig.text(x=[5, 5], y=[3, 5], text=["xytext1:αζΔ❡", "xytext2:∑π∇✉"])
     return fig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ select = [
     "PL",   # pylint
     "RET",  # flake8-return
     "RSE",  # flake8-raise
+    "RUF",  # ruff-specific
     "S",    # flake8-bandit
     "SIM",  # flake8-simplify
     "T20",  # flake8-print


### PR DESCRIPTION
Enable ruff's [ruff-specific (RUF)](https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf) rules and fix violations.

Rules RUF001, RUF002 and RUF003 are all about non-ASCII characters in the source code. I think we should avoid non-ASCII characters with only a few exceptions.