### PR TITLE
Figure.psconvert: Ignore the unrecognized 'metadata' parameter added by pytest-mpl v0.17.0

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -228,6 +228,9 @@ class Figure:
         {verbose}
         """
         kwargs = self._preprocess(**kwargs)
+        # pytest-mpl v0.17.0 added the "metadata" parameter to `Figure.savefig`, which
+        # is not recognized. So remove it before calling `Figure.psconvert`.
+        kwargs.pop("metadata", None)
         # Default cropping the figure to True
         if kwargs.get("A") is None:
             kwargs["A"] = ""


### PR DESCRIPTION
Address https://github.com/GenericMappingTools/pygmt/pull/3043#issuecomment-1950973532:

> > After pinning pandas and xarray with Python 3.10, now we have many failures on macOS/Windows. See https://github.com/GenericMappingTools/pygmt/actions/runs/7946102470/job/21694725831. Need to find out why.
> 
> [`pytest-mpl=0.17.0`](https://github.com/matplotlib/pytest-mpl/releases/tag/v0.17.0) now adds a `metadata` key into our `savefig` call (added in https://github.com/matplotlib/pytest-mpl/pull/196/files I think), and this is not handled by psconvert. We'll need to ignore that `metadata` key somehow.

