### PR TITLE
Update baseline images for basemap tests

### DIFF
--- a/pygmt/tests/baseline/test_basemap.png.dvc
+++ b/pygmt/tests/baseline/test_basemap.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 3cf01816fa5dd3fbc1adc602557bb032
-  size: 6187
+- md5: a0c8f76cac48621f24a14b2c6fa26d09
+  size: 6260
   path: test_basemap.png
+  hash: md5

--- a/pygmt/tests/baseline/test_basemap_compass.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_compass.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 0dc332834d1c765b51d93f1a4f7254e8
-  size: 71151
+- md5: 3e0d9c5fbedf71d7bb0315797e7d0493
+  size: 71791
   path: test_basemap_compass.png
+  hash: md5

--- a/pygmt/tests/baseline/test_basemap_loglog.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_loglog.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 37c36d4fa4524260ea43c6757a3140a1
-  size: 24475
+- md5: 01ea1c00700565057596c12d18c7146d
+  size: 24551
   path: test_basemap_loglog.png
+  hash: md5

--- a/pygmt/tests/baseline/test_basemap_map_scale.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_map_scale.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: e88925c5053369eb516757ec963d691d
-  size: 31044
+- md5: 0660d501d81ef890a9cf94bd92e0673e
+  size: 31423
   path: test_basemap_map_scale.png
+  hash: md5

--- a/pygmt/tests/baseline/test_basemap_polar.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_polar.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: ded4dba2d1c780b85f256eaad2e268f5
-  size: 31886
+- md5: e4bc1a90f4f25220fe759cdb0a709db8
+  size: 31915
   path: test_basemap_polar.png
+  hash: md5

--- a/pygmt/tests/baseline/test_basemap_power_axis.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_power_axis.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: d42769c9b2a802788ac3b3fd0c193c26
-  size: 16446
+- md5: f3151c1afe508404fc9c2cafcd34535d
+  size: 16272
   path: test_basemap_power_axis.png
+  hash: md5

--- a/pygmt/tests/baseline/test_basemap_rose.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_rose.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: f14e2aaafe4667b2dc06ad1684f7a7ee
-  size: 32442
+- md5: 86acd995f29f961bdf86afc22e2afff6
+  size: 32873
   path: test_basemap_rose.png
+  hash: md5

--- a/pygmt/tests/baseline/test_basemap_subplot.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_subplot.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 1b4ae53658eec125ebf8ab4eac78d729
-  size: 8733
+- md5: d7049472c881d3a567e8e583b6ff54e1
+  size: 8752
   path: test_basemap_subplot.png
+  hash: md5

--- a/pygmt/tests/baseline/test_basemap_utm_projection.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_utm_projection.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 05267ec2d3c26463c79603a2527cc5a9
-  size: 9070
+- md5: 5ac71f946749a8c4786416d780ba9ccf
+  size: 9719
   path: test_basemap_utm_projection.png
+  hash: md5

--- a/pygmt/tests/baseline/test_basemap_winkel_tripel.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_winkel_tripel.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 128e58b420ec614da56fd273c4f4c1ea
-  size: 62767
+- md5: 23ae073b94dd213d02dc689fb867c230
+  size: 62561
   path: test_basemap_winkel_tripel.png
+  hash: md5


### PR DESCRIPTION
Update baseline images for test_basemap*.png. Just minor differences in line thickness and texts.

Address #2961.