### PR TITLE
doc: Move virtualfile_from_* methods as low-level API functions

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -289,9 +289,6 @@ conversion of Python variables to GMT virtual files:
 .. autosummary::
     :toctree: generated
 
-    clib.Session.virtualfile_from_matrix
-    clib.Session.virtualfile_from_vectors
-    clib.Session.virtualfile_from_grid
     clib.Session.virtualfile_in
     clib.Session.virtualfile_out
 
@@ -316,3 +313,7 @@ Low level access (these are mostly used by the :mod:`pygmt.clib` package):
     clib.Session.read_virtualfile
     clib.Session.extract_region
     clib.Session.get_libgmt_func
+    clib.Session.virtualfile_from_data
+    clib.Session.virtualfile_from_grid
+    clib.Session.virtualfile_from_matrix
+    clib.Session.virtualfile_from_vectors


### PR DESCRIPTION
Methods like `virtualfile_from_*` are no longer used directly in PyGMT wrappers, so they should be categorized as low-level functions.

**Preview**: https://pygmt-dev--3096.org.readthedocs.build/en/3096/api/index.html#gmt-c-api