### PR TITLE
CI: Use gh to create issues in Check Links workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -68,7 +68,8 @@ jobs:
 
     - name: Create Issue From File
       if: env.lychee_exit_code != 0
-      uses: peter-evans/create-issue-from-file@v5
-      with:
-        title: Link Checker Report on ${{ steps.date.outputs.date }}
-        content-filepath: ./lychee/out.md
+      run: |
+        title="Link Checker Report on ${{ steps.date.outputs.date }}"
+        gh issue create --title "$title" --body-file ./lychee/out.md
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
**Description of proposed changes**

[gh](https://cli.github.com/) is the official GitHub CLI. `gh issue create` can create issues so we don't need to use the `peter-evans/create-issue-from-file` action.

The `gh issue create` command has been used in https://github.com/GenericMappingTools/gmt/blob/master/.github/workflows/remind.yml, and works well (see https://github.com/GenericMappingTools/gmt/issues/8249).