### PR TITLE
Figure.inset: Improve formulation of comment in inline example

### DIFF
--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -128,7 +128,8 @@ def inset(self, **kwargs):
     ...         dcw="MG+gred",
     ...     )
     ...
-    >>> # Map elements outside the "with" statement are plotted in the main figure
+    >>> # Map elements outside the "with" statement are plotted in the main
+    >>> # figure
     >>> fig.logo(position="jBR+o0.2c+w3c")
     >>> fig.show()
     """

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -128,7 +128,7 @@ def inset(self, **kwargs):
     ...         dcw="MG+gred",
     ...     )
     ...
-    >>> # Map elements outside the "with" block are plotted in the main figure
+    >>> # Map elements outside the "with" statement are plotted in the main figure
     >>> fig.logo(position="jBR+o0.2c+w3c")
     >>> fig.show()
     """


### PR DESCRIPTION
**Description of proposed changes**

Related to the reveiw at https://github.com/GenericMappingTools/pygmt/pull/2822#discussion_r1431446611, this PR aims to change `"with" block` to `"with" statement` in the comment of line example of `Figure.inset`.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
