### PR TITLE
Mark unit tests with @pytest.mark.benchmark part 2

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -61,7 +61,7 @@ jobs:
           echo $CONDA/bin >> $GITHUB_PATH
           conda install --solver=libmamba gmt=6.4.0 python=3.12 \
                         numpy pandas xarray netCDF4 packaging \
-                        geopandas pytest pytest-benchmark pytest-mpl
+                        geopandas pyarrow pytest pytest-benchmark pytest-mpl
           python -m pip install -U pytest-codspeed setuptools
 
       # Install the package that we want to test

--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -47,6 +47,7 @@ def test_accessor_set_pixel_registration():
     assert grid.gmt.registration == 1  # ensure changed to pixel registration
 
 
+@pytest.mark.benchmark
 def test_accessor_set_geographic_cartesian_roundtrip():
     """
     Check that we can set a grid to switch between the default Cartesian

--- a/pygmt/tests/test_binstats.py
+++ b/pygmt/tests/test_binstats.py
@@ -4,6 +4,7 @@ Test pygmt.binstats.
 from pathlib import Path
 
 import numpy.testing as npt
+import pytest
 from pygmt import binstats
 from pygmt.helpers import GMTTempFile
 
@@ -26,6 +27,7 @@ def test_binstats_outgrid():
         assert Path(tmpfile.name).stat().st_size > 0  # check that outgrid exists
 
 
+@pytest.mark.benchmark
 def test_binstats_no_outgrid():
     """
     Test binstats with no set outgrid.

--- a/pygmt/tests/test_blockm.py
+++ b/pygmt/tests/test_blockm.py
@@ -46,6 +46,7 @@ def test_blockmean_input_table_matrix(array_func, dataframe):
     npt.assert_allclose(output.iloc[0], [245.888877, 29.978707, -384.0])
 
 
+@pytest.mark.benchmark
 def test_blockmean_input_xyz(dataframe):
     """
     Run blockmean by passing in x/y/z as input.
@@ -101,6 +102,7 @@ def test_blockmean_without_outfile_setting():
     npt.assert_allclose(output.iloc[0], [245.888877, 29.978707, -384.0])
 
 
+@pytest.mark.benchmark
 def test_blockmode_input_dataframe(dataframe):
     """
     Run blockmode by passing in a pandas.DataFrame as input.

--- a/pygmt/tests/test_blockmedian.py
+++ b/pygmt/tests/test_blockmedian.py
@@ -31,6 +31,7 @@ def test_blockmedian_input_dataframe(dataframe):
     npt.assert_allclose(output.iloc[0], [245.88819, 29.97895, -385.0])
 
 
+@pytest.mark.benchmark
 def test_blockmedian_input_table_matrix(dataframe):
     """
     Run blockmedian using table input that is not a pandas.DataFrame but still

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -130,6 +130,7 @@ def test_destroy_session_fails():
     ses.destroy()
 
 
+@pytest.mark.benchmark
 def test_call_module():
     """
     Run a command to see if call_module works.
@@ -388,6 +389,7 @@ def test_write_data_fails():
                 )
 
 
+@pytest.mark.benchmark
 def test_dataarray_to_matrix_works():
     """
     Check that dataarray_to_matrix returns correct output.

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -58,6 +58,7 @@ def test_clib_names():
 
 ###############################################################################
 # Test load_libgmt
+@pytest.mark.benchmark
 def test_load_libgmt():
     """
     Test that loading libgmt works and doesn't crash.

--- a/pygmt/tests/test_clib_put_matrix.py
+++ b/pygmt/tests/test_clib_put_matrix.py
@@ -19,6 +19,7 @@ def fixture_dtypes():
     return "int8 int16 int32 int64 uint8 uint16 uint32 uint64 float32 float64".split()
 
 
+@pytest.mark.benchmark
 def test_put_matrix(dtypes):
     """
     Check that assigning a numpy 2-D array to a dataset works.
@@ -64,6 +65,7 @@ def test_put_matrix_fails():
                 lib.put_matrix(dataset=None, matrix=np.empty((10, 2)), pad=0)
 
 
+@pytest.mark.benchmark
 def test_put_matrix_grid(dtypes):
     """
     Check that assigning a numpy 2-D array to an ASCII and netCDF grid works.

