### PR TITLE
Remove X (Twitter) from README and checklists

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -48,7 +48,6 @@ assignees: ''
 - [ ] Announce the release on:
   - [ ] GMT [forum](https://forum.generic-mapping-tools.org/c/news/) (do this announcement first! draft on https://hackmd.io/@pygmt. requires moderator status)
   - [ ] [ResearchGate](https://www.researchgate.net) (after forum announcement, add new version as research item via the **code** category, be sure to include the corresponding new Zenodo DOI)
-  - [ ] [Twitter](https://twitter.com/gmt_dev) (after forum announcement)
 ---
 
 - [ ] Party :tada: (don't tick before all other checkboxes are ticked!)

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -55,7 +55,6 @@ jobs:
           --exclude "^https://doi.org"
           --exclude "^https://www.researchgate.net/project/"
           --exclude "^https://test.pypi.org/simple/"
-          --exclude "^https://twitter.com/"
           --verbose
           "repository/**/*.rst"
           "repository/**/*.md"

--- a/README.rst
+++ b/README.rst
@@ -46,9 +46,6 @@ PyGMT
 .. image:: https://img.shields.io/badge/Contributor%20Covenant-v2.1%20adopted-ff69b4.svg
     :alt: Contributor Code of Conduct
     :target: CODE_OF_CONDUCT.md
-.. image:: https://img.shields.io/twitter/follow/gmt_dev?style=social
-    :alt: Twitter URL
-    :target: https://twitter.com/gmt_dev
 
 .. placeholder-for-doc-index
 


### PR DESCRIPTION
**Description of proposed changes**

Related to https://github.com/GenericMappingTools/gmt/issues/8190#issuecomment-1890957727, this PR removes the X (Twitter) badge also from the README of the PyGMT repository.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
