### PR TITLE
Rewrap docstrings to 88 characters

### DIFF
--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -1,10 +1,10 @@
 """
 PyGMT is a library for processing geospatial and geophysical data and making
-publication-quality maps and figures. It provides a Pythonic interface for the
-Generic Mapping Tools (GMT), a command-line program widely used across the
-Earth, Ocean, and Planetary sciences and beyond. Besides making GMT more
-accessible to new users, PyGMT aims to provide integration with the PyData
-ecosystem as well as support for rich display in Jupyter notebooks.
+publication-quality maps and figures. It provides a Pythonic interface for the Generic
+Mapping Tools (GMT), a command-line program widely used across the Earth, Ocean, and
+Planetary sciences and beyond. Besides making GMT more accessible to new users, PyGMT
+aims to provide integration with the PyData ecosystem as well as support for rich
+display in Jupyter notebooks.
 
 Main Features
 -------------
@@ -93,8 +93,7 @@ def print_clib_info(file=sys.stdout):
 
 def show_versions(file=sys.stdout):
     """
-    Print various dependency versions which are useful when submitting bug
-    reports.
+    Print various dependency versions which are useful when submitting bug reports.
 
     This includes information about:
 

--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -150,8 +150,7 @@ class GMTDataArrayAccessor:
     @property
     def gtype(self):
         """
-        Coordinate system type of the grid, either 0 (Cartesian) or 1
-        (Geographic).
+        Coordinate system type of the grid, either 0 (Cartesian) or 1 (Geographic).
         """
         return self._gtype
 

--- a/pygmt/clib/__init__.py
+++ b/pygmt/clib/__init__.py
@@ -1,8 +1,8 @@
 """
 Low-level wrapper for the GMT C API.
 
-The pygmt.clib.Session class wraps the GMT C shared library (libgmt) with a
-Pythonic interface. Access to the C library is done through ctypes.
+The pygmt.clib.Session class wraps the GMT C shared library (libgmt) with a Pythonic
+interface. Access to the C library is done through ctypes.
 """
 
 from pygmt.clib.session import Session

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -126,8 +126,7 @@ def dataarray_to_matrix(grid):
 
 def vectors_to_arrays(vectors):
     """
-    Convert 1-D vectors (lists, arrays, or pandas.Series) to C contiguous 1-D
-    arrays.
+    Convert 1-D vectors (lists, arrays, or pandas.Series) to C contiguous 1-D arrays.
 
     Arrays must be in C contiguous order for us to pass their memory pointers
     to GMT. If any are not, convert them to C order (which requires copying the

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -1,8 +1,8 @@
 """
 Utility functions to load libgmt as ctypes.CDLL.
 
-The path to the shared library can be found automatically by ctypes or set
-through the GMT_LIBRARY_PATH environment variable.
+The path to the shared library can be found automatically by ctypes or set through the
+GMT_LIBRARY_PATH environment variable.
 """
 import ctypes
 import os

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1,6 +1,6 @@
 """
-Defines the Session class to create and destroy a GMT API session and provides
-access to the API functions.
+Defines the Session class to create and destroy a GMT API session and provides access to
+the API functions.
 
 Uses ctypes to wrap most of the core functions from the C API.
 """
@@ -369,11 +369,11 @@ class Session:
         @ctp.CFUNCTYPE(ctp.c_int, ctp.c_void_p, ctp.c_char_p)
         def print_func(file_pointer, message):  # noqa: ARG001
             """
-            Callback function that the GMT C API will use to print log and
-            error messages.
+            Callback function that the GMT C API will use to print log and error
+            messages.
 
-            We'll capture the messages and print them to stderr so that they
-            will show up on the Jupyter notebook.
+            We'll capture the messages and print them to stderr so that they will show
+            up on the Jupyter notebook.
             """
             message = message.decode().strip()
             self._error_log.append(message)
@@ -497,8 +497,8 @@ class Session:
 
     def get_common(self, option):
         """
-        Inquire if a GMT common option has been set and return its current
-        value if possible.
+        Inquire if a GMT common option has been set and return its current value if
+        possible.
 
         Parameters
         ----------
@@ -720,9 +720,9 @@ class Session:
         """
         Parse and return an appropriate value for pad if none is given.
 
-        Pad is a bit tricky because, for matrix types, pad control the matrix
-        ordering (row or column major). Using the default pad will set it to
-        column major and mess things up with the numpy arrays.
+        Pad is a bit tricky because, for matrix types, pad control the matrix ordering
+        (row or column major). Using the default pad will set it to column major and
+        mess things up with the numpy arrays.
         """
         pad = kwargs.get("pad", None)
         if pad is None:
@@ -783,8 +783,8 @@ class Session:
 
     def _check_dtype_and_dim(self, array, ndim):
         """
-        Check that a numpy array has the given number of dimensions and is a
-        valid data type.
+        Check that a numpy array has the given number of dimensions and is a valid data
+        type.
 
         Parameters
         ----------

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -1,6 +1,6 @@
 """
-Function to download the Earth seafloor crustal age dataset from the GMT data
-server, and load as :class:`xarray.DataArray`.
+Function to download the Earth seafloor crustal age dataset from the GMT data server,
+and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -1,6 +1,6 @@
 """
-Function to download the IGPP Earth Free-Air Anomaly dataset from the GMT data
-server, and load as :class:`xarray.DataArray`.
+Function to download the IGPP Earth Free-Air Anomaly dataset from the GMT data server,
+and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -1,6 +1,6 @@
 """
-Function to download the EGM2008 Earth Geoid dataset from the GMT data server,
-and load as :class:`xarray.DataArray`.
+Function to download the EGM2008 Earth Geoid dataset from the GMT data server, and load
+as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -1,6 +1,6 @@
 """
-Function to download the Earth magnetic anomaly datasets from the GMT data
-server, and load as :class:`xarray.DataArray`.
+Function to download the Earth magnetic anomaly datasets from the GMT data server, and
+load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -1,6 +1,6 @@
 """
-Function to download the GSHHG Earth Mask dataset from the GMT data server, and
-load as :class:`xarray.DataArray`.
+Function to download the GSHHG Earth Mask dataset from the GMT data server, and load as
+:class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -1,6 +1,6 @@
 """
-Function to download the Earth relief datasets from the GMT data server, and
-load as :class:`xarray.DataArray`.
+Function to download the Earth relief datasets from the GMT data server, and load as
+:class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
@@ -22,8 +22,7 @@ def load_earth_relief(
     use_srtm=False,
 ):
     r"""
-    Load the Earth relief datasets (topography and bathymetry) in various
-    resolutions.
+    Load the Earth relief datasets (topography and bathymetry) in various resolutions.
 
     .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_gebco.jpg
        :width: 80 %

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -1,6 +1,6 @@
 """
-Function to download the IGPP Earth Vertical Gravity Gradient dataset from the
-GMT data server, and load as :class:`xarray.DataArray`.
+Function to download the IGPP Earth Vertical Gravity Gradient dataset from the GMT data
+server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
@@ -19,8 +19,7 @@ def load_earth_vertical_gravity_gradient(
     registration: Literal["gridline", "pixel", None] = None,
 ):
     r"""
-    Load the IGPP Earth Vertical Gravity Gradient dataset in various
-    resolutions.
+    Load the IGPP Earth Vertical Gravity Gradient dataset in various resolutions.
 
     .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_vgg.jpg
        :width: 80 %

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -13,8 +13,8 @@ from pygmt.src import grdcut, which
 
 class Resolution(NamedTuple):
     """
-    The available grid registrations for a given resolution and whether it is a
-    tiled grid.
+    The available grid registrations for a given resolution and whether it is a tiled
+    grid.
 
     Attributes
     ----------

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -41,8 +41,7 @@ def _load_japan_quakes():
 
 def _load_ocean_ridge_points():
     """
-    Load a table of ocean ridge points for the entire world as a
-    pandas.DataFrame.
+    Load a table of ocean ridge points for the entire world as a pandas.DataFrame.
 
     Returns
     -------
@@ -92,8 +91,8 @@ def _load_usgs_quakes():
 
 def _load_fractures_compilation():
     """
-    Load a table of fracture lengths and azimuths as hypothetically digitized
-    from geological maps as a pandas.DataFrame.
+    Load a table of fracture lengths and azimuths as hypothetically digitized from
+    geological maps as a pandas.DataFrame.
 
     Returns
     -------
@@ -110,8 +109,8 @@ def _load_fractures_compilation():
 
 def _load_hotspots():
     """
-    Load a table with the locations, names, and suggested symbol sizes of
-    hotspots as a pandas.DataFrame.
+    Load a table with the locations, names, and suggested symbol sizes of hotspots as a
+    pandas.DataFrame.
 
     The data are from Mueller, Royer, and Lawver, 1993, Geology, vol. 21,
     pp. 275-278. The main 5 hotspots used by Doubrovine et al. [2012]

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -110,8 +110,8 @@ class Figure:
 
     def _preprocess(self, **kwargs):
         """
-        Call the ``figure`` module before each plotting command to ensure we're
-        plotting to this particular figure.
+        Call the ``figure`` module before each plotting command to ensure we're plotting
+        to this particular figure.
         """
         self._activate_figure()
         return kwargs

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -829,8 +829,8 @@ def deprecate_parameter(oldname, newname, deprecate_version, remove_version):
 
     def deprecator(module_func):
         """
-        The decorator that creates the new function to work with both old and
-        new parameters.
+        The decorator that creates the new function to work with both old and new
+        parameters.
         """
 
         @functools.wraps(module_func)

--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -108,9 +108,8 @@ class GMTTempFile:
 @contextmanager
 def tempfile_from_geojson(geojson):
     """
-    Saves any geo-like Python object which implements ``__geo_interface__``
-    (e.g. a geopandas.GeoDataFrame or shapely.geometry) to a temporary OGR_GMT
-    text file.
+    Saves any geo-like Python object which implements ``__geo_interface__`` (e.g. a
+    geopandas.GeoDataFrame or shapely.geometry) to a temporary OGR_GMT text file.
 
     Parameters
     ----------
@@ -165,8 +164,7 @@ def tempfile_from_geojson(geojson):
 @contextmanager
 def tempfile_from_image(image):
     """
