### PR TITLE
Figure.meca: Fix typo pricipal_axis -> principal_axis

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -168,7 +168,7 @@ def convention_params(convention):
         ],
         "mt": ["mrr", "mtt", "mff", "mrt", "mrf", "mtf", "exponent"],
         "partial": ["strike1", "dip1", "strike2", "fault_type", "magnitude"],
-        "pricipal_axis": [
+        "principal_axis": [
             "t_value",
             "t_azimuth",
             "t_plunge",
@@ -401,7 +401,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
     # Convert spec to pandas.DataFrame unless it's a file
     if isinstance(spec, (dict, pd.DataFrame)):  # spec is a dict or pd.DataFrame
         # determine convention from dict keys or pd.DataFrame column names
-        for conv in ["aki", "gcmt", "mt", "partial", "pricipal_axis"]:
+        for conv in ["aki", "gcmt", "mt", "partial", "principal_axis"]:
             if set(convention_params(conv)).issubset(set(spec.keys())):
                 convention = conv
                 break


### PR DESCRIPTION
**Description of proposed changes**

Corrects a typo in `Figure.meca` that was introduced in #2576 and affects PyGMT v0.10.0, resulting in an error like `GMTInvalidInput: Invalid convention 'pricipal_axis'` being raised.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Reported by @yasuit21 at https://twitter.com/yasuit21/status/1724513532312698953#m

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Patches #2576


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
