### PR TITLE
Fix fixture_xr_image to open earth_day_01d_p directly with rioxarray

### DIFF
--- a/pygmt/helpers/caching.py
+++ b/pygmt/helpers/caching.py
@@ -1,12 +1,12 @@
 """
-Functions for download remote data files as cache.
+Functions for downloading remote data files to cache.
 """
 from pygmt.src import which
 
 
 def cache_data():
     """
-    Download GMT remote data files used in PyGMT tests and docs as cache files.
+    Download GMT remote data files used in PyGMT tests and docs to cache folder.
     """
     # List of datasets to download
     datasets = [
@@ -57,7 +57,7 @@ def cache_data():
         # Earth WDMAM grids
         "@earth_wdmam_01d_g",
         "@S90E000.earth_wdmam_03m_g.nc",  # Specific grid for 03m test
-        # Earth day/night grids
+        # Earth day/night images
         "@earth_day_01d_p",
         # Other cache files
         "@capitals.gmt",

--- a/pygmt/tests/baseline/test_tilemap_no_clip_False.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_no_clip_False.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: e2a9a57f61bdca0c21ddec3e1ae5d819
-  size: 16595
+- md5: e55d9848135fc14c9cfc3d2c85bd82bb
+  size: 16472
   path: test_tilemap_no_clip_False.png
+  hash: md5

--- a/pygmt/tests/baseline/test_tilemap_no_clip_True.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_no_clip_True.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 86ce085faad17433dfabba675d0379ee
-  size: 38836
+- md5: 53949854f32b450e55f1be86102387e9
+  size: 38816
   path: test_tilemap_no_clip_True.png
+  hash: md5

--- a/pygmt/tests/baseline/test_tilemap_ogc_wgs84.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_ogc_wgs84.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 6da0601f305a6c3391e4a1aa0aee6173
-  size: 37139
+- md5: 5f225e4dd26f44e07bcbd8e713c67dbe
+  size: 37343
   path: test_tilemap_ogc_wgs84.png
+  hash: md5

--- a/pygmt/tests/baseline/test_tilemap_web_mercator.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_web_mercator.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 2965f6711c5878014491c7e6f791048e
-  size: 62077
+- md5: 14f7afd5d48ed6aed88d495783f0ba42
+  size: 62398
   path: test_tilemap_web_mercator.png
+  hash: md5

--- a/pygmt/tests/test_grdimage_image.py
+++ b/pygmt/tests/test_grdimage_image.py
@@ -1,13 +1,9 @@
 """
 Test Figure.grdimage on 3-band RGB images.
 """
-import numpy as np
-import pandas as pd
 import pytest
-import xarray as xr
 from pygmt import Figure, which
 
-rasterio = pytest.importorskip("rasterio")
 rioxarray = pytest.importorskip("rioxarray")
 
 
@@ -19,28 +15,8 @@ def fixture_xr_image():
     """
     geotiff = which(fname="@earth_day_01d_p", download="c")
     with rioxarray.open_rasterio(filename=geotiff) as rda:
-        if len(rda.band) == 3:  # GMT 6.5.0 or above
+        if len(rda.band) == 3:
             xr_image = rda.load()
-        elif len(rda.band) == 1:  # GMT 6.4.0 or below
-            with rasterio.open(fp=geotiff) as src:
-                df_colormap = pd.DataFrame.from_dict(
-                    data=src.colormap(1), orient="index"
-                )
-                array = src.read()
-
-                red = np.vectorize(df_colormap[0].get)(array)
-                green = np.vectorize(df_colormap[1].get)(array)
-                blue = np.vectorize(df_colormap[2].get)(array)
-                # alpha = np.vectorize(df_colormap[3].get)(array)
-
-            rda.data = red
-            da_red = rda.astype(dtype=np.uint8).copy()
-            rda.data = green
-            da_green = rda.astype(dtype=np.uint8).copy()
-            rda.data = blue
-            da_blue = rda.astype(dtype=np.uint8).copy()
-
-            xr_image = xr.concat(objs=[da_red, da_green, da_blue], dim="band")
         assert xr_image.sizes == {"band": 3, "y": 180, "x": 360}
         return xr_image
 

--- a/pygmt/tests/test_grdimage_image.py
+++ b/pygmt/tests/test_grdimage_image.py
@@ -19,7 +19,9 @@ def fixture_xr_image():
     """
     geotiff = which(fname="@earth_day_01d_p", download="c")
     with rioxarray.open_rasterio(filename=geotiff) as rda:
-        if len(rda.band) == 1:
+        if len(rda.band) == 3:  # GMT 6.5.0 or above
+            xr_image = rda.load()
+        elif len(rda.band) == 1:  # GMT 6.4.0 or below
             with rasterio.open(fp=geotiff) as src:
                 df_colormap = pd.DataFrame.from_dict(
                     data=src.colormap(1), orient="index"


### PR DESCRIPTION
**Description of proposed changes**

Rioxarray can now read the 3-bands from `@earth_day_01d_p` directly without needing to parse the colorinterp information from the GeoTIFF file.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses some of the failing tests in https://github.com/GenericMappingTools/pygmt/issues/2961#issuecomment-1880159618, resolves https://github.com/GenericMappingTools/pygmt/pull/2590#discussion_r1251353479


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
