### PR TITLE
Change the dev dependency 'matplotlib' to 'matplotlib-base' which doesn't require pyqt

### DIFF
--- a/.github/workflows/type_checks.yml
+++ b/.github/workflows/type_checks.yml
@@ -52,7 +52,7 @@ jobs:
             numpy pandas xarray netcdf4 packaging \
             contextily geopandas ipython rioxarray \
             mypy pandas-stubs \
-            matplotlib pytest
+            matplotlib-base pytest
           python -m pip list
 
       - name: Static type check

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
     - codespell
     - ruff>=0.3.0
     # Dev dependencies (unit testing)
-    - matplotlib
+    - matplotlib-base
     - pytest-cov
     - pytest-doctestplus
     - pytest-mpl


### PR DESCRIPTION
**Description of proposed changes**

`matplotlib-base` is the same as `matplotlib` except that it doesn't depend on pyqt.
So `matplotlib-base` is much lighter. https://stackoverflow.com/a/61326297

After changing `matplotlib` to `matplotlib-base`, the directory size of the `pygmt`
environment reduces from 3.3 GB to 2.5 GB for me (on Linux).
