### PR TITLE
Revert "CI: Temporarily delete two examples files to make ReadTheDocs pass again

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,7 +27,8 @@ build:
         then
           exit 183;
         fi
-    pre_build: # Generate api stub files before building
+    pre_build:
+      # Generate api stub files before building
       - make -C doc api
 
 # Build documentation in the doc/ directory with Sphinx

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,11 +27,7 @@ build:
         then
           exit 183;
         fi
-    pre_build:
-      # ReadTheDocs fails to download external resources.
-      # Temporarily delete the two files to make ReadTheDocs building work again.
-      - rm examples/gallery/lines/roads.py examples/gallery/maps/choropleth_map.py
-      # Generate api stub files before building
+    pre_build: # Generate api stub files before building
       - make -C doc api
 
 # Build documentation in the doc/ directory with Sphinx


### PR DESCRIPTION
This reverts commit 801cd2b83fc04583ecf79065a616768abb7c661f.