-    Saves a 3-band :class:`xarray.DataArray` to a temporary GeoTIFF file via
-    rioxarray.
+    Saves a 3-band :class:`xarray.DataArray` to a temporary GeoTIFF file via rioxarray.
 
     Parameters
     ----------

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -144,8 +144,7 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
 
 def download_test_data():
     """
-    Convenience function to download remote data files used in PyGMT tests and
-    docs.
+    Convenience function to download remote data files used in PyGMT tests and docs.
     """
     # List of datasets to download
     datasets = [
@@ -239,8 +238,8 @@ def load_static_earth_relief():
 
 def skip_if_no(package):
     """
-    Generic function to help skip tests when required packages are not present
-    on the testing system.
+    Generic function to help skip tests when required packages are not present on the
+    testing system.
 
     This function returns a pytest mark with a skip condition that will be
     evaluated during test collection. An attempt will be made to import the

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -313,8 +313,7 @@ def non_ascii_to_octal(argstr):
 
 def build_arg_string(kwdict, confdict=None, infile=None, outfile=None):
     r"""
-    Convert keyword dictionaries and input/output files into a GMT argument
-    string.
+    Convert keyword dictionaries and input/output files into a GMT argument string.
 
     Make sure all values in ``kwdict`` have been previously converted to a
     string representation using the ``kwargs_to_strings`` decorator. The only
@@ -513,8 +512,8 @@ def launch_external_viewer(fname, waiting=0):
 
 def args_in_kwargs(args, kwargs):
     """
-    Take a list and a dictionary, and determine if any entries in the list are
-    keys in the dictionary.
+    Take a list and a dictionary, and determine if any entries in the list are keys in
+    the dictionary.
 
     This function is used to determine if at least one of the required
     arguments is passed to raise a GMTInvalidInput Error.

--- a/pygmt/io.py
+++ b/pygmt/io.py
@@ -6,8 +6,8 @@ import xarray as xr
 
 def load_dataarray(filename_or_obj, **kwargs):
     """
-    Open, load into memory, and close a DataArray from a file or file-like
-    object containing a single data variable.
+    Open, load into memory, and close a DataArray from a file or file-like object
+    containing a single data variable.
 
     This is a thin wrapper around :py:func:`xarray.open_dataarray`. It differs
     from :py:func:`xarray.open_dataarray` in that it loads the DataArray into

--- a/pygmt/sphinx_gallery.py
+++ b/pygmt/sphinx_gallery.py
@@ -21,8 +21,7 @@ class PyGMTScraper:
 
     def __call__(self, block, block_vars, gallery_conf):  # noqa: ARG002
         """
-        Called by sphinx-gallery to save the figures generated after running
-        code.
+        Called by sphinx-gallery to save the figures generated after running code.
         """
         image_names = []
         image_path_iterator = block_vars["image_path_iterator"]

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -32,8 +32,7 @@ __doctest_skip__ = ["sphdistance"]
 @kwargs_to_strings(I="sequence", R="sequence")
 def sphdistance(data=None, x=None, y=None, **kwargs):
     r"""
-    Create Voronoi distance, node, or natural nearest-neighbor grid on a
-    sphere.
+    Create Voronoi distance, node, or natural nearest-neighbor grid on a sphere.
 
     Reads a table containing *lon, lat* columns and performs
     the construction of Voronoi polygons. These polygons are

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -19,8 +19,7 @@ from pygmt.io import load_dataarray
 
 class triangulate:  # noqa: N801
     """
-    Delaunay triangulation or Voronoi partitioning and gridding of Cartesian
-    data.
+    Delaunay triangulation or Voronoi partitioning and gridding of Cartesian data.
 
     Triangulate reads in x,y[,z] data and performs Delaunay triangulation,
     i.e., it finds how the points should be connected to give the most
@@ -69,8 +68,7 @@ class triangulate:  # noqa: N801
         data=None, x=None, y=None, z=None, *, output_type, outfile=None, **kwargs
     ):
         """
-        Delaunay triangulation or Voronoi partitioning and gridding of
-        Cartesian data.
+        Delaunay triangulation or Voronoi partitioning and gridding of Cartesian data.
 
         Must provide ``outfile`` or ``outgrid``.
 

--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -23,9 +23,9 @@ from pygmt.helpers import (
 @contextlib.contextmanager
 def tempfile_from_dftrack(track, suffix):
     """
-    Saves pandas.DataFrame track table to a temporary tab-separated ASCII text
-    file with a unique name (to prevent clashes when running x2sys_cross),
-    adding a suffix extension to the end.
+    Saves pandas.DataFrame track table to a temporary tab-separated ASCII text file with
+    a unique name (to prevent clashes when running x2sys_cross), adding a suffix
+    extension to the end.
 
     Parameters
     ----------

--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -16,8 +16,8 @@ from pygmt.exceptions import GMTInvalidInput
 
 def test_accessor_gridline_cartesian():
     """
-    Check that a grid returns a registration value of 0 when Gridline
-    registered, and a gtype value of 1 when using Geographic coordinates.
+    Check that a grid returns a registration value of 0 when Gridline registered, and a
+    gtype value of 1 when using Geographic coordinates.
     """
     fname = which(fname="@test.dat.nc", download="a")
     grid = xr.open_dataarray(fname)
@@ -27,8 +27,8 @@ def test_accessor_gridline_cartesian():
 
 def test_accessor_pixel_geographic():
     """
-    Check that a grid returns a registration value of 1 when Pixel registered,
-    and a gtype value of 0 when using Cartesian coordinates.
+    Check that a grid returns a registration value of 1 when Pixel registered, and a
+    gtype value of 0 when using Cartesian coordinates.
     """
     fname = which(fname="@earth_relief_01d_p", download="a")
     grid = xr.open_dataarray(fname, engine="netcdf4")
@@ -38,8 +38,7 @@ def test_accessor_pixel_geographic():
 
 def test_accessor_set_pixel_registration():
     """
-    Check that we can set a grid to be Pixel registered with a registration
-    value of 1.
+    Check that we can set a grid to be Pixel registered with a registration value of 1.
     """
     grid = xr.DataArray(data=[[0.1, 0.2], [0.3, 0.4]])
     assert grid.gmt.registration == 0  # default to gridline registration
@@ -49,9 +48,8 @@ def test_accessor_set_pixel_registration():
 
 def test_accessor_set_geographic_cartesian_roundtrip():
     """
-    Check that we can set a grid to switch between the default Cartesian
-    coordinate type using a gtype of 1, set it to Geographic 0, and then back
-    to Cartesian again 1.
+    Check that we can set a grid to switch between the default Cartesian coordinate type
+    using a gtype of 1, set it to Geographic 0, and then back to Cartesian again 1.
     """
     grid = xr.DataArray(data=[[0.1, 0.2], [0.3, 0.4]])
     assert grid.gmt.gtype == 0  # default to cartesian coordinate type
@@ -63,8 +61,7 @@ def test_accessor_set_geographic_cartesian_roundtrip():
 
 def test_accessor_set_non_boolean():
     """
-    Check that setting non boolean values on registration and gtype do not
-    work.
+    Check that setting non boolean values on registration and gtype do not work.
     """
     grid = xr.DataArray(data=[[0.1, 0.2], [0.3, 0.4]])
 
@@ -85,8 +82,8 @@ def test_accessor_set_non_boolean():
 )
 def test_accessor_sliced_datacube():
     """
-    Check that a 2-D grid which is sliced from an n-dimensional datacube works
-    with accessor methods.
+    Check that a 2-D grid which is sliced from an n-dimensional datacube works with
+    accessor methods.
 
     This is a regression test for
     https://github.com/GenericMappingTools/pygmt/issues/1578.
@@ -107,8 +104,8 @@ def test_accessor_sliced_datacube():
 
 def test_accessor_grid_source_file_not_exist():
     """
-    Check that the accessor fallbacks to the default registration and gtype
-    when the grid source file (i.e., grid.encoding["source"]) doesn't exist.
+    Check that the accessor fallbacks to the default registration and gtype when the
+    grid source file (i.e., grid.encoding["source"]) doesn't exist.
     """
     # Load the 05m earth relief grid, which is stored as tiles
     grid = load_earth_relief(

--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -76,8 +76,7 @@ def test_basemap_utm_projection(projection):
     """
     Create a Universal Transverse Mercator (Zone 23S) basemap plot.
 
-    Also check that providing the projection as an EPSG code or PROJ4 string
-    works.
+    Also check that providing the projection as an EPSG code or PROJ4 string works.
     """
     projection = projection.replace(
         "EPSG_",
@@ -133,8 +132,8 @@ def test_basemap_map_scale():
 @pytest.mark.mpl_image_compare
 def test_basemap_subplot():
     """
-    Test in subplot mode for the case that the frame parameter of basemap is
-    not specified.
+    Test in subplot mode for the case that the frame parameter of basemap is not
+    specified.
     """
     fig = Figure()
     with fig.subplot(nrows=1, ncols=2, figsize=("10c", "5c")):

--- a/pygmt/tests/test_blockm.py
+++ b/pygmt/tests/test_blockm.py
@@ -36,8 +36,7 @@ def test_blockmean_input_dataframe(dataframe):
 @pytest.mark.parametrize("array_func", [np.array, xr.Dataset])
 def test_blockmean_input_table_matrix(array_func, dataframe):
     """
-    Run blockmean using table input that is not a pandas.DataFrame but still a
-    matrix.
+    Run blockmean using table input that is not a pandas.DataFrame but still a matrix.
     """
     table = array_func(dataframe)
     output = blockmean(data=table, spacing="5m", region=[245, 255, 20, 30])
@@ -64,8 +63,7 @@ def test_blockmean_input_xyz(dataframe):
 
 def test_blockmean_wrong_kind_of_input_table_grid(dataframe):
     """
-    Run blockmean using table input that is not a pandas.DataFrame or file but
-    a grid.
+    Run blockmean using table input that is not a pandas.DataFrame or file but a grid.
     """
     invalid_table = dataframe.bathymetry.to_xarray()
     assert data_kind(invalid_table) == "grid"

--- a/pygmt/tests/test_blockmedian.py
+++ b/pygmt/tests/test_blockmedian.py
@@ -33,8 +33,7 @@ def test_blockmedian_input_dataframe(dataframe):
 
 def test_blockmedian_input_table_matrix(dataframe):
     """
-    Run blockmedian using table input that is not a pandas.DataFrame but still
-    a matrix.
+    Run blockmedian using table input that is not a pandas.DataFrame but still a matrix.
     """
     table = dataframe.to_numpy()
     output = blockmedian(data=table, spacing="5m", region=[245, 255, 20, 30])
@@ -61,8 +60,7 @@ def test_blockmedian_input_xyz(dataframe):
 
 def test_blockmedian_wrong_kind_of_input_table_grid(dataframe):
     """
-    Run blockmedian using table input that is not a pandas.DataFrame or file
-    but a grid.
+    Run blockmedian using table input that is not a pandas.DataFrame or file but a grid.
     """
     invalid_table = dataframe.bathymetry.to_xarray()
     assert data_kind(invalid_table) == "grid"

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -29,12 +29,12 @@ def mock(session, func, returns=None, mock_func=None):
     """
     Mock a GMT C API function to make it always return a given value.
 
-    Used to test that exceptions are raised when API functions fail by
-    producing a NULL pointer as output or non-zero status codes.
+    Used to test that exceptions are raised when API functions fail by producing a NULL
+    pointer as output or non-zero status codes.
 
-    Needed because it's not easy to get some API functions to fail without
-    inducing a Segmentation Fault (which is a good thing because libgmt usually
-    only fails with errors).
+    Needed because it's not easy to get some API functions to fail without inducing a
+    Segmentation Fault (which is a good thing because libgmt usually only fails with
+    errors).
     """
     if mock_func is None:
 

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -68,8 +68,7 @@ def test_load_libgmt():
 @pytest.mark.skipif(sys.platform == "win32", reason="run on UNIX platforms only")
 def test_load_libgmt_fails(monkeypatch):
     """
-    Test that GMTCLibNotFoundError is raised when GMT's shared library cannot
-    be found.
+    Test that GMTCLibNotFoundError is raised when GMT's shared library cannot be found.
     """
     with monkeypatch.context() as mpatch:
         mpatch.setattr(
@@ -244,8 +243,8 @@ def test_clib_full_names_gmt_library_path_undefined_path_empty(
     monkeypatch, gmt_lib_names
 ):
     """
-    Make sure that clib_full_names() returns a generator with expected names
-    when GMT_LIBRARY_PATH is undefined and PATH is empty.
+    Make sure that clib_full_names() returns a generator with expected names when
+    GMT_LIBRARY_PATH is undefined and PATH is empty.
     """
     with monkeypatch.context() as mpatch:
         mpatch.delenv("GMT_LIBRARY_PATH", raising=False)
@@ -260,8 +259,8 @@ def test_clib_full_names_gmt_library_path_defined_path_empty(
     monkeypatch, gmt_lib_names, gmt_lib_realpath
 ):
     """
-    Make sure that clib_full_names() returns a generator with expected names
-    when GMT_LIBRARY_PATH is defined and PATH is empty.
+    Make sure that clib_full_names() returns a generator with expected names when
+    GMT_LIBRARY_PATH is defined and PATH is empty.
     """
     with monkeypatch.context() as mpatch:
         mpatch.setenv("GMT_LIBRARY_PATH", str(PurePath(gmt_lib_realpath).parent))
@@ -276,8 +275,8 @@ def test_clib_full_names_gmt_library_path_undefined_path_included(
     monkeypatch, gmt_lib_names, gmt_lib_realpath, gmt_bin_dir
 ):
     """
