### PR TITLE
pygmt.binstats: Let the parameter 'statistic' support descriptive arguments

### DIFF
--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -76,23 +76,23 @@ def binstats(
         Choose the statistic that will be computed per node based on the points that are
         within *radius* distance of the node. Select one of:
 
-        - ``"mean"``: Compute the mean value (average).
-        - ``"mad"``: Compute the median absolute deviation (MAD).
-        - ``"full"``: Compute the full (max-min) range.
-        - ``"interquartile"``: Compute the 25-75% interquartile range.
-        - ``"min"``: Compute the minimum value.
-        - ``"minpos"``: Compute the minimum of positive values only.
-        - ``"median"``: Compute the median value.
-        - ``"number"``: Compute the number of values.
-        - ``"lms"``: Compute the least median square (LMS) scale.
-        - ``"mode"``: Compute the mode (maximum likelihood).
-        - ``"quantile"``: Compute the selected quantile. The quantile value is in 0-100%
-          range and is specified by the ``quantile_value`` parameter.
-        - ``"rms"``: Compute the root mean square (RMS).
-        - ``"stddev"``: Compute the standard deviation.
-        - ``"max"``: Compute the maximum value.
-        - ``"maxneg"``: Compute the maximum of negative values only.
-        - ``"sum"``: Compute the sum of values.
+        - ``"mean"``: Mean (i.e., average).
+        - ``"mad"``: Median absolute deviation (MAD).
+        - ``"full"``: The full (max-min) range.
+        - ``"interquartile"``: The 25-75% interquartile range.
+        - ``"min"``: Minimum (lowest value).
+        - ``"minpos"``: Minimum of positive values only.
+        - ``"median"``: Median value.
+        - ``"number"``: The number of values per bin.
+        - ``"lms"``: Least median square (LMS) scale.
+        - ``"mode"``: Mode (maximum likelihood estimate).
+        - ``"quantile"``: Selected quantile. The quantile value is specified by the
+          ``quantile_value`` parameter and is in the 0-100% range.
+        - ``"rms"``: Root mean square (RMS).
+        - ``"stddev"``: Standard deviation.
+        - ``"max"``: Maximum (highest value).
+        - ``"maxneg"``: Maximum of negative values only.
+        - ``"sum"``: The sum of the values.
     quantile_value
         The quantile value if ``statistic="quantile"``.
     empty : float

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -65,6 +65,7 @@ def binstats(
     Full GMT docs at :gmt-docs:`gmtbinstats.html`.
 
     {aliases}
+       - C=statistic
 
     Parameters
     ----------

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -76,23 +76,23 @@ def binstats(
         Choose the statistic that will be computed per node based on the points that are
         within *radius* distance of the node. Select one of:
 
-        - **mean**: Compute the mean value (average).
-        - **mad**: Compute the median absolute deviation (MAD).
-        - **full**: Compute the full (max-min) range.
-        - **interquartile**: Compute the 25-75% interquartile range.
-        - **min**: Compute the minimum value.
-        - **minpos**: Compute the minimum of positive values only.
-        - **median**: Compute the median value.
-        - **number**: Compute the number of values.
-        - **lms**: Compute the least median square (LMS) scale.
-        - **mode**: Compute the mode (maximum likelihood).
-        - **quantile**: Compute the selected quantile. The quantile value is in 0-100%
+        - ``"mean"``: Compute the mean value (average).
+        - ``"mad"``: Compute the median absolute deviation (MAD).
+        - ``"full"``: Compute the full (max-min) range.
+        - ``"interquartile"``: Compute the 25-75% interquartile range.
+        - ``"min"``: Compute the minimum value.
+        - ``"minpos"``: Compute the minimum of positive values only.
+        - ``"median"``: Compute the median value.
+        - ``"number"``: Compute the number of values.
+        - ``"lms"``: Compute the least median square (LMS) scale.
+        - ``"mode"``: Compute the mode (maximum likelihood).
+        - ``"quantile"``: Compute the selected quantile. The quantile value is in 0-100%
           range and is specified by the ``quantile_value`` parameter.
-        - **rms**: Compute the root mean square (RMS).
-        - **stddev**: Compute the standard deviation.
-        - **max**: Compute the maximum value.
-        - **maxneg**: Compute the maximum of negative values only.
-        - **sum**: Compute the sum of values.
+        - ``"rms"``: Compute the root mean square (RMS).
+        - ``"stddev"``: Compute the standard deviation.
+        - ``"max"``: Compute the maximum value.
+        - ``"maxneg"``: Compute the maximum of negative values only.
+        - ``"sum"``: Compute the sum of values.
     quantile_value
         The quantile value if ``statistic="quantile"``.
     empty : float

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -83,7 +83,7 @@ def binstats(
         - **minpos**: Compute the minimum of positive values only.
         - **median**: Compute the median value.
         - **number**: Compute the number of values.
-        - **lms**: Compute the LMS scale.
+        - **lms**: Compute the least median square (LMS) scale.
         - **mode**: Compute the mode (maximum likelihood).
         - **quantile**: Compute the selected quantile. The quantile value is in 0-100%
           range and is specified by the ``quantile_value`` parameter.

--- a/pygmt/tests/test_binstats.py
+++ b/pygmt/tests/test_binstats.py
@@ -20,7 +20,7 @@ def test_binstats_outgrid():
             data="@capitals.gmt",
             outgrid=tmpfile.name,
             spacing=5,
-            statistic="z",
+            statistic="sum",
             search_radius="1000k",
             aspatial="2=population",
             region="g",
@@ -37,7 +37,7 @@ def test_binstats_no_outgrid():
     temp_grid = binstats(
         data="@capitals.gmt",
         spacing=5,
-        statistic="z",
+        statistic="sum",
         search_radius="1000k",
         aspatial="2=population",
         region="g",

--- a/pygmt/tests/test_binstats.py
+++ b/pygmt/tests/test_binstats.py
@@ -53,7 +53,7 @@ def test_binstats_no_outgrid():
 
 def test_binstats_quantile():
     """
-    Test binstats with no set outgrid.
+    Test binstats quantile statistic functionality.
     """
     temp_grid = binstats(
         data="@capitals.gmt",

--- a/pygmt/tests/test_binstats.py
+++ b/pygmt/tests/test_binstats.py
@@ -49,3 +49,25 @@ def test_binstats_no_outgrid():
     npt.assert_allclose(temp_grid.min(), 53)
     npt.assert_allclose(temp_grid.median(), 1232714.5)
     npt.assert_allclose(temp_grid.mean(), 4227489)
+
+
+def test_binstats_quantile():
+    """
+    Test binstats with no set outgrid.
+    """
+    temp_grid = binstats(
+        data="@capitals.gmt",
+        spacing=5,
+        statistic="quantile",
+        quantile_value=75,
+        search_radius="1000k",
+        aspatial="2=population",
+        region="g",
+    )
+    assert temp_grid.dims == ("y", "x")
+    assert temp_grid.gmt.gtype is GridType.CARTESIAN
+    assert temp_grid.gmt.registration is GridRegistration.GRIDLINE
+    npt.assert_allclose(temp_grid.max(), 15047685)
+    npt.assert_allclose(temp_grid.min(), 53)
+    npt.assert_allclose(temp_grid.median(), 543664.5)
+    npt.assert_allclose(temp_grid.mean(), 1661363.6)


### PR DESCRIPTION
**Description of proposed changes**

Refactor using the new alias system to make the parameter `statistic` support long-form arguments like `statistic="mean"` instead  of `statistic="a"`.

Upstream documentation at https://docs.generic-mapping-tools.org/dev/gmtbinstats.html

Long-form arguments come from https://github.com/GenericMappingTools/gmt/blob/0ae77bb0ae34d6dcb331156d7ee17a747ba83c57/src/longopt/gmtbinstats_inc.h#L29

**Preview**: https://pygmt-dev--3012.org.readthedocs.build/en/3012/api/generated/pygmt.binstats.html

Address #1651.