### PR TITLE
Add sequence_to_ctypes_array to convert a sequence to a ctypes array

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -2,7 +2,9 @@
 Functions to convert data types into ctypes friendly formats.
 """
 
+import ctypes as ctp
 import warnings
+from collections.abc import Sequence
 
 import numpy as np
 from pygmt.exceptions import GMTInvalidInput
@@ -243,41 +245,53 @@ def as_c_contiguous(array):
     return array
 
 
-def kwargs_to_ctypes_array(argument, kwargs, dtype):
+def sequence_to_ctypes_array(sequence: Sequence, ctype, size: int) -> ctp.Array | None:
     """
-    Convert an iterable argument from kwargs into a ctypes array variable.
+    Convert a sequence into a ctypes array variable.
 
-    If the argument is not present in kwargs, returns ``None``.
+    If the sequence is ``None``, returns ``None``. Otherwise, returns a ctypes array.
 
     Parameters
     ----------
-    argument : str
-        The name of the argument.
-    kwargs : dict
-        Dictionary of keyword arguments.
-    dtype : ctypes type
-        The ctypes array type (e.g., ``ctypes.c_double*4``)
+    sequence
+        The sequence to convert. If None, returns None. Otherwise, it must be a sequence
+        (e.g., list, tuple, numpy array).
+    ctype
+        The ctypes type of the array (e.g., ``ctypes.c_int``).
+    size
+        The size of the array. If the sequence is smaller than the size, the remaining
+        elements will be filled with zeros. If the sequence is larger than the size, an
+        exception will be raised.
 
     Returns
     -------
-    ctypes_value : ctypes array or None
+    ctypes_array
+        The ctypes array variable.
 
     Examples
     --------
-
-    >>> import ctypes as ct
-    >>> value = kwargs_to_ctypes_array("bla", {"bla": [10, 10]}, ct.c_long * 2)
-    >>> type(value)
-    <class 'pygmt.clib.conversion.c_long_Array_2'>
-    >>> should_be_none = kwargs_to_ctypes_array(
-    ...     "swallow", {"bla": 1, "foo": [20, 30]}, ct.c_int * 2
-    ... )
-    >>> print(should_be_none)
+    >>> import ctypes as ctp
+    >>> ctypes_array = sequence_to_ctypes_array([1, 2, 3], ctp.c_long, 3)
+    >>> type(ctypes_array)
+    <class 'pygmt.clib.conversion.c_long_Array_3'>
+    >>> ctypes_array[:]
+    [1, 2, 3]
+    >>> ctypes_array = sequence_to_ctypes_array([1, 2], ctp.c_long, 5)
+    >>> type(ctypes_array)
+    <class 'pygmt.clib.conversion.c_long_Array_5'>
+    >>> ctypes_array[:]
+    [1, 2, 0, 0, 0]
+    >>> ctypes_array = sequence_to_ctypes_array(None, ctp.c_long, 5)
+    >>> print(ctypes_array)
     None
+    >>> ctypes_array = sequence_to_ctypes_array([1, 2, 3, 4, 5, 6], ctp.c_long, 5)
+    Traceback (most recent call last):
+    ...
+    IndexError: invalid index
     """
-    if argument in kwargs:
-        return dtype(*kwargs[argument])
-    return None
+    if sequence is None:
+        return None
+    return (ctype * size)(*sequence)
 
 
 def array_to_datetime(array):

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -256,8 +256,8 @@ def sequence_to_ctypes_array(sequence: Sequence, ctype, size: int) -> ctp.Array 
     Parameters
     ----------
     sequence
-        The sequence to convert. If ``None``, returns ``None``. Otherwise, it must be a sequence
-        (e.g., list, tuple, numpy array).
+        The sequence to convert. If ``None``, returns ``None``. Otherwise, it must be a
+        sequence (e.g., list, tuple, numpy array).
     ctype
         The ctypes type of the array (e.g., ``ctypes.c_int``).
     size

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -247,9 +247,11 @@ def as_c_contiguous(array):
 
 def sequence_to_ctypes_array(sequence: Sequence, ctype, size: int) -> ctp.Array | None:
     """
-    Convert a sequence into a ctypes array variable.
+    Convert a sequence of numbers into a ctypes array variable.
 
     If the sequence is ``None``, returns ``None``. Otherwise, returns a ctypes array.
+    The function only works for sequences of numbers. For converting a sequence of
+    strings, use ``strings_to_ctypes_array`` instead.
 
     Parameters
     ----------

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -256,7 +256,7 @@ def sequence_to_ctypes_array(sequence: Sequence, ctype, size: int) -> ctp.Array 
     Parameters
     ----------
     sequence
-        The sequence to convert. If None, returns None. Otherwise, it must be a sequence
+        The sequence to convert. If ``None``, returns ``None``. Otherwise, it must be a sequence
         (e.g., list, tuple, numpy array).
     ctype
         The ctypes type of the array (e.g., ``ctypes.c_int``).


### PR DESCRIPTION
**Description of proposed changes**

The [`kwargs_to_ctypes_array`](https://github.com/GenericMappingTools/pygmt/blob/32e3cb36a0a2faaebd837ab99986431ee57e8060/pygmt/clib/conversion.py#L246) function was one of the oldest functions in PyGMT. It was first added in PR #55 (It's 2017! Seven years ago!) and has not changed since then.

The function converts a sequence (like a list or a tuple) into a ctypes array, but the sequence must be the argument of a keyword dictionary, so it's called like this:
```
dim = kwargs_to_ctypes_array("dim", kwargs, ctp.c_uint64 * 4)
```
but why not just have a more general function `sequence_to_ctypes_array`, which can be called like:
```
dim = sequence_to_ctypes_array(kwargs.get("dim"), ctp.c_uint64 * 4)
```
The new function also works if `dim` is not a keyword argument:
```
dim = sequence_to_ctypes_array(dim, ctp.c_uint64 * 4)
```

This PR removes the old `kwargs_to_ctypes_array` function and adds the new `sequence_to_ctypes_array` function. It's defined differently and should be called like:
```
dim = sequence_to_ctypes_array(dim, ctp.c_uint64, 4) 
```
which I think is more readable. 

The `Session.create_data` method is also slightly refactored because the `kwargs` parameter makes little sense in this method.

PR #3137 adds a similar function that converts a sequence of strings into a ctypes array. Better to review these two PRs back-to-back.