--- a/pygmt/tests/test_clib_put_strings.py
+++ b/pygmt/tests/test_clib_put_strings.py
@@ -9,6 +9,7 @@ from pygmt.exceptions import GMTCLibError
 from pygmt.helpers import GMTTempFile
 
 
+@pytest.mark.benchmark
 def test_put_strings():
     """
     Check that assigning a numpy array of dtype str to a dataset works.

--- a/pygmt/tests/test_clib_put_vector.py
+++ b/pygmt/tests/test_clib_put_vector.py
@@ -20,6 +20,7 @@ def fixture_dtypes():
     return "int8 int16 int32 int64 uint8 uint16 uint32 uint64 float32 float64".split()
 
 
+@pytest.mark.benchmark
 def test_put_vector(dtypes):
     """
     Check that assigning a numpy array to a dataset works.
@@ -97,6 +98,7 @@ def test_put_vector_mixed_dtypes(dtypes):
                 npt.assert_allclose(newy, y)
 
 
+@pytest.mark.benchmark
 def test_put_vector_string_dtype():
     """
     Passing string type vectors to a dataset.

--- a/pygmt/tests/test_clib_virtualfiles.py
+++ b/pygmt/tests/test_clib_virtualfiles.py
@@ -213,6 +213,7 @@ def test_virtualfile_from_vectors(dtypes):
             assert output == expected
 
 
+@pytest.mark.benchmark
 @pytest.mark.parametrize("dtype", [str, object])
 def test_virtualfile_from_vectors_one_string_or_object_column(dtype):
     """

--- a/pygmt/tests/test_clib_virtualfiles.py
+++ b/pygmt/tests/test_clib_virtualfiles.py
@@ -34,6 +34,7 @@ def fixture_dtypes():
     return "int8 int16 int32 int64 uint8 uint16 uint32 uint64 float32 float64".split()
 
 
+@pytest.mark.benchmark
 def test_virtual_file(dtypes):
     """
     Test passing in data via a virtual file with a Dataset.
@@ -109,6 +110,7 @@ def test_virtual_file_bad_direction():
                 pass
 
 
+@pytest.mark.benchmark
 @pytest.mark.parametrize(
     ("array_func", "kind"),
     [(np.array, "matrix"), (pd.DataFrame, "vector"), (xr.Dataset, "vector")],
@@ -191,6 +193,7 @@ def test_virtualfile_from_data_fail_non_valid_data(data):
             )
 
 
+@pytest.mark.benchmark
 def test_virtualfile_from_vectors(dtypes):
     """
     Test the automation for transforming vectors to virtual file dataset.
@@ -282,6 +285,7 @@ def test_virtualfile_from_vectors_diff_size():
                 pass
 
 
+@pytest.mark.benchmark
 def test_virtualfile_from_matrix(dtypes):
     """
     Test transforming a matrix to virtual file dataset.

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -6,6 +6,7 @@ from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_coast_region():
     """

--- a/pygmt/tests/test_colorbar.py
+++ b/pygmt/tests/test_colorbar.py
@@ -5,6 +5,7 @@ import pytest
 from pygmt import Figure
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_colorbar_box():
     """

--- a/pygmt/tests/test_config.py
+++ b/pygmt/tests/test_config.py
@@ -64,6 +64,7 @@ def test_config_font_annot():
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
 def test_config_format_date_map():
     """

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -46,6 +46,7 @@ def test_contour_vec(region):
     return fig
 
 
