### PR TITLE
Mark unit tests with @pytest.mark.benchmark part 1

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -61,7 +61,7 @@ jobs:
           echo $CONDA/bin >> $GITHUB_PATH
           conda install --solver=libmamba gmt=6.4.0 python=3.12 \
                         numpy pandas xarray netCDF4 packaging \
-                        pytest pytest-benchmark pytest-mpl
+                        geopandas pytest pytest-benchmark pytest-mpl
           python -m pip install -U pytest-codspeed setuptools
 
       # Install the package that we want to test

--- a/pygmt/tests/test_geopandas.py
+++ b/pygmt/tests/test_geopandas.py
@@ -61,6 +61,7 @@ def fixture_gdf_ridge():
     return gdf
 
 
+@pytest.mark.benchmark
 def test_geopandas_info_geodataframe(gdf):
     """
     Check that info can return the bounding box region from a

--- a/pygmt/tests/test_grd2cpt.py
+++ b/pygmt/tests/test_grd2cpt.py
@@ -18,6 +18,7 @@ def fixture_grid():
     return load_static_earth_relief()
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_grd2cpt(grid):
     """

--- a/pygmt/tests/test_grd2xyz.py
+++ b/pygmt/tests/test_grd2xyz.py
@@ -20,6 +20,7 @@ def fixture_grid():
     return load_static_earth_relief()
 
 
+@pytest.mark.benchmark
 def test_grd2xyz(grid):
     """
     Make sure grd2xyz works as expected.

--- a/pygmt/tests/test_grdclip.py
+++ b/pygmt/tests/test_grdclip.py
@@ -55,6 +55,7 @@ def test_grdclip_outgrid(grid, expected_grid):
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
+@pytest.mark.benchmark
 def test_grdclip_no_outgrid(grid, expected_grid):
     """
     Test the below and above parameters for grdclip with no set outgrid.

--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -33,6 +33,7 @@ def test_grdcontour(grid):
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_grdcontour_labels(grid):
     """

--- a/pygmt/tests/test_grdcut.py
+++ b/pygmt/tests/test_grdcut.py
@@ -53,6 +53,7 @@ def test_grdcut_dataarray_in_file_out(grid, expected_grid, region):
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
+@pytest.mark.benchmark
 def test_grdcut_dataarray_in_dataarray_out(grid, expected_grid, region):
     """
     Test grdcut on an input DataArray, and output as DataArray.

--- a/pygmt/tests/test_grdfill.py
+++ b/pygmt/tests/test_grdfill.py
@@ -71,6 +71,7 @@ def fixture_expected_grid():
     )
 
 
+@pytest.mark.benchmark
 def test_grdfill_dataarray_out(grid, expected_grid):
     """
     Test grdfill with a DataArray output.

--- a/pygmt/tests/test_grdfilter.py
+++ b/pygmt/tests/test_grdfilter.py
@@ -39,6 +39,7 @@ def fixture_expected_grid():
     )
 
 
+@pytest.mark.benchmark
 def test_grdfilter_dataarray_in_dataarray_out(grid, expected_grid):
     """
     Test grdfilter with an input DataArray, and output as DataArray.

--- a/pygmt/tests/test_grdgradient.py
+++ b/pygmt/tests/test_grdgradient.py
@@ -53,6 +53,7 @@ def test_grdgradient_outgrid(grid, expected_grid):
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
+@pytest.mark.benchmark
 def test_grdgradient_no_outgrid(grid, expected_grid):
     """
     Test the azimuth and direction parameters for grdgradient with no set

--- a/pygmt/tests/test_grdhisteq.py
+++ b/pygmt/tests/test_grdhisteq.py
@@ -69,7 +69,8 @@ def test_equalize_grid_outgrid_file(grid, expected_grid, region):
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
-def test_equalize_grid_outgrid(grid, expected_grid, region):
+@pytest.mark.benchmark
+def test_equalize_grid_no_outgrid(grid, expected_grid, region):
     """
     Test grdhisteq.equalize_grid with ``outgrid=None``.
     """
@@ -81,6 +82,7 @@ def test_equalize_grid_outgrid(grid, expected_grid, region):
     xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
+@pytest.mark.benchmark
 def test_compute_bins_no_outfile(grid, expected_df, region):
     """
     Test grdhisteq.compute_bins with no ``outfile``.

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -131,6 +131,7 @@ def test_grdimage_shading_xarray(grid, shading):
     return fig_ref, fig_test
 
 
