### PR TITLE
Bump to ruff 0.3.0

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,7 @@
 """
 Sphinx documentation configuration file.
 """
+
 import datetime
 from importlib.metadata import metadata
 

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
     - pip
     # Dev dependencies (style checks)
     - codespell
-    - ruff>=0.2.0
+    - ruff>=0.3.0
     # Dev dependencies (unit testing)
     - matplotlib
     - pytest-cov

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -17,6 +17,7 @@ Here are just a few of the things that PyGMT does well:
     lines, vectors, polygons, and symbols (pre-defined and customized).
   - Generating publication-quality illustrations and making animations.
 """
+
 import atexit as _atexit
 import sys
 from importlib.metadata import version

--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -1,6 +1,7 @@
 """
 GMT accessor for :class:`xarray.DataArray`.
 """
+
 from pathlib import Path
 
 import xarray as xr

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -1,6 +1,7 @@
 """
 Functions to convert data types into ctypes friendly formats.
 """
+
 import warnings
 
 import numpy as np

--- a/pygmt/clib/loading.py
+++ b/pygmt/clib/loading.py
@@ -4,6 +4,7 @@ Utility functions to load libgmt as ctypes.CDLL.
 The path to the shared library can be found automatically by ctypes or set through the
 GMT_LIBRARY_PATH environment variable.
 """
+
 import ctypes
 import os
 import shutil

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -4,6 +4,7 @@ the API functions.
 
 Uses ctypes to wrap most of the core functions from the C API.
 """
+
 import contextlib
 import ctypes as ctp
 import pathlib

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -4,6 +4,7 @@ and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
+
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -4,6 +4,7 @@ and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
+
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -4,6 +4,7 @@ as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
+
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -4,6 +4,7 @@ load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
+
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -4,6 +4,7 @@ Function to download the GSHHG Earth Mask dataset from the GMT data server, and 
 
 The grids are available in various resolutions.
 """
+
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -4,6 +4,7 @@ Function to download the Earth relief datasets from the GMT data server, and loa
 
 The grids are available in various resolutions.
 """
+
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -4,6 +4,7 @@ server, and load as :class:`xarray.DataArray`.
 
 The grids are available in various resolutions.
 """
+
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -1,6 +1,7 @@
 """
 Internal function to load GMT remote datasets.
 """
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar, NamedTuple

--- a/pygmt/datasets/mars_relief.py
+++ b/pygmt/datasets/mars_relief.py
@@ -4,6 +4,7 @@ Function to download the Mars relief dataset from the GMT data server, and load 
 
 The grids are available in various resolutions.
 """
+
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset

--- a/pygmt/datasets/mercury_relief.py
+++ b/pygmt/datasets/mercury_relief.py
@@ -4,6 +4,7 @@ Function to download the Mercury relief dataset from the GMT data server, and lo
 
 The grids are available in various resolutions.
 """
+
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset

--- a/pygmt/datasets/moon_relief.py
+++ b/pygmt/datasets/moon_relief.py
@@ -4,6 +4,7 @@ Function to download the Moon relief dataset from the GMT data server, and load 
 
 The grids are available in various resolutions.
 """
+
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset

--- a/pygmt/datasets/pluto_relief.py
+++ b/pygmt/datasets/pluto_relief.py
@@ -4,6 +4,7 @@ Function to download the Pluto relief dataset from the GMT data server, and load
 
 The grids are available in various resolutions.
 """
+
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -1,6 +1,7 @@
 """
 Functions to load sample data.
 """
+
 from collections.abc import Callable
 from typing import Literal, NamedTuple
 

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -2,6 +2,7 @@
 Function to load raster tile maps from XYZ tile providers, and load as
 :class:`xarray.DataArray`.
 """
+
 from __future__ import annotations
 
 from packaging.version import Version

--- a/pygmt/datasets/venus_relief.py
+++ b/pygmt/datasets/venus_relief.py
@@ -4,6 +4,7 @@ Function to download the Venus relief dataset from the GMT data server, and load
 
 The grids are available in various resolutions.
 """
+
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset

--- a/pygmt/datatypes/__init__.py
+++ b/pygmt/datatypes/__init__.py
@@ -1,5 +1,6 @@
 """
 Wrappers for GMT data types.
 """
+
 from pygmt.datatypes.dataset import _GMT_DATASET
 from pygmt.datatypes.grid import _GMT_GRID

--- a/pygmt/datatypes/dataset.py
+++ b/pygmt/datatypes/dataset.py
@@ -1,6 +1,7 @@
 """
 Wrapper for the GMT_DATASET data type.
 """
