### PR TITLE
CI: Avoid pulling GMT baseline images in the "GMT Dev Tests" workflow

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -120,7 +120,7 @@ jobs:
         run: curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/build-gmt.sh | bash
         env:
           GMT_GIT_REF: ${{ matrix.gmt_git_ref }}
-          GMT_INSTALL_DIR: ${{ github.workspace }}/gmt-install-dir
+          GMT_INSTALL_DIR: ${{ runner.temp }}/gmt-install-dir
         if: runner.os != 'Windows'
 
       - name: Install GMT ${{ matrix.gmt_git_ref }} branch (Windows)
@@ -139,13 +139,15 @@ jobs:
             -DGMT_USE_THREADS=TRUE
           cmake --build .
           cmake --build . --target install
+          cd ..
+          rm -rf gmt/
         env:
           GMT_GIT_REF: ${{ matrix.gmt_git_ref }}
-          GMT_INSTALL_DIR: ${{ github.workspace }}/gmt-install-dir
+          GMT_INSTALL_DIR: ${{ runner.temp }}/gmt-install-dir
         if: runner.os == 'Windows'
 
       - name: Add GMT's bin to PATH
-        run: echo '${{ github.workspace }}/gmt-install-dir/bin' >> $GITHUB_PATH
+        run: echo '${{ runner.temp }}/gmt-install-dir/bin' >> $GITHUB_PATH
 
       # Install dependencies from PyPI
       - name: Install dependencies
@@ -163,7 +165,7 @@ jobs:
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote
-        run: dvc pull && ls -lhR pygmt/tests/baseline/
+        run: dvc pull --verbose && ls -lhR pygmt/tests/baseline/
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub
@@ -191,7 +193,7 @@ jobs:
       - name: Test with pytest
         run: make test PYTEST_EXTRA="-r P"
         env:
-          GMT_LIBRARY_PATH: ${{ github.workspace }}/gmt-install-dir/lib
+          GMT_LIBRARY_PATH: ${{ runner.temp }}/gmt-install-dir/lib
 
       # Upload diff images on test failure
       - name: Upload diff images if any test fails


### PR DESCRIPTION
The "GMT Dev Tests" workflow started to fail recently after PR #2913. See https://github.com/GenericMappingTools/pygmt/actions/runs/7333803702/job/19969730316 for the latest run.

It fails because the `dvc pull` command tries to pull the baseline images in both the PyGMT repository and the GMT repository, mainly because GMT is installed `${{ github.workspace }}/gmt-install-dir` (i.e., in the `pygmt` root directory). 

This PR fixes the issue by installing GMT to a temporary directory `${{ runner.temp }}/gmt-install-dir` and also delete the GMT source codes after installing GMT.

Now it works. See https://github.com/GenericMappingTools/pygmt/actions/runs/7349827937/job/20010428424?pr=2931