### PR TITLE
CI: Configure workflows to run on 'workflow_dispatch' event

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -1,12 +1,16 @@
 # Cache GMT remote data files and upload as artifacts
 #
-# This workflow downloads data files needed by PyGMT tests/documentation from
-# the GMT data server and uploads as workflow artifacts which can be accessed
-# by other GitHub Actions workflows.
+# This workflow downloads data files needed by PyGMT tests/documentation from the GMT
+# data server and uploads as workflow artifacts which can be accessed by other GitHub
+# Actions workflows.
 #
-# It is scheduled to run every Sunday at 12:00 (UTC). If new remote files are
-# needed urgently, maintainers can update the workflow file or the
-# 'pygmt/helpers/caching.py' file to refresh the cache.
+# It is scheduled to run every Sunday at 12:00 (UTC). If new remote files are needed
+# urgently, maintainers can refresh the cache by either ways:
+#
+# 1. Update this workflow file
+# 2. Update the `pygmt/helpers/caching.py` file
+# 3. Go to https://github.com/GenericMappingTools/pygmt/actions/workflows/cache_data.yaml
+#    and click the "Run workflow" button
 #
 name: Cache data
 
@@ -16,6 +20,7 @@ on:
     paths:
       - 'pygmt/helpers/caching.py'
       - '.github/workflows/cache_data.yaml'
+  workflow_dispatch:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -1,11 +1,11 @@
 # Cache GMT remote data files and upload as artifacts
 #
 # This workflow downloads data files needed by PyGMT tests/documentation from the GMT
-# data server and uploads as workflow artifacts which can be accessed by other GitHub
-# Actions workflows.
+# data server and uploads them as workflow artifacts, which can then be accessed by other
+# GitHub Actions workflows.
 #
 # It is scheduled to run every Sunday at 12:00 (UTC). If new remote files are needed
-# urgently, maintainers can refresh the cache by either ways:
+# urgently, maintainers can refresh the cache by one of the following methods:
 #
 # 1. Update this workflow file
 # 2. Update the `pygmt/helpers/caching.py` file

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -10,6 +10,7 @@ name: Check Links
 on:
   # Uncomment the 'pull_request' line below to trigger the workflow in PR
   # pull_request:
+  workflow_dispatch:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -34,6 +34,7 @@ on:
       - 'examples/**'
       - 'README.md'
       - '.github/workflows/ci_docs.yml'
+  workflow_dispatch:
   release:
     types:
       - published

--- a/.github/workflows/ci_doctests.yaml
+++ b/.github/workflows/ci_doctests.yaml
@@ -9,6 +9,7 @@ on:
   # push:
   #   branches: [ main ]
   # pull_request:
+  workflow_dispatch:
   # Schedule weekly tests on Sunday
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -33,6 +33,7 @@ on:
     paths:
       - 'pygmt/**'
       - '.github/workflows/ci_tests.yaml'
+  workflow_dispatch:
   release:
     types:
       - published

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -20,6 +20,7 @@ on:
     paths:
       - 'pygmt/**'
       - '.github/workflows/ci_tests_dev.yaml'
+  workflow_dispatch:
   # Schedule tests on Monday/Wednesday/Friday
   schedule:
     - cron: '0 0 * * 1,3,5'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -17,6 +17,7 @@ on:
     # paths:
     #  - 'pygmt/**'
     #  - '.github/workflows/ci_tests_legacy.yaml'
+  workflow_dispatch:
   # Schedule tests on Tuesday
   schedule:
     - cron: '0 0 * * 2'


### PR DESCRIPTION
**Description of proposed changes**

Inspired by the comment https://github.com/GenericMappingTools/pygmt/issues/2910#issuecomment-1928722002.

Sometimes we want to trigger a workflow to see if everything still works. This can be done by configuring workflows to run on the `workflow_dispatch` event.

The `benchmarks.yml` workflow is already configured with `workflow_dispatch` event. To manually trigger a run, go to https://github.com/GenericMappingTools/pygmt/actions/workflows/benchmarks.yml and click the "Run workflow" button on the right. 

This enable configures more workflows to run on `wotkflow_dispatch` event. Below is a list of workflows that will support manual triggering after this PR. 

- [x] benchmarks.yml
- [x] cache_data.yaml
- [x] check-links.yml
- [x] ci_docs.yml
- [x] ci_doctests.yaml
- [x] ci_tests_dev.yaml
- [x] ci_tests_legacy.yaml
- [x] ci_tests.yaml
- [ ] dvc-diff.yml
- [ ] format-command.yml
- [ ] publish-to-pypi.yml
- [ ] release-baseline-images.yml
- [ ] release-drafter.yml
- [ ] slash-command-dispatch.yml
- [ ] style_checks.yaml
- [ ] type_checks.yml

Reference: https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow