### PR TITLE
CI: Use OIDC token for codecov uploading

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -49,6 +49,8 @@ jobs:
   test:
     name: ${{ matrix.os }} - Python ${{ matrix.python-version }} / NumPy ${{ matrix.numpy-version }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write  # This is required for requesting OIDC token for codecov
     strategy:
       fail-fast: false
       matrix:
@@ -161,7 +163,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.3.1
         with:
+          use_oidc: true
           file: ./coverage.xml # optional
           env_vars: OS,PYTHON,NUMPY
           fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov-action v4.2.0 started to support OIDC token for uploading coverage results, so that we don't need to use secret tokens any more.

Upstream PR: https://github.com/codecov/codecov-action/pull/1330
Usage: https://github.com/codecov/codecov-action#using-oidc

If it works, then we can remove the `CODECOV_TOKEN` secrets from the settings.
