### PR TITLE
Bump to ghotscript 10.03.0

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -87,7 +87,7 @@ jobs:
           create-args: >-
             python=3.12
             gmt=6.5.0
-            ghostscript=10.02.1
+            ghostscript=10.03.0
             numpy
             pandas
             xarray

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -110,7 +110,7 @@ jobs:
           create-args: >-
             python=${{ matrix.python-version }}${{ matrix.optional-packages }}
             gmt=6.5.0
-            ghostscript=10.02.1
+            ghostscript=10.03.0
             numpy=${{ matrix.numpy-version }}
             pandas${{ matrix.pandas-version }}
             xarray${{ matrix.xarray-version }}

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -69,7 +69,7 @@ jobs:
             ninja
             curl
             fftw
-            ghostscript=10.02.1
+            ghostscript=10.03.0
             glib
             hdf5
             libblas

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -6,7 +6,7 @@ dependencies:
     # Required dependencies
     - python=3.12
     - gmt=6.5.0
-    - ghostscript=10.02.1
+    - ghostscript=10.03.0
     - numpy
     - pandas
     - xarray

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
     - python=3.12
     # Required dependencies
     - gmt=6.5.0
+    - ghotscript=10.03.0
     - numpy>=1.23
     - pandas>=1.5
     - xarray>=2022.03


### PR DESCRIPTION
ghostscript 10.03.0 was released one week ago (https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/tag/gs10030). 

This PR bumps the Ghostscript version to 10.03.0. Luckily, we don't have to update baseline images for this new gs version.

The CI tests with Python 3.12 fail because after bumping gs to 10.03.0, the CI uses xarray v2024.02.0, which cause one failure in the doctest (see #3062). We will address #3062 after merging this PR.