### PR TITLE
Figure.timestamp: Remove deprecated parameter 'justification', use justify instead (deprecated since v0.11.0)

### DIFF
--- a/pygmt/src/timestamp.py
+++ b/pygmt/src/timestamp.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from packaging.version import Version
 from pygmt.clib import Session, __gmt_version__
-from pygmt.helpers import build_arg_list, deprecate_parameter, kwargs_to_strings
+from pygmt.helpers import build_arg_list, kwargs_to_strings
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
 __doctest_skip__ = ["timestamp"]
 
 
-@deprecate_parameter("justification", "justify", "v0.11.0", remove_version="v0.13.0")
 @kwargs_to_strings(offset="sequence")
 def timestamp(
     self,


### PR DESCRIPTION
**Description of proposed changes**

This PR removes the deprecated `justification` parameter from Figure.timestamp (deprecated since v0.11.0).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
