### PR TITLE
CI: Use 'gh release' to upload assets to release

### DIFF
--- a/.github/workflows/release-baseline-images.yml
+++ b/.github/workflows/release-baseline-images.yml
@@ -17,6 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'GenericMappingTools/pygmt'
 
+    permissions:
+      # To write assets to GitHub release
+      contents: write
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4.1.1
@@ -35,7 +39,6 @@ jobs:
         shasum -a 256 baseline-images.zip
 
     - name: Upload baseline image as a release asset
-      uses: shogo82148/actions-upload-release-asset@v1.7.5
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: baseline-images.zip
+      run: gh release upload ${{ github.ref_name }} baseline-images.zip
+      env:
+        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
**Description of proposed changes**

Use `gh release` to upload assets to release, so we don't need to use the `shogo82148/actions-upload-release-asset` action anymore.

Reference: https://michael-mckenna.com/how-to-upload-file-to-github-release-in-a-workflow/

The same commit was pushed to my own fork (https://github.com/seisman/pygmt). See https://github.com/seisman/pygmt/actions/runs/8772441014 for the workflow run and the testing release https://github.com/seisman/pygmt/releases/tag/v0.12.0.