### PR TITLE
Simplify two colorbar tests and remove all others

### DIFF
--- a/pygmt/tests/baseline/test_colorbar.png.dvc
+++ b/pygmt/tests/baseline/test_colorbar.png.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: b274fb18c46c404e79dc293af9529567
+  size: 2652
+  hash: md5
+  path: test_colorbar.png

--- a/pygmt/tests/baseline/test_colorbar_box.png.dvc
+++ b/pygmt/tests/baseline/test_colorbar_box.png.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 554a83b4f34c4470e2e2aba765860e84
-  size: 1450
-  path: test_colorbar_box.png

--- a/pygmt/tests/baseline/test_colorbar_box_with_fill.png.dvc
+++ b/pygmt/tests/baseline/test_colorbar_box_with_fill.png.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 92aeb730de6db02fb2cf488f37d799cc
-  size: 1394
-  path: test_colorbar_box_with_fill.png

--- a/pygmt/tests/baseline/test_colorbar_scaled_z_values.png.dvc
+++ b/pygmt/tests/baseline/test_colorbar_scaled_z_values.png.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: e337c879b0db02a0ea5312d306ce7a32
-  size: 1826
-  path: test_colorbar_scaled_z_values.png

--- a/pygmt/tests/baseline/test_colorbar_shading_boolean.png.dvc
+++ b/pygmt/tests/baseline/test_colorbar_shading_boolean.png.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 4ee03ad49ec7264348e4d9c7d642bc37
-  size: 51318
-  path: test_colorbar_shading_boolean.png

--- a/pygmt/tests/baseline/test_colorbar_shading_list.png.dvc
+++ b/pygmt/tests/baseline/test_colorbar_shading_list.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 9a5c688d4b6270cf8823333f7857d47e
-  size: 21912
+- md5: 52364ac84db033b53f7125ce12e95cce
+  size: 25000
   path: test_colorbar_shading_list.png
   hash: md5

--- a/pygmt/tests/baseline/test_colorbar_shading_list.png.dvc
+++ b/pygmt/tests/baseline/test_colorbar_shading_list.png.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 823a04eb5398f1b101cb7ebc4af006f1
-  size: 56049
-  path: test_colorbar_shading_list.png

--- a/pygmt/tests/baseline/test_colorbar_shading_list.png.dvc
+++ b/pygmt/tests/baseline/test_colorbar_shading_list.png.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 9a5c688d4b6270cf8823333f7857d47e
+  size: 21912
+  path: test_colorbar_shading_list.png
+  hash: md5

--- a/pygmt/tests/baseline/test_colorbar_truncated_to_zlow_zhigh.png.dvc
+++ b/pygmt/tests/baseline/test_colorbar_truncated_to_zlow_zhigh.png.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: e2f5d695f6f7a0d385a8d988e7ecdf37
-  size: 2319
-  path: test_colorbar_truncated_to_zlow_zhigh.png

--- a/pygmt/tests/test_colorbar.py
+++ b/pygmt/tests/test_colorbar.py
@@ -7,62 +7,10 @@ from pygmt import Figure
 
 @pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
-def test_colorbar_box():
+def test_colorbar():
     """
-    Create colorbar with box around it.
-    """
-    fig = Figure()
-    fig.colorbar(cmap="rainbow", box=True, position="x0c/0c+w1c/0.5c")
-    return fig
-
-
-@pytest.mark.mpl_image_compare
-def test_colorbar_box_with_fill():
-    """
-    Create colorbar with box that has a different colored fill.
+    Create a simple colorbar.
     """
     fig = Figure()
-    fig.colorbar(cmap="rainbow", box="+gorange", position="x0c/0c+w1c/0.5c")
-    return fig
-
-
-@pytest.mark.mpl_image_compare
-def test_colorbar_truncated_to_zlow_zhigh():
-    """
-    Create colorbar truncated to z-low and z-high.
-    """
-    fig = Figure()
-    fig.colorbar(cmap="rainbow", truncate=[0.15, 0.85], position="x0c/0c+w2c/0.5c")
-    return fig
-
-
-@pytest.mark.mpl_image_compare
-def test_colorbar_scaled_z_values():
-    """
-    Create colorbar with z-values scaled to 0.1x of the original CPT.
-    """
-    fig = Figure()
-    fig.colorbar(cmap="rainbow", scale=0.1, position="x0c/0c+w2c/0.5c")
-    return fig
-
-
-@pytest.mark.mpl_image_compare
-def test_colorbar_shading_boolean():
-    """
-    Create colorbar and set shading with a Boolean value.
-    """
-    fig = Figure()
-    fig.basemap(region=[0, 10, 0, 10], projection="X15c", frame="a")
-    fig.colorbar(cmap="geo", shading=True, frame=True)
-    return fig
-
-
-@pytest.mark.mpl_image_compare
-def test_colorbar_shading_list():
-    """
-    Create colorbar and set shading by passing the high/low values as a list.
-    """
-    fig = Figure()
-    fig.basemap(region=[0, 10, 0, 10], projection="X15c", frame="a")
-    fig.colorbar(cmap="geo", shading=[-0.7, 0.2], frame=True)
+    fig.colorbar(cmap="rainbow", position="x0c/0c+w4c", frame=True)
     return fig

--- a/pygmt/tests/test_colorbar.py
+++ b/pygmt/tests/test_colorbar.py
@@ -14,3 +14,14 @@ def test_colorbar():
     fig = Figure()
     fig.colorbar(cmap="rainbow", position="x0c/0c+w4c", frame=True)
     return fig
+
+
+@pytest.mark.mpl_image_compare
+def test_colorbar_shading_list():
+    """
+    Create colorbar and set shading by passing the high/low values as a list.
+    """
+    fig = Figure()
+    fig.basemap(region=[0, 10, 0, 10], projection="X8c", frame="a")
+    fig.colorbar(cmap="geo", shading=[-0.7, 0.2], frame=True)
+    return fig

--- a/pygmt/tests/test_colorbar.py
+++ b/pygmt/tests/test_colorbar.py
@@ -22,6 +22,6 @@ def test_colorbar_shading_list():
     Create colorbar and set shading by passing the high/low values as a list.
     """
     fig = Figure()
-    fig.basemap(region=[0, 10, 0, 10], projection="X8c", frame="a")
+    fig.basemap(region=[0, 10, 0, 2], projection="X10c/2c", frame="a")
     fig.colorbar(cmap="geo", shading=[-0.7, 0.2], frame=True)
     return fig


### PR DESCRIPTION
See https://github.com/GenericMappingTools/pygmt/issues/2961#issuecomment-1882903268 for context.

This PR removes all existing colorbar tests and add a new, simpler one.