### PR TITLE
SPEC0: Set minimum supported version to Python 3.10+

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -51,21 +51,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.12']
+        python-version: ['3.10', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
         # Is it a draft Pull Request (true or false)?
         isDraft:
           - ${{ github.event.pull_request.draft }}
-        # Only run two jobs (Ubuntu + Python 3.9/3.12) for draft PRs
+        # Only run two jobs (Ubuntu + Python 3.10/3.12) for draft PRs
         exclude:
           - os: macos-latest
             isDraft: true
           - os: windows-latest
             isDraft: true
-        # Pair Python 3.9 with NumPy 1.23 and Python 3.12 with NumPy 1.26
+        # Pair Python 3.10 with NumPy 1.23 and Python 3.12 with NumPy 1.26
         # Only install optional packages on Python 3.12/NumPy 1.26
         include:
-          - python-version: '3.9'
+          - python-version: '3.10'
             numpy-version: '1.23'
             optional-packages: ''
           - python-version: '3.12'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -60,7 +60,7 @@ jobs:
           cache-downloads: false
           cache-environment: true
           create-args: >-
-            python=3.9
+            python=3.10
             gmt=${{ matrix.gmt_version }}
             numpy
             pandas<2

--- a/doc/minversions.rst
+++ b/doc/minversions.rst
@@ -21,7 +21,7 @@ alongside the rest of the Scientific Python ecosystem, and therefore supports:
     * - `Dev <https://github.com/GenericMappingTools/pygmt/milestones>`_ (upcoming release)
       - `Dev Documentation <https://www.pygmt.org/dev>`_ (reflects `main branch <https://github.com/GenericMappingTools/pygmt>`_)
       - >=6.3.0
-      - >=3.9
+      - >=3.10
       - >=1.23
     * - `v0.11.0 <https://github.com/GenericMappingTools/pygmt/releases/tag/v0.11.0>`_ (latest release)
       - `v0.11.0 Documentation <https://www.pygmt.org/v0.11.0>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pygmt"
 description = "A Python interface for the Generic Mapping Tools"
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{name = "The PyGMT Developers", email = "pygmt.team@gmail.com"}]
 keywords = [
     "cartography",
@@ -24,7 +24,6 @@ classifiers = [
     "Intended Audience :: Education",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Following [SPEC 0](https://scientific-python.org/specs/spec-0000/) policy where Python 3.9 should be dropped in 2023 quarter 4.

Changes in this PR:

- [x] Update the minimum Python version in `ci_tests.yaml`
- [x] Update the minimum Python version in `ci_tests_legacy.yaml`
- [x] Update the minimum Python version in `doc/minversions.rst`
- [x] Update the Python version in the `requires-python` field and remove the related entry from `classifiers` in `pyproject.toml`.
- [ ] Update [branch protection rules](https://github.com/GenericMappingTools/pygmt/settings/branches) 

Supersedes PR #2487.

Address #2863.