### PR TITLE
Fix the bug for support of left/right single quotation marks

### DIFF
--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -305,10 +305,11 @@ def non_ascii_to_octal(argstr):
             c: "\\" + format(i, "o")
             for c, i in zip(
                 "•…™—–ﬁž"  # \03x. \030 is undefined
+                "’‘"  # \047 and \140
                 "š"  # \177
                 "Œ†‡Ł⁄‹Š›œŸŽł‰„“”"  # \20x-\21x
                 "ı`´ˆ˜¯˘˙¨‚˚¸'˝˛ˇ",  # \22x-\23x
-                [*range(25, 32), *range(127, 160)],
+                [*range(25, 32), 39, 96, *range(127, 160)],
                 strict=True,
             )
         }

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -430,5 +430,5 @@ def test_text_quotation_marks():
     """
     fig = Figure()
     fig.basemap(projection="X4c/2c", region=[0, 4, 0, 2], frame=0)
-    fig.text(x=2, y=1, text="\\234 \\140 ' \" \\216 \\217", font="20p")
+    fig.text(x=2, y=1, text='\\234 ‘ ’ " “ ”', font="20p")  # noqa: RUF001
     return fig


### PR DESCRIPTION
**Description of proposed changes**

Left/right single quotation marks `‘’` are not translated correctly in PR #2584. Here is a minimal example to reproduce the issue:
```python
>>> import pygmt
>>>
>>> fig = pygmt.Figure()
>>> fig.basemap(region=[0, 10, 0, 5], projection="X10c/5c", frame=True)
>>> fig.text(text="A ' ‘ ’ \" “ ” B", position="CM", font="20p", fill="230")
>>> fig.show()
```
This PR fixes the bug.

| Incorrect result in the main branch | Correct result in this PR |
|---|---|
| ![map](https://github.com/GenericMappingTools/pygmt/assets/3974108/b8e07f7a-0b87-411e-91ab-af9f84ed3bb8) | ![map](https://github.com/GenericMappingTools/pygmt/assets/3974108/321099f7-0c16-4cb5-9f03-04de29f76d9a) |

You may notice that the ASCII character `'` (usually called straight single quotation mark or apostrophe) is typeset like `’` rather than `'`. The reason behind this is complicated. Anyone interested can read the references listed below. With ISOLatin+ charset, users can use octal code `\234` to get the `'` character.

References:

1. https://en.wikipedia.org/wiki/Apostrophe
2. https://typographyforlawyers.com/straight-and-curly-quotes.html
3. https://en.wikipedia.org/wiki/Quotation_mark