### PR TITLE
Figure.grdview: Fix typo in docs

### DIFF
--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -64,7 +64,7 @@ def grdview(self, grid, **kwargs):
     drapegrid : str or xarray.DataArray
         The file name or a DataArray of the image grid to be draped on top
         of the relief provided by grid. [Default determines colors from
-        grid]. Note that ``zscale`` and ``plane`` always refers to the grid.
+        grid]. Note that ``zscale`` and ``plane`` always refer to the grid.
         The drapegrid only provides the information pertaining to colors, which
         (if drapegrid is a grid) will be looked-up via the CPT (see ``cmap``).
     plane : float or str

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -63,8 +63,8 @@ def grdview(self, grid, **kwargs):
         The name of the color palette table to use.
     drapegrid : str or xarray.DataArray
         The file name or a DataArray of the image grid to be draped on top
-        of the relief provided by grid. [Default determines colors from
-        grid]. Note that ``zscale`` and ``plane`` always refer to the grid.
+        of the relief provided by ``grid`` [Default determines colors from grid].
+        Note that ``zscale`` and ``plane`` always refer to the grid.
         The drapegrid only provides the information pertaining to colors, which
         (if drapegrid is a grid) will be looked-up via the CPT (see ``cmap``).
     plane : float or str


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a typo in the documentation of `Figure.grdview`. 

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
