### PR TITLE
Add placeholder codes for wrapping GMT_IMAGE/GMT_CUBE

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -25,7 +25,7 @@ from pygmt.clib.conversion import (
     vectors_to_arrays,
 )
 from pygmt.clib.loading import load_libgmt
-from pygmt.datatypes import _GMT_DATASET, _GMT_GRID
+from pygmt.datatypes import _GMT_CUBE, _GMT_DATASET, _GMT_GRID, _GMT_IMAGE
 from pygmt.exceptions import (
     GMTCLibError,
     GMTCLibNoSessionError,
@@ -1649,7 +1649,9 @@ class Session:
 
     @contextlib.contextmanager
     def virtualfile_out(
-        self, kind: Literal["dataset", "grid"] = "dataset", fname: str | None = None
+        self,
+        kind: Literal["dataset", "grid", "image", "cube"] = "dataset",
+        fname: str | None = None,
     ):
         r"""
         Create a virtual file or an actual file for storing output data.
@@ -1662,8 +1664,8 @@ class Session:
         Parameters
         ----------
         kind
-            The data kind of the virtual file to create. Valid values are ``"dataset"``
-            and ``"grid"``. Ignored if ``fname`` is specified.
+            The data kind of the virtual file to create. Valid values are ``"dataset"``,
+            ``"grid"``, ``"image"`` and ``"cube"``. Ignored if ``fname`` is specified.
         fname
             The name of the actual file to write the output data. No virtual file will
             be created.
@@ -1706,6 +1708,8 @@ class Session:
             family, geometry = {
                 "dataset": ("GMT_IS_DATASET", "GMT_IS_PLP"),
                 "grid": ("GMT_IS_GRID", "GMT_IS_SURFACE"),
+                "image": ("GMT_IS_IMAGE", "GMT_IS_SURFACE"),
+                "cube": ("GMT_IS_CUBE", "GMT_IS_VOLUME"),
             }[kind]
             with self.open_virtualfile(family, geometry, "GMT_OUT", None) as vfile:
                 yield vfile
@@ -1753,7 +1757,8 @@ class Session:
             Name of the virtual file to read.
         kind
             Cast the data into a GMT data container. Valid values are ``"dataset"``,
-            ``"grid"`` and ``None``. If ``None``, will return a ctypes void pointer.
+            ``"grid"``, ``"image"``, ``"cube"``, and ``None``. If ``None``, will return
+            a ctypes void pointer.
 
         Examples
         --------
@@ -1801,9 +1806,12 @@ class Session:
         # _GMT_DATASET).
         if kind is None:  # Return the ctypes void pointer
             return pointer
-        if kind in ["image", "cube"]:
-            raise NotImplementedError(f"kind={kind} is not supported yet.")
-        dtype = {"dataset": _GMT_DATASET, "grid": _GMT_GRID}[kind]
+        dtype = {
+            "dataset": _GMT_DATASET,
+            "grid": _GMT_GRID,
+            "image": _GMT_IMAGE,
+            "cube": _GMT_CUBE,
+        }[kind]
         return ctp.cast(pointer, ctp.POINTER(dtype))
 
     def virtualfile_to_dataset(

--- a/pygmt/datatypes/__init__.py
+++ b/pygmt/datatypes/__init__.py
@@ -2,5 +2,7 @@
 Wrappers for GMT data types.
 """
 
+from pygmt.datatypes.cube import _GMT_CUBE
 from pygmt.datatypes.dataset import _GMT_DATASET
 from pygmt.datatypes.grid import _GMT_GRID
+from pygmt.datatypes.image import _GMT_IMAGE

--- a/pygmt/datatypes/cube.py
+++ b/pygmt/datatypes/cube.py
@@ -1,0 +1,9 @@
+"""
+Wrapper for the GMT_CUBE data type.
+"""
+
+import ctypes as ctp
+
+
+class _GMT_CUBE(ctp.Structure):  # noqa: N801
+    pass

--- a/pygmt/datatypes/image.py
+++ b/pygmt/datatypes/image.py
@@ -1,0 +1,9 @@
+"""
+Wrapper for the GMT_IMAGE data type.
+"""
+
+import ctypes as ctp
+
+
+class _GMT_IMAGE(ctp.Structure):  # noqa: N801
+    pass


### PR DESCRIPTION
I don't think we can finish wrapping `GMT_IMAGE` and `GMT_CUBE` in the next few weeks, so it is better to push them to PyGMT v0.13.0.

This PR cherry-pick codes used in wrapping `GMT_IMAGE`/`GMT_CUBE` (#3150 and #3128) to minimize potential conflicts in #3150 and #3128.