### PR TITLE
Figure.grdimage: Remove deprecated parameter 'bit_color', use 'bitcolor' instead (deprecated since v0.8.0)

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -139,7 +139,7 @@
 ### Deprecations
 
 * Remove the unused pygmt.test() function ([#2652](https://github.com/GenericMappingTools/pygmt/pull/2652))
-* Figure.image: Deprecate parameter "bit_color" to "bitcolor" (remove in v0.12.0) ([#2635](https://github.com/GenericMappingTools/pygmt/pull/2635))
+* Figure.grdimage: Deprecate parameter "bit_color" to "bitcolor" (remove in v0.12.0) ([#2635](https://github.com/GenericMappingTools/pygmt/pull/2635))
 * Figure.text: Remove the deprecated "incols" parameter (deprecated since v0.8.0) ([#2473](https://github.com/GenericMappingTools/pygmt/pull/2473))
 * NEP29: Set minimum required version to Python 3.9+ ([#2487](https://github.com/GenericMappingTools/pygmt/pull/2487))
 * NEP29: Set minimum required version to NumPy 1.22+ ([#2586](https://github.com/GenericMappingTools/pygmt/pull/2586))

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -5,7 +5,6 @@ from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     build_arg_string,
-    deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
@@ -15,7 +14,6 @@ __doctest_skip__ = ["grdimage"]
 
 
 @fmt_docstring
-@deprecate_parameter("bit_color", "bitcolor", "v0.10.0", remove_version="v0.12.0")
 @use_alias(
     B="frame",
     C="cmap",


### PR DESCRIPTION
**Description of proposed changes**

This PR removes the deprecated `bit_color` parameter from `Figure.grdimage` (deprecated since v0.8.0).

Related to #3033 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
