### PR TITLE
Tests: Suppress warnings by explicitly setting output_type to 'file'

### DIFF
--- a/pygmt/tests/test_blockm.py
+++ b/pygmt/tests/test_blockm.py
@@ -82,6 +82,7 @@ def test_blockmean_input_filename():
             data="@tut_ship.xyz",
             spacing="5m",
             region=[245, 255, 20, 30],
+            output_type="file",
             outfile=tmpfile.name,
         )
         assert output is None  # check that output is None since outfile is set

--- a/pygmt/tests/test_blockmedian.py
+++ b/pygmt/tests/test_blockmedian.py
@@ -79,6 +79,7 @@ def test_blockmedian_input_filename():
             data="@tut_ship.xyz",
             spacing="5m",
             region=[245, 255, 20, 30],
+            output_type="file",
             outfile=tmpfile.name,
         )
         assert output is None  # check that output is None since outfile is set

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -70,7 +70,9 @@ def test_grdtrack_input_csvfile_and_dataarray(dataarray, expected_array):
     Run grdtrack by passing in a csvfile and xarray.DataArray as inputs.
     """
     with GMTTempFile() as tmpfile:
-        output = grdtrack(points=POINTS_DATA, grid=dataarray, outfile=tmpfile.name)
+        output = grdtrack(
+            points=POINTS_DATA, grid=dataarray, output_type="file", outfile=tmpfile.name
+        )
         assert output is None  # check that output is None since outfile is set
         assert Path(tmpfile.name).stat().st_size > 0  # check that outfile exists
         output = np.loadtxt(tmpfile.name)

--- a/pygmt/tests/test_project.py
+++ b/pygmt/tests/test_project.py
@@ -62,6 +62,7 @@ def test_project_output_filename(dataframe):
             center=[0, -1],
             azimuth=45,
             flat_earth=True,
+            output_type="file",
             outfile=tmpfile.name,
         )
         assert output is None  # check that output is None since outfile is set

--- a/pygmt/tests/test_select.py
+++ b/pygmt/tests/test_select.py
@@ -56,6 +56,7 @@ def test_select_input_filename():
             data="@tut_ship.xyz",
             region=[250, 251, 26, 27],
             z_subregion=["-/-630", "-120/0+a"],
+            output_type="file",
             outfile=tmpfile.name,
         )
         assert output is None  # check that output is None since outfile is set


### PR DESCRIPTION
Suppress following warnings:
```
pygmt/tests/test_blockm.py::test_blockmean_input_filename
pygmt/tests/test_blockmedian.py::test_blockmedian_input_filename
  /home/runner/work/pygmt/pygmt/pygmt/src/blockm.py:49: RuntimeWarning: Changing 'output_type' from 'pandas' to 'file' since 'outfile' parameter is set. Please use output_type='file' to silence this warning.
    output_type = validate_output_table_type(output_type, outfile=outfile)

pygmt/tests/test_grdtrack.py::test_grdtrack_input_csvfile_and_dataarray
  /home/runner/work/pygmt/pygmt/pygmt/src/grdtrack.py:301: RuntimeWarning: Changing 'output_type' from 'pandas' to 'file' since 'outfile' parameter is set. Please use output_type='file' to silence this warning.
    output_type = validate_output_table_type(output_type, outfile=outfile)

pygmt/tests/test_project.py::test_project_output_filename
  /home/runner/work/pygmt/pygmt/pygmt/src/project.py:235: RuntimeWarning: Changing 'output_type' from 'pandas' to 'file' since 'outfile' parameter is set. Please use output_type='file' to silence this warning.
    output_type = validate_output_table_type(output_type, outfile=outfile)

pygmt/tests/test_select.py::test_select_input_filename
  /home/runner/work/pygmt/pygmt/pygmt/src/select.py:208: RuntimeWarning: Changing 'output_type' from 'pandas' to 'file' since 'outfile' parameter is set. Please use output_type='file' to silence this warning.
    output_type = validate_output_table_type(output_type, outfile=outfile)
```
