### PR TITLE
Set rtol to 1e-4 to avoid system-dependent floating-point differences

### DIFF
--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -233,5 +233,5 @@ def test_x2sys_cross_trackvalues():
         assert isinstance(output, pd.DataFrame)
         assert output.shape == (14338, 12)
         # Check mean of track 1 values (z_1) and track 2 values (z_2)
-        npt.assert_allclose(output.z_1.mean(), -2422.418556)
-        npt.assert_allclose(output.z_2.mean(), -2402.268364)
+        npt.assert_allclose(output.z_1.mean(), -2422.418556, rtol=1e-4)
+        npt.assert_allclose(output.z_2.mean(), -2402.268364, rtol=1e-4)


### PR DESCRIPTION
The following test passes on Linux but fails on macOS:
```
_________________________ test_x2sys_cross_trackvalues _________________________

    @pytest.mark.usefixtures("mock_x2sys_home")
    def test_x2sys_cross_trackvalues():
        """
        Test that x2sys_cross's trackvalues (Z) argument work.
        """
        with TemporaryDirectory(prefix="X2SYS", dir=os.getcwd()) as tmpdir:
            tag = os.path.basename(tmpdir)
            x2sys_init(tag=tag, fmtfile="xyz", force=True)
            output = x2sys_cross(tracks=["@tut_ship.xyz"], tag=tag, trackvalues=True)
    
            assert isinstance(output, pd.DataFrame)
            assert output.shape == (14338, 12)
            # Check mean of track 1 values (z_1) and track 2 values (z_2)
>           npt.assert_allclose(output.z_1.mean(), -2422.418556)

../pygmt/tests/test_x2sys_cross.py:236: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

args = (<function assert_allclose.<locals>.compare at 0x14ef4c2c0>, array(-2422.41820718), array(-2422.418556))
kwds = {'equal_nan': True, 'err_msg': '', 'header': 'Not equal to tolerance rtol=1e-07, atol=0', 'verbose': True}

    @wraps(func)
    def inner(*args, **kwds):
        with self._recreate_cm():
>           return func(*args, **kwds)
E           AssertionError: 
E           Not equal to tolerance rtol=1e-07, atol=0
E           
E           Mismatched elements: 1 / 1 (100%)
E           Max absolute difference: 0.00034882
E           Max relative difference: 1.43997964e-07
E            x: array(-2422.418207)
E            y: array(-2422.418556)
```

Patches #2986.