### PR TITLE
clib: Add virtualfile_to_dataset method for converting virtualfile to a dataset

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -294,6 +294,7 @@ conversion of Python variables to GMT virtual files:
     clib.Session.virtualfile_from_grid
     clib.Session.virtualfile_in
     clib.Session.virtualfile_out
+    clib.Session.return_table
 
 Low level access (these are mostly used by the :mod:`pygmt.clib` package):
 

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -294,7 +294,7 @@ conversion of Python variables to GMT virtual files:
     clib.Session.virtualfile_from_grid
     clib.Session.virtualfile_in
     clib.Session.virtualfile_out
-    clib.Session.return_dataset
+    clib.Session.virtualfile_to_dataset
 
 Low level access (these are mostly used by the :mod:`pygmt.clib` package):
 

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -294,7 +294,7 @@ conversion of Python variables to GMT virtual files:
     clib.Session.virtualfile_from_grid
     clib.Session.virtualfile_in
     clib.Session.virtualfile_out
-    clib.Session.return_table
+    clib.Session.return_dataset
 
 Low level access (these are mostly used by the :mod:`pygmt.clib` package):
 

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -283,8 +283,8 @@ the :meth:`~pygmt.clib.Session.call_module` method:
 
 Passing memory blocks between Python data objects (e.g. :class:`numpy.ndarray`,
 :class:`pandas.Series`, :class:`xarray.DataArray`, etc) and GMT happens through
-*virtual files*. These methods are context managers that automate the
-conversion of Python variables to GMT virtual files:
+*virtual files*. These methods are context managers that automate the conversion of
+Python variables to and from GMT virtual files:
 
 .. autosummary::
     :toctree: generated

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -284,7 +284,7 @@ the :meth:`~pygmt.clib.Session.call_module` method:
 Passing memory blocks between Python data objects (e.g. :class:`numpy.ndarray`,
 :class:`pandas.Series`, :class:`xarray.DataArray`, etc) and GMT happens through
 *virtual files*. These methods are context managers that automate the conversion of
-Python variables to and from GMT virtual files:
+Python objects to and from GMT virtual files:
 
 .. autosummary::
     :toctree: generated

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1741,7 +1741,7 @@ class Session:
     def return_table(
         self,
         output_type: Literal["pandas", "numpy", "file"],
-        vfile: str | None = None,
+        vfile: str,
         column_names: list[str] | None = None,
     ) -> pd.DataFrame | np.ndarray | None:
         """

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1741,7 +1741,7 @@ class Session:
     def virtualfile_to_dataset(
         self,
         output_type: Literal["pandas", "numpy", "file"],
-        vfile: str,
+        vfname: str,
         column_names: list[str] | None = None,
     ) -> pd.DataFrame | np.ndarray | None:
         """
@@ -1757,7 +1757,7 @@ class Session:
             - ``"pandas"`` will return a :class:`pandas.DataFrame` object.
             - ``"numpy"`` will return a :class:`numpy.ndarray` object.
             - ``"file"`` means the result was saved to a file and will return ``None``.
-        vfile
+        vfname
             The virtual file name that stores the result data. Required for ``"pandas"``
             and ``"numpy"`` output type.
         column_names
@@ -1795,7 +1795,7 @@ class Session:
         ...             ) as vouttbl:
         ...                 lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
         ...                 result = lib.virtualfile_to_dataset(
-        ...                     output_type="file", vfile=vouttbl
+        ...                     output_type="file", vfname=vouttbl
         ...                 )
         ...                 assert result is None
         ...                 assert Path(outtmp.name).stat().st_size > 0
@@ -1805,7 +1805,7 @@ class Session:
         ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
         ...             lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
         ...             outnp = lib.virtualfile_to_dataset(
-        ...                 output_type="numpy", vfile=vouttbl
+        ...                 output_type="numpy", vfname=vouttbl
         ...             )
         ...     assert isinstance(outnp, np.ndarray)
         ...
@@ -1814,7 +1814,7 @@ class Session:
         ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
         ...             lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
         ...             outpd = lib.virtualfile_to_dataset(
-        ...                 output_type="pandas", vfile=vouttbl
+        ...                 output_type="pandas", vfname=vouttbl
         ...             )
         ...     assert isinstance(outpd, pd.DataFrame)
         ...
@@ -1824,7 +1824,7 @@ class Session:
         ...             lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
         ...             outpd2 = lib.virtualfile_to_dataset(
         ...                 output_type="pandas",
-        ...                 vfile=vouttbl,
+        ...                 vfname=vouttbl,
         ...                 column_names=["col1", "col2", "col3", "coltext"],
         ...             )
         ...     assert isinstance(outpd2, pd.DataFrame)
