### PR TITLE
Figure.plot/plot3d/rose: Remove deprecated 'color' parameter, use 'fill' instead (deprecated since v0.8.0)

### DIFF
--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -6,7 +6,6 @@ from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     build_arg_string,
     data_kind,
-    deprecate_parameter,
     fmt_docstring,
     is_nonstr_iter,
     kwargs_to_strings,
@@ -16,7 +15,6 @@ from pygmt.src.which import which
 
 
 @fmt_docstring
-@deprecate_parameter("color", "fill", "v0.8.0", remove_version="v0.12.0")
 @use_alias(
     A="straight_line",
     B="frame",

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -6,7 +6,6 @@ from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     build_arg_string,
     data_kind,
-    deprecate_parameter,
     fmt_docstring,
     is_nonstr_iter,
     kwargs_to_strings,
@@ -16,7 +15,6 @@ from pygmt.src.which import which
 
 
 @fmt_docstring
-@deprecate_parameter("color", "fill", "v0.8.0", remove_version="v0.12.0")
 @use_alias(
     A="straight_line",
     B="frame",

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -5,7 +5,6 @@ rose - Plot windrose diagrams or polar histograms.
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_string,
-    deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
@@ -13,7 +12,6 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
-@deprecate_parameter("color", "fill", "v0.8.0", remove_version="v0.12.0")
 @use_alias(
     A="sector",
     B="frame",

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -7,6 +7,7 @@ from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     build_arg_string,
+    deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
@@ -14,6 +15,7 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
+@deprecate_parameter("color", "fill", "v0.8.0", remove_version="v0.12.0")
 @deprecate_parameter(
     "uncertaintycolor", "uncertaintyfill", "v0.8.0", remove_version="v0.12.0"
 )

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -7,7 +7,6 @@ from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     build_arg_string,
-    deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
@@ -15,7 +14,6 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
-@deprecate_parameter("color", "fill", "v0.8.0", remove_version="v0.12.0")
 @deprecate_parameter(
     "uncertaintycolor", "uncertaintyfill", "v0.8.0", remove_version="v0.12.0"
 )


### PR DESCRIPTION
**Description of proposed changes**

This PR removes the deprecated `color` parameter from the following modules (deprecated since v0.8.0).

Related to #3033 

- [x] Figure.plot
- [x] Figure.plot3d
- [x] Figure.rose


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
