### PR TITLE
Use consistent names (vintbl and vingrd) for input virtual files

### DIFF
--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -112,12 +112,11 @@ def binstats(data, **kwargs):
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="vector", data=data)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
-                    module="binstats", args=build_arg_string(kwargs, infile=infile)
+                    module="binstats", args=build_arg_string(kwargs, infile=vintbl)
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -44,16 +44,15 @@ def _blockm(block_method, data, x, y, z, outfile, **kwargs):
     """
     with GMTTempFile(suffix=".csv") as tmpfile:
         with Session() as lib:
-            table_context = lib.virtualfile_in(
+            with lib.virtualfile_in(
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
-            )
-            # Run blockm* on data table
-            with table_context as infile:
+            ) as vintbl:
+                # Run blockm* on data table
                 if outfile is None:
                     outfile = tmpfile.name
                 lib.call_module(
                     module=block_method,
-                    args=build_arg_string(kwargs, infile=infile, outfile=outfile),
+                    args=build_arg_string(kwargs, infile=vintbl, outfile=outfile),
                 )
 
         # Read temporary csv output to a pandas table

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -115,10 +115,9 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
     kwargs = self._preprocess(**kwargs)
 
     with Session() as lib:
-        file_context = lib.virtualfile_in(
+        with lib.virtualfile_in(
             check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
-        )
-        with file_context as fname:
+        ) as vintbl:
             lib.call_module(
-                module="contour", args=build_arg_string(kwargs, infile=fname)
+                module="contour", args=build_arg_string(kwargs, infile=vintbl)
             )

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -151,12 +151,11 @@ def dimfilter(grid, **kwargs):
 
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="raster", data=grid)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
-                    module="dimfilter", args=build_arg_string(kwargs, infile=infile)
+                    module="dimfilter", args=build_arg_string(kwargs, infile=vingrd)
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/filter1d.py
+++ b/pygmt/src/filter1d.py
@@ -119,13 +119,12 @@ def filter1d(data, output_type="pandas", outfile=None, **kwargs):
 
     with GMTTempFile() as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="vector", data=data)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
                 if outfile is None:
                     outfile = tmpfile.name
                 lib.call_module(
                     module="filter1d",
-                    args=build_arg_string(kwargs, infile=infile, outfile=outfile),
+                    args=build_arg_string(kwargs, infile=vintbl, outfile=outfile),
                 )
 
         # Read temporary csv output to a pandas table

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -184,13 +184,12 @@ def grd2cpt(grid, **kwargs):
     if kwargs.get("W") is not None and kwargs.get("Ww") is not None:
         raise GMTInvalidInput("Set only categorical or cyclic to True, not both.")
     with Session() as lib:
-        file_context = lib.virtualfile_in(check_kind="raster", data=grid)
-        with file_context as infile:
+        with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
             if kwargs.get("H") is None:  # if no output is set
-                arg_str = build_arg_string(kwargs, infile=infile)
+                arg_str = build_arg_string(kwargs, infile=vingrd)
             else:  # if output is set
                 outfile, kwargs["H"] = kwargs["H"], True
                 if not outfile or not isinstance(outfile, str):
                     raise GMTInvalidInput("'output' should be a proper file name.")
-                arg_str = build_arg_string(kwargs, infile=infile, outfile=outfile)
+                arg_str = build_arg_string(kwargs, infile=vingrd, outfile=outfile)
             lib.call_module(module="grd2cpt", args=arg_str)

--- a/pygmt/src/grd2xyz.py
+++ b/pygmt/src/grd2xyz.py
@@ -158,13 +158,12 @@ def grd2xyz(grid, output_type="pandas", outfile=None, **kwargs):
 
     with GMTTempFile() as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="raster", data=grid)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
                 if outfile is None:
                     outfile = tmpfile.name
                 lib.call_module(
                     module="grd2xyz",
-                    args=build_arg_string(kwargs, infile=infile, outfile=outfile),
+                    args=build_arg_string(kwargs, infile=vingrd, outfile=outfile),
                 )
 
         # Read temporary csv output to a pandas table

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -97,12 +97,11 @@ def grdclip(grid, **kwargs):
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="raster", data=grid)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
-                    module="grdclip", args=build_arg_string(kwargs, infile=infile)
+                    module="grdclip", args=build_arg_string(kwargs, infile=vingrd)
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -123,8 +123,7 @@ def grdcontour(self, grid, **kwargs):
     """
     kwargs = self._preprocess(**kwargs)
     with Session() as lib:
