### PR TITLE
Improve performance by avoiding loading the GMT library repeatedly

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -87,7 +87,7 @@ DTYPES = {
     np.datetime64: "GMT_DATETIME",
 }
 
-# Load the GMT library outside the Session class to avoid repeating loading.
+# Load the GMT library outside the Session class to avoid repeated loading.
 _libgmt = load_libgmt()
 
 

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -87,6 +87,9 @@ DTYPES = {
     np.datetime64: "GMT_DATETIME",
 }
 
+# load the GMT library outside the Session class so it's loaded once.
+_libgmt = load_libgmt()
+
 
 class Session:
     """
@@ -308,7 +311,7 @@ class Session:
         <class 'ctypes.CDLL.__init__.<locals>._FuncPtr'>
         """
         if not hasattr(self, "_libgmt"):
-            self._libgmt = load_libgmt()
+            self._libgmt = _libgmt
         function = getattr(self._libgmt, name)
         if argtypes is not None:
             function.argtypes = argtypes

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -87,7 +87,7 @@ DTYPES = {
     np.datetime64: "GMT_DATETIME",
 }
 
-# load the GMT library outside the Session class so it's loaded once.
+# Load the GMT library outside the Session class to avoid repeating loading.
 _libgmt = load_libgmt()
 
 

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -215,7 +215,7 @@ class TestLibgmtCount:
     """
 
     loaded_libgmt = load_libgmt()  # Load the GMT library and reuse it when necessary
-    counter = 0  # Count how many times ctypes.CDLL is called
+    counter = 0  # Global counter for how many times ctypes.CDLL is called
 
     def _mock_ctypes_cdll_return(self, libname):  # noqa: ARG002
         """
@@ -226,15 +226,14 @@ class TestLibgmtCount:
         self.counter += 1  # Increase the counter
         return self.loaded_libgmt
 
-    @pytest.fixture()
-    def _mock_ctypes(self, monkeypatch):
-        monkeypatch.setattr(ctypes, "CDLL", self._mock_ctypes_cdll_return)
-
-    @pytest.mark.usefixtures("_mock_ctypes")
-    def test_libgmt_load_counter(self):
+    def test_libgmt_load_counter(self, monkeypatch):
         """
         Make sure that the GMT library is not loaded in every session.
         """
+        # Monkeypatch the ctypes.CDLL function
+        monkeypatch.setattr(ctypes, "CDLL", self._mock_ctypes_cdll_return)
+
+        # Create two sessions and check the global counter
         with Session() as lib:
             _ = lib
         with Session() as lib:

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -211,7 +211,7 @@ class TestLibgmtBrokenLibs:
 
 class TestLibgmtCount:
     """
-    Test that the GMT library is not repeatly loaded in every session.
+    Test that the GMT library is not repeatedly loaded in every session.
     """
 
     loaded_libgmt = load_libgmt()  # Load the GMT library and reuse it when necessary

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -2,6 +2,7 @@
 Test the session management modules.
 """
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -77,9 +78,13 @@ def gmt_func(figname):
     fig.savefig(figname)
 
 
+@pytest.mark.xfail(
+    condition=sys.platform == "win32",
+    reason="The session path uses PID of parent process on Windows",
+)
 def test_session_multiprocessing():
     """
-    Make sure that the multiprocessing is supported if pygmt is re-imported.
+    Make sure that multiprocessing is supported if pygmt is re-imported.
     """
 
     import multiprocessing as mp

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -63,10 +63,9 @@ def test_gmt_compat_6_is_applied(capsys):
 
 def gmt_func(figname):
     """
-    Workaround to let PyGMT support multiprocessing.
+    Workaround for multiprocessing support in PyGMT.
 
-    See
-    https://github.com/GenericMappingTools/pygmt/issues/217#issuecomment-754774875
+    https://github.com/GenericMappingTools/pygmt/issues/217#issuecomment-754774875.
     """
     from importlib import reload
 

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -2,6 +2,7 @@
 Test the session management modules.
 """
 import os
+from pathlib import Path
 
 import pytest
 from pygmt.clib import Session
@@ -57,3 +58,35 @@ def test_gmt_compat_6_is_applied(capsys):
         # Make sure no global "gmt.conf" in the current directory
         assert not os.path.exists("gmt.conf")
         begin()  # Restart the global session
