### PR TITLE
Add tutorial section on passing xr.Dataset with 1-D data_vars as input

### DIFF
--- a/examples/get_started/04_table_inputs.py
+++ b/examples/get_started/04_table_inputs.py
@@ -27,6 +27,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pygmt
+import xarray as xr
 
 # %%
 # ASCII table file
@@ -108,6 +109,39 @@ gdf = gpd.GeoDataFrame(
 fig = pygmt.Figure()
 fig.basemap(region=[0, 10, 0, 5], projection="X10c/5c", frame=True)
 fig.plot(data=gdf, style="c0.2c", fill="purple")
+fig.show()
+
+# %%
+# :class:`xarray.Dataset` with 1-D data variables
+# -----------------------------------------------
+#
+# For slightly advanced users that have tabular-like data stored in an
+# :class:`xarray.Dataset` object, it is also possible to pass this into the ``data``
+# parameter, provided that:
+#
+# 1. The :class:`xarray.Dataset` input is made up of 1-D :class:`xarray.DataArray` data
+#    variables.
+# 2. The data you want to plot or process is stored under ``data_vars``, and not under
+#    ``coords`` in the :class:`xarray.Dataset` data structure. Use
+#    :meth:`xarray.Dataset.reset_coords` if you need to convert a coordinate into a
+#    data variable.
+#
+# This is useful if you are working with data stored in file formats like HDF5 which can
+# be read using :func:`xarray.open_dataset`, but not ``pandas``
+
+# Example xr.Dataset
+index = np.arange(start=0, stop=10)
+distance = np.linspace(start=20, stop=50, num=10)
+elevation = np.logspace(start=1, stop=-3, num=10)
+
+ds = xr.Dataset(
+    data_vars={"distance": (["index"], distance), "y": (["index"], elevation)}
+)
+ds  # noqa: B018
+
+# %%
+fig = pygmt.Figure()
+fig.plot(data=ds, frame=["xaf+lDistance", "yaf+lElevation"])
 fig.show()
 
 # %%


### PR DESCRIPTION
**Description of proposed changes**

Show how an xarray.Dataset with 1-D data variables can be passed into the `data` parameter of PyGMT functions/methods.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses #3146, #1268


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
