### PR TITLE
clib: Refactor the function clib_names using match statements

### DIFF
--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -62,18 +62,18 @@ def load_libgmt(lib_fullnames=None):
     return libgmt
 
 
-def clib_names(os_name):
+def clib_names(os_name: str) -> list[str]:
     """
-    Return the name of GMT's shared library for the current OS.
+    Return the name(s) of GMT's shared library for the current operating system.
 
     Parameters
     ----------
-    os_name : str
+    os_name
         The operating system name as given by ``sys.platform``.
 
     Returns
     -------
-    libnames : list of str
+    libnames
         List of possible names of GMT's shared library.
     """
     match os_name:

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -75,6 +75,11 @@ def clib_names(os_name: str) -> list[str]:
     -------
     libnames
         List of possible names of GMT's shared library.
+
+    Raises
+    ------
+    GMTOSError
+        If the operating system is not supported yet.
     """
     match os_name:
         case "linux":  # Linux

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -77,12 +77,14 @@ def clib_names(os_name: str) -> list[str]:
         List of possible names of GMT's shared library.
     """
     match os_name:
-        case name if name.startswith(("linux", "freebsd")):
+        case "linux":  # Linux
             libnames = ["libgmt.so"]
-        case "darwin":  # Darwin is macOS
+        case "darwin":  # macOS
             libnames = ["libgmt.dylib"]
-        case "win32":
+        case "win32":  # Windows
             libnames = ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
+        case name if name.startswith("freebsd"):  # FreeBSD
+            libnames = ["libgmt.so"]
         case _:
             raise GMTOSError(f"Operating system '{os_name}' not supported.")
     return libnames

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -91,7 +91,7 @@ def clib_names(os_name: str) -> list[str]:
         case name if name.startswith("freebsd"):  # FreeBSD
             libnames = ["libgmt.so"]
         case _:
-            raise GMTOSError(f"Operating system '{os_name}' not supported.")
+            raise GMTOSError(f"Operating system '{os_name}' is not supported.")
     return libnames
 
 

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -76,14 +76,15 @@ def clib_names(os_name):
     libnames : list of str
         List of possible names of GMT's shared library.
     """
-    if os_name.startswith(("linux", "freebsd")):
-        libnames = ["libgmt.so"]
-    elif os_name == "darwin":  # Darwin is macOS
-        libnames = ["libgmt.dylib"]
-    elif os_name == "win32":
-        libnames = ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
-    else:
-        raise GMTOSError(f"Operating system '{os_name}' not supported.")
+    match os_name:
+        case name if name.startswith(("linux", "freebsd")):
+            libnames = ["libgmt.so"]
+        case "darwin":  # Darwin is macOS
+            libnames = ["libgmt.dylib"]
+        case "win32":
+            libnames = ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
+        case _:
+            raise GMTOSError(f"Operating system '{os_name}' not supported.")
     return libnames
 
 

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -50,8 +50,7 @@ def test_clib_names():
     """
     Make sure we get the correct library name for different OS names.
     """
-    for linux in ["linux", "linux2", "linux3"]:
-        assert clib_names(linux) == ["libgmt.so"]
+    assert clib_names("linux") == ["libgmt.so"]
     assert clib_names("darwin") == ["libgmt.dylib"]
     assert clib_names("win32") == ["gmt.dll", "gmt_w64.dll", "gmt_w32.dll"]
     for freebsd in ["freebsd10", "freebsd11", "freebsd12"]:


### PR DESCRIPTION
**Description of proposed changes**

[The `match` statement](https://docs.python.org/3/whatsnew/3.10.html#pep-634-structural-pattern-matching) is a feature introduced in Python 3.10, which is similar to the C `switch...case` statements and can simplify `if-elif-else`.

This PR refactor the `clib_names` function using the new `match` statements. This PR also adds type hints to this simple function.

Please note that, in previous versions, we check the Linux OS using `if os_name.startswith(("linux", "freebsd")):` because in old Python versions, `sys.platform` may return strings like `linux`/`linux2`/`linux3` on Linux. However, since Python 3.3, `sys.platform` always return `linux` on Linux, so we can simplify the check of `linux`.

https://docs.python.org/3/library/sys.html#sys.platform:

> Changed in version 3.3: On Linux, [sys.platform](https://docs.python.org/3/library/sys.html#sys.platform) doesn’t contain the major version anymore. It is always 'linux', instead of 'linux2' or 'linux3'. Since older Python versions include the version number, it is recommended to always use the startswith idiom presented above.

The new version with `match` statement is also slightly faster!

The new version:
```python
In [2]: from pygmt.clib.loading import clib_names

In [3]: %timeit clib_names("linux")
74.9 ns ± 0.148 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [4]: %timeit clib_names("darwin")
86 ns ± 0.121 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [5]: %timeit clib_names("win32")
107 ns ± 0.354 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [6]: %timeit clib_names("freebsd")
170 ns ± 2.02 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

The old version:
```python
In [2]: %timeit clib_names("linux")
141 ns ± 0.64 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [3]: %timeit clib_names("darwin")
150 ns ± 0.397 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [4]: %timeit clib_names("win32")
164 ns ± 2.2 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [5]: %timeit clib_names("freebsd")
146 ns ± 0.27 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```