+
+
+def gmt_func(figname):
+    """
+    Workaround to let PyGMT support multiprocessing.
+
+    See
+    https://github.com/GenericMappingTools/pygmt/issues/217#issuecomment-754774875
+    """
+    from importlib import reload
+
+    import pygmt
+
+    reload(pygmt)
+    fig = pygmt.Figure()
+    fig.basemap(region=[10, 70, -3, 8], projection="X8c/6c", frame="afg")
+    fig.savefig(figname)
+
+
+def test_session_multiprocessing():
+    """
+    Make sure that the multiprocessing is supported if pygmt is re-imported.
+    """
+
+    import multiprocessing as mp
+
+    fig_prefix = "test_session_multiprocessing"
+    with mp.Pool(2) as p:
+        p.map(gmt_func, [f"{fig_prefix}-1.png", f"{fig_prefix}-2.png"])
+    for i in [1, 2]:
+        assert Path(f"{fig_prefix}-{i}.png").exists()
+        Path(f"{fig_prefix}-{i}.png").unlink()

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -2,8 +2,6 @@
 Test the session management modules.
 """
 import os
-import sys
-from pathlib import Path
 
 import pytest
 from pygmt.clib import Session
@@ -59,38 +57,3 @@ def test_gmt_compat_6_is_applied(capsys):
         # Make sure no global "gmt.conf" in the current directory
         assert not os.path.exists("gmt.conf")
         begin()  # Restart the global session
-
-
-def gmt_func(figname):
-    """
-    Workaround for multiprocessing support in PyGMT.
-
-    https://github.com/GenericMappingTools/pygmt/issues/217#issuecomment-754774875.
-    """
-    from importlib import reload
-
-    import pygmt
-
-    reload(pygmt)
-    fig = pygmt.Figure()
-    fig.basemap(region=[10, 70, -3, 8], projection="X8c/6c", frame="afg")
-    fig.savefig(figname)
-
-
-@pytest.mark.xfail(
-    condition=sys.platform == "win32",
-    reason="The session path uses PID of parent process on Windows",
-)
-def test_session_multiprocessing():
-    """
-    Make sure that multiprocessing is supported if pygmt is re-imported.
-    """
-
-    import multiprocessing as mp
-
-    fig_prefix = "test_session_multiprocessing"
-    with mp.Pool(2) as p:
-        p.map(gmt_func, [f"{fig_prefix}-1.png", f"{fig_prefix}-2.png"])
-    for i in [1, 2]:
-        assert Path(f"{fig_prefix}-{i}.png").exists()
-        Path(f"{fig_prefix}-{i}.png").unlink()


### PR DESCRIPTION
**Description of proposed changes**

The [`load_libgmt`](https://github.com/GenericMappingTools/pygmt/blob/bb8234530af41ebcfa15ba4d516754ec2c633b45/pygmt/clib/loading.py#L18) function can search for the GMT library and load it so that we can call GMT API functions in PyGMT. The function is called in the [`Session` class](https://github.com/GenericMappingTools/pygmt/blob/bb8234530af41ebcfa15ba4d516754ec2c633b45/pygmt/clib/session.py#L91)'s [`get_libgmt_func`](https://github.com/GenericMappingTools/pygmt/blob/bb8234530af41ebcfa15ba4d516754ec2c633b45/pygmt/clib/session.py#L275) function.

Although the `get_libgmt_func` function is called multiple times in `Session`'s different methods, the GMT library is only loaded once for each session, as shown below:
https://github.com/GenericMappingTools/pygmt/blob/bb8234530af41ebcfa15ba4d516754ec2c633b45/pygmt/clib/session.py#L310-L311

However, when wrapping GMT modules, we always create a new session and then call the GMT module like this
```
with Session() as lib:
    lib.call_module(...)
```
It means the GMT library is searched and loaded multiple times, as reported in #867.

To verify if the GMT library is loaded multiple times, we just need to add a simple print statement like `print("Loading GMT library")` at the start of the `load_libgmt` function, and then call PyGMT. Here is what you'll see. It's clear that the GMT library are loaded multiple times:
```python
In [1]: import pygmt
Loading GMT library
Loading GMT library

In [2]: fig = pygmt.Figure()
Loading GMT library

In [3]: fig.basemap(region=[0, 10, 0, 10], frame=True, projection="X10c")
Loading GMT library
Loading GMT library

In [4]: fig.savefig("map.png")
Loading GMT library
Loading GMT library
```

It's unnecessary to search for and load the GMT library multiple times, which is actually time-consuming (120 ms for me on macOS).
```
In [1]: from pygmt.clib.loading import load_libgmt

In [2]: %timeit load_libgmt()
118 ms ± 5.75 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

This PR fixes the issue by moving the `load_libgmt` call outside the `Session` class, so that the GMT library is only searched for and loaded once when importing pygmt.

This PR addresses the following comment in PR #867 so it fixes #867:

> So it might be time to rethink loading libgmt in the class instead of as a global instead to avoid searching for it every time.

#867 also proposed another alternative solution:

> Or we figure out a way to not call begin at import time.

This solution may help address issue #217, but it's unclear what exactly we should do and it definitely needs big refactors, so we can explore the solution later. 

It's worth noting that the small changes in this PR **speed up our Tests significantly**! For example, the "Run tests" step now only takes **85 seconds** (on Linux) compared to **250 seconds** in the main branch.