-    Make sure that clib_full_names() returns a generator with expected names
-    when GMT_LIBRARY_PATH is undefined and PATH includes GMT's bin path.
+    Make sure that clib_full_names() returns a generator with expected names when
+    GMT_LIBRARY_PATH is undefined and PATH includes GMT's bin path.
     """
     with monkeypatch.context() as mpatch:
         mpatch.delenv("GMT_LIBRARY_PATH", raising=False)
@@ -293,8 +292,8 @@ def test_clib_full_names_gmt_library_path_defined_path_included(
     monkeypatch, gmt_lib_names, gmt_lib_realpath, gmt_bin_dir
 ):
     """
-    Make sure that clib_full_names() returns a generator with expected names
-    when GMT_LIBRARY_PATH is defined and PATH includes GMT's bin path.
+    Make sure that clib_full_names() returns a generator with expected names when
+    GMT_LIBRARY_PATH is defined and PATH includes GMT's bin path.
     """
     with monkeypatch.context() as mpatch:
         mpatch.setenv("GMT_LIBRARY_PATH", str(PurePath(gmt_lib_realpath).parent))
@@ -311,9 +310,8 @@ def test_clib_full_names_gmt_library_path_incorrect_path_included(
     monkeypatch, gmt_lib_names, gmt_lib_realpath, gmt_bin_dir
 ):
     """
-    Make sure that clib_full_names() returns a generator with expected names
-    when GMT_LIBRARY_PATH is defined but incorrect and PATH includes GMT's bin
-    path.
+    Make sure that clib_full_names() returns a generator with expected names when
+    GMT_LIBRARY_PATH is defined but incorrect and PATH includes GMT's bin path.
     """
     with monkeypatch.context() as mpatch:
         mpatch.setenv("GMT_LIBRARY_PATH", "/not/a/valid/library/path")

--- a/pygmt/tests/test_clib_virtualfiles.py
+++ b/pygmt/tests/test_clib_virtualfiles.py
@@ -64,8 +64,8 @@ def test_virtual_file(dtypes):
 
 def test_virtual_file_fails():
     """
-    Check that opening and closing virtual files raises an exception for non-
-    zero return codes.
+    Check that opening and closing virtual files raises an exception for non- zero
+    return codes.
     """
     vfargs = (
         "GMT_IS_DATASET|GMT_VIA_MATRIX",
@@ -115,8 +115,7 @@ def test_virtual_file_bad_direction():
 )
 def test_virtualfile_from_data_required_z_matrix(array_func, kind):
     """
-    Test that function works when third z column in a matrix is needed and
-    provided.
+    Test that function works when third z column in a matrix is needed and provided.
     """
     shape = (5, 3)
     dataframe = pd.DataFrame(
@@ -142,8 +141,7 @@ def test_virtualfile_from_data_required_z_matrix(array_func, kind):
 
 def test_virtualfile_from_data_required_z_matrix_missing():
     """
-    Test that function fails when third z column in a matrix is needed but not
-    provided.
+    Test that function fails when third z column in a matrix is needed but not provided.
     """
     data = np.ones((5, 2))
     with clib.Session() as lib:
@@ -213,8 +211,7 @@ def test_virtualfile_from_vectors(dtypes):
 @pytest.mark.parametrize("dtype", [str, object])
 def test_virtualfile_from_vectors_one_string_or_object_column(dtype):
     """
-    Test passing in one column with string or object dtype into virtual file
-    dataset.
+    Test passing in one column with string or object dtype into virtual file dataset.
     """
     size = 5
     x = np.arange(size, dtype=np.int32)
@@ -232,8 +229,7 @@ def test_virtualfile_from_vectors_one_string_or_object_column(dtype):
 @pytest.mark.parametrize("dtype", [str, object])
 def test_virtualfile_from_vectors_two_string_or_object_columns(dtype):
     """
-    Test passing in two columns of string or object dtype into virtual file
-    dataset.
+    Test passing in two columns of string or object dtype into virtual file dataset.
     """
     size = 5
     x = np.arange(size, dtype=np.int32)
@@ -321,8 +317,8 @@ def test_virtualfile_from_matrix_slice(dtypes):
 
 def test_virtualfile_from_vectors_pandas(dtypes):
     """
-    Pass vectors to a dataset using pandas.Series, checking both numpy and
-    pyarrow dtypes.
+    Pass vectors to a dataset using pandas.Series, checking both numpy and pyarrow
+    dtypes.
     """
     size = 13
     if find_spec("pyarrow") is not None:

--- a/pygmt/tests/test_config.py
+++ b/pygmt/tests/test_config.py
@@ -41,8 +41,8 @@ def test_config_font_one():
     """
     Test that setting FONT config changes all FONT_* settings except FONT_LOGO.
 
-    Specifically, this test only checks that FONT_ANNOT_PRIMARY,
-    FONT_ANNOT_SECONDARY, FONT_LABEL, and FONT_TITLE are modified.
+    Specifically, this test only checks that FONT_ANNOT_PRIMARY, FONT_ANNOT_SECONDARY,
+    FONT_LABEL, and FONT_TITLE are modified.
     """
     fig = Figure()
     with config(FONT="8p,red"):
@@ -67,8 +67,8 @@ def test_config_font_annot():
 @pytest.mark.mpl_image_compare
 def test_config_format_date_map():
     """
-    Test that setting FORMAT_DATE_MAP config changes how the output date string
-    is plotted.
+    Test that setting FORMAT_DATE_MAP config changes how the output date string is
+    plotted.
 
     Note the space in 'o dd', this acts as a regression test for
     https://github.com/GenericMappingTools/pygmt/issues/247.
@@ -91,8 +91,8 @@ def test_config_format_date_map():
 @pytest.mark.mpl_image_compare
 def test_config_format_time_map():
     """
-    Test that setting FORMAT_TIME_MAP config changes both
-    FORMAT_TIME_PRIMARY_MAP and FORMAT_TIME_SECONDARY_MAP.
+    Test that setting FORMAT_TIME_MAP config changes both FORMAT_TIME_PRIMARY_MAP and
+    FORMAT_TIME_SECONDARY_MAP.
     """
     fig = Figure()
     with config(FORMAT_TIME_MAP="abbreviation"):
@@ -108,8 +108,8 @@ def test_config_format_time_map():
 @pytest.mark.mpl_image_compare
 def test_config_map_annot_offset():
     """
-    Test that setting MAP_ANNOT_OFFSET config changes both
-    MAP_ANNOT_OFFSET_PRIMARY and MAP_ANNOT_OFFSET_SECONDARY.
+    Test that setting MAP_ANNOT_OFFSET config changes both MAP_ANNOT_OFFSET_PRIMARY and
+    MAP_ANNOT_OFFSET_SECONDARY.
     """
     fig = Figure()
     with config(MAP_ANNOT_OFFSET="15p"):
@@ -163,8 +163,8 @@ def test_config_map_grid_pen():
 @pytest.mark.mpl_image_compare
 def test_config_map_tick_length():
     """
-    Test that setting MAP_TICK_LENGTH config changes both
-    MAP_TICK_LENGTH_PRIMARY and MAP_TICK_LENGTH_SECONDARY.
+    Test that setting MAP_TICK_LENGTH config changes both MAP_TICK_LENGTH_PRIMARY and
+    MAP_TICK_LENGTH_SECONDARY.
     """
     fig = Figure()
     with config(MAP_TICK_LENGTH="5p"):

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -77,8 +77,8 @@ def test_contour_from_file(region):
 @pytest.mark.mpl_image_compare(filename="test_contour_vec.png")
 def test_contour_incols_transposed_data(region):
     """
-    Make sure that transposing the data matrix still produces a correct result
-    with incols reordering the columns.
+    Make sure that transposing the data matrix still produces a correct result with
+    incols reordering the columns.
 
     This is a regression test for
     https://github.com/GenericMappingTools/pygmt/issues/1313

--- a/pygmt/tests/test_datasets_earth_age.py
+++ b/pygmt/tests/test_datasets_earth_age.py
@@ -38,8 +38,8 @@ def test_earth_age_01d_with_region():
 
 def test_earth_age_01m_default_registration():
     """
-    Test that the grid returned by default for the 1 arc-minute resolution has
-    a "gridline" registration.
+    Test that the grid returned by default for the 1 arc-minute resolution has a
+    "gridline" registration.
     """
     data = load_earth_age(resolution="01m", region=[-10, -9, 3, 5])
     assert data.shape == (121, 61)

--- a/pygmt/tests/test_datasets_earth_free_air_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_free_air_anomaly.py
@@ -38,8 +38,8 @@ def test_earth_faa_01d_with_region():
 
 def test_earth_faa_01m_default_registration():
     """
-    Test that the grid returned by default for the 1 arc-minute resolution has
-    a "pixel" registration.
+    Test that the grid returned by default for the 1 arc-minute resolution has a "pixel"
+    registration.
     """
     data = load_earth_free_air_anomaly(resolution="01m", region=[-10, -9, 3, 5])
     assert data.shape == (120, 60)

--- a/pygmt/tests/test_datasets_earth_geoid.py
+++ b/pygmt/tests/test_datasets_earth_geoid.py
@@ -38,8 +38,8 @@ def test_earth_geoid_01d_with_region():
 
 def test_earth_geoid_01m_default_registration():
     """
-    Test that the grid returned by default for the 1 arc-minute resolution has
-    a "gridline" registration.
+    Test that the grid returned by default for the 1 arc-minute resolution has a
+    "gridline" registration.
     """
     data = load_earth_geoid(resolution="01m", region=[-10, -9, 3, 5])
     assert data.shape == (121, 61)

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -40,8 +40,8 @@ def test_earth_mag_01d_with_region():
 
 def test_earth_mag_02m_default_registration():
     """
-    Test that the grid returned by default for the 2 arc-minute resolution has
-    a "pixel" registration.
+    Test that the grid returned by default for the 2 arc-minute resolution has a "pixel"
+    registration.
     """
     data = load_earth_magnetic_anomaly(resolution="02m", region=[-10, -9, 3, 5])
     assert data.shape == (60, 30)
@@ -90,8 +90,8 @@ def test_earth_mag4km_01d_with_region():
 
 def test_earth_mag4km_02m_default_registration():
     """
-    Test that the grid returned by default for the 2 arc-minute resolution has
-    a "pixel" registration.
+    Test that the grid returned by default for the 2 arc-minute resolution has a "pixel"
+    registration.
     """
     data = load_earth_magnetic_anomaly(
         resolution="02m",
@@ -162,8 +162,7 @@ def test_earth_mag_03m_wdmam_with_region():
 
 def test_earth_mag_data_source_error():
     """
-    Test that an error is raised when an invalid argument is passed to
-    'data_source'.
+    Test that an error is raised when an invalid argument is passed to 'data_source'.
     """
     with pytest.raises(GMTInvalidInput):
         load_earth_magnetic_anomaly(resolution="01d", data_source="invalid")

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -12,8 +12,7 @@ from pygmt.exceptions import GMTInvalidInput
 @pytest.mark.parametrize("data_source", ["igpp", "synbath"])
 def test_earth_relief_01d_igpp_synbath(data_source):
     """
-    Test some properties of the earth relief 01d data with IGPP and SYNBATH
-    data.
+    Test some properties of the earth relief 01d data with IGPP and SYNBATH data.
     """
     data = load_earth_relief(resolution="01d", data_source=data_source)
     assert data.name == "elevation"
@@ -32,8 +31,7 @@ def test_earth_relief_01d_igpp_synbath(data_source):
 @pytest.mark.parametrize("data_source", ["gebco", "gebcosi"])
 def test_earth_relief_01d_gebco(data_source):
     """
