### PR TITLE
Wrap GMT_Inquire_VirtualFile to get the family of virtualfiles

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1709,6 +1709,35 @@ class Session:
             with self.open_virtualfile(family, geometry, "GMT_OUT", None) as vfile:
                 yield vfile
 
+    def inquire_virtualfile(self, vfname: str) -> int:
+        """
+        Get the family of a virtual file.
+
+        Parameters
+        ----------
+        vfname
+            Name of the virtual file to inquire.
+
+        Returns
+        -------
+        family
+            The family of the virtual file.
+
+        Examples
+        --------
+        >>> from pygmt.clib import Session
+        >>> with Session() as lib:
+        ...     with lib.virtualfile_out(kind="dataset") as vfile:
+        ...         family = lib.inquire_virtualfile(vfile)
+        ...         assert family == lib["GMT_IS_DATASET"]
+        """
+        c_inquire_virtualfile = self.get_libgmt_func(
+            "GMT_Inquire_VirtualFile",
+            argtypes=[ctp.c_void_p, ctp.c_char_p],
+            restype=ctp.c_uint,
+        )
+        return c_inquire_virtualfile(self.session_pointer, vfname.encode())
+
     def read_virtualfile(
         self, vfname: str, kind: Literal["dataset", "grid", None] = None
     ):

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1721,7 +1721,7 @@ class Session:
         Returns
         -------
         family
-            The family of the virtual file.
+            The integer value for the family of the virtual file.
 
         Examples
         --------

--- a/pygmt/tests/test_clib_virtualfiles.py
+++ b/pygmt/tests/test_clib_virtualfiles.py
@@ -379,3 +379,31 @@ def test_virtualfile_from_vectors_arraylike():
         bounds = "\t".join([f"<{min(i):.0f}/{max(i):.0f}>" for i in (x, y, z)])
         expected = f"<vector memory>: N = {size}\t{bounds}\n"
         assert output == expected
+
+
+def test_inquire_virtualfile():
+    """
+    Test that the inquire_virtualfile method returns the correct family.
+
+    Currently, only ouptut virtualfiles are tested.
+    """
+    with clib.Session() as lib:
+        for family in [
+            "GMT_IS_DATASET",
+            "GMT_IS_DATASET|GMT_VIA_MATRIX",
+            "GMT_IS_DATASET|GMT_VIA_VECTOR",
+        ]:
+            with lib.open_virtualfile(
+                family, "GMT_IS_PLP", "GMT_OUT|GMT_IS_REFERENCE", None
+            ) as vfile:
+                assert lib.inquire_virtualfile(vfile) == lib["GMT_IS_DATASET"]
+
+        for family, geometry in [
+            ("GMT_IS_GRID", "GMT_IS_SURFACE"),
+            ("GMT_IS_IMAGE", "GMT_IS_SURFACE"),
+            ("GMT_IS_CUBE", "GMT_IS_VOLUME"),
+            ("GMT_IS_PALETTE", "GMT_IS_NONE"),
+            ("GMT_IS_POSTSCRIPT", "GMT_IS_NONE"),
+        ]:
+            with lib.open_virtualfile(family, geometry, "GMT_OUT", None) as vfile:
+                assert lib.inquire_virtualfile(vfile) == lib[family]

--- a/pygmt/tests/test_clib_virtualfiles.py
+++ b/pygmt/tests/test_clib_virtualfiles.py
@@ -385,7 +385,7 @@ def test_inquire_virtualfile():
     """
     Test that the inquire_virtualfile method returns the correct family.
 
-    Currently, only ouptut virtualfiles are tested.
+    Currently, only output virtual files are tested.
     """
     with clib.Session() as lib:
         for family in [


### PR DESCRIPTION
**Description of proposed changes**

Upstream documentation: http://docs.generic-mapping-tools.org/dev/devdocs/api.html#gmt-inquire-virtualfile

The `GMT_Inquire_VirtualFile` API function takes the name of a virtual file as input, and returns the integer of the family.

This PR wraps up the API function. Tests are also added.

Address the request in https://github.com/GenericMappingTools/pygmt/pull/3115#discussion_r1536476290.

After this PR is merged, we will refactor 
```
def virtualfile_to_grid(self, vfname, outgrid):
    if outgrid is not None:
        return None
    return self.read_virtualfile(vfname, kind="grid").contents.to_dataarray()
```
to something like
```
def virtualfile_to_raster(self, vfname, outgrid, kind="grid"):
    if outgrid is not None:
        return None
    if kind is None: 
        family = self.inquire_virtualfile(vfname)
        kind = {
            self["GMT_IS_GRID"]: "grid",
            self["GMT_IS_IMAGE"]: "image",
            self["GMT_IS_CUBE"]: "cube",
       }[family]
    return self.read_virtualfile(vfname, kind=kind).contents.to_dataarray()
```