### PR TITLE
CI: Remove the 'add reaction' step from the format workflow

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -48,11 +48,3 @@ jobs:
             git commit -am "[format-command] fixes"
             git push
           fi
-
-      - name: Add reaction
-        uses: peter-evans/create-or-update-comment@v4.0.0
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          reactions: hooray


### PR DESCRIPTION
The `/format` slash command takes less than 30 seconds to run, so there is no need to add reactions to the issue comment. 

Removing the "Add reaction" step so we no longer use the `peter-evans/create-or-update-comment` action in any workflows.