### PR TITLE
Refactor test_image to plot @circuit.png instead of test_logo.png

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -12,7 +12,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  pull_request:
+  # pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -12,7 +12,7 @@ name: Cache data
 
 on:
   # Uncomment the 'pull_request' line below to manually re-cache data artifacts
-  # pull_request:
+  pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -11,7 +11,7 @@ name: GMT Legacy Tests
 on:
   # push:
   #   branches: [ main ]
-  # pull_request:
+  pull_request:
     # types: [ready_for_review]
     # paths-ignore:
     #  - 'doc/**'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -11,7 +11,7 @@ name: GMT Legacy Tests
 on:
   # push:
   #   branches: [ main ]
-  pull_request:
+  # pull_request:
     # types: [ready_for_review]
     # paths-ignore:
     #  - 'doc/**'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -76,7 +76,6 @@ jobs:
             rioxarray
             sphinx-gallery
             build
-            dvc
             make
             pip
             pytest
@@ -100,10 +99,6 @@ jobs:
           # Change modification times of the two files, so GMT won't refresh it
           touch ~/.gmt/server/gmt_data_server.txt ~/.gmt/server/gmt_hash_server.txt
           ls -lhR ~/.gmt
-
-      # Pull baseline image data from dvc remote (DAGsHub)
-      - name: Pull baseline image data from dvc remote
-        run: dvc pull pygmt/tests/baseline/test_logo.png && ls -lhR pygmt/tests/baseline/
 
       # Install the package that we want to test
       - name: Install the package

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -202,6 +202,7 @@ def download_test_data():
         "@S90E000.earth_wdmam_03m_g.nc",  # Specific grid for 03m test
         # Other cache files
         "@capitals.gmt",
+        "@circuit.png",
         "@earth_relief_20m_holes.grd",
         "@EGM96_to_36.txt",
         "@MaunaLoa_CO2.txt",

--- a/pygmt/tests/baseline/test_image.png.dvc
+++ b/pygmt/tests/baseline/test_image.png.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: c2e05c0d6fb17bcc7bf2f96193f91ad6
-  size: 10005
+- md5: d7d0d71a44a232d5907dbd44f7a08f18
+  size: 30811
   path: test_image.png

--- a/pygmt/tests/test_image.py
+++ b/pygmt/tests/test_image.py
@@ -1,13 +1,10 @@
 """
 Test Figure.image.
 """
-import sys
-
 import pytest
 from pygmt import Figure
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="crashes on Windows")
 @pytest.mark.mpl_image_compare
 def test_image():
     """

--- a/pygmt/tests/test_image.py
+++ b/pygmt/tests/test_image.py
@@ -1,13 +1,10 @@
 """
 Test Figure.image.
 """
-import os
 import sys
 
 import pytest
 from pygmt import Figure
-
-TEST_IMG = os.path.join(os.path.dirname(__file__), "baseline", "test_logo.png")
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="crashes on Windows")
@@ -17,5 +14,5 @@ def test_image():
     Place images on map.
     """
     fig = Figure()
-    fig.image(TEST_IMG, position="x0/0+w2c", box="+pthin,blue")
+    fig.image(imagefile="@circuit.png", position="x0/0+w2c", box="+pthin,blue")
     return fig


### PR DESCRIPTION
**Description of proposed changes**

So that we don't need to pull test_logo.png from dvc, or run test_logo first to generate the image.

The circuit.png file is from https://github.com/GenericMappingTools/gmtserver-admin/blob/master/cache/circuit.png

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes https://github.com/GenericMappingTools/pygmt/pull/2911#issuecomment-1869905218, patches https://github.com/GenericMappingTools/pygmt/pull/2079#discussion_r956734196, fixes https://github.com/GenericMappingTools/pygmt/pull/518#issuecomment-660431849


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
