### PR TITLE
Figure.makecpt: Mention exchange of background (B) and foreground (F) colors for usage of "reverse"

### DIFF
--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -120,8 +120,8 @@ def makecpt(**kwargs):
         level :func:`pygmt.makecpt` is called.
     reverse : str
         Set this to ``True`` or **c** [Default] to reverse the sense of color
-        progression in the master CPT. Also exchanges the foreground and background
-        colors, including those specified by :gmt-term:`COLOR_BACKGROUND` and
+        progression in the master CPT. Also the foreground and background colors
+        are exchanged, including those specified by :gmt-term:`COLOR_BACKGROUND` and
         :gmt-term:`COLOR_FOREGROUND`. Set this to **z** to reverse the sign of z-values
         in the color table. Note that this change of z-direction happens before
         ``truncate`` and ``series`` values are used so the latter must be compatible

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -120,10 +120,12 @@ def makecpt(**kwargs):
         level :func:`pygmt.makecpt` is called.
     reverse : str
         Set this to ``True`` or **c** [Default] to reverse the sense of color
-        progression in the master CPT. Set this to **z** to reverse the sign
-        of z-values in the color table. Note that this change of z-direction
-        happens before ``truncate`` and ``series`` values are used so the
-        latter must be compatible with the changed z-range. See also
+        progression in the master CPT. Also exchanges the foreground and background
+        colors, including those specified by :gmt-term:`COLOR_BACKGROUND` and
+        :gmt-term:`COLOR_FOREGROUND`. Set this to **z** to reverse the sign of z-values
+        in the color table. Note that this change of z-direction happens before
+        ``truncate`` and ``series`` values are used so the latter must be compatible
+        with the changed z-range. See also
         :gmt-docs:`reference/features.html#manipulating-cpts`.
     overrule_bg : str
         Overrule background, foreground, and NaN colors specified in the master


### PR DESCRIPTION
**Description of proposed changes**

I feel it is fair to mention in the docstring that using the `reverse` parameter of `Figure.makecpt` also exchanges the background (B) and foreground (F) colors.

Upstream GMT documentation: https://docs.generic-mapping-tools.org/6.5/makecpt.html#i


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
