### PR TITLE
CI: Temporarily delete two examples files to make ReadTheDocs pass again

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,7 +27,11 @@ build:
         then
           exit 183;
         fi
-    pre_build: # Generate api stub files before building
+    pre_build:
+      # ReadTheDocs fails to download external resources.
+      # Temporarily delete the two files to make ReadTheDocs building work again.
+      - rm examples/gallery/lines/roads.py examples/gallery/maps/choropleth_map.py
+      # Generate api stub files before building
       - make -C doc api
 
 # Build documentation in the doc/ directory with Sphinx


### PR DESCRIPTION
Same as #2995 to make ReadTheDocs pass again.