### PR TITLE
CI: Use GH_TOKEN instead of GITHUB_TOKEN for GitHub CLI

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -72,4 +72,4 @@ jobs:
         title="Link Checker Report on ${{ steps.date.outputs.date }}"
         gh issue create --title "$title" --body-file ./lychee/out.md
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
The Check Links workflow fails with following message:
```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. 
```
See upstream issue https://github.com/github/docs/issues/21930.

Patches #3166.