### PR TITLE
Use unique earth_age tiles in test_dataset_to_strings_with_none_values

### DIFF
--- a/pygmt/helpers/caching.py
+++ b/pygmt/helpers/caching.py
@@ -42,6 +42,8 @@ def cache_data():
         # Names like @N35E135.earth_relief_03s_g.nc are for internal use only.
         # The naming scheme may change. DO NOT USE IT IN YOUR SCRIPTS.
         "@N00W030.earth_age_01m_g.nc",
+        "@N30E060.earth_age_01m_g.nc",
+        "@N30E090.earth_age_01m_g.nc",
         "@N00W030.earth_faa_01m_p.nc",
         "@N00W030.earth_geoid_01m_g.nc",
         "@S30W060.earth_mag_02m_p.nc",

--- a/pygmt/tests/test_datatypes_dataset.py
+++ b/pygmt/tests/test_datatypes_dataset.py
@@ -151,7 +151,7 @@ def test_dataset_to_strings_with_none_values():
 
     See the bug report at https://github.com/GenericMappingTools/pygmt/issues/3170.
     """
-    tiles = ["@N30W120.earth_relief_15s_p.nc", "@N00W010.earth_relief_15s_p.nc"]
+    tiles = ["@N30E060.earth_age_01m_g.nc", "@N30E090.earth_age_01m_g.nc"]
     paths = which(fname=tiles, download="a")
     assert len(paths) == 2
     # 'paths' may contain an empty string or not, depending on if the tiles are cached.


### PR DESCRIPTION
The `test_dataset_to_strings_with_none_values` test was added in #3174 when addressing issue #3170.

To reproduce issue #3170, the test must delete the tiles from the cache and download them again. The original test usually works but may fail when running multiple tests parallelly (xref #3193). Two tests may download the same file at the same time or `which` may find the local file but then it is deleted when reading.

This PR fixes the problem by using two unique tiles that are not used in other tests. These two tiles are chosen because they're among the tiles with the smallest sizes (the original jp2 files on the GMT data server are smaller than 1 KB). 