### PR TITLE
Use automatic links for full changelog in the release drafter template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -53,7 +53,7 @@ template: |
 
   $CHANGES
 
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+  **Full Changelog**: <https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION>
 
   ### Contributors
 


### PR DESCRIPTION
**Description of proposed changes**

Make the "full changelog" link clickable.

Addressing https://github.com/GenericMappingTools/pygmt/pull/3022#discussion_r1468958361.