@@ -1850,7 +1850,7 @@ class Session:
             return None
 
         # Read the virtual file as a GMT dataset and convert to pandas.DataFrame
-        result = self.read_virtualfile(vfile, kind="dataset").contents.to_dataframe()
+        result = self.read_virtualfile(vfname, kind="dataset").contents.to_dataframe()
         if output_type == "numpy":  # numpy.ndarray output
             return result.to_numpy()
 

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1745,7 +1745,7 @@ class Session:
         column_names: list[str] | None = None,
     ) -> pd.DataFrame | np.ndarray | None:
         """
-        Output a dataset stored in a virtual file in different formats.
+        Output a tabular dataset stored in a virtual file to a different format.
 
         The format of the dataset is determined by the ``output_type`` parameter.
 

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1738,6 +1738,42 @@ class Session:
         dtype = {"dataset": _GMT_DATASET, "grid": _GMT_GRID}[kind]
         return ctp.cast(pointer, ctp.POINTER(dtype))
 
+    def return_table(
+        self,
+        output_type: Literal["pandas", "numpy", "file"],
+        vfile: str,
+        column_names: list[str] | None = None,
+    ) -> pd.DataFrame | np.ndarray | None:
+        """
+        Return an output table from a virtual file based on the output type.
+
+        Parameters
+        ----------
+        output_type
+            The output type. Valid values are ``"pandas"``, ``"numpy"``, or ``"file"``.
+        vfile
+            The virtual file name.
+        column_names
+            The column names for the :class:`pandas.DataFrame` output.
+
+        Returns
+        -------
+        :class:`pandas.DataFrame` or :class:`numpy.ndarray` or None
+            The output table. If ``output_type`` is ``"file"``, returns ``None``.
+        """
+        if output_type == "file":  # Already written to file, so return None
+            return None
+        # Read the virtual file as a GMT dataset and convert to pandas.DataFrame
+        result = self.read_virtualfile(vfile, kind="dataset").contents.to_dataframe()
+        # Assign column names
+        if column_names is not None:
+            result.columns = column_names
+        # Pandas.DataFrame output
+        if output_type == "pandas":
+            return result
+        # NumPy.ndarray output
+        return result.to_numpy()
+
     def extract_region(self):
         """
         Extract the WESN bounding box of the currently active figure.

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1738,7 +1738,7 @@ class Session:
         dtype = {"dataset": _GMT_DATASET, "grid": _GMT_GRID}[kind]
         return ctp.cast(pointer, ctp.POINTER(dtype))
 