-        file_context = lib.virtualfile_in(check_kind="raster", data=grid)
-        with file_context as fname:
+        with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
             lib.call_module(
-                module="grdcontour", args=build_arg_string(kwargs, infile=fname)
+                module="grdcontour", args=build_arg_string(kwargs, infile=vingrd)
             )

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -101,12 +101,11 @@ def grdcut(grid, **kwargs):
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="raster", data=grid)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
-                    module="grdcut", args=build_arg_string(kwargs, infile=infile)
+                    module="grdcut", args=build_arg_string(kwargs, infile=vingrd)
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -79,12 +79,11 @@ def grdfill(grid, **kwargs):
         raise GMTInvalidInput("At least parameter 'mode' or 'L' must be specified.")
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="raster", data=grid)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
-                    module="grdfill", args=build_arg_string(kwargs, infile=infile)
+                    module="grdfill", args=build_arg_string(kwargs, infile=vingrd)
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -134,12 +134,11 @@ def grdfilter(grid, **kwargs):
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="raster", data=grid)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
-                    module="grdfilter", args=build_arg_string(kwargs, infile=infile)
+                    module="grdfilter", args=build_arg_string(kwargs, infile=vingrd)
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -169,12 +169,11 @@ def grdgradient(grid, **kwargs):
                 azimuth, direction, or radiance"""
             )
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="raster", data=grid)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
-                    module="grdgradient", args=build_arg_string(kwargs, infile=infile)
+                    module="grdgradient", args=build_arg_string(kwargs, infile=vingrd)
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -165,12 +165,12 @@ def grdimage(self, grid, **kwargs):
 
     with Session() as lib:
         with (
-            lib.virtualfile_in(check_kind="raster", data=grid) as fname,
+            lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
             lib.virtualfile_in(
                 check_kind="raster", data=kwargs.get("I"), required_data=False
-            ) as shadegrid,
+            ) as vshadegrid,
         ):
-            kwargs["I"] = shadegrid
+            kwargs["I"] = vshadegrid
             lib.call_module(
-                module="grdimage", args=build_arg_string(kwargs, infile=fname)
+                module="grdimage", args=build_arg_string(kwargs, infile=vingrd)
             )

--- a/pygmt/src/grdinfo.py
+++ b/pygmt/src/grdinfo.py
@@ -112,11 +112,10 @@ def grdinfo(grid, **kwargs):
     """
     with GMTTempFile() as outfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="raster", data=grid)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
                 lib.call_module(
                     module="grdinfo",
-                    args=build_arg_string(kwargs, infile=infile, outfile=outfile.name),
+                    args=build_arg_string(kwargs, infile=vingrd, outfile=outfile.name),
                 )
         result = outfile.read()
     return result

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -113,12 +113,11 @@ def grdproject(grid, **kwargs):
         raise GMTInvalidInput("The projection must be specified.")
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="raster", data=grid)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
-                    module="grdproject", args=build_arg_string(kwargs, infile=infile)
+                    module="grdproject", args=build_arg_string(kwargs, infile=vingrd)
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -89,12 +89,11 @@ def grdsample(grid, **kwargs):
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="raster", data=grid)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
-                    module="grdsample", args=build_arg_string(kwargs, infile=infile)
+                    module="grdsample", args=build_arg_string(kwargs, infile=vingrd)
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -294,17 +294,17 @@ def grdtrack(grid, points=None, newcolname=None, outfile=None, **kwargs):
     with GMTTempFile(suffix=".csv") as tmpfile:
         with Session() as lib:
             with (
-                lib.virtualfile_in(check_kind="raster", data=grid) as grdfile,
+                lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
                 lib.virtualfile_in(
                     check_kind="vector", data=points, required_data=False
-                ) as csvfile,
+                ) as vintbl,
             ):
