### PR TITLE
CI: Build GMT dev source code with OpenMP enabled on Linux and GThreads enabled on Linux/macOS

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -86,15 +86,17 @@ jobs:
             pcre
             zlib
 
-      # Checkout current the GMT source codes
-      - name: Checkout the GMT source codes in ${{ matrix.gmt_git_ref }} branch
+      # Checkout current GMT repository
+      - name: Checkout the GMT source from ${{ matrix.gmt_git_ref }} branch
         uses: actions/checkout@v4.1.4
         with:
           repository: 'GenericMappingTools/gmt'
           ref: ${{ matrix.gmt_git_ref }}
           path: 'gmt'
 
-      - name: Build GMT source codes on Linux/macOS
+      # Build GMT from source on Linux/macOS, script is adapted from
+      # https://github.com/GenericMappingTools/gmt/blob/6.5.0/ci/build-gmt.sh
+      - name: Build GMT on Linux/macOS
         run: |
           if [ "$RUNNER_OS" == "macOS" ]; then
             GMT_ENABLE_OPENMP=FALSE
@@ -117,7 +119,7 @@ jobs:
           GMT_INSTALL_DIR: ${{ runner.temp }}/gmt-install-dir
         if: runner.os != 'Windows'
 
-      - name: Build GMT source codes on Windows
+      - name: Build GMT on Windows
         shell: cmd
         run: |
           cd gmt/

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -6,9 +6,8 @@
 # installed by fetching the latest source codes from the GMT master branch and
 # compiling.
 #
-# It is triggered when a pull request is marked as "ready as review", or labeled with
-# 'run/test-gmt-dev'. It is also scheduled to run on Monday, Wednesday, and Friday on
-# the main branch.
+# It is triggered in a pull request if labeled with 'run/test-gmt-dev'.
+# It is also scheduled to run on Monday, Wednesday, and Friday on the main branch.
 #
 name: GMT Dev Tests
 
@@ -87,18 +86,40 @@ jobs:
             pcre
             zlib
 
-      # Build and install latest GMT from GitHub
-      - name: Install GMT ${{ matrix.gmt_git_ref }} branch (Linux/macOS)
-        run: curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/build-gmt.sh | bash
+      # Checkout current the GMT source codes
+      - name: Checkout the GMT source codes in ${{ matrix.gmt_git_ref }} branch
+        uses: actions/checkout@v4.1.4
+        with:
+          repository: 'GenericMappingTools/gmt'
+          ref: ${{ matrix.gmt_git_ref }}
+          path: 'gmt'
+
+      - name: Build GMT source codes on Linux/macOS
+        run: |
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            GMT_ENABLE_OPENMP=FALSE
+          else
+            GMT_ENABLE_OPENMP=TRUE
+          fi
+          cd gmt/
+          mkdir build
+          cd build
+          cmake -G Ninja .. \
+            -DCMAKE_INSTALL_PREFIX=${{ env.GMT_INSTALL_DIR }} \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DGMT_ENABLE_OPENMP=${GMT_ENABLE_OPENMP} \
+            -DGMT_USE_THREADS=TRUE
+          cmake --build .
+          cmake --build . --target install
+          cd ..
+          rm -rf gmt/
         env:
-          GMT_GIT_REF: ${{ matrix.gmt_git_ref }}
           GMT_INSTALL_DIR: ${{ runner.temp }}/gmt-install-dir
         if: runner.os != 'Windows'
 
-      - name: Install GMT ${{ matrix.gmt_git_ref }} branch (Windows)
+      - name: Build GMT source codes on Windows
         shell: cmd
         run: |
-          git clone --depth=1 --single-branch --branch ${{ env.GMT_GIT_REF }} https://github.com/GenericMappingTools/gmt
           cd gmt/
           mkdir build
           cd build
@@ -114,7 +135,6 @@ jobs:
           cd ..
           rm -rf gmt/
         env:
-          GMT_GIT_REF: ${{ matrix.gmt_git_ref }}
           GMT_INSTALL_DIR: ${{ runner.temp }}/gmt-install-dir
         if: runner.os == 'Windows'
 


### PR DESCRIPTION
Enable GThreads support (currently only used by grdfilter) on Linux/macOS and OpenMP support on Linux.

OpenMP is not enabled on macOS, because currently we still fail to let cmake find and link the openmp library on macOS (see https://github.com/GenericMappingTools/gmt/issues/1926).

After this PR, the number of failing tests is reduced from 5(Linux)/5(macOS)/1(Windows) to 1(Linux)/4(macOS)/1(Windows).