### PR TITLE
Update baseline images for grdimage tests

### DIFF
--- a/pygmt/tests/baseline/test_grdimage.png.dvc
+++ b/pygmt/tests/baseline/test_grdimage.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: ff6ea7953be2b98bf7b85f6ee04e23dd
-  size: 180338
+- md5: 4a4d857b9169baf53f4e6a3385539a84
+  size: 162344
   path: test_grdimage.png
+  hash: md5

--- a/pygmt/tests/baseline/test_grdimage_file.png.dvc
+++ b/pygmt/tests/baseline/test_grdimage_file.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: d7f7c58e200283b562fd70d7c22eaf51
-  size: 206241
+- md5: 8ee66ca045cf9031998fef75176681c6
+  size: 152716
   path: test_grdimage_file.png
+  hash: md5

--- a/pygmt/tests/baseline/test_grdimage_global_subset.png.dvc
+++ b/pygmt/tests/baseline/test_grdimage_global_subset.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 877e22361cb6d2ea1fe0efe3fa84a3e3
-  size: 39978
+- md5: 4cf31252e6c47d9263395205335932db
+  size: 65582
   path: test_grdimage_global_subset.png
+  hash: md5

--- a/pygmt/tests/baseline/test_grdimage_slice.png.dvc
+++ b/pygmt/tests/baseline/test_grdimage_slice.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 662b78f3bedde3ddf73647329bf3aab4
-  size: 72658
+- md5: 2481f1366431e4e601ccdaf25830c33e
+  size: 65041
   path: test_grdimage_slice.png
+  hash: md5

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -81,7 +81,7 @@ def test_grdimage_file():
         "@earth_relief_01d_g",
         cmap="ocean",
         region=[-180, 180, -70, 70],
-        projection="W0/10i",
+        projection="W0/10c",
         shading=True,
     )
     return fig

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -181,8 +181,7 @@ def test_grdimage_global_subset(grid_360):
     Specifically checking that xarray.DataArray grids can wrap around the left and right
     sides on a Mollweide projection (W) plot correctly. Note that a Cartesian grid is
     used here instead of a Geographic grid (i.e. GMT_GRID_IS_CARTESIAN). This is a
-    regression test for
-    https://github.com/GenericMappingTools/pygmt/issues/732.
+    regression test for https://github.com/GenericMappingTools/pygmt/issues/732.
     """
     # Get a slice of South America and Africa only (lat=-90:31, lon=-180:41)
     sliced_grid = grid_360[0:121, 0:221]
@@ -191,7 +190,7 @@ def test_grdimage_global_subset(grid_360):
 
     fig = Figure()
     fig.grdimage(
-        grid=sliced_grid, cmap="vik", region="g", projection="W0/3.5c", frame=True
+        grid=sliced_grid, cmap="vik", region="g", projection="W0/10c", frame=True
     )
     return fig
 

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -56,7 +56,7 @@ def test_grdimage(grid):
     Plot an image using an xarray grid.
     """
     fig = Figure()
-    fig.grdimage(grid, cmap="earth", projection="W0/6i")
+    fig.grdimage(grid, cmap="earth", projection="W0/10c")
     return fig
 
 

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -67,7 +67,7 @@ def test_grdimage_slice(grid):
     """
     grid_ = grid.sel(lat=slice(-30, 30))
     fig = Figure()
-    fig.grdimage(grid_, cmap="earth", projection="M6i")
+    fig.grdimage(grid_, cmap="earth", projection="M10c")
     return fig
 
 
@@ -98,7 +98,7 @@ def test_grdimage_default_no_shading(grid, shading):
     """
     grid_ = grid.sel(lat=slice(-30, 30))
     fig = Figure()
-    fig.grdimage(grid_, cmap="earth", projection="M6i", shading=shading)
+    fig.grdimage(grid_, cmap="earth", projection="M10c", shading=shading)
     return fig
 
 


### PR DESCRIPTION
Address #2961.

All baseline images are re-generated using the equivalent GMT CLI.

### `test_grdimage`

```
gmt begin map png
    gmt grdimage @earth_relief_01d_g -Cearth -JW0/10c
gmt end
```

### `test_grdimage_slice`
```
gmt begin map png
    gmt grdcut @earth_relief_01d_g -R-180/180/-30/30 -Gtmp.nc
    gmt grdimage tmp.nc -Cearth -JM10c
gmt end show
```

### `test_grdimage_global_subset`
```
gmt begin map png
gmt grdedit @earth_relief_01d_g -R0/360/-90/90 -Gtmp.nc -fc -D+xx+yy
gmt grdcut tmp.nc -R0/220/-90/30 -Gtmp2.nc
gmt grdimage tmp2.nc -Cvik -Rg -JW0/10c -B
gmt end show
```

### `test_grdimage_file`

```
gmt begin map png
gmt grdimage @earth_relief_01d_g -Cocean -R-180/180/-70/70 -JW0/10c -I
gmt end show
```