### PR TITLE
clib: Change the parameter order and set output_type to pandas in virtualfile_to_dataset

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1740,8 +1740,8 @@ class Session:
 
     def virtualfile_to_dataset(
         self,
-        output_type: Literal["pandas", "numpy", "file"],
         vfname: str,
+        output_type: Literal["pandas", "numpy", "file"] = "pandas",
         column_names: list[str] | None = None,
     ) -> pd.DataFrame | np.ndarray | None:
         """
@@ -1751,15 +1751,15 @@ class Session:
 
         Parameters
         ----------
+        vfname
+            The virtual file name that stores the result data. Required for ``"pandas"``
+            and ``"numpy"`` output type.
         output_type
             Desired output type of the result data.
 
             - ``"pandas"`` will return a :class:`pandas.DataFrame` object.
             - ``"numpy"`` will return a :class:`numpy.ndarray` object.
             - ``"file"`` means the result was saved to a file and will return ``None``.
-        vfname
-            The virtual file name that stores the result data. Required for ``"pandas"``
-            and ``"numpy"`` output type.
         column_names
             The column names for the :class:`pandas.DataFrame` output.
 
@@ -1795,7 +1795,8 @@ class Session:
         ...             ) as vouttbl:
         ...                 lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
         ...                 result = lib.virtualfile_to_dataset(
-        ...                     output_type="file", vfname=vouttbl
+        ...                     vfname=vouttbl,
+        ...                     output_type="file",
         ...                 )
         ...                 assert result is None
         ...                 assert Path(outtmp.name).stat().st_size > 0
@@ -1805,7 +1806,8 @@ class Session:
         ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
         ...             lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
         ...             outnp = lib.virtualfile_to_dataset(
-        ...                 output_type="numpy", vfname=vouttbl
+        ...                 vfname=vouttbl,
+        ...                 output_type="numpy",
         ...             )
         ...     assert isinstance(outnp, np.ndarray)
         ...
@@ -1814,7 +1816,7 @@ class Session:
         ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
         ...             lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
         ...             outpd = lib.virtualfile_to_dataset(
-        ...                 output_type="pandas", vfname=vouttbl
+        ...                 vfname=vouttbl, output_type="pandas"
         ...             )
         ...     assert isinstance(outpd, pd.DataFrame)
         ...
@@ -1823,8 +1825,8 @@ class Session:
         ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
         ...             lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
         ...             outpd2 = lib.virtualfile_to_dataset(
-        ...                 output_type="pandas",
         ...                 vfname=vouttbl,
+        ...                 output_type="pandas",
         ...                 column_names=["col1", "col2", "col3", "coltext"],
         ...             )
         ...     assert isinstance(outpd2, pd.DataFrame)

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1795,8 +1795,7 @@ class Session:
         ...             ) as vouttbl:
         ...                 lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
         ...                 result = lib.virtualfile_to_dataset(
-        ...                     vfname=vouttbl,
-        ...                     output_type="file",
+        ...                     vfname=vouttbl, output_type="file"
         ...                 )
         ...                 assert result is None
         ...                 assert Path(outtmp.name).stat().st_size > 0
@@ -1806,8 +1805,7 @@ class Session:
         ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
         ...             lib.call_module("read", f"{tmpfile.name} {vouttbl} -Td")
         ...             outnp = lib.virtualfile_to_dataset(
-        ...                 vfname=vouttbl,
-        ...                 output_type="numpy",
+        ...                 vfname=vouttbl, output_type="numpy"
         ...             )
         ...     assert isinstance(outnp, np.ndarray)
         ...

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -64,7 +64,7 @@ def _blockm(
                 args=build_arg_string(kwargs, infile=vintbl, outfile=vouttbl),
             )
             return lib.virtualfile_to_dataset(
-                output_type=output_type, vfname=vouttbl, column_names=column_names
+                vfname=vouttbl, output_type=output_type, column_names=column_names
             )
 
 

--- a/pygmt/src/filter1d.py
+++ b/pygmt/src/filter1d.py
@@ -123,4 +123,7 @@ def filter1d(
                 module="filter1d",
                 args=build_arg_string(kwargs, infile=vintbl, outfile=vouttbl),
             )
-        return lib.virtualfile_to_dataset(output_type=output_type, vfname=vouttbl)
+        return lib.virtualfile_to_dataset(
+            vfname=vouttbl,
+            output_type=output_type,
+        )

--- a/pygmt/src/filter1d.py
+++ b/pygmt/src/filter1d.py
@@ -123,7 +123,4 @@ def filter1d(
                 module="filter1d",
                 args=build_arg_string(kwargs, infile=vintbl, outfile=vouttbl),
             )
-        return lib.virtualfile_to_dataset(
-            vfname=vouttbl,
-            output_type=output_type,
-        )
+        return lib.virtualfile_to_dataset(vfname=vouttbl, output_type=output_type)

--- a/pygmt/src/grd2xyz.py
+++ b/pygmt/src/grd2xyz.py
@@ -168,5 +168,5 @@ def grd2xyz(
                 args=build_arg_string(kwargs, infile=vingrd, outfile=vouttbl),
             )
             return lib.virtualfile_to_dataset(
-                output_type=output_type, vfname=vouttbl, column_names=column_names
+                vfname=vouttbl, output_type=output_type, column_names=column_names
             )

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -239,8 +239,8 @@ class grdhisteq:  # noqa: N801
                 )
 
             result = lib.virtualfile_to_dataset(
-                output_type=output_type,
                 vfname=vouttbl,
+                output_type=output_type,
                 column_names=["start", "stop", "bin_id"],
             )
             if output_type == "pandas":

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -318,7 +318,7 @@ def grdtrack(
                 args=build_arg_string(kwargs, infile=vintbl, outfile=vouttbl),
             )
         return lib.virtualfile_to_dataset(
-            output_type=output_type,
             vfname=vouttbl,
+            output_type=output_type,
             column_names=column_names,
         )

--- a/pygmt/src/grdvolume.py
+++ b/pygmt/src/grdvolume.py
@@ -111,4 +111,4 @@ def grdvolume(
                 module="grdvolume",
                 args=build_arg_string(kwargs, infile=vingrd, outfile=vouttbl),
             )
-            return lib.virtualfile_to_dataset(output_type=output_type, vfname=vouttbl)
+            return lib.virtualfile_to_dataset(vfname=vouttbl, output_type=output_type)

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -256,7 +256,7 @@ def project(
                 args=build_arg_string(kwargs, infile=vintbl, outfile=vouttbl),
             )
         return lib.virtualfile_to_dataset(
-            output_type=output_type,
             vfname=vouttbl,
+            output_type=output_type,
             column_names=column_names,
         )

--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -221,7 +221,7 @@ def select(
                 args=build_arg_string(kwargs, infile=vintbl, outfile=vouttbl),
             )
         return lib.virtualfile_to_dataset(
-            output_type=output_type,
             vfname=vouttbl,
+            output_type=output_type,
             column_names=column_names,
         )

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -249,4 +249,4 @@ class triangulate:  # noqa: N801
                     module="triangulate",
                     args=build_arg_string(kwargs, infile=vintbl, outfile=vouttbl),
                 )
-            return lib.virtualfile_to_dataset(output_type=output_type, vfname=vouttbl)
+            return lib.virtualfile_to_dataset(vfname=vouttbl, output_type=output_type)


### PR DESCRIPTION
**Description of proposed changes**

For some module wrappers like `which`, `output_type` makes no sense because the a "file" or "numpy" output is useless. When refactoring these module wrappers, we have to use
```
lib.virtualfile_to_dataset(output_type="pandas", vfname=vouttbl)
```
which doesn't look good.

This PR move the `vfname` parameter before the `output_type` parameter and set `output_type`'s default to `"pandas"`, so that we can use a much shorter version
```
lib.virtualfile_to_dataset(vfname=vouttbl)
```

Putting `vfname` as the first parameter makes more sense because `vfname` is always a required parameter.

Patches #3083.


