### PR TITLE
Add strings_to_ctypes_array to convert a sequence of strings into a ctypes array

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -2,7 +2,9 @@
 Functions to convert data types into ctypes friendly formats.
 """
 
+import ctypes as ctp
 import warnings
+from collections.abc import Sequence
 
 import numpy as np
 from pygmt.exceptions import GMTInvalidInput
@@ -278,6 +280,32 @@ def kwargs_to_ctypes_array(argument, kwargs, dtype):
     if argument in kwargs:
         return dtype(*kwargs[argument])
     return None
+
+
+def strings_to_ctypes_array(strings: Sequence[str]) -> ctp.Array:
+    """
+    Convert a sequence (e.g., a list) of strings into a ctypes array.
+
+    Parameters
+    ----------
+    strings
+        A sequence of strings.
+
+    Returns
+    -------
+    ctypes_array
+        A ctypes array of strings.
+
+    Examples
+    --------
+    >>> strings = ["first", "second", "third"]
+    >>> ctypes_array = strings_to_ctypes_array(strings)
+    >>> type(ctypes_array)
+    <class 'pygmt.clib.conversion.c_char_p_Array_3'>
+    >>> [s.decode() for s in ctypes_array]
+    ['first', 'second', 'third']
+    """
+    return (ctp.c_char_p * len(strings))(*[s.encode() for s in strings])
 
 
 def array_to_datetime(array):

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -19,8 +19,8 @@ from pygmt.clib.conversion import (
     array_to_datetime,
     as_c_contiguous,
     dataarray_to_matrix,
-    strings_to_ctypes_array,
     sequence_to_ctypes_array,
+    strings_to_ctypes_array,
     vectors_to_arrays,
 )
 from pygmt.clib.loading import load_libgmt


### PR DESCRIPTION
**Description of proposed changes**

To pass a list of strings into a ctypes function, currently, we have codes like the below, which is not readable:
```
strings_pointer = (ctp.c_char_p * len(strings))()
strings_pointer[:] = np.char.encode(strings)
```
So better to have a `strings_to_ctypes_array` function, which can hide the technical details.

The above two lines codes can be shortened into a single line of code:
```
strings_pointer = (ctp.c_char_p * len(strings))(*np.char.encode(strings))
```
Actually `np.char.encode` calls the `str.encode` element-wise, so it can be further written as:
```
strings_pointer = (ctp.c_char_p * len(strings))(*[s.encode() for s in strings])
```

The list comprehension version is faster than the `np.char.encode` version:
```
>>> import numpy as np
>>> import ctypes as ctp
>>> strings = ["ABC", "DEFGHI", "ABC123", "ABC1234566"]
>>> %timeit (ctp.c_char_p * 4)(*[s.encode() for s in strings])
1.37 µs ± 3.79 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

>>> %timeit (ctp.c_char_p * 4)(*np.char.encode(strings))
6.17 µs ± 22.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

This PR adds the `strings_to_ctypes_array` function to do the conversion work. It just contains one line of code and doesn't check if the `strings` is an empty list to avoid extra overheads.

PR #3136 is a similar work but for converting a sequence of **numbers** to a ctypes array. These two functions share similar codes but I prefer not to combine them into a single function to avoid too many if-else clauses in the low-level function. Better to review these two PRs back-to-back.