+@pytest.mark.benchmark
 @check_figures_equal()
 def test_grdimage_grid_and_shading_with_xarray(grid, xrgrid):
     """

--- a/pygmt/tests/test_grdimage_image.py
+++ b/pygmt/tests/test_grdimage_image.py
@@ -53,6 +53,7 @@ def test_grdimage_image():
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare(filename="test_grdimage_image.png")
 def test_grdimage_image_dataarray(xr_image):
     """

--- a/pygmt/tests/test_grdinfo.py
+++ b/pygmt/tests/test_grdinfo.py
@@ -16,6 +16,7 @@ def fixture_grid():
     return load_static_earth_relief()
 
 
+@pytest.mark.benchmark
 def test_grdinfo(grid):
     """
     Make sure grdinfo works as expected.

--- a/pygmt/tests/test_grdlandmask.py
+++ b/pygmt/tests/test_grdlandmask.py
@@ -44,6 +44,7 @@ def test_grdlandmask_outgrid(expected_grid):
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
+@pytest.mark.benchmark
 def test_grdlandmask_no_outgrid(expected_grid):
     """
     Test grdlandmask with no set outgrid.

--- a/pygmt/tests/test_grdproject.py
+++ b/pygmt/tests/test_grdproject.py
@@ -58,6 +58,7 @@ def test_grdproject_file_out(grid, expected_grid):
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
+@pytest.mark.benchmark
 @pytest.mark.parametrize(
     "projection",
     ["M10c", "EPSG:3395 +width=10", "+proj=merc +ellps=WGS84 +units=m +width=10"],

--- a/pygmt/tests/test_grdsample.py
+++ b/pygmt/tests/test_grdsample.py
@@ -69,6 +69,7 @@ def test_grdsample_file_out(grid, expected_grid, region, spacing):
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
+@pytest.mark.benchmark
 def test_grdsample_dataarray_out(grid, expected_grid, region, spacing):
     """
     Test grdsample with no outgrid set and the spacing is changed.

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -55,6 +55,7 @@ def fixture_dataframe():
     )
 
 
+@pytest.mark.benchmark
 def test_grdtrack_input_dataframe_and_dataarray(dataarray, dataframe, expected_array):
     """
     Run grdtrack by passing in a pandas.DataFrame and xarray.DataArray as

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -214,6 +214,7 @@ def test_grdview_on_a_plane_styled_with_facadepen(xrgrid):
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_grdview_drapegrid_dataarray(xrgrid):
     """

--- a/pygmt/tests/test_grdvolume.py
+++ b/pygmt/tests/test_grdvolume.py
@@ -75,6 +75,7 @@ def test_grdvolume_no_outfile(grid):
         grdvolume(grid=grid, output_type="file")
 
 
+@pytest.mark.benchmark
 def test_grdvolume_no_outgrid(grid, data, region):
     """
     Test the expected output of grdvolume with no output file set.

--- a/pygmt/tests/test_histogram.py
+++ b/pygmt/tests/test_histogram.py
@@ -15,6 +15,7 @@ def fixture_data(request):
     return request.param(data)
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare(filename="test_histogram.png")
 def test_histogram(data):
     """

--- a/pygmt/tests/test_image.py
+++ b/pygmt/tests/test_image.py
@@ -10,7 +10,6 @@ from pygmt import Figure
 TEST_IMG = os.path.join(os.path.dirname(__file__), "baseline", "test_logo.png")
 
 
-@pytest.mark.benchmark
 @pytest.mark.skipif(sys.platform == "win32", reason="crashes on Windows")
 @pytest.mark.mpl_image_compare
 def test_image():

--- a/pygmt/tests/test_image.py
+++ b/pygmt/tests/test_image.py
@@ -10,6 +10,7 @@ from pygmt import Figure
 TEST_IMG = os.path.join(os.path.dirname(__file__), "baseline", "test_logo.png")
 
 
+@pytest.mark.benchmark
 @pytest.mark.skipif(sys.platform == "win32", reason="crashes on Windows")
 @pytest.mark.mpl_image_compare
 def test_image():

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -119,6 +119,7 @@ def test_info_numpy_array_time_column():
     assert output == expected_output
 
 
+@pytest.mark.benchmark
 @pytest.mark.parametrize(
     "dtype",
     [
@@ -144,6 +145,7 @@ def test_info_pandas_dataframe_date_column(dtype):
     assert output == expected_output
 
 
+@pytest.mark.benchmark
 def test_info_xarray_dataset_time_column():
     """
     Make sure info works on xarray.Dataset 1-D inputs with a time column.

--- a/pygmt/tests/test_inset.py
+++ b/pygmt/tests/test_inset.py
@@ -5,6 +5,7 @@ import pytest
 from pygmt import Figure
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_inset_aliases():
     """

--- a/pygmt/tests/test_io.py
+++ b/pygmt/tests/test_io.py
@@ -8,6 +8,7 @@ from pygmt.helpers import GMTTempFile
 from pygmt.io import load_dataarray
 
 
+@pytest.mark.benchmark
 def test_io_load_dataarray():
     """
     Check that load_dataarray works to read a netCDF grid with

--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -38,6 +38,7 @@ def test_legend_default_position():
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_legend_entries():
     """

--- a/pygmt/tests/test_logo.py
+++ b/pygmt/tests/test_logo.py
@@ -5,6 +5,7 @@ import pytest
 from pygmt import Figure
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_logo():
     """

--- a/pygmt/tests/test_makecpt.py
+++ b/pygmt/tests/test_makecpt.py
@@ -71,6 +71,7 @@ def test_makecpt_plot_colorbar_scaled_with_series(position):
     return fig
 
 
+@pytest.mark.benchmark
 def test_makecpt_output_cpt_file():
     """
     Save the generated static color palette table to a .cpt file.

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -81,6 +81,7 @@ def test_meca_spec_single_focalmecha_file():
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare(filename="test_meca_spec_multiple_focalmecha.png")
 @pytest.mark.parametrize(
     "inputtype", ["dict_mecha", "dict_mecha_mixed", "dataframe", "array2d"]

--- a/pygmt/tests/test_nearneighbor.py
+++ b/pygmt/tests/test_nearneighbor.py
@@ -37,6 +37,7 @@ def test_nearneighbor_input_data(array_func, ship_data):
     npt.assert_allclose(output.mean(), -2378.2385)
 
 
+@pytest.mark.benchmark
 def test_nearneighbor_input_xyz(ship_data):
     """
     Run nearneighbor by passing in x, y, z numpy.ndarrays individually.

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -352,6 +352,7 @@ def test_plot_from_file(region):
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_plot_vectors():
     """

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -378,6 +378,7 @@ def test_plot3d_from_file(region):
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_plot3d_vectors():
     """

--- a/pygmt/tests/test_project.py
+++ b/pygmt/tests/test_project.py
@@ -34,6 +34,7 @@ def test_project_generate():
     )
 
 
