### PR TITLE
CI: Use 'git ls-files' to list all git tracked files

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Commit to the PR branch if any changes
         run: |
           make format
-          find . -type f -not -path '*/\.git/*' -exec grep -Iq . {} \; -exec dos2unix {} \;
-          find . -type f -not -path '*/\.git/*' -exec grep -Iq . {} \; -exec chmod 644 {} \;
+          git ls-files -z | xargs -0 dos2unix --quiet
+          git ls-files -z | xargs -0 chmod 644
           if [[ $(git ls-files -m) ]]; then
             git config --global user.name 'actions-bot'
             git config --global user.email '58130806+actions-bot@users.noreply.github.com'

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Ensure example scripts have at least one code block separator
         run: |
-          grep --files-without-match '# %%' $(find 'examples' -name '*.py') > output.txt
+          git ls-files 'examples/**/*.py' | xargs grep --files-without-match '# %%' > output.txt
           nfiles=$(wc --lines output.txt | awk '{print $1}')
           if [[ $nfiles > 0 ]]; then
             echo "Code block separator '# %%' is required in following example files:"

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -43,8 +43,8 @@ jobs:
 
       - name: Ensure files use UNIX line breaks and have 644 permission
         run: |
-          find . -type f -not -path '*/\.git/*' -exec grep -Iq . {} \; -exec dos2unix --quiet {} \;
-          find . -type f -not -path '*/\.git/*' -exec grep -Iq . {} \; -exec chmod 644 {} \;
+          git ls-files -z | xargs -0 dos2unix --quiet
+          git ls-files -z | xargs -0 chmod 644
           if [[ $(git ls-files -m) ]]; then git --no-pager diff HEAD; exit 1; fi
 
       - name: Ensure example scripts have at least one code block separator


### PR DESCRIPTION
We used the `find` command to find all files in the current directory and exclude the `.git` directory. The `find` command is very long and difficult to understand/maintain. 

Instead, we can use `git ls-files` to list all git-tracked files.

ref: https://stackoverflow.com/a/41085442

Patches https://github.com/GenericMappingTools/pygmt/pull/736