### PR TITLE
CI: Remove the pytest-benchmark plugin from the benchmarks workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -61,7 +61,7 @@ jobs:
           echo $CONDA/bin >> $GITHUB_PATH
           conda install --solver=libmamba gmt=6.4.0 python=3.12 \
                         numpy pandas xarray netCDF4 packaging \
-                        geopandas pytest pytest-benchmark pytest-mpl
+                        geopandas pytest pytest-mpl
           python -m pip install -U pytest-codspeed setuptools
 
       # Download cached remote files (artifacts) from GitHub


### PR DESCRIPTION
The workflow runs (https://github.com/GenericMappingTools/pygmt/actions/runs/7383547777/job/20084932197) says:
```
 ============================= test session starts ==============================
  platform linux -- Python 3.12.1, pytest-7.4.4, pluggy-1.3.0 -- /usr/share/miniconda/bin/python
  codspeed: 2.2.0 (callgraph: enabled)
  CodSpeed had to disable the following plugins: pytest-benchmark
  cachedir: .pytest_cache
  benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
  Matplotlib: 3.8.2
  Freetype: 2.12.1
  rootdir: /home/runner/work/pygmt/pygmt
  configfile: pyproject.toml
  plugins: benchmark-4.0.0, codspeed-2.2.0, mpl-0.16.1
  collecting ... collected 697 items / 631 deselected / 6 skipped / 66 selected
```
It means the `pytest-benchmark` plugin is not needed.


Patches #2908.