### PR TITLE
CI: Run certain GitHub Actions workflows on official repo only

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -32,6 +32,7 @@ concurrency:
 jobs:
   benchmarks:
     runs-on: ubuntu-22.04
+    if: github.repository == 'GenericMappingTools/pygmt'
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -18,6 +18,7 @@ jobs:
   check_links:
     name: Check Links
     runs-on: ubuntu-latest
+    if: github.repository == 'GenericMappingTools/pygmt'
 
     steps:
     - name: Checkout the repository

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -37,6 +37,7 @@ jobs:
   docs:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'GenericMappingTools/pygmt'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_doctests.yaml
+++ b/.github/workflows/ci_doctests.yaml
@@ -21,6 +21,7 @@ jobs:
   test:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'GenericMappingTools/pygmt'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -32,6 +32,7 @@ jobs:
   test:
     name: ${{ matrix.os }} - GMT ${{ matrix.gmt_version }}
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'GenericMappingTools/pygmt'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    if: github.repository == 'GenericMappingTools/pygmt'
+
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5.25.0


### PR DESCRIPTION
**Description of proposed changes**

Noticed at https://github.com/seisman/pygmt/pull/2 that there were a lot of GitHub Actions workflows being ran that might not make sense for forks, so disabling some of them. Specifically:

- [x] benchmarks.yml
- [x] check-links.yml
- [x] ci_docs.yml
- [x] ci_doctests.yaml
- [x] ci_tests_legacy.yaml
- [x] release_drafter.yml

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

The list above are mostly those that run on the main branch or on a cron schedule, which GitHub should have disabled by default already for new forks according to https://github.com/orgs/community/discussions/26704#discussioncomment-5268498. But we can still explicitly disable them.

The benchmarks.yml one should be disabled, otherwise it will error with a message like this (copied from https://github.com/seisman/pygmt/actions/runs/7403301366/job/20143268291?pr=2):

```
  Preparing upload...
  Error: error decoding response body: missing field `status` at line 1 column 58
  Error: Process completed with exit code 1.
```

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
- `/test-gmt-dev`: run full tests on the latest GMT development version
