### PR TITLE
CI: Use macos-14 for GMT Dev Tests workflow

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2022]
+        os: [ubuntu-22.04, macos-14, windows-2022]
         gmt_git_ref: [master]
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
**Description of proposed changes**

Use `macos-14` (Sonoma) instead of `macos-13` (Ventura) in the "GMT Dev Tests" workflow, available since 30 Jan 2024. Note that this uses the M1 Chips!

After merging this PR, we will have tests on 3 versions of macOS:
- `macos-11` Big Sur - used in ci_tests_legacy.yaml
- `macos-13`/`macos-latest` Ventura - used in most of our ci_*.yml files
- `macos-14` Sonoma - used in ci_tests_dev.yaml

Should we also change ci_tests_legacy.yaml to use `macos-12` instead of `macos-11`? It seems like they marked `macos-11` as deprecated in https://github.com/actions/runner-images/pull/9252, but we can probably use it for a while longer.

References:
- https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available
- https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source
- https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Supersedes #2516


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