-                kwargs["G"] = grdfile
+                kwargs["G"] = vingrd
                 if outfile is None:  # Output to tmpfile if outfile is not set
                     outfile = tmpfile.name
                 lib.call_module(
                     module="grdtrack",
-                    args=build_arg_string(kwargs, infile=csvfile, outfile=outfile),
+                    args=build_arg_string(kwargs, infile=vintbl, outfile=outfile),
                 )
 
         # Read temporary csv output to a pandas table

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -146,12 +146,12 @@ def grdview(self, grid, **kwargs):
     kwargs = self._preprocess(**kwargs)
     with Session() as lib:
         with (
-            lib.virtualfile_in(check_kind="raster", data=grid) as fname,
+            lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
             lib.virtualfile_in(
                 check_kind="raster", data=kwargs.get("G"), required_data=False
-            ) as drapegrid,
+            ) as vdrapegrid,
         ):
-            kwargs["G"] = drapegrid
+            kwargs["G"] = vdrapegrid
             lib.call_module(
-                module="grdview", args=build_arg_string(kwargs, infile=fname)
+                module="grdview", args=build_arg_string(kwargs, infile=vingrd)
             )

--- a/pygmt/src/grdvolume.py
+++ b/pygmt/src/grdvolume.py
@@ -105,13 +105,12 @@ def grdvolume(grid, output_type="pandas", outfile=None, **kwargs):
 
     with GMTTempFile() as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="raster", data=grid)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
                 if outfile is None:
                     outfile = tmpfile.name
                 lib.call_module(
                     module="grdvolume",
-                    args=build_arg_string(kwargs, infile=infile, outfile=outfile),
+                    args=build_arg_string(kwargs, infile=vingrd, outfile=outfile),
                 )
 
         # Read temporary csv output to a pandas table

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -135,8 +135,7 @@ def histogram(self, data, **kwargs):
     """
     kwargs = self._preprocess(**kwargs)
     with Session() as lib:
-        file_context = lib.virtualfile_in(check_kind="vector", data=data)
-        with file_context as infile:
+        with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
             lib.call_module(
-                module="histogram", args=build_arg_string(kwargs, infile=infile)
+                module="histogram", args=build_arg_string(kwargs, infile=vintbl)
             )

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -81,12 +81,11 @@ def info(data, **kwargs):
         - str if none of the above parameters are used.
     """
     with Session() as lib:
-        file_context = lib.virtualfile_in(check_kind="vector", data=data)
         with GMTTempFile() as tmpfile:
-            with file_context as fname:
+            with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
                 lib.call_module(
                     module="info",
-                    args=build_arg_string(kwargs, infile=fname, outfile=tmpfile.name),
+                    args=build_arg_string(kwargs, infile=vintbl, outfile=tmpfile.name),
                 )
             result = tmpfile.read()
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -489,6 +489,5 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
     # Assemble -S flag
     kwargs["S"] = f"{data_format}{scale}"
     with Session() as lib:
