### PR TITLE
Bump to ruff 0.2.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
     - pip
     # Dev dependencies (style checks)
     - codespell
-    - ruff>=0.1.9
+    - ruff>=0.2.0
     # Dev dependencies (unit testing)
     - matplotlib
     - pytest-cov

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -194,7 +194,7 @@ def vectors_to_arrays(vectors):
     arrays = []
     for vector in vectors:
         vec_dtype = str(getattr(vector, "dtype", ""))
-        array = np.asarray(a=vector, dtype=dtypes.get(vec_dtype, None))
+        array = np.asarray(a=vector, dtype=dtypes.get(vec_dtype))
         arrays.append(as_c_contiguous(array))
 
     return arrays

--- a/pygmt/tests/test_clib_put_vector.py
+++ b/pygmt/tests/test_clib_put_vector.py
@@ -208,7 +208,7 @@ def test_put_vector_invalid_dtype():
         np.bytes_,
         np.csingle,
         np.cdouble,
-        np.clongfloat,
+        np.clongdouble,
         np.half,
         np.longdouble,
         np.object_,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 88  # E501 (line-too-long)
-show-source = true
+output-format = "full"
 
 [tool.ruff.format]
 line-ending = "lf"  # Use UNIX `\n` line endings for all files


### PR DESCRIPTION
**Description of proposed changes**

[ruff v0.2.0](https://github.com/astral-sh/ruff/releases/tag/v0.2.0) was released on Feb 1, 2024. See https://astral.sh/blog/ruff-v0.2.0 for an overview of changes.

ruff v0.2.0 results in following warnings:
```
ruff check pygmt doc/conf.py examples
warning: The `show-source` option has been deprecated in favor of `output-format`'s "full" and "concise" variants. Please update your configuration to use `output-format = <full|concise>` instead.
pygmt/clib/conversion.py:197:44: SIM910 [*] Use `dtypes.get(vec_dtype)` instead of `dtypes.get(vec_dtype, None)`
    |
195 |     for vector in vectors:
196 |         vec_dtype = str(getattr(vector, "dtype", ""))
197 |         array = np.asarray(a=vector, dtype=dtypes.get(vec_dtype, None))
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM910
198 |         arrays.append(as_c_contiguous(array))
    |
    = help: Replace `dtypes.get(vec_dtype, None)` with `dtypes.get(vec_dtype)`

pygmt/tests/test_clib_put_vector.py:211:9: NPY201 [*] `np.clongfloat` will be removed in NumPy 2.0. Use `numpy.clongdouble` instead.
    |
209 |         np.csingle,
210 |         np.cdouble,
211 |         np.clongfloat,
    |         ^^^^^^^^^^^^^ NPY201
212 |         np.half,
213 |         np.longdouble,
    |
    = help: Replace with `numpy.clongdouble
```

Changes in this PR:

- Bump the required ruff version to `>=0.2.0`
- Update `show-source` to `output-format = "full"`
- Fix new violations