+@pytest.mark.benchmark
 @pytest.mark.parametrize("array_func", [np.array, pd.DataFrame, xr.Dataset])
 def test_project_input_matrix(array_func, dataframe):
     """

--- a/pygmt/tests/test_psconvert.py
+++ b/pygmt/tests/test_psconvert.py
@@ -8,6 +8,7 @@ from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput
 
 
+@pytest.mark.benchmark
 def test_psconvert():
     """
     Check that psconvert creates a figure in the current directory.

--- a/pygmt/tests/test_rose.py
+++ b/pygmt/tests/test_rose.py
@@ -91,6 +91,7 @@ def test_rose_2d_array_multiple(data):
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_rose_plot_data_using_cpt(data):
     """

--- a/pygmt/tests/test_select.py
+++ b/pygmt/tests/test_select.py
@@ -19,6 +19,7 @@ def fixture_dataframe():
     return load_sample_data(name="bathymetry")
 
 
+@pytest.mark.benchmark
 def test_select_input_dataframe(dataframe):
     """
     Run select by passing in a pandas.DataFrame as input.

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -3,10 +3,12 @@ Test the session management modules.
 """
 import os
 
+import pytest
 from pygmt.clib import Session
 from pygmt.session_management import begin, end
 
 
+@pytest.mark.benchmark
 def test_begin_end():
     """
     Run a command inside a begin-end modern mode block.

