### PR TITLE
_load_remote_dataset: Rename parameter names and remove trailing underscore from prefix

### DIFF
--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -101,7 +101,7 @@ def load_earth_age(
     """
     grid = _load_remote_dataset(
         name="earth_age",
-        prefix="earth_age_",
+        prefix="earth_age",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -100,8 +100,8 @@ def load_earth_age(
     ... )
     """
     grid = _load_remote_dataset(
-        dataset_name="earth_age",
-        dataset_prefix="earth_age_",
+        name="earth_age",
+        prefix="earth_age_",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -102,8 +102,8 @@ def load_earth_free_air_anomaly(
     ... )
     """
     grid = _load_remote_dataset(
-        dataset_name="earth_faa",
-        dataset_prefix="earth_faa_",
+        name="earth_faa",
+        prefix="earth_faa_",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -103,7 +103,7 @@ def load_earth_free_air_anomaly(
     """
     grid = _load_remote_dataset(
         name="earth_faa",
-        prefix="earth_faa_",
+        prefix="earth_faa",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -94,7 +94,7 @@ def load_earth_geoid(
     """
     grid = _load_remote_dataset(
         name="earth_geoid",
-        prefix="earth_geoid_",
+        prefix="earth_geoid",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -93,8 +93,8 @@ def load_earth_geoid(
     ... )
     """
     grid = _load_remote_dataset(
-        dataset_name="earth_geoid",
-        dataset_prefix="earth_geoid_",
+        name="earth_geoid",
+        prefix="earth_geoid_",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -137,9 +137,9 @@ def load_earth_magnetic_anomaly(
     ... )
     """
     magnetic_anomaly_sources = {
-        "emag2": "earth_mag_",
-        "emag2_4km": "earth_mag4km_",
-        "wdmam": "earth_wdmam_",
+        "emag2": "earth_mag",
+        "emag2_4km": "earth_mag4km",
+        "wdmam": "earth_wdmam",
     }
     if data_source not in magnetic_anomaly_sources:
         raise GMTInvalidInput(

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -149,8 +149,8 @@ def load_earth_magnetic_anomaly(
     dataset_prefix = magnetic_anomaly_sources[data_source]
     dataset_name = "earth_wdmam" if data_source == "wdmam" else "earth_mag"
     grid = _load_remote_dataset(
-        dataset_name=dataset_name,
-        dataset_prefix=dataset_prefix,
+        name=dataset_name,
+        prefix=dataset_prefix,
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -97,8 +97,8 @@ def load_earth_mask(
     array(0, dtype=int8)
     """
     grid = _load_remote_dataset(
-        dataset_name="earth_mask",
-        dataset_prefix="earth_mask_",
+        name="earth_mask",
+        prefix="earth_mask_",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -98,7 +98,7 @@ def load_earth_mask(
     """
     grid = _load_remote_dataset(
         name="earth_mask",
-        prefix="earth_mask_",
+        prefix="earth_mask",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -168,8 +168,8 @@ def load_earth_relief(
         case "gebco" | "gebcosi":
             dataset_name = "earth_gebco"
     grid = _load_remote_dataset(
-        dataset_name=dataset_name,
-        dataset_prefix=dataset_prefix,
+        name=dataset_name,
+        prefix=dataset_prefix,
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -140,10 +140,10 @@ def load_earth_relief(
     land_only_srtm_resolutions = ["03s", "01s"]
 
     earth_relief_sources = {
-        "igpp": "earth_relief_",
-        "gebco": "earth_gebco_",
-        "gebcosi": "earth_gebcosi_",
-        "synbath": "earth_synbath_",
+        "igpp": "earth_relief",
+        "gebco": "earth_gebco",
+        "gebcosi": "earth_gebcosi",
+        "synbath": "earth_synbath",
     }
     if data_source not in earth_relief_sources:
         raise GMTInvalidInput(
@@ -153,7 +153,7 @@ def load_earth_relief(
     # Choose earth relief data prefix
     if use_srtm and resolution in land_only_srtm_resolutions:
         if data_source == "igpp":
-            dataset_prefix = "srtm_relief_"
+            dataset_prefix = "srtm_relief"
         else:
             raise GMTInvalidInput(
                 f"Option 'use_srtm=True' doesn't work with data source '{data_source}'."

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -105,7 +105,7 @@ def load_earth_vertical_gravity_gradient(
     """
     grid = _load_remote_dataset(
         name="earth_vgg",
-        prefix="earth_vgg_",
+        prefix="earth_vgg",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -104,8 +104,8 @@ def load_earth_vertical_gravity_gradient(
     ... )
     """
     grid = _load_remote_dataset(
-        dataset_name="earth_vgg",
-        dataset_prefix="earth_vgg_",
+        name="earth_vgg",
+        prefix="earth_vgg_",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -401,7 +401,7 @@ def _load_remote_dataset(
             "returned unless only the pixel-registered grid is available."
         )
 
-    fname = f"@{prefix}{resolution}_{registration[0]}"
+    fname = f"@{prefix}_{resolution}_{registration[0]}"
     if resinfo.tiled and region is None:
         raise GMTInvalidInput(
             f"'region' is required for {dataset.description} resolution '{resolution}'."

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -330,8 +330,8 @@ datasets = {
 
 @kwargs_to_strings(region="sequence")
 def _load_remote_dataset(
-    dataset_name: str,
-    dataset_prefix: str,
+    name: str,
+    prefix: str,
     resolution: str,
     region: str | list,
     registration: Literal["gridline", "pixel", None],
@@ -341,9 +341,9 @@ def _load_remote_dataset(
 
     Parameters
     ----------
-    dataset_name
+    name
         The name for the dataset in the 'datasets' dictionary.
-    dataset_prefix
+    prefix
         The prefix for the dataset that will be passed to the GMT C API.
     resolution
         The grid resolution. The suffix ``d``, ``m``, and ``s`` stand for arc-degrees,
@@ -373,7 +373,7 @@ def _load_remote_dataset(
     plotting functions. Refer to :class:`pygmt.GMTDataArrayAccessor` for detailed
     explanations and workarounds.
     """
-    dataset = datasets[dataset_name]
+    dataset = datasets[name]
 
     # Check resolution
     if resolution not in dataset.resolutions:
@@ -401,7 +401,7 @@ def _load_remote_dataset(
             "returned unless only the pixel-registered grid is available."
         )
 
-    fname = f"@{dataset_prefix}{resolution}_{registration[0]}"
+    fname = f"@{prefix}{resolution}_{registration[0]}"
     if resinfo.tiled and region is None:
         raise GMTInvalidInput(
             f"'region' is required for {dataset.description} resolution '{resolution}'."

--- a/pygmt/datasets/mars_relief.py
+++ b/pygmt/datasets/mars_relief.py
@@ -97,7 +97,7 @@ def load_mars_relief(
     """
     grid = _load_remote_dataset(
         name="mars_relief",
-        prefix="mars_relief_",
+        prefix="mars_relief",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/mars_relief.py
+++ b/pygmt/datasets/mars_relief.py
@@ -96,8 +96,8 @@ def load_mars_relief(
     ... )
     """
     grid = _load_remote_dataset(
-        dataset_name="mars_relief",
-        dataset_prefix="mars_relief_",
+        name="mars_relief",
+        prefix="mars_relief_",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/mercury_relief.py
+++ b/pygmt/datasets/mercury_relief.py
@@ -96,8 +96,8 @@ def load_mercury_relief(
     ... )
     """
     grid = _load_remote_dataset(
-        dataset_name="mercury_relief",
-        dataset_prefix="mercury_relief_",
+        name="mercury_relief",
+        prefix="mercury_relief_",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/mercury_relief.py
+++ b/pygmt/datasets/mercury_relief.py
@@ -97,7 +97,7 @@ def load_mercury_relief(
     """
     grid = _load_remote_dataset(
         name="mercury_relief",
-        prefix="mercury_relief_",
+        prefix="mercury_relief",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/moon_relief.py
+++ b/pygmt/datasets/moon_relief.py
@@ -97,7 +97,7 @@ def load_moon_relief(
     """
     grid = _load_remote_dataset(
         name="moon_relief",
-        prefix="moon_relief_",
+        prefix="moon_relief",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/moon_relief.py
+++ b/pygmt/datasets/moon_relief.py
@@ -96,8 +96,8 @@ def load_moon_relief(
     ... )
     """
     grid = _load_remote_dataset(
-        dataset_name="moon_relief",
-        dataset_prefix="moon_relief_",
+        name="moon_relief",
+        prefix="moon_relief_",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/pluto_relief.py
+++ b/pygmt/datasets/pluto_relief.py
@@ -97,7 +97,7 @@ def load_pluto_relief(
     """
     grid = _load_remote_dataset(
         name="pluto_relief",
-        prefix="pluto_relief_",
+        prefix="pluto_relief",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/pluto_relief.py
+++ b/pygmt/datasets/pluto_relief.py
@@ -96,8 +96,8 @@ def load_pluto_relief(
     ... )
     """
     grid = _load_remote_dataset(
-        dataset_name="pluto_relief",
-        dataset_prefix="pluto_relief_",
+        name="pluto_relief",
+        prefix="pluto_relief_",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/venus_relief.py
+++ b/pygmt/datasets/venus_relief.py
@@ -93,8 +93,8 @@ def load_venus_relief(
     ... )
     """
     grid = _load_remote_dataset(
-        dataset_name="venus_relief",
-        dataset_prefix="venus_relief_",
+        name="venus_relief",
+        prefix="venus_relief_",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/datasets/venus_relief.py
+++ b/pygmt/datasets/venus_relief.py
@@ -94,7 +94,7 @@ def load_venus_relief(
     """
     grid = _load_remote_dataset(
         name="venus_relief",
-        prefix="venus_relief_",
+        prefix="venus_relief",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/tests/test_datasets_load_remote_datasets.py
+++ b/pygmt/tests/test_datasets_load_remote_datasets.py
@@ -13,7 +13,7 @@ def load_remote_dataset_wrapper(resolution="01d", region=None, registration=None
     """
     return _load_remote_dataset(
         name="earth_age",
-        prefix="earth_age_",
+        prefix="earth_age",
         resolution=resolution,
         region=region,
         registration=registration,

--- a/pygmt/tests/test_datasets_load_remote_datasets.py
+++ b/pygmt/tests/test_datasets_load_remote_datasets.py
@@ -12,8 +12,8 @@ def load_remote_dataset_wrapper(resolution="01d", region=None, registration=None
     Wrapper for _load_remote_dataset using the earth age dataset as an example.
     """
     return _load_remote_dataset(
-        dataset_name="earth_age",
-        dataset_prefix="earth_age_",
+        name="earth_age",
+        prefix="earth_age_",
         resolution=resolution,
         region=region,
         registration=registration,


### PR DESCRIPTION
- Rename `dataset_name` to `name`
- Rename `dataset_prefix` to `prefix`
- Remove the trailing `_` from `dataset_prefix`, e.g., `dataset_prefix="earth_relief_"` should be `prefix="earth_relief"`.

Closes #3190.