### PR TITLE
Figure.contour & Figur.grdcontour: Improve docstring of pen

### DIFF
--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -102,7 +102,16 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
     skip : bool or str
         [**p**\|\ **t**].
         Skip input points outside region.
-    {pen}
+    pen : str or list
+        [*type*]\ *pen*\ [**+c**\ [**l**\|\ **f**]].
+        *type*, if present, can be **a** for annotated contours or **c** for regular
+        contours [Default]. The pen sets the attributes for the particular line.
+        Default pen for annotated contours is ``"0.75p,black"`` and for regular
+        contours ``"0.25p,black"``. Normally, all contours are drawn with a fixed
+        color determined by the pen setting. If **+cl** is appended the colors of the
+        contour lines are taken from the CPT (see ``interval``). If **+cf** is
+        appended the colors from the CPT file are applied to the contour annotations.
+        Select **+c** for both effects.
     label : str
         Add a legend entry for the contour being plotted. Normally, the
         annotated contour is selected for the legend. You can select the

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -109,7 +109,7 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
         Default pen for annotated contours is ``"0.75p,black"`` and for regular
         contours ``"0.25p,black"``. Normally, all contours are drawn with a fixed
         color determined by the pen setting. If **+cl** is appended the colors of the
-        contour lines are taken from the CPT (see ``interval``). If **+cf** is
+        contour lines are taken from the CPT (see ``levels``). If **+cf** is
         appended the colors from the CPT file are applied to the contour annotations.
         Select **+c** for both effects.
     label : str

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -86,7 +86,16 @@ def grdcontour(self, grid, **kwargs):
         five controlling algorithms. See :gmt-docs:`grdcontour.html#g` for
         details.
     {verbose}
-    {pen}
+    pen : str or list
+        [*type*]\ *pen*\ [**+c**\ [**l**\|\ **f**]].
+        *type*, if present, can be **a** for annotated contours or **c** for regular
+        contours [Default]. The pen sets the attributes for the particular line.
+        Default pen for annotated contours is ``"0.75p,black"`` and for regular
+        contours ``"0.25p,black"``. Normally, all contours are drawn with a fixed
+        color determined by the pen setting. If **+cl** is appended the colors of the
+        contour lines are taken from the CPT (see ``interval``). If **+cf** is
+        appended the colors from the CPT file are applied to the contour annotations.
+        Select **+c** for both effects.
     {panel}
     {coltypes}
     label : str

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -93,7 +93,7 @@ def grdcontour(self, grid, **kwargs):
         Default pen for annotated contours is ``"0.75p,black"`` and for regular
         contours ``"0.25p,black"``. Normally, all contours are drawn with a fixed
         color determined by the pen setting. If **+cl** is appended the colors of the
-        contour lines are taken from the CPT (see ``interval``). If **+cf** is
+        contour lines are taken from the CPT (see ``levels``). If **+cf** is
         appended the colors from the CPT file are applied to the contour annotations.
         Select **+c** for both effects.
     {panel}


### PR DESCRIPTION
**Description of proposed changes**

This PR improves the docstring for the `pen` parameter of `Figure.contour` and `Figure.grdcontour`.
 
Fixes #2704 

**Preview**: 
- `Figure.contour`: https://pygmt-dev--3210.org.readthedocs.build/en/3210/api/generated/pygmt.Figure.contour.html
- `Figure.grdcontour`: https://pygmt-dev--3210.org.readthedocs.build/en/3210/api/generated/pygmt.Figure.grdcontour.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