-        file_context = lib.virtualfile_in(check_kind="vector", data=spec)
-        with file_context as fname:
-            lib.call_module(module="meca", args=build_arg_string(kwargs, infile=fname))
+        with lib.virtualfile_in(check_kind="vector", data=spec) as vintbl:
+            lib.call_module(module="meca", args=build_arg_string(kwargs, infile=vintbl))

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -145,14 +145,13 @@ def nearneighbor(data=None, x=None, y=None, z=None, **kwargs):
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            table_context = lib.virtualfile_in(
+            with lib.virtualfile_in(
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
-            )
-            with table_context as infile:
+            ) as vintbl:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
-                    module="nearneighbor", args=build_arg_string(kwargs, infile=infile)
+                    module="nearneighbor", args=build_arg_string(kwargs, infile=vintbl)
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -251,9 +251,7 @@ def plot(  # noqa: PLR0912
             kwargs[flag] = ""
 
     with Session() as lib:
-        file_context = lib.virtualfile_in(
+        with lib.virtualfile_in(
             check_kind="vector", data=data, x=x, y=y, extra_arrays=extra_arrays
-        )
-
-        with file_context as fname:
-            lib.call_module(module="plot", args=build_arg_string(kwargs, infile=fname))
+        ) as vintbl:
+            lib.call_module(module="plot", args=build_arg_string(kwargs, infile=vintbl))

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -226,7 +226,7 @@ def plot3d(  # noqa: PLR0912
             kwargs[flag] = ""
 
     with Session() as lib:
-        file_context = lib.virtualfile_in(
+        with lib.virtualfile_in(
             check_kind="vector",
             data=data,
             x=x,
@@ -234,9 +234,7 @@ def plot3d(  # noqa: PLR0912
             z=z,
             extra_arrays=extra_arrays,
             required_z=True,
-        )
-
-        with file_context as fname:
+        ) as vintbl:
             lib.call_module(
-                module="plot3d", args=build_arg_string(kwargs, infile=fname)
+                module="plot3d", args=build_arg_string(kwargs, infile=vintbl)
             )

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -228,13 +228,11 @@ def project(data=None, x=None, y=None, z=None, outfile=None, **kwargs):
             outfile = tmpfile.name
         with Session() as lib:
             if kwargs.get("G") is None:
-                table_context = lib.virtualfile_in(
+                with lib.virtualfile_in(
                     check_kind="vector", data=data, x=x, y=y, z=z, required_z=False
-                )
-
-                # Run project on the temporary (csv) data table
-                with table_context as infile:
-                    arg_str = build_arg_string(kwargs, infile=infile, outfile=outfile)
+                ) as vintbl:
+                    # Run project on the temporary (csv) data table
+                    arg_str = build_arg_string(kwargs, infile=vintbl, outfile=outfile)
             else:
                 arg_str = build_arg_string(kwargs, outfile=outfile)
             lib.call_module(module="project", args=arg_str)

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -200,9 +200,7 @@ def rose(self, data=None, length=None, azimuth=None, **kwargs):
     kwargs = self._preprocess(**kwargs)
 
     with Session() as lib:
-        file_context = lib.virtualfile_in(
+        with lib.virtualfile_in(
             check_kind="vector", data=data, x=length, y=azimuth
-        )
-
-        with file_context as fname:
-            lib.call_module(module="rose", args=build_arg_string(kwargs, infile=fname))
+        ) as vintbl:
+            lib.call_module(module="rose", args=build_arg_string(kwargs, infile=vintbl))

--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -199,13 +199,12 @@ def select(data=None, outfile=None, **kwargs):
 
     with GMTTempFile(suffix=".csv") as tmpfile:
         with Session() as lib:
-            table_context = lib.virtualfile_in(check_kind="vector", data=data)
-            with table_context as infile:
+            with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
                 if outfile is None:
                     outfile = tmpfile.name
                 lib.call_module(
                     module="select",
-                    args=build_arg_string(kwargs, infile=infile, outfile=outfile),
+                    args=build_arg_string(kwargs, infile=vintbl, outfile=outfile),
                 )
 
         # Read temporary csv output to a pandas table

--- a/pygmt/src/sph2grd.py
+++ b/pygmt/src/sph2grd.py
@@ -74,12 +74,11 @@ def sph2grd(data, **kwargs):
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="vector", data=data)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
-                    module="sph2grd", args=build_arg_string(kwargs, infile=infile)
+                    module="sph2grd", args=build_arg_string(kwargs, infile=vintbl)
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -118,12 +118,11 @@ def sphdistance(data=None, x=None, y=None, **kwargs):
         raise GMTInvalidInput("Both 'region' and 'spacing' must be specified.")
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="vector", data=data, x=x, y=y)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="vector", data=data, x=x, y=y) as vintbl:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
-                    module="sphdistance", args=build_arg_string(kwargs, infile=infile)
+                    module="sphdistance", args=build_arg_string(kwargs, infile=vintbl)
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/sphinterpolate.py
+++ b/pygmt/src/sphinterpolate.py
@@ -68,13 +68,12 @@ def sphinterpolate(data, **kwargs):
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(check_kind="vector", data=data)
-            with file_context as infile:
+            with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
                     module="sphinterpolate",
