### PR TITLE
Make a duplicate fixture for pandas dtypes including pyarrow types

### DIFF
--- a/pygmt/tests/test_clib_virtualfiles.py
+++ b/pygmt/tests/test_clib_virtualfiles.py
@@ -34,6 +34,19 @@ def fixture_dtypes():
     return "int8 int16 int32 int64 uint8 uint16 uint32 uint64 float32 float64".split()
 
 
+@pytest.fixture(scope="module", name="dtypes_pandas")
+def fixture_dtypes_pandas(dtypes):
+    """
+    List of supported pandas dtypes.
+    """
+    dtypes_pandas = dtypes.copy()
+
+    if find_spec("pyarrow") is not None:
+        dtypes_pandas.extend([f"{dtype}[pyarrow]" for dtype in dtypes_pandas])
+
+    return tuple(dtypes_pandas)
+
+
 def test_virtual_file(dtypes):
     """
     Test passing in data via a virtual file with a Dataset.
@@ -315,16 +328,14 @@ def test_virtualfile_from_matrix_slice(dtypes):
             assert output == expected
 
 
-def test_virtualfile_from_vectors_pandas(dtypes):
+def test_virtualfile_from_vectors_pandas(dtypes_pandas):
     """
     Pass vectors to a dataset using pandas.Series, checking both numpy and pyarrow
     dtypes.
     """
     size = 13
-    if find_spec("pyarrow") is not None:
-        dtypes.extend([f"{dtype}[pyarrow]" for dtype in dtypes])
 
-    for dtype in dtypes:
+    for dtype in dtypes_pandas:
         data = pd.DataFrame(
             data={
                 "x": np.arange(size),

--- a/pygmt/tests/test_clib_virtualfiles.py
+++ b/pygmt/tests/test_clib_virtualfiles.py
@@ -261,11 +261,10 @@ def test_virtualfile_from_vectors_two_string_or_object_columns(dtype):
         assert output == expected
 
 
-def test_virtualfile_from_vectors_transpose():
+def test_virtualfile_from_vectors_transpose(dtypes):
     """
     Test transforming matrix columns to virtual file dataset.
     """
-    dtypes = "float32 float64 int32 int64 uint32 uint64".split()
     shape = (7, 5)
     for dtype in dtypes:
         data = np.arange(shape[0] * shape[1], dtype=dtype).reshape(shape)


### PR DESCRIPTION
**Description of proposed changes**

Explicitly copying the numpy `dtypes` fixture in `test_clib_virtualfiles.py` to a new `dtypes_pandas` fixture that includes pyarrow types, so that modifications to the original numpy `dtypes` fixture won't affect other tests.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes https://github.com/GenericMappingTools/pygmt/pull/2936#issuecomment-1873225032


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
