### PR TITLE
Update baseline images for histogram, inset, logo, legend, velo, wiggle and ternary

### DIFF
--- a/pygmt/tests/baseline/test_histogram.png.dvc
+++ b/pygmt/tests/baseline/test_histogram.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 8499f1d0ef232ece53300c6aaf611607
-  size: 10794
+- md5: 63d28a2592bcdaaf2e51a0d8d9c11504
+  size: 10822
   path: test_histogram.png
+  hash: md5

--- a/pygmt/tests/baseline/test_inset_aliases.png.dvc
+++ b/pygmt/tests/baseline/test_inset_aliases.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: e70a202d0e548835276809936db1db98
-  size: 29870
+- md5: 813f2c05cf552a9a015c4cc44c9e4246
+  size: 30075
   path: test_inset_aliases.png
+  hash: md5

--- a/pygmt/tests/baseline/test_inset_context_manager.png.dvc
+++ b/pygmt/tests/baseline/test_inset_context_manager.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: e67ec1065197f878282949b8c79a7e2b
-  size: 10506
+- md5: fad7ee8d74cd61f73a8f218be6b0f9c0
+  size: 10547
   path: test_inset_context_manager.png
+  hash: md5

--- a/pygmt/tests/baseline/test_legend_default_position.png.dvc
+++ b/pygmt/tests/baseline/test_legend_default_position.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: f66de197af63f42c14afe153ab79d69a
-  size: 20395
+- md5: e4800fef6c670c29ba79296e2d7032af
+  size: 20701
   path: test_legend_default_position.png
+  hash: md5

--- a/pygmt/tests/baseline/test_legend_position.png.dvc
+++ b/pygmt/tests/baseline/test_legend_position.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: b80a0ec0f5de45bdc196c19adfb5a471
-  size: 24883
+- md5: c0e2d094a25066a6a3cf473579ab97b8
+  size: 25243
   path: test_legend_position.png
+  hash: md5

--- a/pygmt/tests/baseline/test_legend_specfile.png.dvc
+++ b/pygmt/tests/baseline/test_legend_specfile.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: cd750916aa10cc298edd16fee92a55f5
-  size: 52793
+- md5: 8cb19cc2939be8df0f813b822718d1f8
+  size: 52883
   path: test_legend_specfile.png
+  hash: md5

--- a/pygmt/tests/baseline/test_logo.png.dvc
+++ b/pygmt/tests/baseline/test_logo.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 19bb4cb6709926615cad9c05d5701b0c
-  size: 31802
+- md5: a261222d0d214a2b4cad31a670b9fe03
+  size: 31954
   path: test_logo.png
+  hash: md5

--- a/pygmt/tests/baseline/test_logo_on_a_map.png.dvc
+++ b/pygmt/tests/baseline/test_logo_on_a_map.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 2c9c6a32042a171e4fa34df5f8eccdf4
-  size: 70884
+- md5: c2efdf64f52fa34d1cc962e001bb5dc5
+  size: 70814
   path: test_logo_on_a_map.png
+  hash: md5

--- a/pygmt/tests/baseline/test_ternary.png.dvc
+++ b/pygmt/tests/baseline/test_ternary.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 2d8e82e8fb76c0cda924ce6f0ccaef77
-  size: 61962
+- md5: 065ea10a2ed961df29defd6a1dfd1a4c
+  size: 62296
   path: test_ternary.png
+  hash: md5

--- a/pygmt/tests/baseline/test_ternary_1_label.png.dvc
+++ b/pygmt/tests/baseline/test_ternary_1_label.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 7278b6cdaf0076840927380a22d03846
-  size: 63228
+- md5: 8046b09ffd4020ac84b43704b39597d3
+  size: 63378
   path: test_ternary_1_label.png
+  hash: md5

--- a/pygmt/tests/baseline/test_ternary_3_labels.png.dvc
+++ b/pygmt/tests/baseline/test_ternary_3_labels.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: e303384766b3b5e31cad90a9b5e61136
-  size: 64570
+- md5: af08eb16a966e9e8b72137c22c880c60
+  size: 64686
   path: test_ternary_3_labels.png
+  hash: md5

--- a/pygmt/tests/baseline/test_velo_numpy_array_numeric_only.png.dvc
+++ b/pygmt/tests/baseline/test_velo_numpy_array_numeric_only.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: b0c130e6fb6e29446cf88412adff4a90
-  size: 44243
+- md5: 44e226325f73e43b4cb62c26680371a8
+  size: 44580
   path: test_velo_numpy_array_numeric_only.png
+  hash: md5

--- a/pygmt/tests/baseline/test_wiggle.png.dvc
+++ b/pygmt/tests/baseline/test_wiggle.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: b2ec57def4e0325f4a4904e9e37cec0d
-  size: 9175
+- md5: 78ca6cf49e085f5c450d2421f3a6bcb9
+  size: 9136
   path: test_wiggle.png
+  hash: md5


### PR DESCRIPTION
Address https://github.com/GenericMappingTools/pygmt/issues/2961.

Only minor changes due to gs version bumping.