### PR TITLE
Set GMT_SESSION_NAME to a unique name on Windows for multiprocessing support

### DIFF
--- a/pygmt/session_management.py
+++ b/pygmt/session_management.py
@@ -1,7 +1,11 @@
 """
 Modern mode session management modules.
 """
+import os
+import sys
+
 from pygmt.clib import Session
+from pygmt.helpers import unique_name
 
 
 def begin():
@@ -12,6 +16,10 @@ def begin():
 
     Only meant to be used once for creating the global session.
     """
+    # On Windows, need to set GMT_SESSION_NAME to a unique value
+    if sys.platform == "win32":
+        os.environ["GMT_SESSION_NAME"] = unique_name()
+
     prefix = "pygmt-session"
     with Session() as lib:
         lib.call_module(module="begin", args=prefix)

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -1,7 +1,9 @@
 """
 Test the session management modules.
 """
+import multiprocessing as mp
 import os
+from importlib import reload
 from pathlib import Path
 
 import pytest
@@ -67,8 +69,6 @@ def _gmt_func_wrapper(figname):
     Currently, we have to import pygmt and reload it in each process. Workaround from
     https://github.com/GenericMappingTools/pygmt/issues/217#issuecomment-754774875.
     """
-    from importlib import reload
-
     import pygmt
 
     reload(pygmt)
@@ -81,9 +81,6 @@ def test_session_multiprocessing():
     """
     Make sure that multiprocessing is supported if pygmt is re-imported.
     """
-
-    import multiprocessing as mp
-
     prefix = "test_session_multiprocessing"
     with mp.Pool(2) as p:
         p.map(_gmt_func_wrapper, [f"{prefix}-1.png", f"{prefix}-2.png"])

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -2,6 +2,7 @@
 Test the session management modules.
 """
 import os
+from pathlib import Path
 
 import pytest
 from pygmt.clib import Session
@@ -57,3 +58,34 @@ def test_gmt_compat_6_is_applied(capsys):
         # Make sure no global "gmt.conf" in the current directory
         assert not os.path.exists("gmt.conf")
         begin()  # Restart the global session
+
+
+def _gmt_func_wrapper(figname):
+    """
+    A wrapper for running PyGMT scripts with multiprocessing.
+
+    Currently, we have to import pygmt and reload it in each process. Workaround from
+    https://github.com/GenericMappingTools/pygmt/issues/217#issuecomment-754774875.
+    """
+    from importlib import reload
+
+    import pygmt
+
+    reload(pygmt)
+    fig = pygmt.Figure()
+    fig.basemap(region=[10, 70, -3, 8], projection="X8c/6c", frame="afg")
+    fig.savefig(figname)
+
+
+def test_session_multiprocessing():
+    """
+    Make sure that multiprocessing is supported if pygmt is re-imported.
+    """
+
+    import multiprocessing as mp
+
+    prefix = "test_session_multiprocessing"
+    with mp.Pool(2) as p:
+        p.map(_gmt_func_wrapper, [f"{prefix}-1.png", f"{prefix}-2.png"])
+    Path(f"{prefix}-1.png").unlink()
+    Path(f"{prefix}-2.png").unlink()


### PR DESCRIPTION
This PR adds the workaround in https://github.com/GenericMappingTools/pygmt/issues/217#issuecomment-754774875 as a test to make sure that the workaround for multiprocessing support (i.e., reload pygmt in each process) works as expected.

As mentioned in https://github.com/GenericMappingTools/pygmt/issues/217#issuecomment-762649874, the workaround didn't work on Windows. This PR also addresses this issue by setting `GMT_SESSION_NAME` to a unique name on Windows.

xref: https://github.com/GenericMappingTools/gmt/blob/104bcdbafd13eb96260b445910ce3587a362dbc0/src/gmt_api.c#L1036

The newly added test fails on Windows (https://github.com/GenericMappingTools/pygmt/actions/runs/7378717925/job/20074178686?pr=2938) and the commit 07ae8f1445972d1200f04384267524ba63472969 fixes it (see https://github.com/GenericMappingTools/pygmt/actions/runs/7378788411/job/20074335235?pr=2938).