-    def return_dataset(
+    def virtualfile_to_dataset(
         self,
         output_type: Literal["pandas", "numpy", "file"],
         vfile: str,
@@ -1794,7 +1794,7 @@ class Session:
         ...                 kind="dataset", fname=outtmp.name
         ...             ) as vouttbl:
         ...                 lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
-        ...                 result = lib.return_dataset(
+        ...                 result = lib.virtualfile_to_dataset(
         ...                     output_type="file", vfile=vouttbl
         ...                 )
         ...                 assert result is None
@@ -1804,21 +1804,25 @@ class Session:
         ...     with Session() as lib:
         ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
         ...             lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
-        ...             outnp = lib.return_dataset(output_type="numpy", vfile=vouttbl)
+        ...             outnp = lib.virtualfile_to_dataset(
+        ...                 output_type="numpy", vfile=vouttbl
+        ...             )
         ...     assert isinstance(outnp, np.ndarray)
         ...
         ...     # pandas output
         ...     with Session() as lib:
         ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
         ...             lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
-        ...             outpd = lib.return_dataset(output_type="pandas", vfile=vouttbl)
+        ...             outpd = lib.virtualfile_to_dataset(
+        ...                 output_type="pandas", vfile=vouttbl
+        ...             )
         ...     assert isinstance(outpd, pd.DataFrame)
         ...
         ...     # pandas output with specified column names
         ...     with Session() as lib:
         ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
         ...             lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
-        ...             outpd2 = lib.return_dataset(
+        ...             outpd2 = lib.virtualfile_to_dataset(
         ...                 output_type="pandas",
         ...                 vfile=vouttbl,
         ...                 column_names=["col1", "col2", "col3", "coltext"],

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1741,7 +1741,7 @@ class Session:
     def return_table(
         self,
         output_type: Literal["pandas", "numpy", "file"],
-        vfile: str,
+        vfile: str | None = None,
         column_names: list[str] | None = None,
     ) -> pd.DataFrame | np.ndarray | None:
         """
@@ -1750,16 +1750,21 @@ class Session:
         Parameters
         ----------
         output_type
-            The output type. Valid values are ``"pandas"``, ``"numpy"``, or ``"file"``.
+            Desired output type of the result data.
+
+            - ``"pandas"`` will return a :class:`pandas.DataFrame` object.
+            - ``"numpy"`` will return a :class:`numpy.ndarray` object.
+            - ``"file"`` means the result was saved to a file and will return ``None``.
         vfile
-            The virtual file name.
+            The virtual file name that stores the result data. Required for ``"pandas"``
+            and ``"numpy"`` output type.
         column_names
             The column names for the :class:`pandas.DataFrame` output.
 
         Returns
         -------
-        :class:`pandas.DataFrame` or :class:`numpy.ndarray` or None
-            The output table. If ``output_type`` is ``"file"``, returns ``None``.
+        table
+            The output table. If ``output_type="file"`` returns ``None``.
 
         Examples
         --------
@@ -1835,16 +1840,16 @@ class Session:
         """
         if output_type == "file":  # Already written to file, so return None
             return None
+
         # Read the virtual file as a GMT dataset and convert to pandas.DataFrame
         result = self.read_virtualfile(vfile, kind="dataset").contents.to_dataframe()
+        if output_type == "numpy":  # numpy.ndarray output
+            return result.to_numpy()
+
         # Assign column names
         if column_names is not None:
             result.columns = column_names
-        # Pandas.DataFrame output
-        if output_type == "pandas":
-            return result
-        # NumPy.ndarray output
-        return result.to_numpy()
+        return result  # pandas.DataFrame output
 
     def extract_region(self):
         """

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1738,14 +1738,16 @@ class Session:
         dtype = {"dataset": _GMT_DATASET, "grid": _GMT_GRID}[kind]
         return ctp.cast(pointer, ctp.POINTER(dtype))
 
-    def return_table(
+    def return_dataset(
         self,
         output_type: Literal["pandas", "numpy", "file"],
         vfile: str,
         column_names: list[str] | None = None,
     ) -> pd.DataFrame | np.ndarray | None:
         """
-        Return an output table from a virtual file based on the output type.
+        Output a dataset stored in a virtual file in different formats.
+
+        The format of the dataset is determined by the ``output_type`` parameter.
 
         Parameters
         ----------
@@ -1763,8 +1765,8 @@ class Session:
 
         Returns
         -------
-        table
-            The output table. If ``output_type="file"`` returns ``None``.
+        result
+            The result dataset. If ``output_type="file"`` returns ``None``.
 
         Examples
         --------
@@ -1792,7 +1794,9 @@ class Session:
         ...                 kind="dataset", fname=outtmp.name
         ...             ) as vouttbl:
         ...                 lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
-        ...                 result = lib.return_table(output_type="file", vfile=vouttbl)
+        ...                 result = lib.return_dataset(
+        ...                     output_type="file", vfile=vouttbl
+        ...                 )
         ...                 assert result is None
         ...                 assert Path(outtmp.name).stat().st_size > 0
         ...
@@ -1800,21 +1804,21 @@ class Session:
         ...     with Session() as lib:
         ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
         ...             lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
-        ...             outnp = lib.return_table(output_type="numpy", vfile=vouttbl)
+        ...             outnp = lib.return_dataset(output_type="numpy", vfile=vouttbl)
         ...     assert isinstance(outnp, np.ndarray)
         ...
         ...     # pandas output
         ...     with Session() as lib:
         ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
         ...             lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
-        ...             outpd = lib.return_table(output_type="pandas", vfile=vouttbl)
+        ...             outpd = lib.return_dataset(output_type="pandas", vfile=vouttbl)
         ...     assert isinstance(outpd, pd.DataFrame)
         ...
         ...     # pandas output with specified column names
         ...     with Session() as lib:
         ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
         ...             lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
-        ...             outpd2 = lib.return_table(
+        ...             outpd2 = lib.return_dataset(
         ...                 output_type="pandas",
         ...                 vfile=vouttbl,
         ...                 column_names=["col1", "col2", "col3", "coltext"],


### PR DESCRIPTION
Add the new `Session.virtualfile_to_dataset()` method to simplify the logic of dealing with table outputs in different wrappers. Draft PR #3092 shows how the new `Session.virtualfile_to_dataset()` method can simplify other wrappers.

