### PR TITLE
Remove sequence_plus converter from kwargs_to_string

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -633,7 +633,6 @@ def kwargs_to_strings(**conversions):
     * 'sequence': transforms a sequence (list, tuple) into a ``'/'`` separated
       string
     * 'sequence_comma': transforms a sequence into a ``','`` separated string
-    * 'sequence_plus': transforms a sequence into a ``'+'`` separated string
 
     Parameters
     ----------
@@ -719,11 +718,7 @@ def kwargs_to_strings(**conversions):
     >>> module(["data1.txt", "data2.txt"], ("20p", "20p"), R=[1, 2, 3, 4])
     ['data1.txt', 'data2.txt'] 20p/20p {'R': '1/2/3/4'}
     """
-    separators = {
-        "sequence": "/",
-        "sequence_comma": ",",
-        "sequence_plus": "+",
-    }
+    separators = {"sequence": "/", "sequence_comma": ","}
 
     for arg, fmt in conversions.items():
         if fmt not in separators:

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -630,9 +630,8 @@ def kwargs_to_strings(**conversions):
 
     Conversions available:
 
-    * 'sequence': transforms a sequence (list, tuple) into a ``'/'`` separated
-      string
-    * 'sequence_comma': transforms a sequence into a ``','`` separated string
+    * "sequence": transform a sequence (list, tuple) into a ``"/"`` separated string
+    * "sequence_comma": transform a sequence into a ``","`` separated string
 
     Parameters
     ----------


### PR DESCRIPTION
**Description of proposed changes**

After #3116, `sequence_plus` is no longer used in the project. It also makes no sense to allow a "+"-separated sequence as arguments, since it's not Pythonic.