### PR TITLE
Gallery example "Custom symbols": Mention own coustom symbols

### DIFF
--- a/examples/gallery/symbols/custom_symbols.py
+++ b/examples/gallery/symbols/custom_symbols.py
@@ -2,21 +2,20 @@
 Custom symbols
 ==============
 
-The :meth:`pygmt.Figure.plot` method can plot individual custom symbols
-by passing the corresponding symbol name together with the **k** shortcut to
-the ``style`` parameter.
+The :meth:`pygmt.Figure.plot` method can plot individual custom symbols by
+passing the corresponding symbol name together with the **k** shortcut to the
+``style`` parameter.
 
 In total 41 custom symbols are already included of which the following plot
-shows five exemplary ones. The symbols are shown underneath their
-corresponding names. For the remaining symbols see the GMT Technical
-Reference :gmt-docs:`reference/custom-symbols.html`.
+shows five exemplary ones. The symbols are shown underneath their corresponding
+names. For the remaining symbols see the GMT Technical Reference
+:gmt-docs:`reference/custom-symbols.html`.
 
-Beside these built-in custom symbols GMT allows users to define their own
-custom symbols. For this a specific macro language is used. An detailed
+Beside these built-in custom symbols GMT allows users to define their own custom
+symbols. For this a specific macro language is used. A detailed
 introduction can be found at
-:gmt-docs:`reference/custom-symbols.html#the-macro-language`
-After defining such a symbol it can be used in the same way as a built-in
-custom symbol.
+:gmt-docs:`reference/custom-symbols.html#the-macro-language`. After defining such
+a symbol it can be used in the same way as a built-in custom symbol.
 
 *Please note*: Custom symbols can not be used in auto-legends yet.
 """
@@ -27,32 +26,27 @@ import pygmt
 fig = pygmt.Figure()
 fig.basemap(region=[0, 8, 0, 3], projection="X12c/4c", frame=True)
 
-# define pen and fontstyle for annotations
+# Define pen and fontstyle for annotations
 pen = "1p,black"
 font = "15p,Helvetica-Bold"
 
-# use the volcano symbol with a size of 1.5c,
-# fill color is set to "seagreen"
+# Use the volcano symbol with a size of 1.5c, fill color is set to "seagreen"
 fig.plot(x=1, y=1.25, style="kvolcano/1.5c", pen=pen, fill="seagreen")
 fig.text(x=1, y=2.5, text="volcano", font=font)
 
-# use the astroid symbol with a size of 1.5c,
-# fill color is set to "red3"
+# Use the astroid symbol with a size of 1.5c, fill color is set to "red3"
 fig.plot(x=2.5, y=1.25, style="kastroid/1.5c", pen=pen, fill="red3")
 fig.text(x=2.5, y=2.5, text="astroid", font=font)
 
-# use the flash symbol with a size of 1.5c,
-# fill color is set to "darkorange"
+# Use the flash symbol with a size of 1.5c, fill color is set to "darkorange"
 fig.plot(x=4, y=1.25, style="kflash/1.5c", pen=pen, fill="darkorange")
 fig.text(x=4, y=2.5, text="flash", font=font)
 
-# use the star4 symbol with a size of 1.5c,
-# fill color is set to "dodgerblue4"
+# Use the star4 symbol with a size of 1.5c, fill color is set to "dodgerblue4"
 fig.plot(x=5.5, y=1.25, style="kstar4/1.5c", pen=pen, fill="dodgerblue4")
 fig.text(x=5.5, y=2.5, text="star4", font=font)
 
-# use the hurricane symbol with a size of 1.5c,
-# fill color is set to "magenta4"
+# Use the hurricane symbol with a size of 1.5c, fill color is set to "magenta4"
 fig.plot(x=7, y=1.25, style="khurricane/1.5c", pen=pen, fill="magenta4")
 fig.text(x=7, y=2.5, text="hurricane", font=font)
 

--- a/examples/gallery/symbols/custom_symbols.py
+++ b/examples/gallery/symbols/custom_symbols.py
@@ -4,10 +4,21 @@ Custom symbols
 
 The :meth:`pygmt.Figure.plot` method can plot individual custom symbols
 by passing the corresponding symbol name together with the **k** shortcut to
-the ``style`` parameter. In total 41 custom symbols are already included of
-which the following plot shows five exemplary ones. The symbols are shown
-underneath their corresponding names. For the remaining symbols see the GMT
-Technical Reference :gmt-docs:`reference/custom-symbols.html`.
+the ``style`` parameter.
+
+In total 41 custom symbols are already included of which the following plot
+shows five exemplary ones. The symbols are shown underneath their
+corresponding names. For the remaining symbols see the GMT Technical
+Reference :gmt-docs:`reference/custom-symbols.html`.
+
+Beside these built-in custom symbols GMT allows users to define their own
+custom symbols. For this a specific macro language is used. An detailed
+introduction can be found at
+https://docs.generic-mapping-tools.org/6.5/reference/custom-symbols.html#the-macro-language.
+After defining such a symbol it can be used in the same way as a built-in
+custom symbol.
+
+*Please note*: Custom symbols can not be used in auto-legends yet.
 """
 
 # %%

