### PR TITLE
CI: Fail the DVC step if dvc fails to pulling baseline images

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -141,9 +141,7 @@ jobs:
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote
-        run: |
-          dvc pull --verbose
-          ls -lhR pygmt/tests/baseline/
+        run: dvc pull --verbose && ls -lhR pygmt/tests/baseline/
 
       # Install the package that we want to test
       - name: Install the package

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -163,9 +163,7 @@ jobs:
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote
-        run: |
-          dvc pull
-          ls -lhR pygmt/tests/baseline/
+        run: dvc pull && ls -lhR pygmt/tests/baseline/
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -103,9 +103,7 @@ jobs:
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote
-        run: |
-          dvc pull pygmt/tests/baseline/test_logo.png --verbose
-          ls -lhR pygmt/tests/baseline/
+        run: dvc pull pygmt/tests/baseline/test_logo.png && ls -lhR pygmt/tests/baseline/
 
       # Install the package that we want to test
       - name: Install the package

--- a/.github/workflows/release-baseline-images.yml
+++ b/.github/workflows/release-baseline-images.yml
@@ -25,9 +25,7 @@ jobs:
       uses: iterative/setup-dvc@v1.1.2
 
     - name: Pull baseline image data from dvc remote
-      run: |
-        dvc pull
-        ls -lhR pygmt/tests/baseline/
+      run: dvc pull && ls -lhR pygmt/tests/baseline/
 
     - name: Create the baseline image asset in zip format
       run: |


### PR DESCRIPTION
This run (https://github.com/GenericMappingTools/pygmt/actions/runs/7320479198/job/19939638528) fails because `dvc` fails to pull baseline images from the DVC remote server. Ideally, it should fail at the step "Pull baseline image data from dvc remote", not the "Run tests" step.

The "Pull baseline image data from dvc remote" step contains two commands:
```
dvc pull
ls -lhR pygmt/tests/baseline/
```
Even though sometimes `dvc pull` fails, the `ls -lhR pygmt/tests/baseline/` command always succeeds with exit code = 0, thus the step always succeeds.

This PR merges the two commands into a single one:
```
dvc pull && ls -lhR pygmt/tests/baseline/
```
If `dvc pull` fails, the `ls` command won't be run and the step exit code will be the one from `dvc`.