### PR TITLE
CI: Run "GMT Dev Tests" if PR is labeled with 'run/test-gmt-dev'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,6 @@ Fixes #
 **Slash Commands**
 
 You can write slash commands (`/command`) in the first line of a comment to perform
-specific operations. Supported slash commands are:
+specific operations. Supported slash command is:
 
 - `/format`: automatically format and lint the code
-- `/test-gmt-dev`: run full tests on the latest GMT development version

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -16,6 +16,7 @@ on:
   # push:
   #   branches: [ main ]
   pull_request:
+    types: [ labeled ]
     paths:
       - 'pygmt/**'
       - '.github/workflows/ci_tests_dev.yaml'

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -16,7 +16,7 @@ on:
   # push:
   #   branches: [ main ]
   pull_request:
-    types: [ labeled ]
+    types: [ labeled, synchronize ]
     paths:
       - 'pygmt/**'
       - '.github/workflows/ci_tests_dev.yaml'

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -1,14 +1,14 @@
 # Test PyGMT with GMT dev version on Linux/macOS/Windows
 #
-# This workflow runs regular PyGMT tests with the GMT dev version, and also
-# pre-release versions of several dependencies like NumPy, Pandas, Xarray, etc.
-# If any tests fail, it also uploads the diff images as workflow artifacts.
-# The GMT dev version is installed by fetching the latest source codes from
-# the GMT master branch and compiling.
+# This workflow runs regular PyGMT tests with the GMT dev version, and also pre-release
+# versions of several dependencies like NumPy, Pandas, Xarray, etc. If any tests fail,
+# it also uploads the diff images as workflow artifacts. The GMT dev version is
+# installed by fetching the latest source codes from the GMT master branch and
+# compiling.
 #
-# It is triggered when a pull request is marked as "ready as review", or using
-# the slash command `/test-gmt-dev`. It is also scheduled to run on Monday,
-# Wednesday, and Friday on the main branch.
+# It is triggered when a pull request is marked as "ready as review", or labeled with
+# 'run/test-gmt-dev'. It is also scheduled to run on Monday, Wednesday, and Friday on
+# the main branch.
 #
 name: GMT Dev Tests
 
@@ -20,8 +20,6 @@ on:
     paths:
       - 'pygmt/**'
       - '.github/workflows/ci_tests_dev.yaml'
-  repository_dispatch:
-    types: [test-gmt-dev-command]
   # Schedule tests on Monday/Wednesday/Friday
   schedule:
     - cron: '0 0 * * 1,3,5'
@@ -48,30 +46,9 @@ jobs:
       # Checkout current git repository
       - name: Checkout
         uses: actions/checkout@v4.1.1
-        if: github.event_name != 'repository_dispatch'
         with:
           # fetch all history so that setuptools-scm works
           fetch-depth: 0
-
-      # Checkout the pull request branch
-      - name: Checkout
-        uses: actions/checkout@v4.1.1
-        if: github.event_name == 'repository_dispatch'
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.client_payload.pull_request.head.ref }}
-          # fetch all history so that setuptools-scm works
-          fetch-depth: 0
-
-      - name: Show job URL
-        uses: peter-evans/create-or-update-comment@v3.1.0
-        if: github.event_name == 'repository_dispatch' && runner.os == 'Linux'
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          body: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       # Install Micromamba with conda-forge dependencies
       - name: Setup Micromamba

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -16,7 +16,6 @@ on:
   # push:
   #   branches: [ main ]
   pull_request:
-    types: [ready_for_review]
     paths:
       - 'pygmt/**'
       - '.github/workflows/ci_tests_dev.yaml'
@@ -32,6 +31,7 @@ jobs:
   test_gmt_dev:
     name: ${{ matrix.os }} - GMT ${{ matrix.gmt_git_ref }}
     runs-on: ${{ matrix.os }}
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run/test-gmt-dev')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -16,7 +16,7 @@ on:
   # push:
   #   branches: [ main ]
   pull_request:
-    types: [ labeled, synchronize ]
+    types: [ opened, reopened, labeled, synchronize ]
     paths:
       - 'pygmt/**'
       - '.github/workflows/ci_tests_dev.yaml'

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -1,6 +1,6 @@
 # Support slash commands in pull requests
 #
-# Currently, two slash commands `format` and `test-gmt-dev` are supported.
+# Currently, only one slash command `format` is supported.
 #
 name: Slash Command Dispatch
 on:
@@ -19,6 +19,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commands: |
             format
-            test-gmt-dev
           issue-type: pull-request
           permission: none


### PR DESCRIPTION
**Description of proposed changes**

Similar to https://github.com/GenericMappingTools/pygmt/pull/2958.

Slash command `/test-gmt-dev` is no longer supported. To enable the "GMT Dev Tests" workflow, just add the `run/test-gmt-dev` label (needs written permission to this repository).