### PR TITLE
pygmt.grdvolume: Refactor to store output in virtual files instead of temporary files

### DIFF
--- a/pygmt/src/grdvolume.py
+++ b/pygmt/src/grdvolume.py
@@ -4,8 +4,8 @@ grdvolume - Calculate grid volume and area constrained by a contour.
 
 from typing import Literal
 
+import numpy as np
 import pandas as pd
-import xarray as xr
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_string,
@@ -31,7 +31,7 @@ def grdvolume(
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: str | None = None,
     **kwargs,
-) -> pd.DataFrame | xr.DataArray | None:
+) -> pd.DataFrame | np.ndarray | None:
     r"""
     Determine the volume between the surface of a grid and a plane.
 

--- a/pygmt/src/grdvolume.py
+++ b/pygmt/src/grdvolume.py
@@ -72,7 +72,8 @@ def grdvolume(
     ret
         Return type depends on ``outfile`` and ``output_type``:
 
-        - None if ``outfile`` is set (output will be stored in file set by ``outfile``)
+        - ``None`` if ``outfile`` is set (output will be stored in file set by
+          ``outfile``)
         - :class:`pandas.DataFrame` or :class:`numpy.ndarray` if ``outfile`` is not set
           (depends on ``output_type``)
 

--- a/pygmt/src/grdvolume.py
+++ b/pygmt/src/grdvolume.py
@@ -2,10 +2,12 @@
 grdvolume - Calculate grid volume and area constrained by a contour.
 """
 
+from typing import Literal
+
 import pandas as pd
+import xarray as xr
 from pygmt.clib import Session
 from pygmt.helpers import (
-    GMTTempFile,
     build_arg_string,
     fmt_docstring,
     kwargs_to_strings,
@@ -24,7 +26,12 @@ __doctest_skip__ = ["grdvolume"]
     V="verbose",
 )
 @kwargs_to_strings(C="sequence", R="sequence")
-def grdvolume(grid, output_type="pandas", outfile=None, **kwargs):
+def grdvolume(
+    grid,
+    output_type: Literal["pandas", "numpy", "file"] = "pandas",
+    outfile: str | None = None,
+    **kwargs,
+) -> pd.DataFrame | xr.DataArray | None:
     r"""
     Determine the volume between the surface of a grid and a plane.
 
@@ -41,15 +48,8 @@ def grdvolume(grid, output_type="pandas", outfile=None, **kwargs):
     Parameters
     ----------
     {grid}
-    output_type : str
-        Determine the format the output data will be returned in [Default is
-        ``pandas``]:
-
-            - ``numpy`` - :class:`numpy.ndarray`
-            - ``pandas``-  :class:`pandas.DataFrame`
-            - ``file`` - ASCII file (requires ``outfile``)
-    outfile : str
-        The file name for the output ASCII file.
+    {output_type}
+    {outfile}
     contour : str, float, or list
         *cval*\|\ *low/high/delta*\|\ **r**\ *low/high*\|\ **r**\ *cval*.
         Find area, volume and mean height (volume/area) inside and above the
@@ -69,14 +69,12 @@ def grdvolume(grid, output_type="pandas", outfile=None, **kwargs):
 
     Returns
     -------
-    ret : pandas.DataFrame or numpy.ndarray or None
+    ret
         Return type depends on ``outfile`` and ``output_type``:
 
-        - None if ``outfile`` is set (output will be stored in file set by
-          ``outfile``)
-        - :class:`pandas.DataFrame` or :class:`numpy.ndarray` if ``outfile``
-          is not set (depends on ``output_type`` [Default is
-          :class:`pandas.DataFrame`])
+        - None if ``outfile`` is set (output will be stored in file set by ``outfile``)
+        - :class:`pandas.DataFrame` or :class:`numpy.ndarray` if ``outfile`` is not set
+          (depends on ``output_type``)
 
     Example
     -------
@@ -103,22 +101,13 @@ def grdvolume(grid, output_type="pandas", outfile=None, **kwargs):
     """
     output_type = validate_output_table_type(output_type, outfile=outfile)
 
-    with GMTTempFile() as tmpfile:
-        with Session() as lib:
-            with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
-                if outfile is None:
-                    outfile = tmpfile.name
-                lib.call_module(
-                    module="grdvolume",
-                    args=build_arg_string(kwargs, infile=vingrd, outfile=outfile),
-                )
-
-        # Read temporary csv output to a pandas table
-        if outfile == tmpfile.name:  # if user did not set outfile, return pd.DataFrame
-            result = pd.read_csv(tmpfile.name, sep="\t", header=None, comment=">")
-        elif outfile != tmpfile.name:  # return None if outfile set, output in outfile
-            result = None
-
-        if output_type == "numpy":
-            result = result.to_numpy()
-    return result
+    with Session() as lib:
+        with (
+            lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
+            lib.virtualfile_out(kind="dataset", fname=outfile) as vouttbl,
+        ):
+            lib.call_module(
+                module="grdvolume",
+                args=build_arg_string(kwargs, infile=vingrd, outfile=vouttbl),
+            )
+            return lib.virtualfile_to_dataset(output_type=output_type, vfname=vouttbl)


### PR DESCRIPTION
Address #1318 and #2730.

**Preview**: https://pygmt-dev--3102.org.readthedocs.build/en/3102/api/generated/pygmt.grdvolume.html#pygmt.grdvolume

Benchmarks:

```
>>> from pygmt import grdvolume
>>> for i in [50, 25, 10, 5, 2, 1, 0.1]:
...     %timeit df = grdvolume("@earth_relief_01d_g", contour=[200, 400, i])
...
```
This branch:
```
12.7 ms ± 42 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
15.8 ms ± 78 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
25.1 ms ± 149 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
40.8 ms ± 244 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
87.2 ms ± 209 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
165 ms ± 227 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
1.57 s ± 4.11 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Main branch:
```
10.3 ms ± 39.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
13.4 ms ± 23.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
22.4 ms ± 29.2 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
37.6 ms ± 43.2 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
83 ms ± 136 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
159 ms ± 225 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
1.52 s ± 1.12 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
This branch is slightly slower than the main branch, mainly because:

1. this module is computational-intensive, so most of the time are spent in computation, rather than I/O
2. For most real cases, the number of specified contours is small (e.g., 2000 for the last run), so using tempfile or virtualfile should have very close performance. 