### PR TITLE
Use pip instead of micromamba to list the installed packages

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -126,7 +126,7 @@ jobs:
 
       # Show installed pkg information for postmortem diagnostic
       - name: List installed packages
-        run: micromamba list
+        run: python -m pip list
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote


### PR DESCRIPTION
The `micromamba list` command only lists packages from pypi so we can't know the exact packages that are installed. See https://github.com/mamba-org/mamba/issues/2059 for the upstream issue report and https://github.com/GenericMappingTools/pygmt/actions/runs/8042005126/job/21962067095 for the CI job run. 