--- a/examples/gallery/symbols/custom_symbols.py
+++ b/examples/gallery/symbols/custom_symbols.py
@@ -6,16 +6,15 @@ The :meth:`pygmt.Figure.plot` method can plot individual custom symbols by
 passing the corresponding symbol name together with the **k** shortcut to the
 ``style`` parameter.
 
-In total 41 custom symbols are already included of which the following plot
-shows five exemplary ones. The symbols are shown underneath their corresponding
-names. For the remaining symbols see the GMT Technical Reference
+In total 41 custom symbols are already included of which the following plot shows
+five exemplary ones. The symbols are shown underneath their corresponding names.
+For the remaining symbols see the GMT Technical Reference
 :gmt-docs:`reference/custom-symbols.html`.
 
 Beside these built-in custom symbols GMT allows users to define their own custom
-symbols. For this a specific macro language is used. A detailed
-introduction can be found at
-:gmt-docs:`reference/custom-symbols.html#the-macro-language`. After defining such
-a symbol it can be used in the same way as a built-in custom symbol.
+symbols. For this a specific macro language is used. A detailed introduction can
+be found at :gmt-docs:`reference/custom-symbols.html#the-macro-language`. After
+defining such a symbol it can be used in the same way as a built-in custom symbol.
 
 *Please note*: Custom symbols can not be used in auto-legends yet.
 """

--- a/examples/gallery/symbols/custom_symbols.py
+++ b/examples/gallery/symbols/custom_symbols.py
@@ -12,7 +12,7 @@ For the remaining symbols see the GMT Technical Reference
 :gmt-docs:`reference/custom-symbols.html`.
 
 Beside these built-in custom symbols GMT allows users to define their own custom
-symbols. For this a specific macro language is used. A detailed introduction can
+symbols. For this, a specific macro language is used. A detailed introduction can
 be found at :gmt-docs:`reference/custom-symbols.html#the-macro-language`. After
 defining such a symbol it can be used in the same way as a built-in custom symbol.
 

--- a/examples/gallery/symbols/custom_symbols.py
+++ b/examples/gallery/symbols/custom_symbols.py
@@ -14,7 +14,7 @@ Reference :gmt-docs:`reference/custom-symbols.html`.
 Beside these built-in custom symbols GMT allows users to define their own
 custom symbols. For this a specific macro language is used. An detailed
 introduction can be found at
-https://docs.generic-mapping-tools.org/6.5/reference/custom-symbols.html#the-macro-language.
+:gmt-docs:`reference/custom-symbols.html#the-macro-language`
 After defining such a symbol it can be used in the same way as a built-in
 custom symbol.
 


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a comment to the already existing gallery example [Custom symbols](https://www.pygmt.org/dev/gallery/symbols/custom_symbols.html) regarding own custom symbols.

Actually, issue #1349 suggests adding a standalone gallery example or tutorial. However, the macro language that is used to define own custom symbols is quite complicated, there is no difference to GMT, and the GMT documentation is quite detailed (please see https://docs.generic-mapping-tools.org/6.5/reference/custom-symbols.html#the-macro-language). Furthermore, plotting own custom symbols works similar to plotting built-in custom symbols (except including the `.def` file extension). So, mentioning the possibility of creating own custom symbols and the reference to the GMT documentation in the PyGMT gallery example [Custom symbols](https://www.pygmt.org/dev/gallery/symbols/custom_symbols.html) may be enough.

**Preview**: https://pygmt-dev--3186.org.readthedocs.build/en/3186/gallery/symbols/custom_symbols.html

Fixes #1349 (partly)

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
