### PR TITLE
Enable the test_load_libgmt_fails test on Windows

### DIFF
--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -69,7 +69,7 @@ def test_load_libgmt_fails(monkeypatch):
     """
     with monkeypatch.context() as mpatch:
         if sys.platform == "win32":
-            mpatch.setattr(ctypes.util, "find_library", lambda name: None)  # noqa: ARG005
+            mpatch.setattr(ctypes.util, "find_library", lambda name: "fakegmt.dll")  # noqa: ARG005
         mpatch.setattr(
             sys,
             "platform",

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -63,12 +63,13 @@ def test_load_libgmt():
     check_libgmt(load_libgmt())
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="run on UNIX platforms only")
 def test_load_libgmt_fails(monkeypatch):
     """
     Test that GMTCLibNotFoundError is raised when GMT's shared library cannot be found.
     """
     with monkeypatch.context() as mpatch:
+        if sys.platform == "win32":
+            mpatch.setattr(ctypes.util, "find_library", lambda name: None)  # noqa: ARG005
         mpatch.setattr(
             sys,
             "platform",


### PR DESCRIPTION
The `test_load_libgmt_fails` test makes sure that `load_libgmt` raises an exception if the gmt library is not found. Previously, the test was disabled on Windows because `find_library` can always find the gmt library in PATH. This PR enables the test on Windows by monkeypatch the return value of the `find_library` function.

Now the test passes on Linux/macOS/Windows.