### PR TITLE
Datetime tutorial: Change symbol usde in first code example to fix failing under Windows

### DIFF
--- a/examples/tutorials/advanced/date_time_charts.py
+++ b/examples/tutorials/advanced/date_time_charts.py
@@ -29,8 +29,8 @@ import xarray as xr
 # data points stored in the list ``x``. Additionally, dates are passed into
 # the ``region`` parameter in the format ``[x_start, x_end, y_start, y_end]``,
 # where the date range is plotted on the x-axis. An additional notable
-# parameter is ``style``, where it's specified that data points are to be
-# plotted in an **X** shape with a size of 0.3 centimeters.
+# parameter is ``style``, where it's specified that data points are plotted
+# as circles with a diameter of 0.3 centimeters.
 
 x = [
     datetime.date(2010, 6, 1),
@@ -47,7 +47,7 @@ fig.plot(
     frame=["WSen", "afg"],
     x=x,
     y=y,
-    style="x0.3c",
+    style="c0.3c",
     pen="1p",
 )
 fig.show()


### PR DESCRIPTION
**Description of proposed changes**

The datetime tutorial fails under Windows using GMT 6.5 (https://github.com/GenericMappingTools/pygmt/issues/3038#issue-2117763987). This is not the case under Linux and Mac. There seem to be an difference in the `gmt_1.ps` file (https://github.com/GenericMappingTools/pygmt/issues/3038#issuecomment-1929144678).

This PR changes the symbol used in the first code example of the datetime tutorial from `x` to `c` (circles), as this example fails under Windows for any of the line symbols `x`, `y`, `-`, `+` (please see https://github.com/GenericMappingTools/pygmt/issues/3038#issuecomment-1926439808).

Releated to issue #3038

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