-    Test some properties of the earth relief 01d data with GEBCO and GEBOCSI
-    data.
+    Test some properties of the earth relief 01d data with GEBCO and GEBOCSI data.
     """
     data = load_earth_relief(resolution="01d", data_source=data_source)
     assert data.attrs["units"] == "meters"
@@ -159,8 +157,8 @@ def test_earth_relief_invalid_data_source():
 
 def test_earth_relief_invalid_data_source_with_use_srtm():
     """
-    Test loading earth relief with use_srtm=True and an incompatible
-    data_source argument.
+    Test loading earth relief with use_srtm=True and an incompatible data_source
+    argument.
     """
     with pytest.raises(GMTInvalidInput):
         load_earth_relief(
@@ -174,8 +172,8 @@ def test_earth_relief_invalid_data_source_with_use_srtm():
 
 def test_earth_relief_15s_default_registration():
     """
-    Test that the grid returned by default for the 15 arc-second resolution has
-    a "pixel" registration.
+    Test that the grid returned by default for the 15 arc-second resolution has a
+    "pixel" registration.
     """
     data = load_earth_relief(resolution="15s", region=[-10, -9.5, 4, 5])
     assert data.shape == (240, 120)
@@ -190,8 +188,8 @@ def test_earth_relief_15s_default_registration():
 
 def test_earth_relief_03s_default_registration():
     """
-    Test that the grid returned by default for the 3 arc-second resolution has
-    a "gridline" registration.
+    Test that the grid returned by default for the 3 arc-second resolution has a
+    "gridline" registration.
     """
     data = load_earth_relief(resolution="03s", region=[-10, -9.8, 4.9, 5])
     assert data.shape == (121, 241)

--- a/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
+++ b/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
@@ -41,8 +41,8 @@ def test_earth_vertical_gravity_gradient_01d_with_region():
 
 def test_earth_vertical_gravity_gradient_01m_default_registration():
     """
-    Test that the grid returned by default for the 1 arc-minute resolution has
-    a "pixel" registration.
+    Test that the grid returned by default for the 1 arc-minute resolution has a "pixel"
+    registration.
     """
     data = load_earth_vertical_gravity_gradient(
         resolution="01m", region=[-10, -9, 3, 5]

--- a/pygmt/tests/test_datasets_load_remote_datasets.py
+++ b/pygmt/tests/test_datasets_load_remote_datasets.py
@@ -40,8 +40,8 @@ def test_load_remote_dataset_invalid_registration():
 
 def test_load_remote_dataset_tiled_grid_without_region():
     """
-    Make sure _load_remote_dataset fails when trying to load a tiled grid
-    without specifying a region.
+    Make sure _load_remote_dataset fails when trying to load a tiled grid without
+    specifying a region.
     """
     with pytest.raises(GMTInvalidInput):
         load_remote_dataset_wrapper(resolution="01m")
@@ -49,8 +49,8 @@ def test_load_remote_dataset_tiled_grid_without_region():
 
 def test_load_remote_dataset_incorrect_resolution_registration():
     """
-    Make sure _load_remote_dataset fails when trying to load a grid
-    registration with an unavailable resolution.
+    Make sure _load_remote_dataset fails when trying to load a grid registration with an
+    unavailable resolution.
     """
     with pytest.raises(GMTInvalidInput):
         load_remote_dataset_wrapper(

--- a/pygmt/tests/test_dimfilter.py
+++ b/pygmt/tests/test_dimfilter.py
@@ -74,8 +74,8 @@ def test_dimfilter_no_outgrid(grid, expected_grid):
 
 def test_dimfilter_fails(grid):
     """
-    Check that dimfilter fails correctly when not all of sectors, filters, and
-    distance are specified.
+    Check that dimfilter fails correctly when not all of sectors, filters, and distance
+    are specified.
     """
     with pytest.raises(GMTInvalidInput):
         dimfilter(grid=grid, sectors="l6", distance=4)

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -58,8 +58,7 @@ def test_figure_region_country_codes():
 
 def test_figure_repr():
     """
-    Make sure that figure output's PNG and HTML printable representations look
-    ok.
+    Make sure that figure output's PNG and HTML printable representations look ok.
     """
     fig = Figure()
     fig.basemap(region=[0, 1, 2, 3], frame=True)
@@ -91,8 +90,7 @@ def test_figure_savefig_exists():
 
 def test_figure_savefig_geotiff():
     """
-    Make sure .tif generates a normal TIFF file and .tiff generates a GeoTIFF
-    file.
+    Make sure .tif generates a normal TIFF file and .tiff generates a GeoTIFF file.
     """
     fig = Figure()
     fig.basemap(region=[0, 10, 0, 10], projection="M10c", frame=True)
@@ -156,8 +154,8 @@ def test_figure_savefig_geotiff():
 
 def test_figure_savefig_directory_nonexists():
     """
-    Make sure that Figure.savefig() raises a FileNotFoundError when the parent
-    directory doesn't exist.
+    Make sure that Figure.savefig() raises a FileNotFoundError when the parent directory
+    doesn't exist.
     """
     fig = Figure()
     fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
@@ -290,8 +288,8 @@ def test_figure_savefig():
 
 def test_figure_savefig_worldfile():
     """
-    Check if a world file is created for supported formats and raise an error
-    for unsupported formats.
+    Check if a world file is created for supported formats and raise an error for
+    unsupported formats.
     """
     fig = Figure()
     fig.basemap(region=[0, 1, 0, 1], projection="X1c/1c", frame=True)
@@ -341,8 +339,7 @@ def test_figure_shift_origin():
 
 def test_figure_show_invalid_method():
     """
-    Test to check if an error is raised when an invalid method is passed to
-    show.
+    Test to check if an error is raised when an invalid method is passed to show.
     """
     fig = Figure()
     fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
@@ -353,8 +350,8 @@ def test_figure_show_invalid_method():
 @pytest.mark.skipif(HAS_IPYTHON, reason="run without IPython installed")
 def test_figure_show_notebook_error_without_ipython():
     """
-    Test to check if an error is raised when display method is 'notebook', but
-    IPython is not installed.
+    Test to check if an error is raised when display method is 'notebook', but IPython
+    is not installed.
     """
     fig = Figure()
     fig.basemap(region=[0, 1, 2, 3], frame=True)
@@ -373,8 +370,7 @@ def test_figure_display_external():
 
 def test_figure_set_display_invalid():
     """
-    Test to check if an error is raised when an invalid method is passed to
-    set_display.
+    Test to check if an error is raised when an invalid method is passed to set_display.
     """
     with pytest.raises(GMTInvalidInput):
         set_display(method="invalid")
@@ -382,8 +378,7 @@ def test_figure_set_display_invalid():
 
 def test_figure_deprecated_xshift_yshift():
     """
-    Check if deprecation of parameters X/Y/xshift/yshift work correctly if
-    used.
+    Check if deprecation of parameters X/Y/xshift/yshift work correctly if used.
     """
     fig = Figure()
     fig.basemap(region=[0, 1, 0, 1], projection="X1c/1c", frame=True)

--- a/pygmt/tests/test_filter1d.py
+++ b/pygmt/tests/test_filter1d.py
@@ -58,8 +58,8 @@ def test_filter1d_no_filter(data):
 
 def test_filter1d_no_outfile_specified(data):
     """
-    Test that filter1d fails when outpput_type is set to 'file' but no output
-    file name is specified.
+    Test that filter1d fails when outpput_type is set to 'file' but no output file name
+    is specified.
     """
     with pytest.raises(GMTInvalidInput):
         filter1d(data=data, filter_type="g5", output_type="file")

--- a/pygmt/tests/test_geopandas.py
+++ b/pygmt/tests/test_geopandas.py
@@ -14,8 +14,8 @@ shapely = pytest.importorskip("shapely")
 @pytest.fixture(scope="module", name="gdf")
 def fixture_gdf():
     """
-    Create a sample geopandas GeoDataFrame object with shapely geometries of
-    different types.
+    Create a sample geopandas GeoDataFrame object with shapely geometries of different
+    types.
     """
     linestring = shapely.geometry.LineString([(20, 15), (30, 15)])
     polygon = shapely.geometry.Polygon([(20, 10), (23, 10), (23, 14), (20, 14)])
@@ -43,8 +43,8 @@ def fixture_gdf():
 @pytest.fixture(scope="module", name="gdf_ridge")
 def fixture_gdf_ridge():
     """
-    Read a @RidgeTest.shp shapefile into a geopandas.GeoDataFrame and reproject
-    the geometry.
+    Read a @RidgeTest.shp shapefile into a geopandas.GeoDataFrame and reproject the
+    geometry.
     """
     # Read shapefile into a geopandas.GeoDataFrame
     shapefile = which(
@@ -64,8 +64,7 @@ def fixture_gdf_ridge():
 @pytest.mark.benchmark
 def test_geopandas_info_geodataframe(gdf):
     """
-    Check that info can return the bounding box region from a
-    geopandas.GeoDataFrame.
+    Check that info can return the bounding box region from a geopandas.GeoDataFrame.
     """
     output = info(data=gdf, per_column=True)
     npt.assert_allclose(actual=output, desired=[0.0, 35.0, 0.0, 20.0])
@@ -81,8 +80,8 @@ def test_geopandas_info_geodataframe(gdf):
 )
 def test_geopandas_info_shapely(gdf, geomtype, desired):
     """
-    Check that info can return the bounding box region from a shapely.geometry
-    object that has a __geo_interface__ property.
+    Check that info can return the bounding box region from a shapely.geometry object
+    that has a __geo_interface__ property.
     """
     geom = gdf.loc[geomtype].geometry
     output = info(data=geom, per_column=True)
@@ -92,8 +91,8 @@ def test_geopandas_info_shapely(gdf, geomtype, desired):
 @pytest.mark.mpl_image_compare
 def test_geopandas_plot_default_square():
     """
-    Check the default behavior of plotting a geopandas DataFrame with Point
-    geometry in 2d.
+    Check the default behavior of plotting a geopandas DataFrame with Point geometry in
+    2d.
     """
     point = shapely.geometry.Point(1, 2)
     gdf = gpd.GeoDataFrame(geometry=[point])
@@ -105,8 +104,8 @@ def test_geopandas_plot_default_square():
 @pytest.mark.mpl_image_compare
 def test_geopandas_plot3d_default_cube():
     """
-    Check the default behavior of plotting a geopandas DataFrame with
-    MultiPoint geometry in 3d.
+    Check the default behavior of plotting a geopandas DataFrame with MultiPoint
+    geometry in 3d.
     """
     multipoint = shapely.geometry.MultiPoint([(0.5, 0.5, 0.5), (1.5, 1.5, 1.5)])
     gdf = gpd.GeoDataFrame(geometry=[multipoint])
@@ -125,8 +124,8 @@ def test_geopandas_plot3d_default_cube():
 @pytest.mark.mpl_image_compare
 def test_geopandas_plot_non_default_circle():
     """
-    Check the default behavior of plotting geopandas DataFrame with Point
-    geometry in 2d.
+    Check the default behavior of plotting geopandas DataFrame with Point geometry in
+    2d.
     """
     point = shapely.geometry.Point(1, 2)
     gdf = gpd.GeoDataFrame(geometry=[point])
@@ -138,8 +137,8 @@ def test_geopandas_plot_non_default_circle():
 @pytest.mark.mpl_image_compare
 def test_geopandas_plot3d_non_default_circle():
     """
-    Check the default behavior of plotting geopandas DataFrame with MultiPoint
-    geometry in 3d.
+    Check the default behavior of plotting geopandas DataFrame with MultiPoint geometry
+    in 3d.
     """
     multipoint = shapely.geometry.MultiPoint([(0.5, 0.5, 0.5), (1.5, 1.5, 1.5)])
     gdf = gpd.GeoDataFrame(geometry=[multipoint])
@@ -186,8 +185,8 @@ def test_geopandas_plot3d_non_default_circle():
 @pytest.mark.mpl_image_compare(filename="test_geopandas_plot_int_dtypes.png")
 def test_geopandas_plot_int_dtypes(gdf_ridge, dtype):
     """
