### PR TITLE
non_ascii_to_octal: Return the input string if it only contains printable ASCII characters

### DIFF
--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -233,6 +233,10 @@ def non_ascii_to_octal(argstr):
     >>> non_ascii_to_octal("ABC ±120° DEF α ♥")
     'ABC \\261120\\260 DEF @~\\141@~ @%34%\\252@%%'
     """  # noqa: RUF002
+    # Return the string if it only contains printable ASCII characters from 32 to 126.
+    if all(32 <= ord(c) <= 126 for c in argstr):
+        return argstr
+
     # Dictionary mapping non-ASCII characters to octal codes
     mapping = {}
 


### PR DESCRIPTION
**Description of proposed changes**

The `non_ascii_to_octal` function was added in #2584 to convert any non-ASCII characters in a string to the corresponding octal codes. It's applied to all argument strings and texts passed in `Figure.text`. In most cases, we don't use non-ASCII characters, so applying this function is not necessary.

This PR improve the `non_ascii_to_octal` function so that it simply return the input string if the input string doesn't contain any non-ASCII characters.

Here is the benchmark.

**Main branch**
```python
In [1]: from pygmt.helpers import non_ascii_to_octal

In [2]: argstr = "".join([chr(c) for c in range(32, 127)])

In [3]: argstr
Out[3]: ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'

In [4]: %timeit non_ascii_to_octal(argstr)
243 µs ± 1.08 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [5]: %timeit non_ascii_to_octal(argstr + "α")
244 µs ± 1.03 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
**This PR**
```python
In [1]: from pygmt.helpers import non_ascii_to_octal

In [2]: argstr = "".join([chr(c) for c in range(32, 127)])

In [3]: argstr
Out[3]: ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'

In [4]: %timeit non_ascii_to_octal(argstr)
5.82 µs ± 8.87 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [5]: %timeit non_ascii_to_octal(argstr + "α")
240 µs ± 233 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

For strings that don't contain any non-ASCII characters, this PR is much faster (5.8 µs vs 243 µs).