### PR TITLE
Add type hints to the check_libgmt function and improve docstrings and tests

### DIFF
--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -150,32 +150,29 @@ def clib_full_names(env=None):
         yield libname
 
 
-def check_libgmt(libgmt):
+def check_libgmt(libgmt: ctypes.CDLL):
     """
-    Make sure that libgmt was loaded correctly.
+    Make sure the GMT shared library was loaded correctly.
 
-    Checks if it defines some common required functions.
-
-    Does nothing if everything is fine. Raises an exception if any of the
-    functions are missing.
+    Checks if the GMT shared library defines a few of the required functions. Does
+    nothing if everything is fine. Raises an exception if any of the functions are
+    missing.
 
     Parameters
     ----------
-    libgmt : :py:class:`ctypes.CDLL`
+    libgmt
         A shared library loaded using ctypes.
 
     Raises
     ------
     GMTCLibError
     """
-    # Check if a few of the functions we need are in the library
-    functions = ["Create_Session", "Get_Enum", "Call_Module", "Destroy_Session"]
-    for func in functions:
+    for func in ["Create_Session", "Get_Enum", "Call_Module", "Destroy_Session"]:
         if not hasattr(libgmt, "GMT_" + func):
             msg = (
                 f"Error loading '{libgmt._name}'. Couldn't access function GMT_{func}. "
-                "Ensure that you have installed an up-to-date GMT version 6 library. "
-                "Please set the environment variable 'GMT_LIBRARY_PATH' to the "
-                "directory of the GMT 6 library."
+                "Ensure that you have installed an up-to-date GMT version 6 library and "
+                "set the environment variable 'GMT_LIBRARY_PATH' to the directory of "
+                "the GMT 6 library."
             )
             raise GMTCLibError(msg)

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -35,13 +35,7 @@ def test_check_libgmt():
     Make sure check_libgmt fails when given a bogus library.
     """
     libgmt = FakedLibGMT("/path/to/libgmt.so")
-    msg = (
-        f"Error loading '{libgmt._name}'. "
-        "Couldn't access function GMT_Create_Session. "
-        "Ensure that you have installed an up-to-date GMT version 6 library. "
-        "Please set the environment variable 'GMT_LIBRARY_PATH' to the "
-        "directory of the GMT 6 library."
-    )
+    msg = f"Error loading '{libgmt}'. Couldn't access function GMT_Create_Session."
     with pytest.raises(GMTCLibError, match=msg):
         check_libgmt(libgmt)
 


### PR DESCRIPTION
**Description of proposed changes**

This PR makes some changes to the `clib.loading.check_libgmt` function:

1. Add type hints to the parameters
2. Improve the docstrings
3. Simplify the test