### PR TITLE
CI: Ignore ResearchGate homepage in the links check

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -53,7 +53,7 @@ jobs:
           --exclude "^https://www.generic-mapping-tools.org/remote-datasets/%s$"
           --exclude "^https://hackmd.io/@pygmt"
           --exclude "^https://doi.org"
-          --exclude "^https://www.researchgate.net/project/"
+          --exclude "^https://www.researchgate.net/"
           --exclude "^https://test.pypi.org/simple/"
           --verbose
           "repository/**/*.rst"


### PR DESCRIPTION
The link https://www.researchgate.net/project/ is no longer used in our project and the link https://www.researchgate.net/ should be skipped.

Address https://github.com/GenericMappingTools/pygmt/issues/3114.