### PR TITLE
CI: Trigger workflows based on changed files

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,10 +12,7 @@ on:
     paths:
       - 'pygmt/**/*.py'
       - '.github/workflows/benchmarks.yml'
-  pull_request:
-    paths:
-      - 'pygmt/**/*.py'
-      - '.github/workflows/benchmarks.yml'
+  # pull_request:
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.
   workflow_dispatch:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,12 +11,10 @@ on:
     branches: [ main ]
     paths:
       - 'pygmt/**/*.py'
-      - '!pygmt/tests/**'
       - '.github/workflows/benchmarks.yml'
   pull_request:
     paths:
       - 'pygmt/**/*.py'
-      - '!pygmt/tests/**'
       - '.github/workflows/benchmarks.yml'
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - 'pygmt/**/*.py'
       - '.github/workflows/benchmarks.yml'
+  # Uncomment the 'pull_request' line below to trigger the workflow in PR
   # pull_request:
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -5,14 +5,14 @@
 # by other GitHub Actions workflows.
 #
 # It is scheduled to run every Sunday at 12:00 (UTC). If new remote files are
-# needed urgently, maintainers can update the workflow file or
+# needed urgently, maintainers can update the workflow file or the
 # 'pygmt/helpers/caching.py' file to refresh the cache.
 #
 name: Cache data
 
 on:
   pull_request:
-    # Make any changes to the following files to refresh the cache
+    # Make any changes to the following files to refresh the cache in PRs
     paths:
       - 'pygmt/helpers/caching.py'
       - '.github/workflows/cache_data.yaml'

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -18,13 +18,22 @@ name: Docs
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'pygmt/**/*.py'
+      - '!pygmt/tests/**'
+      - 'doc/**'
+      - 'examples/**'
+      - 'README.rst'
+      - '.github/workflows/ci_docs.yml'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    paths-ignore:
-      - 'pygmt/tests/**'
-      - '*.md'
-      - 'LICENSE.txt'
-      - '.gitignore'
+    paths:
+      - 'pygmt/**/*.py'
+      - '!pygmt/tests/**'
+      - 'doc/**'
+      - 'examples/**'
+      - 'README.rst'
+      - '.github/workflows/ci_docs.yml'
   release:
     types:
       - published

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -26,12 +26,12 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'pygmt/**/*.py'
+      - 'pygmt/**'
       - '.github/workflows/ci_tests.yaml'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:
-      - 'pygmt/**/*.py'
+      - 'pygmt/**'
       - '.github/workflows/ci_tests.yaml'
   release:
     types:

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -25,15 +25,14 @@ name: Tests
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'pygmt/**/*.py'
+      - '.github/workflows/ci_tests.yaml'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    paths-ignore:
-      - 'doc/**'
-      - 'examples/**'
-      - '*.md'
-      - 'README.rst'
-      - 'LICENSE.txt'
-      - '.gitignore'
+    paths:
+      - 'pygmt/**/*.py'
+      - '.github/workflows/ci_tests.yaml'
   release:
     types:
       - published

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -17,13 +17,9 @@ on:
   #   branches: [ main ]
   pull_request:
     types: [ready_for_review]
-    paths-ignore:
-      - 'doc/**'
-      - 'examples/**'
-      - '*.md'
-      - 'README.rst'
-      - 'LICENSE.txt'
-      - '.gitignore'
+    paths:
+      - 'pygmt/**/*.py'
+      - '.github/workflows/ci_tests_dev.yaml'
   repository_dispatch:
     types: [test-gmt-dev-command]
   # Schedule tests on Monday/Wednesday/Friday

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -18,7 +18,7 @@ on:
   pull_request:
     types: [ready_for_review]
     paths:
-      - 'pygmt/**/*.py'
+      - 'pygmt/**'
       - '.github/workflows/ci_tests_dev.yaml'
   repository_dispatch:
     types: [test-gmt-dev-command]

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -13,13 +13,9 @@ on:
   #   branches: [ main ]
   # pull_request:
     # types: [ready_for_review]
-    # paths-ignore:
-    #  - 'doc/**'
-    #  - 'examples/**'
-    #  - '*.md'
-    #  - 'README.rst'
-    #  - 'LICENSE.txt'
-    #  - '.gitignore'
+    # paths:
+    #  - 'pygmt/**/*.py'
+    #  - '.github/workflows/ci_tests_legacy.yaml'
   # Schedule tests on Tuesday
   schedule:
     - cron: '0 0 * * 2'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -14,7 +14,7 @@ on:
   # pull_request:
     # types: [ready_for_review]
     # paths:
-    #  - 'pygmt/**/*.py'
+    #  - 'pygmt/**'
     #  - '.github/workflows/ci_tests_legacy.yaml'
   # Schedule tests on Tuesday
   schedule:

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -11,6 +11,7 @@ name: GMT Legacy Tests
 on:
   # push:
   #   branches: [ main ]
+  # Uncomment the 'pull_request' line below to trigger the workflow in PR
   # pull_request:
     # types: [ready_for_review]
     # paths:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -20,6 +20,7 @@ on:
     branches: [ main ]
     paths:
       - 'pygmt/**'
+      - '!pygmt/tests/**'
       - 'Makefile'
       - 'MANIFEST.in'
       - 'pyproject.toml'

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -17,8 +17,14 @@ name: Publish to PyPI
 # Only run for pushes to the main branch and releases.
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
+    paths:
+      - 'pygmt/**'
+      - 'Makefile'
+      - 'MANIFEST.in'
+      - 'pyproject.toml'
+      - 'README.rst'
+      - '.github/workflows/publish-to-pypi.yml'
   release:
     types:
       - published

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,7 +8,6 @@ name: Release Drafter
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
     branches:
       - main
 

--- a/.github/workflows/type_checks.yml
+++ b/.github/workflows/type_checks.yml
@@ -10,7 +10,13 @@ name: Static Type Checks
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'pygmt/**/*.py'
+      - '.github/workflows/type_checks.yml'
   pull_request:
+    paths:
+      - 'pygmt/**/*.py'
+      - '.github/workflows/type_checks.yml'
   # Schedule daily tests
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
Some workflow runs are unnecessary and waste CI resources. For example, PR #2950 contains no codes or docs changes, but when it was merged into the main branch, workflows "Tests" and "Docs" were still triggered (see https://github.com/GenericMappingTools/pygmt/actions?query=branch%3Amain).

This PR updates the workflow trigger conditions based on changes files, to save CI resources.

- [x] benchmarks.yml
- [x] cache_data.yaml
- [x] check-links.yml
- [x] ci_docs.yml
- [x] ci_doctests.yaml
- [x] ci_tests_dev.yaml
- [x] ci_tests_legacy.yaml
- [x] ci_tests.yaml
- [x] dvc-diff.yml
- [x] format-command.yml
- [x] publish-to-pypi.yml
- [x] release-baseline-images.yml
- [x] release-drafter.yml
- [x] slash-command-dispatch.yml
- [x] style_checks.yaml
- [x] type_checks.yml