### PR TITLE
NEP29: Set minimum required version to NumPy 1.23+

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -62,11 +62,11 @@ jobs:
             isDraft: true
           - os: windows-latest
             isDraft: true
-        # Pair Python 3.9 with NumPy 1.22 and Python 3.12 with NumPy 1.26
+        # Pair Python 3.9 with NumPy 1.23 and Python 3.12 with NumPy 1.26
         # Only install optional packages on Python 3.12/NumPy 1.26
         include:
           - python-version: '3.9'
-            numpy-version: '1.22'
+            numpy-version: '1.23'
             optional-packages: ''
           - python-version: '3.12'
             numpy-version: '1.26'

--- a/README.rst
+++ b/README.rst
@@ -271,7 +271,7 @@ Compatibility with GMT/Python/NumPy versions
       - `Dev Documentation <https://www.pygmt.org/dev>`_ (reflects `main branch <https://github.com/GenericMappingTools/pygmt>`_)
       - >=6.3.0
       - >=3.9
-      - >=1.22
+      - >=1.23
     * - `v0.10.0 <https://github.com/GenericMappingTools/pygmt/releases/tag/v0.10.0>`_ (latest release)
       - `v0.10.0 Documentation <https://www.pygmt.org/v0.10.0>`_
       - >=6.3.0

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -7,7 +7,7 @@ dependencies:
     - python=3.12
     - gmt=6.5.0
     - ghostscript=10.02.1
-    - numpy>=1.22
+    - numpy
     - pandas
     - xarray
     - netCDF4

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -94,7 +94,7 @@ Dependencies
 
 PyGMT requires the following libraries to be installed:
 
-* `numpy <https://numpy.org>`__ (>= 1.22)
+* `numpy <https://numpy.org>`__ (>= 1.23)
 * `pandas <https://pandas.pydata.org>`__
 * `xarray <https://xarray.dev/>`__
 * `netCDF4 <https://unidata.github.io/netcdf4-python>`__

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
     - python=3.12
     # Required dependencies
     - gmt=6.5.0
-    - numpy>=1.22
+    - numpy>=1.23
     - pandas
     - xarray
     - netCDF4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
 ]
 dependencies = [
-    "numpy>=1.22",
+    "numpy>=1.23",
     "pandas",
     "xarray",
     "netCDF4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Required packages
-numpy>=1.22
+numpy>=1.23
 pandas
 xarray
 netCDF4


### PR DESCRIPTION
**Description of proposed changes**

Following NEP29 policy where NumPy 1.22 is to be dropped on or after 1 Jan 2024 (in a minor version increment, i.e. for PyGMT v0.11.0). Bumps minimum supported NumPy version to 1.23 in the pyproject.toml, requirements.txt and environment.yml files. Also update installation documentation to mention NumPy 1.22+ requirement.

This is in line with PyGMT's policy on [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule) at https://www.pygmt.org/v0.10.0/maintenance.html#dependencies-policy.

Supersedes #2586