+
 import ctypes as ctp
 
 

--- a/pygmt/datatypes/grid.py
+++ b/pygmt/datatypes/grid.py
@@ -1,6 +1,7 @@
 """
 Wrapper for the GMT_GRID data type.
 """
+
 import ctypes as ctp
 
 

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -1,6 +1,7 @@
 """
 Define the Figure class that handles all plotting.
 """
+
 import base64
 import os
 from pathlib import Path

--- a/pygmt/helpers/__init__.py
+++ b/pygmt/helpers/__init__.py
@@ -1,6 +1,7 @@
 """
 Functions, classes, decorators, and context managers to help wrap GMT modules.
 """
+
 from pygmt.helpers.decorators import (
     deprecate_parameter,
     fmt_docstring,

--- a/pygmt/helpers/caching.py
+++ b/pygmt/helpers/caching.py
@@ -1,6 +1,7 @@
 """
 Functions for downloading remote data files to cache.
 """
+
 from pygmt.src import which
 
 

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -5,6 +5,7 @@ Apply them to functions wrapping GMT modules to automate: alias generation for
 arguments, insert common text into docstrings, transform arguments to strings,
 etc.
 """
+
 import functools
 import textwrap
 import warnings
@@ -455,9 +456,9 @@ def fmt_docstring(module_func):
             aliases.append(f"- {arg} = {alias}")
         filler_text["aliases"] = "\n".join(aliases)
 
-    filler_text[
-        "table-like"
-    ] = "numpy.ndarray, pandas.DataFrame, xarray.Dataset, or geopandas.GeoDataFrame"
+    filler_text["table-like"] = (
+        "numpy.ndarray, pandas.DataFrame, xarray.Dataset, or geopandas.GeoDataFrame"
+    )
     filler_text["table-classes"] = (
         ":class:`numpy.ndarray`, a :class:`pandas.DataFrame`, an\n"
         "    :class:`xarray.Dataset` made up of 1-D :class:`xarray.DataArray`\n"

--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -1,6 +1,7 @@
 """
 Utilities for dealing with temporary file management.
 """
+
 import os
 import uuid
 from contextlib import contextmanager

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -1,6 +1,7 @@
 """
 Helper functions for testing.
 """
+
 import importlib
 import inspect
 import os

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -1,6 +1,7 @@
 """
 Utilities and common tasks for wrapping the GMT modules.
 """
+
 # ruff: noqa: RUF001
 import os
 import pathlib

--- a/pygmt/helpers/validators.py
+++ b/pygmt/helpers/validators.py
@@ -1,6 +1,7 @@
 """
 Functions to check if given arguments are valid.
 """
+
 import warnings
 
 from pygmt.exceptions import GMTInvalidInput

--- a/pygmt/io.py
+++ b/pygmt/io.py
@@ -1,6 +1,7 @@
 """
 PyGMT input/output (I/O) utilities.
 """
+
 import xarray as xr
 
 

--- a/pygmt/session_management.py
+++ b/pygmt/session_management.py
@@ -1,6 +1,7 @@
 """
 Modern mode session management modules.
 """
+
 import os
 import sys
 

--- a/pygmt/src/__init__.py
+++ b/pygmt/src/__init__.py
@@ -1,6 +1,7 @@
 """
 Source code for PyGMT methods.
 """
+
 from pygmt.src.basemap import basemap
 from pygmt.src.binstats import binstats
 from pygmt.src.blockm import blockmean, blockmedian, blockmode

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -1,6 +1,7 @@
 """
 binstats - Bin spatial data and determine statistics per bin
 """
+
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -2,6 +2,7 @@
 blockm - Block average (x, y, z) data tables by mean, median, or mode
 estimation.
 """
+
 import pandas as pd
 from pygmt.clib import Session
 from pygmt.helpers import (

--- a/pygmt/src/config.py
+++ b/pygmt/src/config.py
@@ -1,6 +1,7 @@
 """
 config - set GMT defaults globally or locally.
 """
+
 from inspect import Parameter, Signature
 from typing import ClassVar
 

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -1,6 +1,7 @@
 """
 grdcontour - Plot a contour figure.
 """
+
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -1,6 +1,7 @@
 """
 grdimage - Plot grids or images.
 """
+
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -163,11 +164,12 @@ def grdimage(self, grid, **kwargs):
         )
 
     with Session() as lib:
-        with lib.virtualfile_in(
-            check_kind="raster", data=grid
-        ) as fname, lib.virtualfile_in(
-            check_kind="raster", data=kwargs.get("I"), required_data=False
-        ) as shadegrid:
+        with (
+            lib.virtualfile_in(check_kind="raster", data=grid) as fname,
+            lib.virtualfile_in(
+                check_kind="raster", data=kwargs.get("I"), required_data=False
+            ) as shadegrid,
+        ):
             kwargs["I"] = shadegrid
             lib.call_module(
                 module="grdimage", args=build_arg_string(kwargs, infile=fname)

--- a/pygmt/src/grdinfo.py
+++ b/pygmt/src/grdinfo.py
@@ -1,6 +1,7 @@
 """
 grdinfo - Retrieve info about grid file.
 """
+
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -1,6 +1,7 @@
 """
 grdlandmask - Create a "wet-dry" mask grid from shoreline data base
 """
+
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -1,6 +1,7 @@
 """
 grdproject - Forward and inverse map transformation of grids.
 """
+
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -1,6 +1,7 @@
 """
 grdtrack - Sample grids at specified (x,y) locations.
 """
+
 import pandas as pd
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
@@ -292,11 +293,12 @@ def grdtrack(grid, points=None, newcolname=None, outfile=None, **kwargs):
 
     with GMTTempFile(suffix=".csv") as tmpfile:
         with Session() as lib:
-            with lib.virtualfile_in(
-                check_kind="raster", data=grid
-            ) as grdfile, lib.virtualfile_in(
-                check_kind="vector", data=points, required_data=False
-            ) as csvfile:
+            with (
+                lib.virtualfile_in(check_kind="raster", data=grid) as grdfile,
+                lib.virtualfile_in(
+                    check_kind="vector", data=points, required_data=False
+                ) as csvfile,
+            ):
                 kwargs["G"] = grdfile
                 if outfile is None:  # Output to tmpfile if outfile is not set
                     outfile = tmpfile.name

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -1,6 +1,7 @@
 """
 grdview - Create a three-dimensional plot from a grid.
 """
+
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -144,11 +145,12 @@ def grdview(self, grid, **kwargs):
     """
     kwargs = self._preprocess(**kwargs)
     with Session() as lib:
-        with lib.virtualfile_in(
-            check_kind="raster", data=grid
-        ) as fname, lib.virtualfile_in(
-            check_kind="raster", data=kwargs.get("G"), required_data=False
-        ) as drapegrid:
+        with (
+            lib.virtualfile_in(check_kind="raster", data=grid) as fname,
+            lib.virtualfile_in(
+                check_kind="raster", data=kwargs.get("G"), required_data=False
+            ) as drapegrid,
+        ):
             kwargs["G"] = drapegrid
             lib.call_module(
                 module="grdview", args=build_arg_string(kwargs, infile=fname)

--- a/pygmt/src/grdvolume.py
+++ b/pygmt/src/grdvolume.py
@@ -1,6 +1,7 @@
 """
 grdvolume - Calculate grid volume and area constrained by a contour.
 """
+
 import pandas as pd
 from pygmt.clib import Session
 from pygmt.helpers import (

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -1,6 +1,7 @@
 """
 Histogram - Create a histogram
 """
+
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -1,6 +1,7 @@
 """
 image - Plot an image.
 """
+
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -1,6 +1,7 @@
 """
 info - Get information about data tables.
 """
+
 import numpy as np
 from pygmt.clib import Session
 from pygmt.helpers import (

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -1,6 +1,7 @@
 """
 inset - Create inset figures.
 """
+
 import contextlib
 
 from pygmt.clib import Session

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -1,6 +1,7 @@
 """
 makecpt - Make GMT color palette tables.
 """
+
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -1,6 +1,7 @@
 """
 meca - Plot focal mechanisms.
 """
+
 import numpy as np
 import pandas as pd
 from pygmt.clib import Session

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -1,6 +1,7 @@
 """
 plot - Plot in two dimensions.
 """
+
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -1,6 +1,7 @@
 """
 plot3d - Plot in three dimensions.
 """
+
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -1,6 +1,7 @@
 """
 project - Project data onto lines or great circles, or generate tracks.
 """
+
 import pandas as pd
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput

--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -1,6 +1,7 @@
 """
 select - Select data table subsets based on multiple spatial criteria.
 """
+
 import pandas as pd
 from pygmt.clib import Session
 from pygmt.helpers import (

--- a/pygmt/src/shift_origin.py
+++ b/pygmt/src/shift_origin.py
@@ -1,6 +1,7 @@
 """
 shift_origin - Shift plot origin in x and/or y directions.
 """
+
 from __future__ import annotations
 
 from pygmt.clib import Session

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -1,6 +1,7 @@
 """
 solar - Plot day-night terminators and twilight.
 """
+
 from __future__ import annotations
 
 from typing import Literal

--- a/pygmt/src/sph2grd.py
+++ b/pygmt/src/sph2grd.py
@@ -1,6 +1,7 @@
 """
 sph2grd - Compute grid from spherical harmonic coefficients
 """
+
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -2,6 +2,7 @@
 sphdistance - Create Voronoi distance, node,
 or natural nearest-neighbor grid on a sphere
 """
+
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (

--- a/pygmt/src/sphinterpolate.py
+++ b/pygmt/src/sphinterpolate.py
@@ -1,6 +1,7 @@
 """
 sphinterpolate - Spherical gridding in tension of data on a sphere
 """
+
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -1,6 +1,7 @@
 """
 subplot - Manage modern mode figure subplot configuration and selection.
 """
+
 import contextlib
 
 from pygmt.clib import Session

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -2,6 +2,7 @@
 surface - Grid table data using adjustable tension continuous curvature
 splines.
 """
+
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -1,6 +1,7 @@
 """
 ternary - Plot data on ternary diagrams.
 """
+
 import pandas as pd
 from packaging.version import Version
 from pygmt.clib import Session, __gmt_version__

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -1,6 +1,7 @@
 """
 text - Plot text on a figure.
 """
+
 import numpy as np
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -1,6 +1,7 @@
 """
 tilemap - Plot XYZ tile maps.
 """
+
 from __future__ import annotations
 
 from pygmt.clib import Session

--- a/pygmt/src/timestamp.py
+++ b/pygmt/src/timestamp.py
@@ -1,6 +1,7 @@
 """
 timestamp - Plot the GMT timestamp logo.
 """
+
 from __future__ import annotations
 
 import warnings

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -1,6 +1,7 @@
 """
 velo - Plot velocity vectors, crosses, anisotropy bars, and wedges.
 """
+
 import numpy as np
 import pandas as pd
 from pygmt.clib import Session

--- a/pygmt/src/which.py
+++ b/pygmt/src/which.py
@@ -1,6 +1,7 @@
 """
 which - Find the full path to specified files.
 """
+
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,

--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -1,6 +1,7 @@
 """
 x2sys_cross - Calculate crossovers between track data files.
 """
+
 import contextlib
 import os
 from pathlib import Path

--- a/pygmt/src/x2sys_init.py
+++ b/pygmt/src/x2sys_init.py
@@ -1,6 +1,7 @@
 """
 x2sys_init - Initialize a new x2sys track database.
 """
+
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_string, fmt_docstring, kwargs_to_strings, use_alias
 

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -1,6 +1,7 @@
 """
 xyz2grd - Convert data table to a grid.
 """
+
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (

--- a/pygmt/tests/test_accessor.py
+++ b/pygmt/tests/test_accessor.py
@@ -1,6 +1,7 @@
 """
 Test the behaviour of the GMTDataArrayAccessor class.
 """
+
 import os
 import sys
 from pathlib import Path

--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -1,6 +1,7 @@
 """
 Test Figure.basemap.
 """
+
 import pytest
 from pygmt import Figure
 

--- a/pygmt/tests/test_binstats.py
+++ b/pygmt/tests/test_binstats.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.binstats.
 """
+
 from pathlib import Path
 
 import numpy.testing as npt

--- a/pygmt/tests/test_blockm.py
+++ b/pygmt/tests/test_blockm.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.blockmean and pygmt.blockmode.
 """
+
 from pathlib import Path
 
 import numpy as np

--- a/pygmt/tests/test_blockmedian.py
+++ b/pygmt/tests/test_blockmedian.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.blockmedian.
 """
+
 from pathlib import Path
 
 import numpy.testing as npt

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -1,6 +1,7 @@
 """
 Test the wrappers for the C API.
 """
+
 import os
 from contextlib import contextmanager
 from pathlib import Path

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -1,6 +1,7 @@
 """
 Test the functions that load libgmt.
 """
+
 import ctypes
 import os
 import shutil

--- a/pygmt/tests/test_clib_put_matrix.py
+++ b/pygmt/tests/test_clib_put_matrix.py
@@ -1,6 +1,7 @@
 """
 Test the functions that put matrix data into GMT.
 """
+
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/pygmt/tests/test_clib_put_strings.py
+++ b/pygmt/tests/test_clib_put_strings.py
@@ -1,6 +1,7 @@
 """
 Test the functions that put string data into GMT.
 """
+
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/pygmt/tests/test_clib_put_vector.py
+++ b/pygmt/tests/test_clib_put_vector.py
@@ -1,6 +1,7 @@
 """
 Test the functions that put vector data into GMT.
 """
+
 import datetime
 import itertools
 

--- a/pygmt/tests/test_clib_virtualfiles.py
+++ b/pygmt/tests/test_clib_virtualfiles.py
@@ -1,6 +1,7 @@
 """
 Test the C API functions related to virtual files.
 """
+
 import os
 from importlib.util import find_spec
 from itertools import product
@@ -99,8 +100,10 @@ def test_virtual_file_fails():
     # Test the status check when closing the virtual file
     # Mock the opening to return 0 (success) so that we don't open a file that
     # we won't close later.
-    with clib.Session() as lib, mock(lib, "GMT_Open_VirtualFile", returns=0), mock(
-        lib, "GMT_Close_VirtualFile", returns=1
+    with (
+        clib.Session() as lib,
+        mock(lib, "GMT_Open_VirtualFile", returns=0),
+        mock(lib, "GMT_Close_VirtualFile", returns=1),
     ):
         with pytest.raises(GMTCLibError):
             with lib.open_virtualfile(*vfargs):

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -1,6 +1,7 @@
 """
 Test Figure.coast.
 """
+
 import pytest
 from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput

--- a/pygmt/tests/test_colorbar.py
+++ b/pygmt/tests/test_colorbar.py
@@ -1,6 +1,7 @@
 """
 Test Figure.colorbar.
 """
+
 import pytest
 from pygmt import Figure
 

--- a/pygmt/tests/test_config.py
+++ b/pygmt/tests/test_config.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.config.
 """
+
 import pytest
 from pygmt import Figure, config
 

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -1,6 +1,7 @@
 """
 Test Figure.contour.
 """
+
 import os
 
 import numpy as np

--- a/pygmt/tests/test_datasets_earth_age.py
+++ b/pygmt/tests/test_datasets_earth_age.py
@@ -1,6 +1,7 @@
 """
 Test basic functionality for loading Earth seafloor crust age datasets.
 """
+
 import numpy as np
 import numpy.testing as npt
 from pygmt.datasets import load_earth_age

--- a/pygmt/tests/test_datasets_earth_free_air_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_free_air_anomaly.py
@@ -1,6 +1,7 @@
 """
 Test basic functionality for loading Earth free air anomaly datasets.
 """
+
 import numpy as np
 import numpy.testing as npt
 from pygmt.datasets import load_earth_free_air_anomaly

--- a/pygmt/tests/test_datasets_earth_geoid.py
+++ b/pygmt/tests/test_datasets_earth_geoid.py
@@ -1,6 +1,7 @@
 """
 Test basic functionality for loading Earth geoid datasets.
 """
+
 import numpy as np
 import numpy.testing as npt
 from pygmt.datasets import load_earth_geoid

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -1,6 +1,7 @@
 """
 Test basic functionality for loading Earth magnetic anomaly datasets.
 """
+
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/pygmt/tests/test_datasets_earth_mask.py
+++ b/pygmt/tests/test_datasets_earth_mask.py
@@ -1,6 +1,7 @@
 """
 Test basic functionality for loading Earth mask datasets.
 """
+
 import numpy as np
 import numpy.testing as npt
 from pygmt.datasets import load_earth_mask

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -1,6 +1,7 @@
 """
 Test basic functionality for loading Earth relief datasets.
 """
+
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
+++ b/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
@@ -1,6 +1,7 @@
 """
 Test basic functionality for loading Earth vertical gravity gradient datasets.
 """
+
 import numpy as np
 import numpy.testing as npt
 from pygmt.datasets import load_earth_vertical_gravity_gradient

--- a/pygmt/tests/test_datasets_load_remote_datasets.py
+++ b/pygmt/tests/test_datasets_load_remote_datasets.py
@@ -1,6 +1,7 @@
 """
 Test the _load_remote_dataset function.
 """
+
 import pytest
 from packaging.version import Version
 from pygmt.clib import __gmt_version__

--- a/pygmt/tests/test_datasets_mars_relief.py
+++ b/pygmt/tests/test_datasets_mars_relief.py
@@ -1,6 +1,7 @@
 """
 Test basic functionality for loading Mars relief datasets.
 """
+
 import numpy as np
 import numpy.testing as npt
 from pygmt.datasets import load_mars_relief

--- a/pygmt/tests/test_datasets_mercury_relief.py
+++ b/pygmt/tests/test_datasets_mercury_relief.py
@@ -1,6 +1,7 @@
 """
 Test basic functionality for loading Mercury relief datasets.
 """
+
 import numpy as np
 import numpy.testing as npt
 from pygmt.datasets import load_mercury_relief

--- a/pygmt/tests/test_datasets_moon_relief.py
+++ b/pygmt/tests/test_datasets_moon_relief.py
@@ -1,6 +1,7 @@
 """
 Test basic functionality for loading Moon relief datasets.
 """
+
 import numpy as np
 import numpy.testing as npt
 from pygmt.datasets import load_moon_relief

--- a/pygmt/tests/test_datasets_pluto_relief.py
+++ b/pygmt/tests/test_datasets_pluto_relief.py
@@ -1,6 +1,7 @@
 """
 Test basic functionality for loading Pluto relief datasets.
 """
+
 import numpy as np
 import numpy.testing as npt
 from pygmt.datasets import load_pluto_relief

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -1,6 +1,7 @@
 """
 Test basic functionality for loading sample datasets.
 """
+
 import numpy.testing as npt
 import pandas as pd
 import pytest

--- a/pygmt/tests/test_datasets_venus_relief.py
+++ b/pygmt/tests/test_datasets_venus_relief.py
@@ -1,6 +1,7 @@
 """
 Test basic functionality for loading Venus relief datasets.
 """
+
 import numpy as np
 import numpy.testing as npt
 from pygmt.datasets import load_venus_relief

--- a/pygmt/tests/test_dimfilter.py
+++ b/pygmt/tests/test_dimfilter.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.dimfilter.
 """
+
 from pathlib import Path
 
 import pytest

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -3,6 +3,7 @@ Test the behavior of the Figure class.
 
 Doesn't include the plotting commands which have their own test files.
 """
+
 import importlib
 import os
 from pathlib import Path

--- a/pygmt/tests/test_filter1d.py
+++ b/pygmt/tests/test_filter1d.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.filter1d.
 """
+
 from pathlib import Path
 
 import numpy as np

--- a/pygmt/tests/test_geopandas.py
+++ b/pygmt/tests/test_geopandas.py
@@ -1,6 +1,7 @@
 """
 Test integration with geopandas.
 """
+
 import numpy.testing as npt
 import pandas as pd
 import pytest

--- a/pygmt/tests/test_grd2cpt.py
+++ b/pygmt/tests/test_grd2cpt.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.grd2cpt.
 """
+
 import os
 
 import pytest

--- a/pygmt/tests/test_grd2xyz.py
+++ b/pygmt/tests/test_grd2xyz.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.grd2xyz.
 """
+
 from pathlib import Path
 
 import numpy as np

--- a/pygmt/tests/test_grdclip.py
+++ b/pygmt/tests/test_grdclip.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.grdclip.
 """
+
 from pathlib import Path
 
 import pytest

--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -1,6 +1,7 @@
 """
 Test Figure.grdcontour.
 """
+
 import os
 
 import numpy as np

--- a/pygmt/tests/test_grdcut.py
+++ b/pygmt/tests/test_grdcut.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.grdcut.
 """
+
 import numpy as np
 import pytest
 import xarray as xr

--- a/pygmt/tests/test_grdfill.py
+++ b/pygmt/tests/test_grdfill.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.grdfill.
 """
+
 from pathlib import Path
 
 import numpy as np

--- a/pygmt/tests/test_grdfilter.py
+++ b/pygmt/tests/test_grdfilter.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.grdfilter.
 """
+
 from pathlib import Path
 
 import numpy as np

--- a/pygmt/tests/test_grdgradient.py
+++ b/pygmt/tests/test_grdgradient.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.grdgradient.
 """
+
 from pathlib import Path
 
 import pytest

--- a/pygmt/tests/test_grdhisteq.py
+++ b/pygmt/tests/test_grdhisteq.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.grdhisteq.
 """
+
 from pathlib import Path
 
 import numpy as np

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -1,6 +1,7 @@
 """
 Test Figure.grdimage.
 """
+
 import numpy as np
 import pytest
 import xarray as xr

--- a/pygmt/tests/test_grdimage_image.py
+++ b/pygmt/tests/test_grdimage_image.py
@@ -1,6 +1,7 @@
 """
 Test Figure.grdimage on 3-band RGB images.
 """
+
 import pytest
 from pygmt import Figure, which
 

--- a/pygmt/tests/test_grdinfo.py
+++ b/pygmt/tests/test_grdinfo.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.grdinfo.
 """
+
 import numpy as np
 import pytest
 from pygmt import grdinfo

--- a/pygmt/tests/test_grdlandmask.py
+++ b/pygmt/tests/test_grdlandmask.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.grdlandmask.
 """
+
 from pathlib import Path
 
 import pytest

--- a/pygmt/tests/test_grdproject.py
+++ b/pygmt/tests/test_grdproject.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.grdproject.
 """
+
 from pathlib import Path
 
 import pytest

--- a/pygmt/tests/test_grdsample.py
+++ b/pygmt/tests/test_grdsample.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.grdsample.
 """
+
 from pathlib import Path
 
 import pytest

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.grdtrack.
 """
+
 import os
 from pathlib import Path
 

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -1,6 +1,7 @@
 """
 Test Figure.grdview.
 """
+
 import pytest
 from pygmt import Figure, grdcut
 from pygmt.exceptions import GMTInvalidInput

--- a/pygmt/tests/test_grdvolume.py
+++ b/pygmt/tests/test_grdvolume.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.grdvolume.
 """
+
 from pathlib import Path
 
 import numpy as np

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -1,6 +1,7 @@
 """
 Test the helper functions/classes/etc used in wrapping GMT.
 """
+
 import os
 
 import numpy as np

--- a/pygmt/tests/test_histogram.py
+++ b/pygmt/tests/test_histogram.py
@@ -1,6 +1,7 @@
 """
 Test Figure.histogram.
 """
+
 import pandas as pd
 import pytest
 from pygmt import Figure

--- a/pygmt/tests/test_image.py
+++ b/pygmt/tests/test_image.py
@@ -1,6 +1,7 @@
 """
 Test Figure.image.
 """
+
 import pytest
 from pygmt import Figure
 

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.info.
 """
+
 import os
 import pathlib
 import sys

--- a/pygmt/tests/test_init.py
+++ b/pygmt/tests/test_init.py
@@ -1,6 +1,7 @@
 """
 Test functions in __init__.
 """
+
 import io
 
 import pygmt

--- a/pygmt/tests/test_inset.py
+++ b/pygmt/tests/test_inset.py
@@ -1,6 +1,7 @@
 """
 Test Figure.inset.
 """
+
 import pytest
 from pygmt import Figure
 

--- a/pygmt/tests/test_io.py
+++ b/pygmt/tests/test_io.py
@@ -1,6 +1,7 @@
 """
 Test input/output (I/O) utilities.
 """
+
 import numpy as np
 import pytest
 import xarray as xr

--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -1,6 +1,7 @@
 """
 Test Figure.legend.
 """
+
 import pytest
 from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput

--- a/pygmt/tests/test_logo.py
+++ b/pygmt/tests/test_logo.py
@@ -1,6 +1,7 @@
 """
 Test Figure.logo.
 """
+
 import pytest
 from pygmt import Figure
 

--- a/pygmt/tests/test_makecpt.py
+++ b/pygmt/tests/test_makecpt.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.makecpt.
 """
+
 import os
 from pathlib import Path
 

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -1,6 +1,7 @@
 """
 Test Figure.meca.
 """
+
 import numpy as np
 import pandas as pd
 import pytest

--- a/pygmt/tests/test_nearneighbor.py
+++ b/pygmt/tests/test_nearneighbor.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.nearneighbor.
 """
+
 from pathlib import Path
 
 import numpy as np

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -1,6 +1,7 @@
 """
 Test Figure.plot.
 """
+
 import datetime
 import os
 from pathlib import Path

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -1,6 +1,7 @@
 """
 Test Figure.plot3d.
 """
+
 import os
 from pathlib import Path
 

--- a/pygmt/tests/test_project.py
+++ b/pygmt/tests/test_project.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.project.
 """
+
 from pathlib import Path
 
 import numpy as np

--- a/pygmt/tests/test_psconvert.py
+++ b/pygmt/tests/test_psconvert.py
@@ -1,6 +1,7 @@
 """
 Test Figure.psconvert.
 """
+
 import os
 
 import pytest

--- a/pygmt/tests/test_rose.py
+++ b/pygmt/tests/test_rose.py
@@ -1,6 +1,7 @@
 """
 Test Figure.rose.
 """
+
 import numpy as np
 import pytest
 from pygmt import Figure

--- a/pygmt/tests/test_select.py
+++ b/pygmt/tests/test_select.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.select.
 """
+
 from pathlib import Path
 
 import numpy.testing as npt

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -1,6 +1,7 @@
 """
 Test the session management modules.
 """
+
 import multiprocessing as mp
 import os
 from importlib import reload

--- a/pygmt/tests/test_solar.py
+++ b/pygmt/tests/test_solar.py
@@ -1,6 +1,7 @@
 """
 Test Figure.solar.
 """
+
 import datetime
 
 import pytest

--- a/pygmt/tests/test_sph2grd.py
+++ b/pygmt/tests/test_sph2grd.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.sph2grd.
 """
+
 from pathlib import Path
 
 import numpy.testing as npt

--- a/pygmt/tests/test_sphdistance.py
+++ b/pygmt/tests/test_sphdistance.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.sphdistance.
 """
+
 from pathlib import Path
 
 import numpy as np

--- a/pygmt/tests/test_sphinterpolate.py
+++ b/pygmt/tests/test_sphinterpolate.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.sphinterpolate.
 """
+
 from pathlib import Path
 
 import numpy.testing as npt

--- a/pygmt/tests/test_sphinx_gallery.py
+++ b/pygmt/tests/test_sphinx_gallery.py
@@ -1,6 +1,7 @@
 """
 Test the sphinx-gallery scraper and code required to make it work.
 """
+
 import os
 from tempfile import TemporaryDirectory
 

--- a/pygmt/tests/test_subplot.py
+++ b/pygmt/tests/test_subplot.py
@@ -1,6 +1,7 @@
 """
 Test Figure.subplot.
 """
+
 import pytest
 from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.surface.
 """
+
 from pathlib import Path
 
 import pandas as pd

--- a/pygmt/tests/test_ternary.py
+++ b/pygmt/tests/test_ternary.py
@@ -1,6 +1,7 @@
 """
 Test Figure.ternary.
 """
+
 import numpy as np
 import pytest
 from pygmt import Figure

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -1,6 +1,7 @@
 """
 Test Figure.text.
 """
+
 import os
 
 import numpy as np

--- a/pygmt/tests/test_tilemap.py
+++ b/pygmt/tests/test_tilemap.py
@@ -1,6 +1,7 @@
 """
 Test Figure.tilemap.
 """
+
 import pytest
 from pygmt import Figure
 

--- a/pygmt/tests/test_timestamp.py
+++ b/pygmt/tests/test_timestamp.py
@@ -1,6 +1,7 @@
 """
 Test Figure.timestamp.
 """
+
 import pytest
 from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput

--- a/pygmt/tests/test_triangulate.py
+++ b/pygmt/tests/test_triangulate.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.triangulate.
 """
+
 from pathlib import Path
 
 import numpy as np

--- a/pygmt/tests/test_velo.py
+++ b/pygmt/tests/test_velo.py
@@ -1,6 +1,7 @@
 """
 Test Figure.velo.
 """
+
 import pandas as pd
 import pytest
 from pygmt import Figure

--- a/pygmt/tests/test_which.py
+++ b/pygmt/tests/test_which.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.which.
 """
+
 from pathlib import Path
 
 import pytest

--- a/pygmt/tests/test_wiggle.py
+++ b/pygmt/tests/test_wiggle.py
@@ -1,6 +1,7 @@
 """
 Test Figure.wiggle.
 """
+
 import numpy as np
 import pytest
 from pygmt import Figure

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.x2sys_cross.
 """
+
 import copy
 import os
 from pathlib import Path

--- a/pygmt/tests/test_x2sys_init.py
+++ b/pygmt/tests/test_x2sys_init.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.x2sys_init.
 """
+
 import os
 from tempfile import TemporaryDirectory
 

--- a/pygmt/tests/test_xyz2grd.py
+++ b/pygmt/tests/test_xyz2grd.py
@@ -1,6 +1,7 @@
 """
 Test pygmt.xyz2grd.
 """
+
 from pathlib import Path
 
 import numpy as np


### PR DESCRIPTION
[ruff v0.3.0](https://github.com/astral-sh/ruff/releases/tag/v0.3.0) was released a few hours ago. This PR formats the source codes with ruff 0.3.0. The changes are caused by two ruff changes:

1. Add a blank line after the module docstring (https://github.com/astral-sh/ruff/pull/8283)
2. Wrap multiple context managers in with parentheses when targeting Python 3.9 or newer (https://github.com/astral-sh/ruff/pull/9222)