### PR TITLE
CI: Download cached remote files in benchmarks.yml

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -64,6 +64,24 @@ jobs:
                         geopandas pytest pytest-benchmark pytest-mpl
           python -m pip install -U pytest-codspeed setuptools
 
+      # Download cached remote files (artifacts) from GitHub
+      - name: Download remote data from GitHub
+        uses: dawidd6/action-download-artifact@v3.0.0
+        with:
+          workflow: cache_data.yaml
+          workflow_conclusion: success
+          name: gmt-cache
+          path: .gmt
+
+      # Move downloaded files to ~/.gmt directory and list them
+      - name: Move and list downloaded remote files
+        run: |
+          mkdir -p ~/.gmt
+          mv .gmt/* ~/.gmt
+          # Change modification times of the two files, so GMT won't refresh it
+          touch ~/.gmt/server/gmt_data_server.txt ~/.gmt/server/gmt_hash_server.txt
+          ls -lhR ~/.gmt
+
       # Install the package that we want to test
       - name: Install the package
         run: make install


### PR DESCRIPTION
**Description of proposed changes**

Make the benchmark GitHub Actions workflow more reliable by pre-downloading some cached files.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Current benchmark tests at 94e4598729c017ade68f86b75d1e697f3075ab63 takes [12min26s](https://github.com/GenericMappingTools/pygmt/actions/runs/7334994690/job/19972375688) to run. In this PR, it also takes [12min26s](https://github.com/GenericMappingTools/pygmt/actions/runs/7341924342/job/19990402017?pr=2923) :sweat_smile:

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Patches #2908.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
