### PR TITLE
Increase image comparison tolerance to 3.6 for test_grdimage_global_subset

### DIFF
--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -173,7 +173,7 @@ def test_grdimage_over_dateline(xrgrid):
     return fig
 
 
-@pytest.mark.mpl_image_compare(tolerance=3.0)
+@pytest.mark.mpl_image_compare(tolerance=3.6)
 def test_grdimage_global_subset(grid_360):
     """
     Ensure subsets of grids are plotted correctly on a global map.


### PR DESCRIPTION
Test `test_grdimage_global_subset` fails in the GMT Dev workflow (https://github.com/GenericMappingTools/pygmt/actions/runs/7662374855/job/20883498402). The differences are tiny and can be fixed by increase the tolerance to 3.6

baseline:
![baseline](https://github.com/GenericMappingTools/pygmt/assets/3974108/a07f5de9-fe62-4bd4-9fff-b9b235d5927c)

result:
![result](https://github.com/GenericMappingTools/pygmt/assets/3974108/fd034983-db04-49f9-af5c-39613b4990a3)

diff:
![result-failed-diff](https://github.com/GenericMappingTools/pygmt/assets/3974108/f4f99e48-4611-4150-887e-ab945d7488f8)
