### PR TITLE
CI: Temporarily delete two examples files to make ReadTheDocs pass again

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,7 +26,11 @@ build:
         then
           exit 183;
         fi
-    pre_build: # Generate api stub files before building
+    pre_build:
+      # ReadTheDocs fails to download external resources.
+      # Temporarily delete the two files to make ReadTheDocs building work again.
+      - rm examples/gallery/lines/roads.py examples/gallery/maps/choropleth_map.py
+      # Generate api stub files before building
       - make -C doc api
 
 # Build documentation in the doc/ directory with Sphinx


### PR DESCRIPTION
**Description of proposed changes**

As mentioned in https://github.com/GenericMappingTools/pygmt/pull/2994#issue-2079658685, ReadTheDocs building started to crash recently, likely because it fails to download external resources used in some gallery examples.

In this PR, two example files `examples/gallery/lines/roads.py` and `examples/gallery/maps/choropleth_map.py` are deleted, to make ReadTheDocs pass again. Please note that the changes only affect documentation preview in PRs and don't affect the dev documentation at https://pygmt.org/dev. Will open a separate PR to revert changes in this PR later.