### PR TITLE
Add gallery example showing how to fill the area between two curves

### DIFF
--- a/examples/gallery/lines/curves_area.py
+++ b/examples/gallery/lines/curves_area.py
@@ -1,0 +1,59 @@
+"""
+Area between curves
+-------------------
+Using the ``M`` parameter of the :meth:`pygmt.Figure.plot` method it is possible
+to fill the area between two curves y_1 and y_2 with color. Different fills (colors
+or patterns) can be used for the areas y_1 > y_2 and y_1 < y_2. Optionally, the
+curves can be drawn.
+"""
+
+# %%
+import numpy as np
+import pandas as pd
+import pygmt as gmt
+
+# -----------------------------------------------------------------------------
+# Generate some test data and create a pandas DataFrame
+x = np.arange(-10, 10.2, 0.1)
+y1 = np.sin(x * 3)
+y2 = np.sin(x / 2)
+
+data = np.array([x, y1, y2])
+data_tp = data.transpose()
+
+data_df = pd.DataFrame(data_tp, columns=["x", "y1", "y2"])
+
+# -----------------------------------------------------------------------------
+# Set up new Figure instance
+fig = gmt.Figure()
+fig.basemap(region=[-10, 10, -5, 5], projection="X15c/5c", frame=True)
+
+fig.plot(
+    data=data_df,
+    fill="orange",
+    M="c+gsteelblue+lshort < long",
+    label="short > long",
+)
+
+fig.legend()
+
+fig.show()
+
+
+# %%
+# Additionally we can draw the curves.
+
+# Set up new Figure instance
+fig = gmt.Figure()
+fig.basemap(region=[-10, 10, -5, 5], projection="X15c/5c", frame=True)
+
+fig.plot(
+    data=data_df,
+    fill="p8",
+    pen="1p,black,solid",
+    M="c+gp17+p1p,black,dashed",
+)
+
+fig.show()
+
+# sphinx_gallery_thumbnail_number = 1


### PR DESCRIPTION
**Description of proposed changes**

[**-M**](https://docs.generic-mapping-tools.org/dev/plot.html#m) of `plot` allows to fill the area between two curves with colors or patterns. This PR addes a gallery example showing how to do this:

- [ ] PR to add alias for **-M** (new in GMT 6.5.0)
- [ ] Add code for gallery example
- [ ] Add documentation and comments

**Preview**:

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
