### PR TITLE
Let 'ruff check --fix' always exit with zero

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test_no_images: PYTEST_ARGS=-o addopts="--verbose --durations=0 --durations-min=
 test_no_images: _runtest
 
 format:
-	ruff check --fix $(FORMAT_FILES)
+	ruff check --fix --exit-zero $(FORMAT_FILES)
 	ruff format $(FORMAT_FILES)
 
 check:


### PR DESCRIPTION
**Description of proposed changes**

If `ruff check --fix` finds any violations that cannot be fixed, it by default returns a non-zero code, and then `ruff format` won't be executed. Sometimes, these violations can be automatically fixed by `ruff format`. Thus, we have to run `ruff format` manually and run `make format` again. This is not ideal. 

This PR adds the `--exit-zero` option to `ruff check --fix` so that the command always returns zero even if there are lint violations. Then the `ruff format` command always runs.




