### PR TITLE
Gallery: Start only the first word of the title with an upper-case letter

### DIFF
--- a/examples/gallery/3d_plots/scatter3d.py
+++ b/examples/gallery/3d_plots/scatter3d.py
@@ -1,5 +1,5 @@
 """
-3-D Scatter plots
+3-D scatter plots
 =================
 
 The :meth:`pygmt.Figure.plot3d` method can be used to plot symbols in 3-D.

--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -1,5 +1,5 @@
 """
-RGB Image
+RGB image
 =========
 
 The :meth:`pygmt.Figure.grdimage` method can be used to plot Red, Green, Blue

--- a/examples/gallery/maps/borders.py
+++ b/examples/gallery/maps/borders.py
@@ -1,5 +1,5 @@
 """
-Political Boundaries
+Political boundaries
 ====================
 
 The ``borders`` parameter of :meth:`pygmt.Figure.coast` specifies levels of

--- a/examples/gallery/maps/choropleth_map.py
+++ b/examples/gallery/maps/choropleth_map.py
@@ -1,5 +1,5 @@
 """
-Choropleth Map
+Choropleth map
 ==============
 
 The :meth:`pygmt.Figure.plot` method allows us to plot geographical data such

--- a/examples/gallery/symbols/patterns.py
+++ b/examples/gallery/symbols/patterns.py
@@ -1,5 +1,5 @@
 r"""
-Bit and Hachure Patterns
+Bit and hachure patterns
 ========================
 
 PyGMT allows using bit or hachure patterns via the ``fill`` parameter


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to update the titles of the Gallery examples to start consistently only the first word with an upper-case letter.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
