### PR TITLE
Switch to official GitHub action for managing app tokens

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Generate token from GenericMappingTools bot
-      - uses: tibdex/github-app-token@v2
+      - uses: actions/create-github-app-token@v1.9
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       # Checkout the pull request branch
       - uses: actions/checkout@v4.1.1

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Generate token from GenericMappingTools bot
-      - uses: actions/create-github-app-token@v1.9
+      - uses: actions/create-github-app-token@v1.9.3
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}


### PR DESCRIPTION
**Description of proposed changes**

Switch from the [tibdex/github-app-token action](https://github.com/tibdex/github-app-token) to generate PAT token which are used in the /format slash command to the official GitHub action for this purpose (https://github.com/actions/create-github-app-token).

Fixes #3164