### PR TITLE
ruff: Fix Python 3.10 violations

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -214,7 +214,11 @@ html_context = {
     "doc_path": "doc",
     "galleries": sphinx_gallery_conf["gallery_dirs"],
     "gallery_dir": dict(
-        zip(sphinx_gallery_conf["gallery_dirs"], sphinx_gallery_conf["examples_dirs"])
+        zip(
+            sphinx_gallery_conf["gallery_dirs"],
+            sphinx_gallery_conf["examples_dirs"],
+            strict=True,
+        )
     ),
     "github_repo": repository,
     "github_version": "main",

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1297,7 +1297,9 @@ class Session:
             if len(string_arrays) == 1:
                 strings = string_arrays[0]
             elif len(string_arrays) > 1:
-                strings = np.array([" ".join(vals) for vals in zip(*string_arrays)])
+                strings = np.array(
+                    [" ".join(vals) for vals in zip(*string_arrays, strict=True)]
+                )
             strings = np.asanyarray(a=strings, dtype=str)
             self.put_strings(
                 dataset, family="GMT_IS_VECTOR|GMT_IS_DUPLICATE", strings=strings

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -1,7 +1,8 @@
 """
 Functions to load sample data.
 """
-from typing import Callable, Literal, NamedTuple
+from collections.abc import Callable
+from typing import Literal, NamedTuple
 
 import pandas as pd
 from pygmt.exceptions import GMTInvalidInput

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -172,9 +172,9 @@ def data_kind(data=None, x=None, y=None, z=None, required_z=False, required_data
     'image'
     """
     # determine the data kind
-    if isinstance(data, (str, pathlib.PurePath)):
+    if isinstance(data, str | pathlib.PurePath):
         kind = "file"
-    elif isinstance(data, (bool, int, float)) or (data is None and not required_data):
+    elif isinstance(data, bool | int | float) or (data is None and not required_data):
         kind = "arg"
     elif isinstance(data, xr.DataArray):
         kind = "image" if len(data.dims) == 3 else "grid"

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -257,6 +257,7 @@ def non_ascii_to_octal(argstr):
                 "◊〈®©™∑"  # \34x-35x
                 "〉∫⌠⌡",  # \36x-37x. \360 and \377 are undefined
                 [*range(32, 127), *range(160, 240), *range(241, 255)],
+                strict=True,
             )
         }
     )
@@ -282,6 +283,7 @@ def non_ascii_to_octal(argstr):
                 "➠➡➢➣➤➥➦➧➨➩➪➫➬➭➮➯"  # \34x-\35x
                 "➱➲➳➴➵➶➷➸➹➺➻➼➽➾",  # \36x-\37x. \360 and \377 are undefined
                 [*range(32, 127), *range(161, 240), *range(241, 255)],
+                strict=True,
             )
         }
     )
@@ -300,6 +302,7 @@ def non_ascii_to_octal(argstr):
                 "Œ†‡Ł⁄‹Š›œŸŽł‰„“”"  # \20x-\21x
                 "ı`´ˆ˜¯˘˙¨‚˚¸'˝˛ˇ",  # \22x-\23x
                 [*range(25, 32), *range(127, 160)],
+                strict=True,
             )
         }
     )

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -399,7 +399,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
     kwargs = self._preprocess(**kwargs)
 
     # Convert spec to pandas.DataFrame unless it's a file
-    if isinstance(spec, (dict, pd.DataFrame)):  # spec is a dict or pd.DataFrame
+    if isinstance(spec, dict | pd.DataFrame):  # spec is a dict or pd.DataFrame
         # determine convention from dict keys or pd.DataFrame column names
         for conv in ["aki", "gcmt", "mt", "partial", "principal_axis"]:
             if set(convention_params(conv)).issubset(set(spec.keys())):

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -217,7 +217,7 @@ def text_(  # noqa: PLR0912
                 extra_arrays.append(np.atleast_1d(arg))
             else:  # font or justify is str type
                 extra_arrays.append(np.atleast_1d(arg).astype(str))
-        elif isinstance(arg, (int, float, str)):
+        elif isinstance(arg, int | float | str):
             kwargs["F"] += f"{flag}{arg}"
 
     if isinstance(position, str):

--- a/pygmt/tests/test_clib_virtualfiles.py
+++ b/pygmt/tests/test_clib_virtualfiles.py
@@ -239,7 +239,9 @@ def test_virtualfile_from_vectors_one_string_or_object_column(dtype):
             with GMTTempFile() as outfile:
                 lib.call_module("convert", f"{vfile} ->{outfile.name}")
                 output = outfile.read(keep_tabs=True)
-        expected = "".join(f"{i}\t{j}\t{k}\n" for i, j, k in zip(x, y, strings))
+        expected = "".join(
+            f"{i}\t{j}\t{k}\n" for i, j, k in zip(x, y, strings, strict=True)
+        )
         assert output == expected
 
 
@@ -260,7 +262,8 @@ def test_virtualfile_from_vectors_two_string_or_object_columns(dtype):
                 lib.call_module("convert", f"{vfile} ->{outfile.name}")
                 output = outfile.read(keep_tabs=True)
         expected = "".join(
-            f"{h}\t{i}\t{j} {k}\n" for h, i, j, k in zip(x, y, strings1, strings2)
+            f"{h}\t{i}\t{j} {k}\n"
+            for h, i, j, k in zip(x, y, strings1, strings2, strict=True)
         )
         assert output == expected
 

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -353,7 +353,7 @@ def test_text_transparency():
     """
     x = np.arange(1, 10)
     y = np.arange(11, 20)
-    text = [f"TEXT-{i}-{j}" for i, j in zip(x, y)]
+    text = [f"TEXT-{i}-{j}" for i, j in zip(x, y, strict=True)]
 
     fig = Figure()
     fig.basemap(region=[0, 10, 10, 20], projection="X10c", frame=True)
@@ -368,7 +368,7 @@ def test_text_varying_transparency():
     """
     x = np.arange(1, 10)
     y = np.arange(11, 20)
-    text = [f"TEXT-{i}-{j}" for i, j in zip(x, y)]
+    text = [f"TEXT-{i}-{j}" for i, j in zip(x, y, strict=True)]
     transparency = np.arange(10, 100, 10)
 
     fig = Figure()


### PR DESCRIPTION
**Description of proposed changes**

Fixes the following ruff violations with Python 3.10+
- [x] B905 [*] zip() without an explicit strict= parameter - https://docs.astral.sh/ruff/rules/zip-without-explicit-strict
- [x] UP035 [*] Import from collections.abc instead: Callable - https://docs.astral.sh/ruff/rules/deprecated-import
- [x] UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)` - https://docs.astral.sh/ruff/rules/non-pep604-isinstance (should we ignore this, because the docs says `X | Y` might be slower than `(X, Y)`?)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses https://github.com/GenericMappingTools/pygmt/pull/3039#issuecomment-1927252931


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
