### PR TITLE
Silence PytestUnknownMarkWarning by setting marker for pytest-benchmark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,3 +160,6 @@ max-args=10
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "--verbose --durations=0 --durations-min=0.2 --doctest-modules --mpl --mpl-results-path=results"
+markers = [
+    "benchmark: mark a test with custom benchmark settings.",
+]


### PR DESCRIPTION
**Description of proposed changes**

Registering custom marker for pytest-benchmark in pyproject.toml to silence PytestUnknownMarkWarning.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Alternative solution would be to install `pytest-benchmark` in all the Continuous Integration workflow files.

References:
- https://docs.pytest.org/en/7.4.x/example/markers.html#registering-markers
- https://stackoverflow.com/questions/60806473/pytestunknownmarkwarning-unknown-pytest-mark-xxx-is-this-a-typo

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Patches https://github.com/GenericMappingTools/pygmt/pull/2908#issuecomment-1868827632

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
