### PR TITLE
pygmt.select: Improve performance by storing output in virtual files

### DIFF
--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -191,7 +191,8 @@ def select(
     ret
         Return type depends on ``outfile`` and ``output_type``:
 
-        - None if ``outfile`` is set (output will be stored in file set by ``outfile``)
+        - ``None`` if ``outfile`` is set (output will be stored in file set by
+          ``outfile``)
         - :class:`pandas.DataFrame` or :class:`numpy.ndarray` if ``outfile`` is not set
           (depends on ``output_type``)
 


### PR DESCRIPTION
Similar to #3102 but for `select`.

**Preview**: https://pygmt-dev--3108.org.readthedocs.build/en/3108/api/generated/pygmt.select.html#pygmt.select