### PR TITLE
Figure.grdimage: Remove the unsupported 'img_out'/'A' parameter

### DIFF
--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -2,6 +2,7 @@
 grdimage - Plot grids or images.
 """
 from pygmt.clib import Session
+from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     build_arg_string,
     deprecate_parameter,
@@ -16,7 +17,6 @@ __doctest_skip__ = ["grdimage"]
 @fmt_docstring
 @deprecate_parameter("bit_color", "bitcolor", "v0.10.0", remove_version="v0.12.0")
 @use_alias(
-    A="img_out",
     B="frame",
     C="cmap",
     D="img_in",
@@ -76,21 +76,6 @@ def grdimage(self, grid, **kwargs):
     Parameters
     ----------
     {grid}
-    img_out : str
-        *out_img*\[=\ *driver*].
-        Save an image in a raster format instead of PostScript. Append
-        *out_img* to select the image file name and extension. If the
-        extension is one of .bmp, .gif, .jpg, .png, or .tif then no driver
-        information is required. For other output formats you must append
-        the required GDAL driver. The *driver* is the driver code name used
-        by GDAL; see your GDAL installation's documentation for available
-        drivers. Append a **+c**\ *args* string where *args* is a list
-        of one or more concatenated number of GDAL **-co** arguments. For
-        example, to write a GeoPDF with the TerraGo format use
-        ``=PDF+cGEO_ENCODING=OGC_BP``. **Notes**: (1) If a tiff file (.tif)
-        is selected then we will write a GeoTiff image if the GMT
-        projection syntax translates into a PROJ syntax, otherwise a plain
-        tiff file is produced. (2) Any vector elements will be lost.
     {frame}
     {cmap}
     img_in : str
@@ -171,6 +156,13 @@ def grdimage(self, grid, **kwargs):
     >>> fig.show()
     """
     kwargs = self._preprocess(**kwargs)
+
+    # Do not support -A option
+    if any(kwargs.get(arg) is not None for arg in ["A", "img_out"]):
+        raise GMTInvalidInput(
+            "Parameter 'img_out'/'A' is not implemented. "
+            "Please consider submitting a feature request to us."
+        )
 
     with Session() as lib:
         with lib.virtualfile_from_data(

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -241,3 +241,14 @@ def test_grdimage_central_meridians_and_standard_parallels(grid, proj_type, lon0
     )
     fig_test.grdimage(grid, projection=f"{proj_type}{lon0}/{lat0}/15c", cmap="geo")
     return fig_ref, fig_test
+
+
+def test_grdimage_imgout(grid):
+    """
+    Test that an exception is raised if img_out/A is given.
+    """
+    fig = Figure()
+    with pytest.raises(GMTInvalidInput):
+        fig.grdimage(grid, img_out="out.png")
+    with pytest.raises(GMTInvalidInput):
+        fig.grdimage(grid, A="out.png")

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -243,7 +243,7 @@ def test_grdimage_central_meridians_and_standard_parallels(grid, proj_type, lon0
     return fig_ref, fig_test
 
 
-def test_grdimage_imgout(grid):
+def test_grdimage_imgout_fails(grid):
     """
     Test that an exception is raised if img_out/A is given.
     """


### PR DESCRIPTION
As proposed in https://github.com/GenericMappingTools/pygmt/pull/2765#issuecomment-1864131592, we will NOT support the `img_out`/`A` parameter in the `Figure.grdimage` method. The related feature will be added to a new function/method if requested.

Supersede #2765.


