### PR TITLE
Adopt SPEC 0 policy and drop NEP 29 policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -16,7 +16,7 @@ assignees: ''
 - [ ] Wrap Y ()
 
 **Before release**:
-- [ ] Check [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) to see if we need to bump the minimum Python and NumPy versions
+- [ ] Check [SPEC 0](https://scientific-python.org/specs/spec-0000/) to see if we need to bump the minimum supported versions of Python and core package dependencies
 - [ ] Run `make codespell` to check common misspellings. If there are any, either fix them or add them to `ignore-words-list` in `pyproject.toml`
 - [ ] Check to ensure that:
   - [ ] All tests pass in the ["GMT Legacy Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_legacy.yaml)

--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -16,7 +16,7 @@ assignees: ''
 - [ ] Wrap Y ()
 
 **Before release**:
-- [ ] Check [SPEC 0](https://scientific-python.org/specs/spec-0000/) to see if we need to bump the minimum supported versions of Python and core package dependencies
+- [ ] Check [SPEC 0](https://scientific-python.org/specs/spec-0000/) to see if we need to bump the minimum supported versions of Python and core package dependencies (NumPy/Pandas/Xarray)
 - [ ] Run `make codespell` to check common misspellings. If there are any, either fix them or add them to `ignore-words-list` in `pyproject.toml`
 - [ ] Check to ensure that:
   - [ ] All tests pass in the ["GMT Legacy Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_legacy.yaml)

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -17,7 +17,7 @@
 # In draft pull request, only two jobs on Linux are triggered to save on
 # Continuous Integration resources:
 #
-# - Minimum supported Python/NumPy versions following [SPEC 0](https://scientific-python.org/specs/spec-0000/)
+# - Minimum supported Python/NumPy/Pandas/Xarray versions following [SPEC 0](https://scientific-python.org/specs/spec-0000/)
 # - Latest Python/NumPy versions + optional packages (e.g. GeoPandas)
 #
 name: Tests

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -17,7 +17,7 @@
 # In draft pull request, only two jobs on Linux are triggered to save on
 # Continuous Integration resources:
 #
-# - Minimum [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy) Python/NumPy versions
+# - Minimum supported Python/NumPy versions following [SPEC 0](https://scientific-python.org/specs/spec-0000/)
 # - Latest Python/NumPy versions + optional packages (e.g. GeoPandas)
 #
 name: Tests

--- a/README.rst
+++ b/README.rst
@@ -253,16 +253,15 @@ Other non-official Python wrappers for GMT (not maintained):
 
 .. doc-index-end-before
 
-Minimum Supported GMT/Python/NumPy Versions
--------------------------------------------
+Minimum Supported Versions of GMT/Python/Core package dependencies
+------------------------------------------------------------------
 
-PyGMT has adopted `NEP29 <https://numpy.org/neps/nep-0029-deprecation_policy>`__
-alongside the rest of the Scientific Python ecosystem, and therefore supports:
+PyGMT has adopted `SPEC 0 <https://scientific-python.org/specs/spec-0000/>`__ alongside
+the rest of the Scientific Python ecosystem, and therefore:
 
-* All minor versions of Python released 42 months prior to the project, and at minimum
-  the two latest minor versions.
-* All minor versions of NumPy released in the 24 months prior to the project, and at
-  minimum the last three minor versions.
+* Support for Python versions be dropped 3 years after their initial release.
+* Support for core package dependencies be dropped 2 years after their initial release.
 
-For the supported GMT versions as well as the minimum required Python and NumPy versions
-please see `Minimum Required Versions <https://www.pygmt.org/dev/minversions.html>`__.
+For the supported GMT versions as well as the minimum required versions of Python and
+core package dependencies, please see
+`Minimum Required Versions <https://www.pygmt.org/dev/minversions.html>`__.

--- a/README.rst
+++ b/README.rst
@@ -260,7 +260,7 @@ PyGMT has adopted `SPEC 0 <https://scientific-python.org/specs/spec-0000/>`__ al
 the rest of the Scientific Python ecosystem, and therefore:
 
 * Support for Python versions be dropped 3 years after their initial release.
-* Support for core package dependencies be dropped 2 years after their initial release.
+* Support for core package dependencies (NumPy/Pandas/Xarray) be dropped 2 years after their initial release.
 
 For the supported GMT versions as well as the minimum required versions of Python and
 core package dependencies, please see

--- a/README.rst
+++ b/README.rst
@@ -253,8 +253,8 @@ Other non-official Python wrappers for GMT (not maintained):
 
 .. doc-index-end-before
 
-Minimum Supported Versions of GMT/Python/Core package dependencies
-------------------------------------------------------------------
+Minimum Supported Versions
+--------------------------
 
 PyGMT has adopted `SPEC 0 <https://scientific-python.org/specs/spec-0000/>`__ alongside
 the rest of the Scientific Python ecosystem, and therefore:
@@ -264,4 +264,4 @@ the rest of the Scientific Python ecosystem, and therefore:
 
 For the supported GMT versions as well as the minimum required versions of Python and
 core package dependencies, please see
-`Minimum Required Versions <https://www.pygmt.org/dev/minversions.html>`__.
+`Minimum Supported Versions <https://www.pygmt.org/dev/minversions.html>`__.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -40,7 +40,7 @@
 
     api/index.rst
     changes.md
-    Minimum Supported Versions <minversions.rst>
+    minversions.rst
 
 .. toctree::
     :maxdepth: 2

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -123,7 +123,7 @@ PyGMT has adopted [SPEC 0](https://scientific-python.org/specs/spec-0000/) along
 the rest of the Scientific Python ecosystem, and therefore:
 
 * Support for Python versions be dropped 3 years after their initial release.
-* Support for core package dependencies be dropped 2 years after their initial release.
+* Support for core package (NumPy/Pandas/Xarray) dependencies be dropped 2 years after their initial release.
 
 In `pyproject.toml`, the `requires-python` key should be set to the minimum supported
 version of Python. Minimum supported versions of Python and core package dependencies
@@ -220,7 +220,8 @@ publishing the actual release notes at {doc}`changes`.
    last release (e.g., use `git shortlog HEAD...v0.4.0 -sne`).
 8. Update `doc/minversions.rst` with new information on the new release version,
    including a vX.Y.Z documentation link, and minimum required versions of GMT, Python
-   and core packages. Follow [SPEC 0](https://scientific-python.org/specs/spec-0000/)
+   and core packages (NumPy/Pandas/Xarray). Follow
+   [SPEC 0](https://scientific-python.org/specs/spec-0000/)
    for updates.
 9. Refresh citation information. Specifically, the BibTeX in `README.rst` and
    `CITATION.cff` needs to be updated with any metadata changes, including the

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -221,8 +221,7 @@ publishing the actual release notes at {doc}`changes`.
 8. Update `doc/minversions.rst` with new information on the new release version,
    including a vX.Y.Z documentation link, and minimum required versions of GMT, Python
    and core package dependencies (NumPy/Pandas/Xarray). Follow
-   [SPEC 0](https://scientific-python.org/specs/spec-0000/)
-   for updates.
+   [SPEC 0](https://scientific-python.org/specs/spec-0000/) for updates.
 9. Refresh citation information. Specifically, the BibTeX in `README.rst` and
    `CITATION.cff` needs to be updated with any metadata changes, including the
    DOI, release date, and version information. Please also follow

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -119,17 +119,15 @@ to change the default behaviour at <https://docs.readthedocs.io/en/stable/config
 
 ## Dependencies Policy
 
-PyGMT has adopted [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy)
-alongside the rest of the Scientific Python ecosystem, and therefore supports:
+PyGMT has adopted [SPEC 0](https://scientific-python.org/specs/spec-0000/) alongside
+the rest of the Scientific Python ecosystem, and therefore:
 
-* All minor versions of Python released 42 months prior to the project,
-  and at minimum the two latest minor versions.
-* All minor versions of NumPy released in the 24 months prior to the project,
-  and at minimum the last three minor versions.
+* Support for Python versions be dropped 3 years after their initial release.
+* Support for core package dependencies be dropped 2 years after their initial release.
 
-In `pyproject.toml`, the `requires-python` key should be set to the minimum
-supported version of Python. Minimum Python and NumPy version support should be
-adjusted upward on every major and minor release, but never on a patch release.
+In `pyproject.toml`, the `requires-python` key should be set to the minimum supported
+version of Python. Minimum supported versions of Python and core package dependencies
+should be adjusted upward on every major and minor release, but never on a patch release.
 
 
 ## Backwards Compatibility and Deprecation Policy
@@ -221,9 +219,8 @@ publishing the actual release notes at {doc}`changes`.
    GitHub accounts. Sort their names by the number of commits made since the
    last release (e.g., use `git shortlog HEAD...v0.4.0 -sne`).
 8. Update `doc/minversions.rst` with new information on the new release version,
-   including a vX.Y.Z documentation link, and minimum required GMT/Python/NumPy
-   versions. Follow
-   [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html#detailed-description)
+   including a vX.Y.Z documentation link, and minimum required versions of GMT, Python
+   and core packages. Follow [SPEC 0](https://scientific-python.org/specs/spec-0000/)
    for updates.
 9. Refresh citation information. Specifically, the BibTeX in `README.rst` and
    `CITATION.cff` needs to be updated with any metadata changes, including the

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -123,7 +123,7 @@ PyGMT has adopted [SPEC 0](https://scientific-python.org/specs/spec-0000/) along
 the rest of the Scientific Python ecosystem, and therefore:
 
 * Support for Python versions be dropped 3 years after their initial release.
-* Support for core package (NumPy/Pandas/Xarray) dependencies be dropped 2 years after their initial release.
+* Support for core package dependencies (NumPy/Pandas/Xarray) be dropped 2 years after their initial release.
 
 In `pyproject.toml`, the `requires-python` key should be set to the minimum supported
 version of Python. Minimum supported versions of Python and core package dependencies
@@ -220,7 +220,7 @@ publishing the actual release notes at {doc}`changes`.
    last release (e.g., use `git shortlog HEAD...v0.4.0 -sne`).
 8. Update `doc/minversions.rst` with new information on the new release version,
    including a vX.Y.Z documentation link, and minimum required versions of GMT, Python
-   and core packages (NumPy/Pandas/Xarray). Follow
+   and core package dependencies (NumPy/Pandas/Xarray). Follow
    [SPEC 0](https://scientific-python.org/specs/spec-0000/)
    for updates.
 9. Refresh citation information. Specifically, the BibTeX in `README.rst` and

--- a/doc/minversions.rst
+++ b/doc/minversions.rst
@@ -1,13 +1,11 @@
 Minimum Supported GMT/Python/NumPy Versions
 -------------------------------------------
 
-PyGMT has adopted `NEP29 <https://numpy.org/neps/nep-0029-deprecation_policy>`__
-alongside the rest of the Scientific Python ecosystem, and therefore supports:
+PyGMT has adopted `SPEC 0 <https://scientific-python.org/specs/spec-0000/>`__ alongside
+the rest of the Scientific Python ecosystem, and therefore:
 
-* All minor versions of Python released 42 months prior to the project, and at minimum
-  the two latest minor versions.
-* All minor versions of NumPy released in the 24 months prior to the project, and at
-  minimum the last three minor versions.
+* Support for Python versions be dropped 3 years after their initial release.
+* Support for core package dependencies be dropped 2 years after their initial release.
 
 .. list-table::
     :widths: 25 30 15 20 15

--- a/doc/minversions.rst
+++ b/doc/minversions.rst
@@ -5,7 +5,7 @@ PyGMT has adopted `SPEC 0 <https://scientific-python.org/specs/spec-0000/>`__ al
 the rest of the Scientific Python ecosystem, and therefore:
 
 * Support for Python versions be dropped 3 years after their initial release.
-* Support for core package dependencies be dropped 2 years after their initial release.
+* Support for core package dependencies (NumPy/Pandas/Xarray) be dropped 2 years after their initial release.
 
 .. list-table::
     :widths: 25 30 15 20 15

--- a/doc/minversions.rst
+++ b/doc/minversions.rst
@@ -1,5 +1,5 @@
-Minimum Supported GMT/Python/NumPy Versions
--------------------------------------------
+Minimum Supported Versions
+--------------------------
 
 PyGMT has adopted `SPEC 0 <https://scientific-python.org/specs/spec-0000/>`__ alongside
 the rest of the Scientific Python ecosystem, and therefore:


### PR DESCRIPTION
The [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) policy is superseded by the [SPEC 0](https://scientific-python.org/specs/spec-0000/) policy.

Address https://github.com/GenericMappingTools/pygmt/issues/2863.