-    Check that plotting a geopandas.GeoDataFrame with integer columns works,
-    including int32 and int64 (non-nullable), Int32 and Int64 (nullable).
+    Check that plotting a geopandas.GeoDataFrame with integer columns works, including
+    int32 and int64 (non-nullable), Int32 and Int64 (nullable).
 
     This is a regression test for
     https://github.com/GenericMappingTools/pygmt/issues/2497

--- a/pygmt/tests/test_grd2cpt.py
+++ b/pygmt/tests/test_grd2cpt.py
@@ -22,8 +22,8 @@ def fixture_grid():
 @pytest.mark.mpl_image_compare
 def test_grd2cpt(grid):
     """
-    Test creating a CPT with grd2cpt to create a CPT based off a grid input and
-    plot it with a color bar.
+    Test creating a CPT with grd2cpt to create a CPT based off a grid input and plot it
+    with a color bar.
     """
     fig = Figure()
     fig.basemap(frame="a", projection="W0/15c", region="d")
@@ -59,8 +59,7 @@ def test_grd2cpt_output_to_cpt_file(grid):
 
 def test_grd2cpt_unrecognized_data_type():
     """
-    Test that an error will be raised if an invalid data type is passed to
-    grid.
+    Test that an error will be raised if an invalid data type is passed to grid.
     """
     with pytest.raises(GMTInvalidInput):
         grd2cpt(grid=0)

--- a/pygmt/tests/test_grd2xyz.py
+++ b/pygmt/tests/test_grd2xyz.py
@@ -91,8 +91,7 @@ def test_grd2xyz_outfile_incorrect_output_type(grid):
 
 def test_grd2xyz_pandas_output_with_o(grid):
     """
-    Test that grd2xyz fails when outcols is set and output_type is set to
-    'pandas'.
+    Test that grd2xyz fails when outcols is set and output_type is set to 'pandas'.
     """
     with pytest.raises(GMTInvalidInput):
         grd2xyz(grid=grid, output_type="pandas", outcols="2")

