### PR TITLE
CI: Fix the condition for cancel builds on ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,7 @@ build:
         if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && \
           git diff --quiet origin/main -- \
               doc/ \
+              examples \
               pygmt/**/*.py \
               ':!pygmt/tests' \
               README.md \

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,7 +21,7 @@ build:
               examples \
               pygmt/**/*.py \
               ':!pygmt/tests' \
-              README.md \
+              README.rst \
               ci/requirements/docs.yml \
               .readthedocs.yaml;
         then


### PR DESCRIPTION
Should NOT cancel ReadTheDocs builds if any files in the `examples` directory have changed.

Also fix `README.md` to `README.rst`.

Patches #2955.