-                    args=build_arg_string(kwargs, infile=infile),
+                    args=build_arg_string(kwargs, infile=vintbl),
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -160,14 +160,13 @@ def surface(data=None, x=None, y=None, z=None, **kwargs):
     """
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(
+            with lib.virtualfile_in(
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
-            )
-            with file_context as infile:
+            ) as vintbl:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
-                    module="surface", args=build_arg_string(kwargs, infile=infile)
+                    module="surface", args=build_arg_string(kwargs, infile=vintbl)
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -87,9 +87,8 @@ def ternary(self, data, alabel=None, blabel=None, clabel=None, **kwargs):
         data = data.to_numpy()
 
     with Session() as lib:
-        file_context = lib.virtualfile_in(check_kind="vector", data=data)
-        with file_context as infile:
+        with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
             lib.call_module(
                 module="ternary",
-                args=build_arg_string(kwargs, infile=infile),
+                args=build_arg_string(kwargs, infile=vintbl),
             )

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -237,8 +237,7 @@ def text_(  # noqa: PLR0912
         )
 
     with Session() as lib:
-        file_context = lib.virtualfile_in(
+        with lib.virtualfile_in(
             check_kind="vector", data=textfiles, x=x, y=y, extra_arrays=extra_arrays
-        )
-        with file_context as fname:
-            lib.call_module(module="text", args=build_arg_string(kwargs, infile=fname))
+        ) as vintbl:
+            lib.call_module(module="text", args=build_arg_string(kwargs, infile=vintbl))

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -164,8 +164,7 @@ def tilemap(
         kwargs["R"] = "/".join(str(coordinate) for coordinate in region)
 
     with Session() as lib:
-        file_context = lib.virtualfile_in(check_kind="raster", data=raster)
-        with file_context as infile:
+        with lib.virtualfile_in(check_kind="raster", data=raster) as vingrd:
             lib.call_module(
-                module="grdimage", args=build_arg_string(kwargs, infile=infile)
+                module="grdimage", args=build_arg_string(kwargs, infile=vingrd)
             )

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -254,7 +254,5 @@ def velo(self, data=None, **kwargs):
         )
 
     with Session() as lib:
-        file_context = lib.virtualfile_in(check_kind="vector", data=data)
-
-        with file_context as fname:
-            lib.call_module(module="velo", args=build_arg_string(kwargs, infile=fname))
+        with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
+            lib.call_module(module="velo", args=build_arg_string(kwargs, infile=vintbl))

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -107,11 +107,9 @@ def wiggle(
             kwargs["G"].append(fillnegative + "+n")
 
     with Session() as lib:
-        file_context = lib.virtualfile_in(
+        with lib.virtualfile_in(
             check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
-        )
-
-        with file_context as fname:
+        ) as vintbl:
             lib.call_module(
-                module="wiggle", args=build_arg_string(kwargs, infile=fname)
+                module="wiggle", args=build_arg_string(kwargs, infile=vintbl)
             )

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -152,14 +152,13 @@ def xyz2grd(data=None, x=None, y=None, z=None, **kwargs):
 
     with GMTTempFile(suffix=".nc") as tmpfile:
         with Session() as lib:
-            file_context = lib.virtualfile_in(
+            with lib.virtualfile_in(
                 check_kind="vector", data=data, x=x, y=y, z=z, required_z=True
-            )
-            with file_context as infile:
+            ) as vintbl:
                 if (outgrid := kwargs.get("G")) is None:
                     kwargs["G"] = outgrid = tmpfile.name  # output to tmpfile
                 lib.call_module(
-                    module="xyz2grd", args=build_arg_string(kwargs, infile=infile)
+                    module="xyz2grd", args=build_arg_string(kwargs, infile=vintbl)
                 )
 
         return load_dataarray(outgrid) if outgrid == tmpfile.name else None


### PR DESCRIPTION
**Description of proposed changes**

In issue https://github.com/GenericMappingTools/pygmt/issues/2755, we decided to use consistent names for virtual files.

For inputs, they are `vintbl` for tables and `vingrd` for grids. This PR updates all the virtual file names.

Closes #2755.