### PR TITLE
Update baseline images for grd2cpt, makecpt and subplot tests

### DIFF
--- a/pygmt/tests/baseline/test_grd2cpt.png.dvc
+++ b/pygmt/tests/baseline/test_grd2cpt.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 6d535fbb53a470a3a12fafeab1cf4f66
-  size: 22230
+- md5: 3ef5930b17345f3f50ac65c0a8d46c22
+  size: 22020
   path: test_grd2cpt.png
+  hash: md5

--- a/pygmt/tests/baseline/test_makecpt_categorical.png.dvc
+++ b/pygmt/tests/baseline/test_makecpt_categorical.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 703142a6ca0fbf079f82d9287631ad83
-  size: 1955
+- md5: 7f9c8ddaf7c1da61b06459182c60cab0
+  size: 1831
   path: test_makecpt_categorical.png
+  hash: md5

--- a/pygmt/tests/baseline/test_makecpt_continuous.png.dvc
+++ b/pygmt/tests/baseline/test_makecpt_continuous.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: aa7573082f6bf1635b051ef165d6ba44
-  size: 2853
+- md5: b0f663b1e029cb76fc9bf771cb237b41
+  size: 2440
   path: test_makecpt_continuous.png
+  hash: md5

--- a/pygmt/tests/baseline/test_makecpt_cyclic.png.dvc
+++ b/pygmt/tests/baseline/test_makecpt_cyclic.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 150c12b8d8959561bdf36d380dc23d10
-  size: 3747
+- md5: 7e7d5d650a45fe92e56d52415078ec6a
+  size: 3789
   path: test_makecpt_cyclic.png
+  hash: md5

--- a/pygmt/tests/baseline/test_makecpt_plot_colorbar.png.dvc
+++ b/pygmt/tests/baseline/test_makecpt_plot_colorbar.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 989d9bf57f716f4721f14992bf39a359
-  size: 2529
+- md5: c690fe78fafb2f3184e59a9fdf71b0eb
+  size: 2490
   path: test_makecpt_plot_colorbar.png
+  hash: md5

--- a/pygmt/tests/baseline/test_makecpt_plot_colorbar_scaled_with_series.png.dvc
+++ b/pygmt/tests/baseline/test_makecpt_plot_colorbar_scaled_with_series.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 99bb2d95750b1d0be7ac3ad1ee5fae52
-  size: 3378
+- md5: 00a0d3c6fa455414d391ab3f1cd11349
+  size: 3184
   path: test_makecpt_plot_colorbar_scaled_with_series.png
+  hash: md5

--- a/pygmt/tests/baseline/test_makecpt_reverse_color_and_zsign.png.dvc
+++ b/pygmt/tests/baseline/test_makecpt_reverse_color_and_zsign.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 88e3aa96a640c2d61e8e93ca459210f1
-  size: 3611
+- md5: 57608311311085dad38177c85671c441
+  size: 3466
   path: test_makecpt_reverse_color_and_zsign.png
+  hash: md5

--- a/pygmt/tests/baseline/test_makecpt_reverse_color_only.png.dvc
+++ b/pygmt/tests/baseline/test_makecpt_reverse_color_only.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 6b39a96fe69ce94e16f29fb8e28b22c1
-  size: 3954
+- md5: 6d89c3555e5ac3f92d38e27493072f40
+  size: 3958
   path: test_makecpt_reverse_color_only.png
+  hash: md5

--- a/pygmt/tests/baseline/test_makecpt_truncated_zlow_zhigh.png.dvc
+++ b/pygmt/tests/baseline/test_makecpt_truncated_zlow_zhigh.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 0c362a54bfa6db6359c9028393f65c7b
-  size: 2898
+- md5: b6c4eb20f4c642562815ed3ffd39453f
+  size: 2492
   path: test_makecpt_truncated_zlow_zhigh.png
+  hash: md5

--- a/pygmt/tests/baseline/test_subplot_autolabel_margins_title.png.dvc
+++ b/pygmt/tests/baseline/test_subplot_autolabel_margins_title.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: e1e6312073c2ca423d2034d193858929
-  size: 23036
+- md5: a4af27ae0468c63a8d6200c6a7f9908f
+  size: 22646
   path: test_subplot_autolabel_margins_title.png
+  hash: md5

--- a/pygmt/tests/baseline/test_subplot_basic_frame.png.dvc
+++ b/pygmt/tests/baseline/test_subplot_basic_frame.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 91b55787b5aae4b5e65e885d9185c1e1
-  size: 7693
+- md5: 192b6e13adb19e698ea584295ddcfec1
+  size: 7724
   path: test_subplot_basic_frame.png
+  hash: md5

--- a/pygmt/tests/baseline/test_subplot_clearance_and_shared_xy_axis_layout.png.dvc
+++ b/pygmt/tests/baseline/test_subplot_clearance_and_shared_xy_axis_layout.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 27fb1ece45f0dccc0642a87c08165b02
-  size: 8930
+- md5: 2070952590776d7d98cab88a06924c78
+  size: 8782
   path: test_subplot_clearance_and_shared_xy_axis_layout.png
+  hash: md5

--- a/pygmt/tests/baseline/test_subplot_direct.png.dvc
+++ b/pygmt/tests/baseline/test_subplot_direct.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 643e93a421f06688d77288c3629f242c
-  size: 6853
+- md5: 61c8c5376cc625a0ea943978dadfe53a
+  size: 6807
   path: test_subplot_direct.png
+  hash: md5

--- a/pygmt/tests/baseline/test_subplot_outside_plotting_positioning.png.dvc
+++ b/pygmt/tests/baseline/test_subplot_outside_plotting_positioning.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 976a01a8c9f583918c00b5a81fddaf84
-  size: 12112
+- md5: ab48de732fa2243e78db5ce3eb62819b
+  size: 11565
   path: test_subplot_outside_plotting_positioning.png
+  hash: md5


### PR DESCRIPTION
Address #2961.

- Most `grd2cpt` and `makecpt` failures are caused by font size changes of colobar annotations, likely by upstream PR https://github.com/GenericMappingTools/gmt/pull/6802
- One exception is `test_makecpt_categorical.png`, caused by upstream changes in https://github.com/GenericMappingTools/gmt/issues/7830.
- Most `subplot` failures are caused by gs version bumping, but `test_subplot_outside_plotting_positioning.png` failure is caused by annotation size changes