### PR TITLE
Add zoom_adjust param to pygmt.datasets.load_tile_map and Figure.tilemap

### DIFF
--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -91,9 +91,8 @@ def load_tile_map(
         is ``2``].
 
     zoom_adjust
-        Optional. The amount to adjust a chosen zoom level if it is chosen
-        automatically. Values outside of -1 to 1 are not recommended as they can lead to
-        slow execution.
+        The amount to adjust a chosen zoom level if it is chosen automatically. Values
+        outside of -1 to 1 are not recommended as they can lead to slow execution.
 
         .. note::
            The `zoom_adjust` parameter requires ``contextily>=1.5.0``.

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -90,10 +90,10 @@ def load_tile_map(
         will stop trying to fetch more tiles from a rate-limited API [Default
         is ``2``].
 
-    zoom_adjust : int or None
+    zoom_adjust
         Optional. The amount to adjust a chosen zoom level if it is chosen
         automatically. Values outside of -1 to 1 are not recommended as they can lead to
-        slow execution. [Default is ``None``].
+        slow execution.
 
         .. note::
            The `zoom_adjust` parameter requires ``contextily>=1.5.0``.

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -133,8 +133,10 @@ def load_tile_map(
             "`mamba install -c conda-forge contextily` "
             "to install the package."
         )
+
+    contextily_kwargs = {}
     if zoom_adjust is not None:
-        contextily_kwargs = {"zoom_adjust": zoom_adjust}
+        contextily_kwargs["zoom_adjust"] = zoom_adjust
         if Version(contextily.__version__) < Version("1.5.0"):
             raise TypeError(
                 "The `zoom_adjust` parameter requires `contextily>=1.5.0` to work. "

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -95,7 +95,7 @@ def load_tile_map(
         outside of -1 to 1 are not recommended as they can lead to slow execution.
 
         .. note::
-           The `zoom_adjust` parameter requires ``contextily>=1.5.0``.
+           The ``zoom_adjust`` parameter requires ``contextily>=1.5.0``.
 
     Returns
     -------

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -168,7 +168,7 @@ def load_tile_map(
     dataarray = xr.DataArray(
         data=rgb_image,
         coords={
-            "band": np.uint8([0, 1, 2]),  # Red, Green, Blue
+            "band": np.array(object=[0, 1, 2], dtype=np.uint8),  # Red, Green, Blue
             "y": np.linspace(start=top, stop=bottom, num=rgb_image.shape[1]),
             "x": np.linspace(start=left, stop=right, num=rgb_image.shape[2]),
         },

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -2,6 +2,7 @@
 Function to load raster tile maps from XYZ tile providers, and load as
 :class:`xarray.DataArray`.
 """
+from packaging.version import Version
 
 try:
     import contextily
@@ -132,6 +133,13 @@ def load_tile_map(
             "`mamba install -c conda-forge contextily` "
             "to install the package."
         )
+    if zoom_adjust is not None:
+        contextily_kwargs = {"zoom_adjust": zoom_adjust}
+        if Version(contextily.__version__) < Version("1.5.0"):
+            raise TypeError(
+                "The `zoom_adjust` parameter requires `contextily>=1.5.0` to work. "
+                "Please upgrade contextily, or manually set the `zoom` level instead."
+            )
 
     west, east, south, north = region
     image, extent = contextily.bounds2img(
@@ -144,7 +152,7 @@ def load_tile_map(
         ll=lonlat,
         wait=wait,
         max_retries=max_retries,
-        zoom_adjust=zoom_adjust,
+        **contextily_kwargs,
     )
 
     # Turn RGBA img from channel-last to channel-first and get 3-band RGB only

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -92,6 +92,9 @@ def load_tile_map(
         automatically. Values outside of -1 to 1 are not recommended as they
         can lead to slow execution. [Default is ``None``].
 
+        .. versionadded:: 0.11.0
+           Requires ``contextily>=1.5.0``.
+
     Returns
     -------
     raster : xarray.DataArray

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -90,8 +90,8 @@ def load_tile_map(
 
     zoom_adjust : int or None
         Optional. The amount to adjust a chosen zoom level if it is chosen
-        automatically. Values outside of -1 to 1 are not recommended as they
-        can lead to slow execution. [Default is ``None``].
+        automatically. Values outside of -1 to 1 are not recommended as they can lead to
+        slow execution. [Default is ``None``].
 
         .. versionadded:: 0.11.0
            Requires ``contextily>=1.5.0``.

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -95,8 +95,8 @@ def load_tile_map(
         automatically. Values outside of -1 to 1 are not recommended as they can lead to
         slow execution. [Default is ``None``].
 
-        .. versionadded:: 0.11.0
-           Requires ``contextily>=1.5.0``.
+        .. note::
+           The `zoom_adjust` parameter requires ``contextily>=1.5.0``.
 
     Returns
     -------

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -16,7 +16,15 @@ import xarray as xr
 __doctest_requires__ = {("load_tile_map"): ["contextily"]}
 
 
-def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_retries=2):
+def load_tile_map(
+    region,
+    zoom="auto",
+    source=None,
+    lonlat=True,
+    wait=0,
+    max_retries=2,
+    zoom_adjust=None,
+):
     """
     Load a georeferenced raster tile map from XYZ tile providers.
 
@@ -79,6 +87,11 @@ def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_ret
         will stop trying to fetch more tiles from a rate-limited API [Default
         is ``2``].
 
+    zoom_adjust : int or None
+        Optional. The amount to adjust a chosen zoom level if it is chosen
+        automatically. Values outside of -1 to 1 are not recommended as they
+        can lead to slow execution. [Default is ``None``].
+
     Returns
     -------
     raster : xarray.DataArray
@@ -128,6 +141,7 @@ def load_tile_map(region, zoom="auto", source=None, lonlat=True, wait=0, max_ret
         ll=lonlat,
         wait=wait,
         max_retries=max_retries,
+        zoom_adjust=zoom_adjust,
     )
 
     # Turn RGBA img from channel-last to channel-first and get 3-band RGB only

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -51,9 +51,9 @@ def load_tile_map(
         ``"auto"`` to automatically determine the zoom level based on the
         bounding box region extent].
 
-        **Note**: The maximum possible zoom level may be smaller than ``22``,
-        and depends on what is supported by the chosen web tile provider
-        source.
+        .. note::
+           The maximum possible zoom level may be smaller than ``22``, and depends on
+           what is supported by the chosen web tile provider source.
 
     source : xyzservices.TileProvider or str
         Optional. The tile source: web tile provider or path to a local file.
@@ -73,8 +73,8 @@ def load_tile_map(
           basemap. See
           :doc:`contextily:working_with_local_files`.
 
-        IMPORTANT: Tiles are assumed to be in the Spherical Mercator projection
-        (EPSG:3857).
+        .. important::
+           Tiles are assumed to be in the Spherical Mercator projection (EPSG:3857).
 
     lonlat : bool
         Optional. If ``False``, coordinates in ``region`` are assumed to be

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -2,6 +2,8 @@
 Function to load raster tile maps from XYZ tile providers, and load as
 :class:`xarray.DataArray`.
 """
+from __future__ import annotations
+
 from packaging.version import Version
 
 try:
@@ -24,7 +26,7 @@ def load_tile_map(
     lonlat=True,
     wait=0,
     max_retries=2,
-    zoom_adjust=None,
+    zoom_adjust: int | None = None,
 ):
     """
     Load a georeferenced raster tile map from XYZ tile providers.

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -118,8 +118,8 @@ def tilemap(
         automatically. Values outside of -1 to 1 are not recommended as they can lead to
         slow execution. [Default is ``None``].
 
-        .. versionadded:: 0.11.0
-           Requires ``contextily>=1.5.0``.
+        .. note::
+           The `zoom_adjust` parameter requires ``contextily>=1.5.0``.
 
     kwargs : dict
         Extra keyword arguments to pass to :meth:`pygmt.Figure.grdimage`.

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -118,7 +118,7 @@ def tilemap(
         outside of -1 to 1 are not recommended as they can lead to slow execution.
 
         .. note::
-           The `zoom_adjust` parameter requires ``contextily>=1.5.0``.
+           The ``zoom_adjust`` parameter requires ``contextily>=1.5.0``.
 
     kwargs : dict
         Extra keyword arguments to pass to :meth:`pygmt.Figure.grdimage`.

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -1,6 +1,8 @@
 """
 tilemap - Plot XYZ tile maps.
 """
+from __future__ import annotations
+
 from pygmt.clib import Session
 from pygmt.datasets.tile_map import load_tile_map
 from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
@@ -37,7 +39,7 @@ def tilemap(
     lonlat=True,
     wait=0,
     max_retries=2,
-    zoom_adjust=None,
+    zoom_adjust: int | None = None,
     **kwargs,
 ):
     r"""

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -116,6 +116,9 @@ def tilemap(
         automatically. Values outside of -1 to 1 are not recommended as they
         can lead to slow execution. [Default is ``None``].
 
+        .. versionadded:: 0.11.0
+           Requires ``contextily>=1.5.0``.
+
     kwargs : dict
         Extra keyword arguments to pass to :meth:`pygmt.Figure.grdimage`.
 

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -30,7 +30,15 @@ except ImportError:
 )
 @kwargs_to_strings(c="sequence_comma", p="sequence")  # R="sequence",
 def tilemap(
-    self, region, zoom="auto", source=None, lonlat=True, wait=0, max_retries=2, **kwargs
+    self,
+    region,
+    zoom="auto",
+    source=None,
+    lonlat=True,
+    wait=0,
+    max_retries=2,
+    zoom_adjust=None,
+    **kwargs,
 ):
     r"""
     Plots an XYZ tile map.
@@ -103,6 +111,11 @@ def tilemap(
         will stop trying to fetch more tiles from a rate-limited API [Default
         is ``2``].
 
+    zoom_adjust : int or None
+        Optional. The amount to adjust a chosen zoom level if it is chosen
+        automatically. Values outside of -1 to 1 are not recommended as they
+        can lead to slow execution. [Default is ``None``].
+
     kwargs : dict
         Extra keyword arguments to pass to :meth:`pygmt.Figure.grdimage`.
 
@@ -131,6 +144,7 @@ def tilemap(
         lonlat=lonlat,
         wait=wait,
         max_retries=max_retries,
+        zoom_adjust=zoom_adjust,
     )
 
     # Reproject raster from Spherical Mercator (EPSG:3857) to

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -114,9 +114,8 @@ def tilemap(
         is ``2``].
 
     zoom_adjust
-        Optional. The amount to adjust a chosen zoom level if it is chosen
-        automatically. Values outside of -1 to 1 are not recommended as they can lead to
-        slow execution.
+        The amount to adjust a chosen zoom level if it is chosen automatically. Values
+        outside of -1 to 1 are not recommended as they can lead to slow execution.
 
         .. note::
            The `zoom_adjust` parameter requires ``contextily>=1.5.0``.

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -113,10 +113,10 @@ def tilemap(
         will stop trying to fetch more tiles from a rate-limited API [Default
         is ``2``].
 
-    zoom_adjust : int or None
+    zoom_adjust
         Optional. The amount to adjust a chosen zoom level if it is chosen
         automatically. Values outside of -1 to 1 are not recommended as they can lead to
-        slow execution. [Default is ``None``].
+        slow execution.
 
         .. note::
            The `zoom_adjust` parameter requires ``contextily>=1.5.0``.

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -74,9 +74,9 @@ def tilemap(
         ``"auto"`` to automatically determine the zoom level based on the
         bounding box region extent].
 
-        **Note**: The maximum possible zoom level may be smaller than ``22``,
-        and depends on what is supported by the chosen web tile provider
-        source.
+        .. note::
+           The maximum possible zoom level may be smaller than ``22``, and depends on
+           what is supported by the chosen web tile provider source.
 
     source : xyzservices.TileProvider or str
         Optional. The tile source: web tile provider or path to a local file.
@@ -96,8 +96,8 @@ def tilemap(
           basemap. See
           :doc:`contextily:working_with_local_files`.
 
-        IMPORTANT: Tiles are assumed to be in the Spherical Mercator projection
-        (EPSG:3857).
+        .. important::
+           Tiles are assumed to be in the Spherical Mercator projection (EPSG:3857).
 
     lonlat : bool
         Optional. If ``False``, coordinates in ``region`` are assumed to be

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -113,8 +113,8 @@ def tilemap(
 
     zoom_adjust : int or None
         Optional. The amount to adjust a chosen zoom level if it is chosen
-        automatically. Values outside of -1 to 1 are not recommended as they
-        can lead to slow execution. [Default is ``None``].
+        automatically. Values outside of -1 to 1 are not recommended as they can lead to
+        slow execution. [Default is ``None``].
 
         .. versionadded:: 0.11.0
            Requires ``contextily>=1.5.0``.


### PR DESCRIPTION
**Description of proposed changes**

The `zoom_adjust` parameter is used to adjust the automatic zoom level by integer increments.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Preview** at https://pygmt-dev--2934.org.readthedocs.build/en/2934/api/generated/pygmt.datasets.load_tile_map.html

Note: This requires `contextily>=1.5.0`, see https://github.com/geopandas/contextily/pull/228.

Example usage:

```python
import contextily
import pygmt

region = [-157.84, -157.8, 21.255, 21.285]  # West, East, South, North
fig = pygmt.Figure()
with fig.subplot(ncols=2, figsize=("15c", "6c"), sharey=True):
    # Regular zoom level
    fig.tilemap(
        zoom="auto",
        region=region,
        source=contextily.providers.CartoDB.Positron,
        panel=0,
        frame="+tAuto Zoom",
    )
    # Zoom level -1 (more zoomed out)
    fig.tilemap(
        zoom="auto",
        region=region,
        source=contextily.providers.CartoDB.Positron,
        zoom_adjust=-1,
        panel=1,
        frame="+tAuto Zoom -1",
    )
fig.savefig("zoom_adjust.png")
fig.show(width=1000)
```
produces

![zoom_adjust](https://github.com/GenericMappingTools/pygmt/assets/23487320/ecc7906d-d416-4137-bfb9-08de334e1fcd)


<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
