### PR TITLE
Figure.velo: Remove deprecated parameters color/uncertaintycolor, use fill/uncertaintyfill (deprecated since v0.8.0)

### DIFF
--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -14,7 +14,6 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
-@deprecate_parameter("color", "fill", "v0.8.0", remove_version="v0.12.0")
 @use_alias(
     A="vector",
     B="frame",

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -7,7 +7,6 @@ from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     build_arg_string,
-    deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
@@ -16,9 +15,6 @@ from pygmt.helpers import (
 
 @fmt_docstring
 @deprecate_parameter("color", "fill", "v0.8.0", remove_version="v0.12.0")
-@deprecate_parameter(
-    "uncertaintycolor", "uncertaintyfill", "v0.8.0", remove_version="v0.12.0"
-)
 @use_alias(
     A="vector",
     B="frame",


### PR DESCRIPTION
**Description of proposed changes**

This PR removes the deprecated `uncertaintycolor` and `color` parameters from `Figure.velo` (deprecated since v0.8.0).

Related to #3033 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