--- a/pygmt/tests/test_solar.py
+++ b/pygmt/tests/test_solar.py
@@ -39,6 +39,7 @@ def test_solar_terminators():
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare(filename="test_solar_set_terminator_datetime.png")
 @pytest.mark.parametrize(
     "terminator_datetime",

--- a/pygmt/tests/test_sph2grd.py
+++ b/pygmt/tests/test_sph2grd.py
@@ -4,6 +4,7 @@ Test pygmt.sph2grd.
 from pathlib import Path
 
 import numpy.testing as npt
+import pytest
 from pygmt import sph2grd
 from pygmt.helpers import GMTTempFile
 
@@ -20,6 +21,7 @@ def test_sph2grd_outgrid():
         assert Path(tmpfile.name).stat().st_size > 0  # check that outgrid exists
 
 
+@pytest.mark.benchmark
 def test_sph2grd_no_outgrid():
     """
     Test sph2grd with no set outgrid.

--- a/pygmt/tests/test_sphdistance.py
+++ b/pygmt/tests/test_sphdistance.py
@@ -48,6 +48,7 @@ def test_sphdistance_outgrid(array):
         assert Path(tmpfile.name).stat().st_size > 0  # check that outgrid exists
 
 
+@pytest.mark.benchmark
 def test_sphdistance_no_outgrid(array):
     """
     Test sphdistance with no set outgrid.

--- a/pygmt/tests/test_sphinterpolate.py
+++ b/pygmt/tests/test_sphinterpolate.py
@@ -28,6 +28,7 @@ def test_sphinterpolate_outgrid(mars):
         assert Path(tmpfile.name).stat().st_size > 0  # check that outgrid exists
 
 
+@pytest.mark.benchmark
 def test_sphinterpolate_no_outgrid(mars):
     """
     Test sphinterpolate with no set outgrid.

--- a/pygmt/tests/test_subplot.py
+++ b/pygmt/tests/test_subplot.py
@@ -6,6 +6,7 @@ from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_subplot_basic_frame():
     """

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -103,6 +103,7 @@ def test_surface_input_data_array(data, region, spacing, expected_grid):
     check_values(output, expected_grid)
 
 
+@pytest.mark.benchmark
 def test_surface_input_xyz(data, region, spacing, expected_grid):
     """
     Run surface by passing in x, y, z numpy.ndarrays individually.

--- a/pygmt/tests/test_ternary.py
+++ b/pygmt/tests/test_ternary.py
@@ -64,6 +64,7 @@ def test_ternary(array):
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_ternary_3_labels(array):
     """

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -46,6 +46,7 @@ def test_text_single_line_of_text(region, projection):
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_text_multiple_lines_of_text(region, projection):
     """

--- a/pygmt/tests/test_tilemap.py
+++ b/pygmt/tests/test_tilemap.py
@@ -24,6 +24,7 @@ def test_tilemap_web_mercator():
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_tilemap_ogc_wgs84():
     """

--- a/pygmt/tests/test_timestamp.py
+++ b/pygmt/tests/test_timestamp.py
@@ -61,6 +61,7 @@ def test_timestamp_offset():
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_timestamp_font(faketime):
     """

--- a/pygmt/tests/test_triangulate.py
+++ b/pygmt/tests/test_triangulate.py
@@ -70,6 +70,7 @@ def test_delaunay_triples_input_table_matrix(array_func, dataframe, expected_dat
     pd.testing.assert_frame_equal(left=output, right=expected_dataframe)
 
 
+@pytest.mark.benchmark
 def test_delaunay_triples_input_xyz(dataframe, expected_dataframe):
     """
     Run triangulate.delaunay_triples by passing in x, y, z numpy.ndarrays
@@ -129,6 +130,7 @@ def test_delaunay_triples_invalid_format(dataframe):
         triangulate.delaunay_triples(data=dataframe, output_type=1)
 
 
+@pytest.mark.benchmark
 def test_regular_grid_no_outgrid(dataframe, expected_grid):
     """
     Run triangulate.regular_grid with no set outgrid and see it load into an

--- a/pygmt/tests/test_velo.py
+++ b/pygmt/tests/test_velo.py
@@ -63,6 +63,7 @@ def test_velo_without_spec(dataframe):
         fig.velo(data=dataframe)
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_velo_pandas_dataframe(dataframe):
     """

--- a/pygmt/tests/test_which.py
+++ b/pygmt/tests/test_which.py
@@ -18,6 +18,7 @@ def test_which():
         assert Path(cached_file).name == fname
 
 
+@pytest.mark.benchmark
 def test_which_multiple():
     """
     Make sure `which` returns file paths for multiple @files correctly.

--- a/pygmt/tests/test_wiggle.py
+++ b/pygmt/tests/test_wiggle.py
@@ -33,6 +33,7 @@ def test_wiggle():
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare(filename="test_wiggle.png")
 def test_wiggle_data_incols():
     """

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -71,6 +71,7 @@ def test_x2sys_cross_input_file_output_dataframe():
         assert columns[6:] == ["head_1", "head_2", "vel_1", "vel_2", "z_X", "z_M"]
 
 
+@pytest.mark.benchmark
 @pytest.mark.usefixtures("mock_x2sys_home")
 def test_x2sys_cross_input_dataframe_output_dataframe(tracks):
     """

--- a/pygmt/tests/test_x2sys_init.py
+++ b/pygmt/tests/test_x2sys_init.py
@@ -35,6 +35,7 @@ def test_x2sys_init_region_spacing():
             assert "-I5/5" in tail_line
 
 
+@pytest.mark.benchmark
 @pytest.mark.usefixtures("mock_x2sys_home")
 def test_x2sys_init_units_gap():
     """

--- a/pygmt/tests/test_xyz2grd.py
+++ b/pygmt/tests/test_xyz2grd.py
@@ -39,6 +39,7 @@ def fixture_expected_grid():
     )
 
 
+@pytest.mark.benchmark
 @pytest.mark.parametrize("array_func", [np.array, xr.Dataset])
 def test_xyz2grd_input_array(array_func, ship_data, expected_grid):
     """


### PR DESCRIPTION
**Description of proposed changes**

Follow-up to #2908, this is where we mark the unit tests for any PyGMT functions we want to benchmark with the [`@pytest.mark.benchmark`](https://github.com/ionelmc/pytest-benchmark) decorator.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

See https://github.com/GenericMappingTools/pygmt/pull/2911#issuecomment-1868800856 below on which tests have been marked for benchmarking. Will first prioritize PyGMT functions that use temporary files, or are commonly used ones. General discussion on which tests to mark can go in #2910.

Note: We have purposely not installed `pytest-mpl` in `benchmarks.yml`, so the benchmarks are ran without any image comparison. This allows for faster benchmark runs, and it also means we don't need to setup `dvc` in the workflow.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Part 1 of addressing #2910. Covers test functions from `test_geopandas` to `test_xyz2grd` according to the list in https://github.com/GenericMappingTools/pygmt/issues/2910#issuecomment-1869852471.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
