### PR TITLE
Remove sequence_space converter from kwargs_to_string

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -634,7 +634,6 @@ def kwargs_to_strings(**conversions):
       string
     * 'sequence_comma': transforms a sequence into a ``','`` separated string
     * 'sequence_plus': transforms a sequence into a ``'+'`` separated string
-    * 'sequence_space': transforms a sequence into a ``' '`` separated string
 
     Parameters
     ----------
@@ -645,7 +644,7 @@ def kwargs_to_strings(**conversions):
 
     Examples
     --------
-    >>> @kwargs_to_strings(R="sequence", i="sequence_comma", files="sequence_space")
+    >>> @kwargs_to_strings(R="sequence", i="sequence_comma")
     ... def module(*args, **kwargs):
     ...     "A module that prints the arguments it received"
     ...     print("{", end="")
@@ -670,7 +669,7 @@ def kwargs_to_strings(**conversions):
     >>> module(i=[1, 2])
     {'i': '1,2'}
     >>> module(files=["data1.txt", "data2.txt"])
-    {'files': 'data1.txt data2.txt'}
+    {'files': ['data1.txt', 'data2.txt']}
     >>> # Other non-boolean arguments are passed along as they are
     >>> module(123, bla=(1, 2, 3), foo=True, A=False, i=(5, 6))
     {'A': False, 'bla': (1, 2, 3), 'foo': True, 'i': '5,6'}
@@ -695,7 +694,6 @@ def kwargs_to_strings(**conversions):
     >>> # Here is a more realistic example
     >>> # See https://github.com/GenericMappingTools/pygmt/issues/2361
     >>> @kwargs_to_strings(
-    ...     files="sequence_space",
     ...     offset="sequence",
     ...     R="sequence",
     ...     i="sequence_comma",
@@ -711,21 +709,20 @@ def kwargs_to_strings(**conversions):
     ...     )
     ...     print("}")
     >>> module(files=["data1.txt", "data2.txt"])
-    data1.txt data2.txt -54p/-54p {}
+    ['data1.txt', 'data2.txt'] -54p/-54p {}
     >>> module(["data1.txt", "data2.txt"])
-    data1.txt data2.txt -54p/-54p {}
+    ['data1.txt', 'data2.txt'] -54p/-54p {}
     >>> module(files=["data1.txt", "data2.txt"], offset=("20p", "20p"))
-    data1.txt data2.txt 20p/20p {}
+    ['data1.txt', 'data2.txt'] 20p/20p {}
     >>> module(["data1.txt", "data2.txt"], ("20p", "20p"))
-    data1.txt data2.txt 20p/20p {}
+    ['data1.txt', 'data2.txt'] 20p/20p {}
     >>> module(["data1.txt", "data2.txt"], ("20p", "20p"), R=[1, 2, 3, 4])
-    data1.txt data2.txt 20p/20p {'R': '1/2/3/4'}
+    ['data1.txt', 'data2.txt'] 20p/20p {'R': '1/2/3/4'}
     """
     separators = {
         "sequence": "/",
         "sequence_comma": ",",
         "sequence_plus": "+",
-        "sequence_space": " ",
     }
 
     for arg, fmt in conversions.items():


### PR DESCRIPTION
**Description of proposed changes**

Remove `sequence_space` converter from `@kwargs_to_string`, which is no longer needed after #3132. For reference, it was initially added in #325.

Address https://github.com/GenericMappingTools/pygmt/pull/3132#discussion_r1569927691.