+@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare(filename="test_contour_matrix.png")
 @pytest.mark.parametrize(
     "array_func",

--- a/pygmt/tests/test_datasets_load_remote_datasets.py
+++ b/pygmt/tests/test_datasets_load_remote_datasets.py
@@ -19,6 +19,21 @@ def load_remote_dataset_wrapper(resolution="01d", region=None, registration=None
     )
 
 
+@pytest.mark.benchmark
+def test_load_remote_dataset_benchmark_with_region():
+    """
+    Benchmark loading a remote dataset with 'region'.
+    """
+    data = load_remote_dataset_wrapper(resolution="01d", region=[-10, 10, -5, 5])
+    assert data.name == "seafloor_age"
+    assert data.attrs["long_name"] == "age of seafloor crust"
+    assert data.attrs["cpt"] == "@earth_age.cpt"
+    assert data.attrs["units"] == "Myr"
+    assert data.attrs["horizontal_datum"] == "WGS84"
+    assert data.gmt.registration == 0
+    assert data.shape == (11, 21)
+
+
 def test_load_remote_dataset_invalid_resolutions():
     """
     Make sure _load_remote_dataset fails for invalid resolutions.

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -180,6 +180,7 @@ def test_load_notre_dame_topography():
     assert data["z"].max() == 960
 
 
+@pytest.mark.benchmark
 def test_earth_relief_holes():
     """
     Check that the @earth_relief_20m_holes.grd dataset loads without errors.

--- a/pygmt/tests/test_dimfilter.py
+++ b/pygmt/tests/test_dimfilter.py
@@ -59,6 +59,7 @@ def test_dimfilter_outgrid(grid, expected_grid):
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
+@pytest.mark.benchmark
 def test_dimfilter_no_outgrid(grid, expected_grid):
     """
     Test the required parameters for dimfilter with no set outgrid.

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -56,6 +56,7 @@ def test_figure_region_country_codes():
     npt.assert_allclose(fig.region, np.array([0.0, 360.0, -90.0, 90.0]))
 
 
+@pytest.mark.benchmark
 def test_figure_repr():
     """
     Make sure that figure output's PNG and HTML printable representations look

--- a/pygmt/tests/test_filter1d.py
+++ b/pygmt/tests/test_filter1d.py
@@ -22,7 +22,7 @@ def fixture_data():
 
 def test_filter1d_no_outfile(data):
     """
-    Test filter1d with no set outgrid.
+    Test filter1d with no set outfile.
     """
     result = filter1d(data=data, filter_type="g5")
     assert result.shape == (671, 2)
@@ -79,13 +79,17 @@ def test_filter1d_outfile_incorrect_output_type(data):
             assert Path(tmpfile.name).stat().st_size > 0  # check that outfile exists
 
 
+@pytest.mark.benchmark
 def test_filter1d_format(data):
     """
     Test that correct formats are returned.
     """
     time_series_default = filter1d(data=data, filter_type="g5")
     assert isinstance(time_series_default, pd.DataFrame)
+    assert time_series_default.shape == (671, 2)
     time_series_array = filter1d(data=data, filter_type="g5", output_type="numpy")
     assert isinstance(time_series_array, np.ndarray)
+    assert time_series_array.shape == (671, 2)
     time_series_df = filter1d(data=data, filter_type="g5", output_type="pandas")
     assert isinstance(time_series_df, pd.DataFrame)
+    assert time_series_df.shape == (671, 2)


### PR DESCRIPTION
**Description of proposed changes**

Follow-up to https://github.com/GenericMappingTools/pygmt/pull/2908, this is where we mark the unit tests for any PyGMT functions we want to benchmark with the [@pytest.mark.benchmark](https://github.com/ionelmc/pytest-benchmark) decorator.

Benchmark report at https://codspeed.io/GenericMappingTools/pygmt/branches/pytest/mark-benchmark-part2

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

See https://github.com/GenericMappingTools/pygmt/pull/2924#issuecomment-1870085928 below on which new tests have been marked for benchmarking. Will prioritize PyGMT functions that use temporary files, and low-level clib functions that should be benchmarked. General discussion on which tests to mark can go in https://github.com/GenericMappingTools/pygmt/issues/2910.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Part 2 of addressing https://github.com/GenericMappingTools/pygmt/issues/2910. Covers test functions from test_binstats to test_filter1d according to the list in https://github.com/GenericMappingTools/pygmt/issues/2910#issuecomment-1869852471.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
