### PR TITLE
pygmt.grdtrack: Add 'output_type' parameter for output in pandas/numpy/file formats

### DIFF
--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -268,7 +268,8 @@ def grdtrack(
     ret
         Return type depends on ``outfile`` and ``output_type``:
 
-        - None if ``outfile`` is set (output will be stored in file set by ``outfile``)
+        - ``None`` if ``outfile`` is set (output will be stored in file set by
+          ``outfile``)
         - :class:`pandas.DataFrame` or :class:`numpy.ndarray` if ``outfile`` is not set
           (depends on ``output_type``)
 


### PR DESCRIPTION
**Description of proposed changes**

Same as #3103 but for `grdtrack`.

**Preview**: https://pygmt-dev--3106.org.readthedocs.build/en/3106/api/generated/pygmt.grdtrack.html#pygmt.grdtrack

Benchmarks:
```
>>> import pygmt
>>> points = pygmt.datasets.load_sample_data(name="ocean_ridge_points")
>>> for inc in ["30m", "10m", "06m"]:
...     %timeit df = pygmt.grdtrack(points=points, grid=f"@earth_relief_{inc}_g", newcolname="bathymetry")
...
```

Main branch:
```
20.5 ms ± 154 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
57.6 ms ± 227 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
139 ms ± 268 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

This branch:
```
14.1 ms ± 3.08 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
49.1 ms ± 174 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
130 ms ± 161 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```