### PR TITLE
Refactor the test_call_module_empty_argument test

### DIFF
--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -159,10 +159,11 @@ def test_call_module_empty_argument():
     """
     call_module should work if an empty string or an empty list is passed as argument.
     """
+    Figure()
     with clib.Session() as lib:
-        lib.call_module("defaults", "")
+        lib.call_module("logo", "")
     with clib.Session() as lib:
-        lib.call_module("defaults", [])
+        lib.call_module("logo", [])
 
 
 def test_call_module_invalid_argument_type():


### PR DESCRIPTION
**Description of proposed changes**

The `test_call_module_empty_argument` test was added in PR #3139 to make sure that passing an empty argument string or list works as expected.

There are very few GMT modules that can work without an argument, so I chose `gmt defaults` in PR #3139, but it outputs a long list of GMT configurations, which is quite annoying.

This PR refactors the test to use `logo` instead, which can work without an argument.

Patches #3139.