### PR TITLE
Replace deprecated delim_whitespace parameter to sep='\s+'

### DIFF
--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -26,7 +26,7 @@ def _load_japan_quakes():
     return pd.read_csv(
         fname,
         header=1,
-        delim_whitespace=True,
+        sep=r"\s+",
         names=[
             "year",
             "month",
@@ -52,7 +52,7 @@ def _load_ocean_ridge_points():
     fname = which("@ridge.txt", download="c")
     return pd.read_csv(
         fname,
-        delim_whitespace=True,
+        sep=r"\s+",
         names=["longitude", "latitude"],
         skiprows=1,
         comment=">",
@@ -102,9 +102,7 @@ def _load_fractures_compilation():
         the fractures.
     """
     fname = which("@fractures_06.txt", download="c")
-    data = pd.read_csv(
-        fname, header=None, delim_whitespace=True, names=["azimuth", "length"]
-    )
+    data = pd.read_csv(fname, header=None, sep=r"\s+", names=["azimuth", "length"])
     return data[["length", "azimuth"]]
 
 
@@ -167,7 +165,7 @@ def _load_rock_sample_compositions():
     fname = which("@ternary.txt", download="c")
     return pd.read_csv(
         fname,
-        delim_whitespace=True,
+        sep=r"\s+",
         header=None,
         names=["limestone", "water", "air", "permittivity"],
     )
@@ -183,7 +181,7 @@ def _load_notre_dame_topography():
         The data table with columns "x", "y", and "z".
     """
     fname = which("@Table_5_11.txt", download="c")
-    return pd.read_csv(fname, delim_whitespace=True, header=None, names=["x", "y", "z"])
+    return pd.read_csv(fname, sep=r"\s+", header=None, names=["x", "y", "z"])
 
 
 def _load_maunaloa_co2():
@@ -197,7 +195,7 @@ def _load_maunaloa_co2():
     """
     fname = which("@MaunaLoa_CO2.txt", download="c")
     return pd.read_csv(
-        fname, header=None, skiprows=1, delim_whitespace=True, names=["date", "co2_ppm"]
+        fname, header=None, skiprows=1, sep=r"\s+", names=["date", "co2_ppm"]
     )
 
 

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -18,7 +18,7 @@ def fixture_data():
     """
     Load the point data from the test file.
     """
-    return pd.read_table(POINTS_DATA, header=None, delim_whitespace=True)
+    return pd.read_table(POINTS_DATA, header=None, sep=r"\s+")
 
 
 @pytest.fixture(scope="module", name="region")

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -51,7 +51,7 @@ def fixture_dataframe():
     Load a pandas DataFrame with points.
     """
     return pd.read_csv(
-        POINTS_DATA, delim_whitespace=True, header=None, names=["longitude", "latitude"]
+        POINTS_DATA, sep=r"\s+", header=None, names=["longitude", "latitude"]
     )
 
 

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -18,7 +18,7 @@ def fixture_data():
     """
     fname = which("@Table_5_11_mean.xyz", download="c")
     return pd.read_csv(
-        fname, delim_whitespace=True, header=None, names=["x", "y", "z"], skiprows=1
+        fname, sep=r"\s+", header=None, names=["x", "y", "z"], skiprows=1
     )
 
 

--- a/pygmt/tests/test_triangulate.py
+++ b/pygmt/tests/test_triangulate.py
@@ -19,7 +19,7 @@ def fixture_dataframe():
     """
     fname = which("@Table_5_11_mean.xyz", download="c")
     return pd.read_csv(
-        fname, delim_whitespace=True, header=None, names=["x", "y", "z"], skiprows=1
+        fname, sep=r"\s+", header=None, names=["x", "y", "z"], skiprows=1
     )[:10]
 
 


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