--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -37,8 +37,7 @@ def test_grdcontour(grid):
 @pytest.mark.mpl_image_compare
 def test_grdcontour_labels(grid):
     """
-    Plot a contour image using a xarray grid with contour labels and alternate
-    colors.
+    Plot a contour image using a xarray grid with contour labels and alternate colors.
     """
     fig = Figure()
     fig.grdcontour(

--- a/pygmt/tests/test_grdfill.py
+++ b/pygmt/tests/test_grdfill.py
@@ -17,8 +17,8 @@ from pygmt.helpers.testing import load_static_earth_relief
 @pytest.fixture(scope="module", name="grid")
 def fixture_grid():
     """
-    Load the grid data from the static_earth_relief file and set value(s) to
-    NaN and inf.
+    Load the grid data from the static_earth_relief file and set value(s) to NaN and
+    inf.
     """
     grid = load_static_earth_relief()
     grid[3:6, 3:5] = np.nan

--- a/pygmt/tests/test_grdgradient.py
+++ b/pygmt/tests/test_grdgradient.py
@@ -40,8 +40,7 @@ def fixture_expected_grid():
 
 def test_grdgradient_outgrid(grid, expected_grid):
     """
-    Test the azimuth and direction parameters for grdgradient with a set
-    outgrid.
+    Test the azimuth and direction parameters for grdgradient with a set outgrid.
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         result = grdgradient(
@@ -56,8 +55,7 @@ def test_grdgradient_outgrid(grid, expected_grid):
 @pytest.mark.benchmark
 def test_grdgradient_no_outgrid(grid, expected_grid):
     """
-    Test the azimuth and direction parameters for grdgradient with no set
-    outgrid.
+    Test the azimuth and direction parameters for grdgradient with no set outgrid.
 
     This is a regression test for
     https://github.com/GenericMappingTools/pygmt/issues/1807.

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -21,8 +21,7 @@ def fixture_grid():
 @pytest.fixture(scope="module", name="grid_360")
 def fixture_grid_360(grid):
     """
-    Earth relief grid with longitude range from 0 to 360 (instead of -180 to
-    180).
+    Earth relief grid with longitude range from 0 to 360 (instead of -180 to 180).
     """
     _grid = grid.copy()  # get a copy of original earth_relief grid
     _grid.encoding.pop("source")  # unlink earth_relief netCDF source
@@ -135,8 +134,8 @@ def test_grdimage_shading_xarray(grid, shading):
 @check_figures_equal()
 def test_grdimage_grid_and_shading_with_xarray(grid, xrgrid):
     """
-    Test that shading works well when xarray.DataArray is input to both the
-    ``grid`` and ``shading`` arguments.
+    Test that shading works well when xarray.DataArray is input to both the ``grid`` and
+    ``shading`` arguments.
     """
     fig_ref, fig_test = Figure(), Figure()
     fig_ref.grdimage(
@@ -179,10 +178,10 @@ def test_grdimage_global_subset(grid_360):
     """
     Ensure subsets of grids are plotted correctly on a global map.
 
-    Specifically checking that xarray.DataArray grids can wrap around the left
-    and right sides on a Mollweide projection (W) plot correctly. Note that a
-    Cartesian grid is used here instead of a Geographic grid (i.e.
-    GMT_GRID_IS_CARTESIAN). This is a regression test for
+    Specifically checking that xarray.DataArray grids can wrap around the left and right
+    sides on a Mollweide projection (W) plot correctly. Note that a Cartesian grid is
+    used here instead of a Geographic grid (i.e. GMT_GRID_IS_CARTESIAN). This is a
+    regression test for
     https://github.com/GenericMappingTools/pygmt/issues/732.
     """
     # Get a slice of South America and Africa only (lat=-90:31, lon=-180:41)
@@ -202,8 +201,8 @@ def test_grdimage_global_subset(grid_360):
 @pytest.mark.parametrize("proj_type", ["H", "W"])
 def test_grdimage_central_meridians(grid, proj_type, lon0):
     """
-    Test that plotting a grid with different central meridians (lon0) using
-    Hammer (H) and Mollweide (W) projection systems work.
+    Test that plotting a grid with different central meridians (lon0) using Hammer (H)
+    and Mollweide (W) projection systems work.
     """
     fig_ref, fig_test = Figure(), Figure()
     fig_ref.grdimage(

--- a/pygmt/tests/test_grdimage_image.py
+++ b/pygmt/tests/test_grdimage_image.py
@@ -14,8 +14,8 @@ rioxarray = pytest.importorskip("rioxarray")
 @pytest.fixture(scope="module", name="xr_image")
 def fixture_xr_image():
     """
-    Load the image data from Blue Marble as an xarray.DataArray with shape
-    {"band": 3, "y": 180, "x": 360}.
+    Load the image data from Blue Marble as an xarray.DataArray with shape {"band": 3,
+    "y": 180, "x": 360}.
     """
     geotiff = which(fname="@earth_day_01d_p", download="c")
     with rioxarray.open_rasterio(filename=geotiff) as rda:
@@ -70,8 +70,7 @@ def test_grdimage_image_dataarray(xr_image):
 )
 def test_grdimage_image_dataarray_unsupported_dtype(dtype, xr_image):
     """
-    Plot a 3-band RGB image using xarray.DataArray input, with an unsupported
-    data type.
+    Plot a 3-band RGB image using xarray.DataArray input, with an unsupported data type.
     """
     fig = Figure()
     image = xr_image.astype(dtype=dtype)

--- a/pygmt/tests/test_grdlandmask.py
+++ b/pygmt/tests/test_grdlandmask.py
@@ -60,8 +60,7 @@ def test_grdlandmask_no_outgrid(expected_grid):
 
 def test_grdlandmask_fails():
     """
-    Check that grdlandmask fails correctly when region and spacing are not
-    given.
+    Check that grdlandmask fails correctly when region and spacing are not given.
     """
     with pytest.raises(GMTInvalidInput):
         grdlandmask()

--- a/pygmt/tests/test_grdproject.py
+++ b/pygmt/tests/test_grdproject.py
@@ -67,8 +67,7 @@ def test_grdproject_no_outgrid(grid, projection, expected_grid):
     """
     Test grdproject with no set outgrid.
 
-    Also check that providing the projection as an EPSG code or PROJ4 string
-    works.
+    Also check that providing the projection as an EPSG code or PROJ4 string works.
     """
     assert grid.gmt.gtype == 1  # Geographic grid
     result = grdproject(

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -58,8 +58,7 @@ def fixture_dataframe():
 @pytest.mark.benchmark
 def test_grdtrack_input_dataframe_and_dataarray(dataarray, dataframe, expected_array):
     """
-    Run grdtrack by passing in a pandas.DataFrame and xarray.DataArray as
-    inputs.
+    Run grdtrack by passing in a pandas.DataFrame and xarray.DataArray as inputs.
     """
     output = grdtrack(points=dataframe, grid=dataarray, newcolname="bathymetry")
     assert isinstance(output, pd.DataFrame)
@@ -126,8 +125,7 @@ def test_grdtrack_profile(dataarray):
 
 def test_grdtrack_wrong_kind_of_points_input(dataarray, dataframe):
     """
-    Run grdtrack using points input that is not a pandas.DataFrame (matrix) or
-    file.
+    Run grdtrack using points input that is not a pandas.DataFrame (matrix) or file.
     """
     invalid_points = dataframe.longitude.to_xarray()
 
@@ -138,8 +136,7 @@ def test_grdtrack_wrong_kind_of_points_input(dataarray, dataframe):
 
 def test_grdtrack_wrong_kind_of_grid_input(dataarray, dataframe):
     """
-    Run grdtrack using grid input that is not as xarray.DataArray (grid) or
-    file.
+    Run grdtrack using grid input that is not as xarray.DataArray (grid) or file.
     """
     invalid_grid = dataarray.to_dataset()
 

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -67,9 +67,8 @@ def test_grdview_wrong_kind_of_grid(xrgrid):
 @pytest.mark.mpl_image_compare
 def test_grdview_with_perspective(gridfile):
     """
-    Run grdview by passing in a grid and setting a perspective viewpoint with
-    an azimuth from the SouthEast and an elevation angle 15 degrees from the
-    z-plane.
+    Run grdview by passing in a grid and setting a perspective viewpoint with an azimuth
+    from the SouthEast and an elevation angle 15 degrees from the z-plane.
     """
     fig = Figure()
     fig.grdview(grid=gridfile, projection="Q15c+", perspective=[135, 15], frame=True)
@@ -79,9 +78,9 @@ def test_grdview_with_perspective(gridfile):
 @pytest.mark.mpl_image_compare
 def test_grdview_with_perspective_and_zscale(xrgrid):
     """
-    Run grdview by passing in a grid and setting a perspective viewpoint with
-    an azimuth from the SouthWest and an elevation angle 30 degrees from the
-    z-plane, plus a z-axis scaling factor of 0.005.
+    Run grdview by passing in a grid and setting a perspective viewpoint with an azimuth
+    from the SouthWest and an elevation angle 30 degrees from the z-plane, plus a z-axis
+    scaling factor of 0.005.
     """
     fig = Figure()
     fig.grdview(grid=xrgrid, perspective=[225, 30], zscale=0.005)
@@ -91,9 +90,9 @@ def test_grdview_with_perspective_and_zscale(xrgrid):
 @pytest.mark.mpl_image_compare
 def test_grdview_with_perspective_and_zsize(xrgrid):
     """
-    Run grdview by passing in a grid and setting a perspective viewpoint with
-    an azimuth from the SouthWest and an elevation angle 30 degrees from the
-    z-plane, plus a z-axis size of 10cm.
+    Run grdview by passing in a grid and setting a perspective viewpoint with an azimuth
+    from the SouthWest and an elevation angle 30 degrees from the z-plane, plus a z-axis
+    size of 10cm.
     """
     fig = Figure()
     fig.grdview(grid=xrgrid, perspective=[225, 30], zsize="10c")
@@ -103,8 +102,7 @@ def test_grdview_with_perspective_and_zsize(xrgrid):
 @pytest.mark.mpl_image_compare
 def test_grdview_with_cmap_for_image_plot(xrgrid):
     """
-    Run grdview by passing in a grid and setting a colormap for producing an
-    image plot.
+    Run grdview by passing in a grid and setting a colormap for producing an image plot.
     """
     fig = Figure()
     fig.grdview(grid=xrgrid, cmap="oleron", surftype="i")
@@ -114,8 +112,8 @@ def test_grdview_with_cmap_for_image_plot(xrgrid):
 @pytest.mark.mpl_image_compare
 def test_grdview_with_cmap_for_surface_monochrome_plot(xrgrid):
     """
-    Run grdview by passing in a grid and setting a colormap for producing a
-    surface monochrome plot.
+    Run grdview by passing in a grid and setting a colormap for producing a surface
+    monochrome plot.
     """
     fig = Figure()
     fig.grdview(grid=xrgrid, cmap="oleron", surftype="s+m")
@@ -125,8 +123,8 @@ def test_grdview_with_cmap_for_surface_monochrome_plot(xrgrid):
 @pytest.mark.mpl_image_compare
 def test_grdview_with_cmap_for_perspective_surface_plot(xrgrid):
     """
-    Run grdview by passing in a grid and setting a colormap for producing a
-    surface plot with a 3-D perspective viewpoint.
+    Run grdview by passing in a grid and setting a colormap for producing a surface plot
+    with a 3-D perspective viewpoint.
     """
     fig = Figure()
     fig.grdview(
@@ -138,8 +136,8 @@ def test_grdview_with_cmap_for_perspective_surface_plot(xrgrid):
 @pytest.mark.mpl_image_compare
 def test_grdview_on_a_plane(xrgrid):
     """
-    Run grdview by passing in a grid and plotting it on a z-plane, while
-    setting a 3-D perspective viewpoint.
+    Run grdview by passing in a grid and plotting it on a z-plane, while setting a 3-D
+    perspective viewpoint.
     """
     fig = Figure()
     fig.grdview(grid=xrgrid, plane=100, perspective=[225, 30], zscale=0.005)
@@ -149,8 +147,8 @@ def test_grdview_on_a_plane(xrgrid):
 @pytest.mark.mpl_image_compare
 def test_grdview_on_a_plane_with_colored_frontal_facade(xrgrid):
     """
-    Run grdview by passing in a grid and plotting it on a z-plane whose frontal
-    facade is colored gray, while setting a 3-D perspective viewpoint.
+    Run grdview by passing in a grid and plotting it on a z-plane whose frontal facade
+    is colored gray, while setting a 3-D perspective viewpoint.
     """
     fig = Figure()
     fig.grdview(grid=xrgrid, plane="100+ggray", perspective=[225, 30], zscale=0.005)
@@ -160,8 +158,8 @@ def test_grdview_on_a_plane_with_colored_frontal_facade(xrgrid):
 @pytest.mark.mpl_image_compare
 def test_grdview_with_perspective_and_zaxis_frame(xrgrid, region):
     """
-    Run grdview by passing in a grid and plotting an annotated vertical z-axis
-    frame on a Transverse Mercator (T) projection.
+    Run grdview by passing in a grid and plotting an annotated vertical z-axis frame on
+    a Transverse Mercator (T) projection.
     """
     fig = Figure()
     projection = f"T{(region[0]+region[1])/2}/{abs((region[2]+region[3])/2)}"
@@ -178,8 +176,8 @@ def test_grdview_with_perspective_and_zaxis_frame(xrgrid, region):
 @pytest.mark.mpl_image_compare
 def test_grdview_surface_plot_styled_with_contourpen(xrgrid):
     """
-    Run grdview by passing in a grid with styled contour lines plotted on top
-    of a surface plot.
+    Run grdview by passing in a grid with styled contour lines plotted on top of a
+    surface plot.
     """
     fig = Figure()
     fig.grdview(grid=xrgrid, cmap="relief", surftype="s", contourpen="0.5p,black,dash")
@@ -189,8 +187,8 @@ def test_grdview_surface_plot_styled_with_contourpen(xrgrid):
 @pytest.mark.mpl_image_compare
 def test_grdview_surface_mesh_plot_styled_with_meshpen(xrgrid):
     """
-    Run grdview by passing in a grid with styled mesh lines plotted on top of a
-    surface mesh plot.
+    Run grdview by passing in a grid with styled mesh lines plotted on top of a surface
+    mesh plot.
     """
     fig = Figure()
     fig.grdview(grid=xrgrid, cmap="relief", surftype="sm", meshpen="0.5p,black,dash")
@@ -200,8 +198,8 @@ def test_grdview_surface_mesh_plot_styled_with_meshpen(xrgrid):
 @pytest.mark.mpl_image_compare
 def test_grdview_on_a_plane_styled_with_facadepen(xrgrid):
     """
-    Run grdview by passing in a grid and plotting it on a z-plane with styled
-    lines for the frontal facade.
+    Run grdview by passing in a grid and plotting it on a z-plane with styled lines for
+    the frontal facade.
     """
     fig = Figure()
     fig.grdview(
@@ -218,8 +216,8 @@ def test_grdview_on_a_plane_styled_with_facadepen(xrgrid):
 @pytest.mark.mpl_image_compare
 def test_grdview_drapegrid_dataarray(xrgrid):
     """
-    Run grdview by passing in both a grid and drapegrid as an xarray.DataArray,
-    setting a colormap for producing an image plot.
+    Run grdview by passing in both a grid and drapegrid as an xarray.DataArray, setting
+    a colormap for producing an image plot.
     """
     drapegrid = 1.1 * xrgrid
 

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -151,8 +151,8 @@ def test_args_in_kwargs():
 
 def test_skip_if_no():
     """
-    Test that the skip_if_no helper testing function returns a
-    pytest.mask.skipif mark decorator.
+    Test that the skip_if_no helper testing function returns a pytest.mask.skipif mark
+    decorator.
     """
     # Check pytest.mark with a dependency that can be imported
     mark_decorator = skip_if_no(package="numpy")

--- a/pygmt/tests/test_init.py
+++ b/pygmt/tests/test_init.py
@@ -8,8 +8,8 @@ import pygmt
 
 def test_show_versions():
     """
-    Check that pygmt.show_versions() reports version information from PyGMT,
-    the operating system, dependencies and the GMT library.
+    Check that pygmt.show_versions() reports version information from PyGMT, the
+    operating system, dependencies and the GMT library.
     """
     buf = io.StringIO()
     pygmt.show_versions(file=buf)

--- a/pygmt/tests/test_inset.py
+++ b/pygmt/tests/test_inset.py
@@ -21,8 +21,8 @@ def test_inset_aliases():
 @pytest.mark.mpl_image_compare
 def test_inset_context_manager():
     """
-    Test that the inset context manager works and, once closed, plotting
-    elements are added to the larger figure.
+    Test that the inset context manager works and, once closed, plotting elements are
+    added to the larger figure.
     """
     fig = Figure()
     fig.basemap(region=[-74, -69.5, 41, 43], projection="M9c", frame=True)

--- a/pygmt/tests/test_io.py
+++ b/pygmt/tests/test_io.py
@@ -11,8 +11,8 @@ from pygmt.io import load_dataarray
 @pytest.mark.benchmark
 def test_io_load_dataarray():
     """
-    Check that load_dataarray works to read a netCDF grid with
-    GMTDataArrayAccessor information loaded.
+    Check that load_dataarray works to read a netCDF grid with GMTDataArrayAccessor
+    information loaded.
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         rng = np.random.default_rng()

--- a/pygmt/tests/test_makecpt.py
+++ b/pygmt/tests/test_makecpt.py
@@ -62,8 +62,7 @@ def test_makecpt_plot_colorbar(position):
 @pytest.mark.mpl_image_compare
 def test_makecpt_plot_colorbar_scaled_with_series(position):
     """
-    Use static color palette table scaled to a min/max series and plot it on a
-    colorbar.
+    Use static color palette table scaled to a min/max series and plot it on a colorbar.
     """
     fig = Figure()
     makecpt(cmap="oleron", series=[0, 1000])
@@ -122,8 +121,7 @@ def test_makecpt_reverse_color_only(position):
 @pytest.mark.mpl_image_compare
 def test_makecpt_reverse_color_and_zsign(position):
     """
-    Use static color palette table with both its colors and z-value sign
-    reversed.
+    Use static color palette table with both its colors and z-value sign reversed.
     """
     fig = Figure()
     makecpt(cmap="earth", reverse="cz", series=[0, 1000])
@@ -134,8 +132,8 @@ def test_makecpt_reverse_color_and_zsign(position):
 @pytest.mark.mpl_image_compare
 def test_makecpt_continuous(position):
     """
-    Use static color palette table that is continuous from blue to white and
-    scaled from 0 to 1000 m.
+    Use static color palette table that is continuous from blue to white and scaled from
+    0 to 1000 m.
     """
     fig = Figure()
     makecpt(cmap="blue,white", continuous=True, series=[0, 1000])

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -314,8 +314,7 @@ def test_meca_spec_ndarray_no_convention():
 
 def test_meca_spec_ndarray_mismatched_columns():
     """
-    Raise an exception if the ndarray input doesn't have the expected number of
-    columns.
+    Raise an exception if the ndarray input doesn't have the expected number of columns.
     """
     fig = Figure()
     fig.basemap(region=[-125, -122, 47, 49], projection="M6c", frame=True)

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -94,8 +94,8 @@ def test_plot_fail_no_data(data, region):
 
 def test_plot_fail_1d_array_with_data(data, region):
     """
-    Should raise an exception if array fill, size, intensity and transparency
-    are used with matrix.
+    Should raise an exception if array fill, size, intensity and transparency are used
+    with matrix.
     """
     fig = Figure()
     kwargs = {"data": data, "region": region, "projection": "X10c", "frame": "afg"}
@@ -381,8 +381,8 @@ def test_plot_lines_with_arrows():
     """
     Plot lines with arrows.
 
-    The test is slightly different from test_plot_vectors(). Here the vectors
-    are plotted as lines, with arrows at the end.
+    The test is slightly different from test_plot_vectors(). Here the vectors are
+    plotted as lines, with arrows at the end.
 
     The test also checks if the API crashes. See
     https://github.com/GenericMappingTools/pygmt/issues/406.
@@ -459,8 +459,8 @@ def test_plot_datetime():
 @pytest.mark.parametrize("func", [str, Path])
 def test_plot_ogrgmt_file_multipoint_default_style(func):
     """
-    Make sure that OGR/GMT files with MultiPoint geometry are plotted as
-    squares and not as line (default GMT style).
+    Make sure that OGR/GMT files with MultiPoint geometry are plotted as squares and not
+    as line (default GMT style).
     """
     with GMTTempFile(suffix=".gmt") as tmpfile:
         gmt_file = """# @VGMT1.0 @GMULTIPOINT

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -74,8 +74,8 @@ def test_plot3d_red_circles_zsize(data, region):
 
 def test_plot3d_fail_1d_array_with_data(data, region):
     """
-    Should raise an exception if array fill, size, intensity and transparency
-    are used with matrix.
+    Should raise an exception if array fill, size, intensity and transparency are used
+    with matrix.
     """
     fig = Figure()
     kwargs = {"data": data, "region": region, "projection": "X10c", "frame": "afg"}
@@ -435,8 +435,8 @@ def test_plot3d_scalar_xyz():
 @pytest.mark.parametrize("func", [str, Path])
 def test_plot3d_ogrgmt_file_multipoint_default_style(func):
     """
-    Make sure that OGR/GMT files with MultiPoint geometry are plotted as cubes
-    and not as line (default GMT style).
+    Make sure that OGR/GMT files with MultiPoint geometry are plotted as cubes and not
+    as line (default GMT style).
     """
     with GMTTempFile(suffix=".gmt") as tmpfile:
         gmt_file = """# @VGMT1.0 @GMULTIPOINT

--- a/pygmt/tests/test_project.py
+++ b/pygmt/tests/test_project.py
@@ -53,8 +53,7 @@ def test_project_input_matrix(array_func, dataframe):
 
 def test_project_output_filename(dataframe):
     """
-    Run project by passing in a pandas.DataFrame, and output to an ASCII txt
-    file.
+    Run project by passing in a pandas.DataFrame, and output to an ASCII txt file.
     """
     with GMTTempFile() as tmpfile:
         output = project(
@@ -77,8 +76,8 @@ def test_project_output_filename(dataframe):
 
 def test_project_incorrect_parameters():
     """
-    Run project by providing incorrect parameters such as 1) no `center`; 2) no
-    `data` or `generate`; and 3) `generate` with `convention`.
+    Run project by providing incorrect parameters such as 1) no `center`; 2) no `data`
+    or `generate`; and 3) `generate` with `convention`.
     """
     with pytest.raises(GMTInvalidInput):
         # No `center`

--- a/pygmt/tests/test_rose.py
+++ b/pygmt/tests/test_rose.py
@@ -20,8 +20,8 @@ def fixture_data():
 @pytest.fixture(scope="module", name="data_fractures_compilation")
 def fixture_data_fractures_compilation():
     """
-    Load the sample fractures compilation dataset which contains fracture
-    lengths and azimuths as hypothetically digitized from geological maps.
+    Load the sample fractures compilation dataset which contains fracture lengths and
+    azimuths as hypothetically digitized from geological maps.
 
     Lengths are stored in the first column, azimuths in the second.
     """
@@ -51,8 +51,7 @@ def test_rose_data_file(data_fractures_compilation):
 @pytest.mark.mpl_image_compare
 def test_rose_2d_array_single():
     """
-    Test supplying a 2-D numpy array containing a single pair of lengths and
-    directions.
+    Test supplying a 2-D numpy array containing a single pair of lengths and directions.
     """
     data = np.array([[40, 60]])
     fig = Figure()
@@ -73,8 +72,7 @@ def test_rose_2d_array_single():
 @pytest.mark.mpl_image_compare
 def test_rose_2d_array_multiple(data):
     """
-    Test supplying a 2-D numpy array containing a list of lengths and
-    directions.
+    Test supplying a 2-D numpy array containing a list of lengths and directions.
     """
     fig = Figure()
     fig.rose(
@@ -95,8 +93,7 @@ def test_rose_2d_array_multiple(data):
 @pytest.mark.mpl_image_compare
 def test_rose_plot_data_using_cpt(data):
     """
-    Test supplying a 2-D numpy array containing a list of lengths and
-    directions.
+    Test supplying a 2-D numpy array containing a list of lengths and directions.
 
     Use a cmap to color sectors.
     """
@@ -118,8 +115,7 @@ def test_rose_plot_data_using_cpt(data):
 @pytest.mark.mpl_image_compare
 def test_rose_plot_with_transparency(data_fractures_compilation):
     """
-    Test supplying the sample fractures compilation dataset to the data
-    parameter.
+    Test supplying the sample fractures compilation dataset to the data parameter.
 
     Use transparency.
     """
@@ -142,8 +138,7 @@ def test_rose_plot_with_transparency(data_fractures_compilation):
 @pytest.mark.mpl_image_compare
 def test_rose_no_sectors(data_fractures_compilation):
     """
-    Test supplying the sample fractures compilation dataset to the data
-    parameter.
+    Test supplying the sample fractures compilation dataset to the data parameter.
 
     Plot data without defining a sector width, add a title and rename labels.
     """
@@ -164,8 +159,7 @@ def test_rose_no_sectors(data_fractures_compilation):
 @pytest.mark.mpl_image_compare
 def test_rose_bools(data_fractures_compilation):
     """
-    Test supplying the sample fractures compilation dataset to the data
-    parameter.
+    Test supplying the sample fractures compilation dataset to the data parameter.
 
     Test bools.
     """

--- a/pygmt/tests/test_select.py
+++ b/pygmt/tests/test_select.py
@@ -33,8 +33,7 @@ def test_select_input_dataframe(dataframe):
 
 def test_select_input_table_matrix(dataframe):
     """
-    Run select using table input that is not a pandas.DataFrame but still a
-    matrix.
+    Run select using table input that is not a pandas.DataFrame but still a matrix.
 
     Also testing the reverse (I) alias.
     """

--- a/pygmt/tests/test_solar.py
+++ b/pygmt/tests/test_solar.py
@@ -11,8 +11,8 @@ from pygmt.exceptions import GMTInvalidInput
 @pytest.mark.mpl_image_compare
 def test_solar_terminators():
     """
-    Test passing the solar argument with a time string and no terminator type
-    to confirm the default terminator type.
+    Test passing the solar argument with a time string and no terminator type to confirm
+    the default terminator type.
     """
     fig = Figure()
     fig.basemap(region="d", projection="W0/15c", frame="a")
@@ -50,8 +50,7 @@ def test_solar_terminators():
 )
 def test_solar_set_terminator_datetime(terminator_datetime):
     """
-    Test passing the solar argument with the day_night terminator and a
-    datetime string.
+    Test passing the solar argument with the day_night terminator and a datetime string.
     """
     fig = Figure()
     fig.solar(
@@ -80,8 +79,8 @@ def test_invalid_terminator_type():
 
 def test_invalid_parameter():
     """
-    Test if solar fails when it receives a GMT argument for 'T' instead of the
-    PyGMT arguments for 'terminator' and 'terminator_datetime'.
+    Test if solar fails when it receives a GMT argument for 'T' instead of the PyGMT
+    arguments for 'terminator' and 'terminator_datetime'.
     """
     fig = Figure()
     with pytest.raises(GMTInvalidInput):
@@ -108,8 +107,8 @@ def test_invalid_datetime():
 @pytest.mark.mpl_image_compare(filename="test_solar_set_terminator_datetime.png")
 def test_solar_default_terminator():
     """
-    Test passing the solar argument with a time string and no terminator type
-    to confirm the default terminator type.
+    Test passing the solar argument with a time string and no terminator type to confirm
+    the default terminator type.
     """
     fig = Figure()
     fig.solar(

--- a/pygmt/tests/test_sphdistance.py
+++ b/pygmt/tests/test_sphdistance.py
@@ -65,8 +65,7 @@ def test_sphdistance_no_outgrid(array):
 
 def test_sphdistance_fails(array):
     """
-    Check that sphdistance fails correctly when neither increment nor region is
-    given.
+    Check that sphdistance fails correctly when neither increment nor region is given.
     """
     with pytest.raises(GMTInvalidInput):
         sphdistance(data=array)

--- a/pygmt/tests/test_subplot.py
+++ b/pygmt/tests/test_subplot.py
@@ -10,8 +10,8 @@ from pygmt.exceptions import GMTInvalidInput
 @pytest.mark.mpl_image_compare
 def test_subplot_basic_frame():
     """
-    Create a subplot figure with 1 vertical row and 2 horizontal columns, and
-    ensure map frame setting is applied to all subplot figures.
+    Create a subplot figure with 1 vertical row and 2 horizontal columns, and ensure map
+    frame setting is applied to all subplot figures.
     """
     fig = Figure()
 
@@ -60,8 +60,8 @@ def test_subplot_autolabel_margins_title():
 @pytest.mark.mpl_image_compare
 def test_subplot_clearance_and_shared_xy_axis_layout():
     """
-    Ensure subplot clearance works, and that the layout can be set to use
-    shared X and Y axis labels across columns and rows.
+    Ensure subplot clearance works, and that the layout can be set to use shared X and Y
+    axis labels across columns and rows.
     """
     fig = Figure()
 
@@ -84,8 +84,8 @@ def test_subplot_clearance_and_shared_xy_axis_layout():
 
 def test_subplot_figsize_and_subsize_error():
     """
-    Check that an error is raised when both figsize and subsize parameters are
-    passed into subplot.
+    Check that an error is raised when both figsize and subsize parameters are passed
+    into subplot.
     """
     fig = Figure()
     with pytest.raises(GMTInvalidInput):

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -114,8 +114,8 @@ def test_text_nonexistent_filename():
 @pytest.mark.mpl_image_compare
 def test_text_position(region):
     """
-    Print text at center middle (CM) and eight other positions
-    (Top/Middle/Bottom x Left/Centre/Right).
+    Print text at center middle (CM) and eight other positions (Top/Middle/Bottom x
+    Left/Centre/Right).
     """
     fig = Figure()
     fig.text(region=region, projection="x1c", frame="a", position="CM", text="C M")
@@ -148,9 +148,9 @@ def test_text_invalid_inputs(region):
 @pytest.mark.mpl_image_compare
 def test_text_position_offset_with_line(region):
     """
-    Print text at centre middle (CM) and eight other positions
-    (Top/Middle/Bottom x Left/Centre/Right), offset by 0.5 cm, with a line
-    drawn from the original to the shifted point.
+    Print text at centre middle (CM) and eight other positions (Top/Middle/Bottom x
+    Left/Centre/Right), offset by 0.5 cm, with a line drawn from the original to the
+    shifted point.
     """
     fig = Figure()
     fig.text(region=region, projection="x1c", frame="a", position="CM", text="C M")
@@ -273,8 +273,8 @@ def test_text_justify_bottom_right_and_top_left(region, projection):
 @pytest.mark.mpl_image_compare
 def test_text_justify_parsed_from_textfile():
     """
-    Print text justified based on a column from textfile, using justify=True
-    boolean operation.
+    Print text justified based on a column from textfile, using justify=True boolean
+    operation.
 
     Loosely based on "All great-circle paths lead to Rome" gallery example at
     https://docs.generic-mapping-tools.org/latest/gallery/ex23.html
@@ -293,8 +293,8 @@ def test_text_justify_parsed_from_textfile():
 @pytest.mark.mpl_image_compare
 def test_text_angle_font_justify_from_textfile():
     """
-    Print text with x, y, angle, font, justify, and text arguments parsed from
-    the textfile.
+    Print text with x, y, angle, font, justify, and text arguments parsed from the
+    textfile.
     """
     fig = Figure()
     with GMTTempFile(suffix=".txt") as tempfile:

--- a/pygmt/tests/test_tilemap.py
+++ b/pygmt/tests/test_tilemap.py
@@ -28,8 +28,8 @@ def test_tilemap_web_mercator():
 @pytest.mark.mpl_image_compare
 def test_tilemap_ogc_wgs84():
     """
-    Create a tilemap plot using longitude/latitude coordinates (OGC:WGS84),
-    centred on the international date line.
+    Create a tilemap plot using longitude/latitude coordinates (OGC:WGS84), centred on
+    the international date line.
     """
     fig = Figure()
     fig.tilemap(
@@ -46,8 +46,8 @@ def test_tilemap_ogc_wgs84():
 @pytest.mark.parametrize("no_clip", [False, True])
 def test_tilemap_no_clip(no_clip):
     """
-    Create a tilemap plot clipped to the Southern Hemisphere when no_clip is
-    False, but for the whole globe when no_clip is True.
+    Create a tilemap plot clipped to the Southern Hemisphere when no_clip is False, but
+    for the whole globe when no_clip is True.
     """
     fig = Figure()
     fig.tilemap(

--- a/pygmt/tests/test_timestamp.py
+++ b/pygmt/tests/test_timestamp.py
@@ -8,8 +8,8 @@ from pygmt import Figure, config
 @pytest.fixture(scope="module", name="faketime")
 def fixture_faketime():
     """
-    Fake datetime that will be passed to the "timefmt" parameter, so that the
-    timestamp string always has a fixed value.
+    Fake datetime that will be passed to the "timefmt" parameter, so that the timestamp
+    string always has a fixed value.
     """
     return "9999-99-99T99:99:99"
 
@@ -39,8 +39,7 @@ def test_timestamp_justification():
     """
     Check if the "justification" parameter works.
 
-    Only a subset of justification codes are tested to avoid overlapping
-    timestamps.
+    Only a subset of justification codes are tested to avoid overlapping timestamps.
     """
     fig = Figure()
     fig.basemap(projection="X10c/5c", region=[0, 10, 0, 5], frame=0)
@@ -85,8 +84,8 @@ def test_timestamp_text(faketime):
 @pytest.mark.mpl_image_compare
 def test_timestamp_text_truncated():
     """
-    Passing a text string longer than 64 characters raises a warning and the
-    string will be truncated.
+    Passing a text string longer than 64 characters raises a warning and the string will
+    be truncated.
     """
     fig = Figure()
     with pytest.warns(expected_warning=RuntimeWarning) as record:

--- a/pygmt/tests/test_triangulate.py
+++ b/pygmt/tests/test_triangulate.py
@@ -62,8 +62,7 @@ def fixture_expected_grid():
 @pytest.mark.parametrize("array_func", [np.array, xr.Dataset])
 def test_delaunay_triples_input_table_matrix(array_func, dataframe, expected_dataframe):
     """
-    Run triangulate.delaunay_triples by passing in a numpy.array or
-    xarray.Dataset.
+    Run triangulate.delaunay_triples by passing in a numpy.array or xarray.Dataset.
     """
     table = array_func(dataframe)
     output = triangulate.delaunay_triples(data=table)
@@ -73,8 +72,7 @@ def test_delaunay_triples_input_table_matrix(array_func, dataframe, expected_dat
 @pytest.mark.benchmark
 def test_delaunay_triples_input_xyz(dataframe, expected_dataframe):
     """
-    Run triangulate.delaunay_triples by passing in x, y, z numpy.ndarrays
-    individually.
+    Run triangulate.delaunay_triples by passing in x, y, z numpy.ndarrays individually.
     """
     output = triangulate.delaunay_triples(x=dataframe.x, y=dataframe.y, z=dataframe.z)
     pd.testing.assert_frame_equal(left=output, right=expected_dataframe)
@@ -90,8 +88,7 @@ def test_delaunay_triples_input_xy_no_z(dataframe, expected_dataframe):
 
 def test_delaunay_triples_wrong_kind_of_input(dataframe):
     """
-    Run triangulate.delaunay_triples using grid input that is not
-    file/matrix/vectors.
+    Run triangulate.delaunay_triples using grid input that is not file/matrix/vectors.
     """
     data = dataframe.z.to_xarray()  # convert pandas.Series to xarray.DataArray
     assert data_kind(data) == "grid"
@@ -164,8 +161,8 @@ def test_regular_grid_with_outgrid_param(dataframe, expected_grid):
 
 def test_regular_grid_invalid_format(dataframe):
     """
-    Test that triangulate.regular_grid fails with outgrid that is not None or a
-    proper file name.
+    Test that triangulate.regular_grid fails with outgrid that is not None or a proper
+    file name.
     """
     with pytest.raises(GMTInvalidInput):
         triangulate.regular_grid(data=dataframe, outgrid=True)

--- a/pygmt/tests/test_wiggle.py
+++ b/pygmt/tests/test_wiggle.py
@@ -65,8 +65,8 @@ def test_wiggle_data_incols():
 
 def test_wiggle_fill_multiple():
     """
-    Check that wiggle fails when the parameters color and
-    fillpositive/fillnegative are used together.
+    Check that wiggle fails when the parameters color and fillpositive/fillnegative are
+    used together.
     """
     x = np.arange(-2, 2, 0.02)
     y = np.zeros(x.size)
@@ -93,8 +93,7 @@ def test_wiggle_fill_multiple():
 
 def test_wiggle_use_color():
     """
-    Check that wiggle raises a warning when the deprecated parameter color is
-    used.
+    Check that wiggle raises a warning when the deprecated parameter color is used.
     """
     x = np.arange(-2, 2, 0.02)
     y = np.zeros(x.size)

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -18,8 +18,8 @@ from pygmt.helpers import data_kind
 @pytest.fixture(name="mock_x2sys_home")
 def _fixture_mock_x2sys_home(monkeypatch):
     """
-    Set the X2SYS_HOME environment variable to the current working directory
-    for the test session.
+    Set the X2SYS_HOME environment variable to the current working directory for the
+    test session.
     """
     monkeypatch.setenv("X2SYS_HOME", os.getcwd())
 
@@ -37,8 +37,8 @@ def fixture_tracks():
 @pytest.mark.usefixtures("mock_x2sys_home")
 def test_x2sys_cross_input_file_output_file():
     """
-    Run x2sys_cross by passing in a filename, and output internal crossovers to
-    an ASCII txt file.
+    Run x2sys_cross by passing in a filename, and output internal crossovers to an ASCII
+    txt file.
     """
     with TemporaryDirectory(prefix="X2SYS", dir=os.getcwd()) as tmpdir:
         tag = os.path.basename(tmpdir)
@@ -56,8 +56,8 @@ def test_x2sys_cross_input_file_output_file():
 @pytest.mark.usefixtures("mock_x2sys_home")
 def test_x2sys_cross_input_file_output_dataframe():
     """
-    Run x2sys_cross by passing in a filename, and output internal crossovers to
-    a pandas.DataFrame.
+    Run x2sys_cross by passing in a filename, and output internal crossovers to a
+    pandas.DataFrame.
     """
     with TemporaryDirectory(prefix="X2SYS", dir=os.getcwd()) as tmpdir:
         tag = os.path.basename(tmpdir)
@@ -75,8 +75,8 @@ def test_x2sys_cross_input_file_output_dataframe():
 @pytest.mark.usefixtures("mock_x2sys_home")
 def test_x2sys_cross_input_dataframe_output_dataframe(tracks):
     """
-    Run x2sys_cross by passing in one dataframe, and output internal crossovers
-    to a pandas.DataFrame.
+    Run x2sys_cross by passing in one dataframe, and output internal crossovers to a
+    pandas.DataFrame.
     """
     with TemporaryDirectory(prefix="X2SYS", dir=os.getcwd()) as tmpdir:
         tag = os.path.basename(tmpdir)
@@ -96,8 +96,8 @@ def test_x2sys_cross_input_dataframe_output_dataframe(tracks):
 @pytest.mark.usefixtures("mock_x2sys_home")
 def test_x2sys_cross_input_two_dataframes():
     """
-    Run x2sys_cross by passing in two pandas.DataFrame tables with a time
-    column, and output external crossovers to a pandas.DataFrame.
+    Run x2sys_cross by passing in two pandas.DataFrame tables with a time column, and
+    output external crossovers to a pandas.DataFrame.
     """
     with TemporaryDirectory(prefix="X2SYS", dir=os.getcwd()) as tmpdir:
         tag = os.path.basename(tmpdir)
@@ -133,8 +133,8 @@ def test_x2sys_cross_input_two_dataframes():
 @pytest.mark.usefixtures("mock_x2sys_home")
 def test_x2sys_cross_input_dataframe_with_nan(tracks):
     """
-    Run x2sys_cross by passing in one dataframe with NaN values, and output
-    internal crossovers to a pandas.DataFrame.
+    Run x2sys_cross by passing in one dataframe with NaN values, and output internal
+    crossovers to a pandas.DataFrame.
     """
     with TemporaryDirectory(prefix="X2SYS", dir=os.getcwd()) as tmpdir:
         tag = os.path.basename(tmpdir)
@@ -157,8 +157,8 @@ def test_x2sys_cross_input_dataframe_with_nan(tracks):
 @pytest.mark.usefixtures("mock_x2sys_home")
 def test_x2sys_cross_input_two_filenames():
     """
-    Run x2sys_cross by passing in two filenames, and output external crossovers
-    to a pandas.DataFrame.
+    Run x2sys_cross by passing in two filenames, and output external crossovers to a
+    pandas.DataFrame.
     """
     with TemporaryDirectory(prefix="X2SYS", dir=os.getcwd()) as tmpdir:
         tag = os.path.basename(tmpdir)
@@ -184,8 +184,8 @@ def test_x2sys_cross_input_two_filenames():
 
 def test_x2sys_cross_invalid_tracks_input_type(tracks):
     """
-    Run x2sys_cross using tracks input that is not a pandas.DataFrame (matrix)
-    or str (file) type, which would raise a GMTInvalidInput error.
+    Run x2sys_cross using tracks input that is not a pandas.DataFrame (matrix) or str
+    (file) type, which would raise a GMTInvalidInput error.
     """
     invalid_tracks = tracks[0].to_xarray().z
     assert data_kind(invalid_tracks) == "grid"
@@ -196,8 +196,8 @@ def test_x2sys_cross_invalid_tracks_input_type(tracks):
 @pytest.mark.usefixtures("mock_x2sys_home")
 def test_x2sys_cross_region_interpolation_numpoints():
     """
-    Test that x2sys_cross's region (R), interpolation (l) and numpoints (W)
-    arguments work.
+    Test that x2sys_cross's region (R), interpolation (l) and numpoints (W) arguments
+    work.
     """
     with TemporaryDirectory(prefix="X2SYS", dir=os.getcwd()) as tmpdir:
         tag = os.path.basename(tmpdir)

--- a/pygmt/tests/test_x2sys_init.py
+++ b/pygmt/tests/test_x2sys_init.py
@@ -11,8 +11,8 @@ from pygmt import x2sys_init
 @pytest.fixture(name="mock_x2sys_home")
 def _fixture_mock_x2sys_home(monkeypatch):
     """
-    Set the X2SYS_HOME environment variable to the current working directory
-    for the test session.
+    Set the X2SYS_HOME environment variable to the current working directory for the
+    test session.
     """
     monkeypatch.setenv("X2SYS_HOME", os.getcwd())
 
@@ -20,8 +20,8 @@ def _fixture_mock_x2sys_home(monkeypatch):
 @pytest.mark.usefixtures("mock_x2sys_home")
 def test_x2sys_init_region_spacing():
     """
-    Test that x2sys_init's region (R) and spacing (I) sequence arguments accept
-    a list properly.
+    Test that x2sys_init's region (R) and spacing (I) sequence arguments accept a list
+    properly.
     """
     with TemporaryDirectory(prefix="X2SYS", dir=os.getcwd()) as tmpdir:
         tag = os.path.basename(tmpdir)
@@ -39,8 +39,7 @@ def test_x2sys_init_region_spacing():
 @pytest.mark.usefixtures("mock_x2sys_home")
 def test_x2sys_init_units_gap():
     """
-    Test that x2sys_init's units (N) and gap (W) arguments accept a list
-    properly.
+    Test that x2sys_init's units (N) and gap (W) arguments accept a list properly.
     """
     with TemporaryDirectory(prefix="X2SYS", dir=os.getcwd()) as tmpdir:
         tag = os.path.basename(tmpdir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,8 +80,8 @@ black = true
 recursive = true
 pre-summary-newline = true
 make-summary-multi-line = true
-wrap-summaries = 79
-wrap-descriptions = 79
+wrap-summaries = 88
+wrap-descriptions = 88
 
 [tool.mypy]
 exclude = ["pygmt/tests/"]


### PR DESCRIPTION
**Description of proposed changes**

As mentioned in https://github.com/GenericMappingTools/pygmt/issues/962#issuecomment-1868849496, this PR changes `wrap-summaries` and `wrap-descriptions` to 88 and reformat all docstrings. Please note that descriptions are not re-wrapped due to known docformatter limitations.