### PR TITLE
CI: Set cache-downloads to false to speedup the "Setup Micromamba" step

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -72,7 +72,7 @@ jobs:
             channels:
               - conda-forge
               - nodefaults
-          cache-downloads: true
+          cache-downloads: false
           cache-environment: true
           create-args: >-
             python=3.12

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -101,7 +101,7 @@ jobs:
             channels:
               - conda-forge
               - nodefaults
-          cache-downloads: true
+          cache-downloads: false
           cache-environment: true
           create-args: >-
             python=${{ matrix.python-version }}${{ matrix.optional-packages }}

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -101,8 +101,8 @@ jobs:
             channels:
               - conda-forge
               - nodefaults
-          cache-downloads: true
-          cache-environment: false
+          cache-downloads: false
+          cache-environment: true
           create-args: >-
             python=${{ matrix.python-version }}${{ matrix.optional-packages }}
             gmt=6.4.0

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -101,8 +101,8 @@ jobs:
             channels:
               - conda-forge
               - nodefaults
-          cache-downloads: false
-          cache-environment: true
+          cache-downloads: true
+          cache-environment: false
           create-args: >-
             python=${{ matrix.python-version }}${{ matrix.optional-packages }}
             gmt=6.4.0

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -95,7 +95,7 @@ jobs:
             channels:
               - conda-forge
               - nodefaults
-          cache-downloads: true
+          cache-downloads: false
           cache-environment: true
           create-args: >-
             python=3.12

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -59,7 +59,7 @@ jobs:
             channels:
               - conda-forge
               - nodefaults
-          cache-downloads: true
+          cache-downloads: false
           cache-environment: true
           create-args: >-
             python=3.9


### PR DESCRIPTION
Currently, we set both `cache-downloads` and `cache-environment` options to `true` in the `mamba-org/setup-micromamba` action. So, in the "Setup Micromamba" step, we see information like below:
```
Restoring downloads from `/home/runner/micromamba/pkgs` ...
  Received 209715200 of 614617264 (34.1%), 199.6 MBs/sec
  Received 528482304 of 614617264 (86.0%), 251.7 MBs/sec
  Cache Size: ~586 MB (614617264 B)
  /usr/bin/tar -xf /home/runner/work/_temp/6f85073e-da84-4b9b-a62e-5a406ad9f613/cache.tzst -P -C /home/runner/work/pygmt/pygmt --use-compress-program unzstd
  Received 614617264 of 614617264 (100.0%), 195.2 MBs/sec
  Cache restored successfully
  Restored cache with key `micromamba-downloads--linux-64`
Restoring environment `pygmt` from `/home/runner/micromamba/envs/pygmt` ...
  Received 192937984 of 559585675 (34.5%), 184.0 MBs/sec
  Received 452984832 of 559585675 (81.0%), 216.0 MBs/sec
  Cache Size: ~534 MB (559585675 B)
  /usr/bin/tar -xf /home/runner/work/_temp/5b8debfc-6237-4bc9-ba5b-6f421a5ad7ff/cache.tzst -P -C /home/runner/work/pygmt/pygmt --use-compress-program unzstd
  Received 559585675 of 559585675 (100.0%), 177.8 MBs/sec
  Cache restored successfully
  Restored cache with key `micromamba-environment--linux-64-pygmt-args-62be375-root-dcc80ee`
```
Apparently, `cache-downloads` caches/restores the packages in the `/home/runner/micromamba/pkgs` directory and `cache-environment` caches/restores the environment from `/home/runner/micromamba/envs/pygmt`. The cached packages are NOT used in the following steps, thus caching downloads is unnecessary.

This PR changes the `cache-downloads` option to `false` in `ci_*.yml` workflows.

Comparing this branch (https://github.com/GenericMappingTools/pygmt/actions/runs/7384789955/job/20088312682?pr=2946) with the main branch (https://github.com/GenericMappingTools/pygmt/actions/runs/7383547780/job/20084932207), the "Setup Micromamba" step is now faster by a few seconds on Linux and 10-100 seconds faster on Windows.