### PR TITLE
Update the list of cached data files

### DIFF
--- a/pygmt/helpers/caching.py
+++ b/pygmt/helpers/caching.py
@@ -57,9 +57,9 @@ def cache_data():
         "@N00W030.earth_vgg_01m_p.nc",
         "@S90E000.earth_wdmam_03m_g.nc",
         "@N00W030.mars_relief_01m_g.nc",
-        "@N00W030.mercury_relief_01m_p.nc",
-        "@N00W030.moon_relief_01m_p.nc",
-        "@N00W030.pluto_relief_01m_p.nc",
+        "@N00W030.mercury_relief_01m_g.nc",
+        "@N00W030.moon_relief_01m_g.nc",
+        "@N00W030.pluto_relief_01m_g.nc",
         "@N00W030.venus_relief_01m_g.nc",
         # List of cache files.
         "@EGM96_to_36.txt",

--- a/pygmt/tests/test_datatypes_dataset.py
+++ b/pygmt/tests/test_datatypes_dataset.py
@@ -151,7 +151,7 @@ def test_dataset_to_strings_with_none_values():
 
     See the bug report at https://github.com/GenericMappingTools/pygmt/issues/3170.
     """
-    tiles = ["@N30W120.earth_relief_15s_p.nc", "@N00E000.earth_relief_15s_p.nc"]
+    tiles = ["@N30W120.earth_relief_15s_p.nc", "@N00W010.earth_relief_15s_p.nc"]
     paths = which(fname=tiles, download="a")
     assert len(paths) == 2
     # 'paths' may contain an empty string or not, depending on if the tiles are cached.


### PR DESCRIPTION
The Tests workflow run show following messages, which means these files are not cached and are downloaded:
```
_________________ test_mercury_relief_01m_default_registration _________________
----------------------------- Captured stderr call -----------------------------
Notice:  [NOTICE]: Remote data courtesy of GMT data server oceania [http://oceania.generic-mapping-tools.org/]
Notice:  [NOTICE]: Messenger Mercury Relief at 01x01 arc minutes reduced by Gaussian Cartesian filtering (2 km fullwidth) [Becker et al., 2016].
Notice:  [NOTICE]:   -> Download 30x30 degree grid tile (mercury_relief_01m_g): N00W030
__________________ test_moon_relief_01m_default_registration ___________________
----------------------------- Captured stderr call -----------------------------
Notice:  [NOTICE]: Remote data courtesy of GMT data server oceania [http://oceania.generic-mapping-tools.org/]
Notice:  [NOTICE]: LOLA Moon Relief at 01x01 arc minutes reduced by Gaussian Cartesian filtering (1.4 km fullwidth) [Mazarico et al., 2013].
Notice:  [NOTICE]:   -> Download 30x30 degree grid tile (moon_relief_01m_g): N00W030
__________________ test_pluto_relief_01m_default_registration __________________
----------------------------- Captured stderr call -----------------------------
Notice:  [NOTICE]: Remote data courtesy of GMT data server oceania [http://oceania.generic-mapping-tools.org/]
Notice:  [NOTICE]: New Horizons Pluto Relief at 01x01 arc minutes reduced by Gaussian Cartesian filtering (1 km fullwidth) [Moore et al., 2016].
Notice:  [NOTICE]:   -> Download 30x30 degree grid tile (pluto_relief_01m_g): N00W030
___________________ test_dataset_to_strings_with_none_values ___________________
----------------------------- Captured stderr call -----------------------------
Notice:  [NOTICE]: Remote data courtesy of GMT data server oceania [http://oceania.generic-mapping-tools.org/]
Notice:  [NOTICE]: SRTM15 Earth Relief v2.5.5 original at 15x15 arc seconds [Tozer et al., 2019].
Notice:  [NOTICE]:   -> Download 10x10 degree grid tile (earth_relief_15s_p): N00E000
```

This PR fixes the issue.