### PR TITLE
CI: Disable the Benchmarks workflow on release events

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ on:
   # Run in PRs but only if the PR has the 'run/benchmark' label
   pull_request:
     types: [ opened, reopened, labeled, synchronize ]
-  # `workflow_dispatch` allows CodSpeed to trigger backtest
+  # 'workflow_dispatch' allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.
   workflow_dispatch:
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,7 +1,7 @@
 # Run performance benchmarks
 #
-# Continuous benchmarking using pytest-codspeed. Measures the execution speed
-# of tests marked with @pytest.mark.benchmark decorator.
+# Continuous benchmarking using pytest-codspeed. Measures the execution speed of tests
+# marked with @pytest.mark.benchmark decorator.
 
 name: Benchmarks
 
@@ -15,8 +15,8 @@ on:
   # Run in PRs but only if the PR has the 'run/benchmark' label
   pull_request:
     types: [ opened, reopened, labeled, synchronize ]
-  # 'workflow_dispatch' allows CodSpeed to trigger backtest
-  # performance analysis in order to generate initial data.
+  # 'workflow_dispatch' allows CodSpeed to trigger backtest performance analysis
+  # in order to generate initial data.
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -18,9 +18,6 @@ on:
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.
   workflow_dispatch:
-  release:
-    types:
-      - published
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
`CodSpeed` doesn't support benchmarks for `release` events.

Address https://github.com/GenericMappingTools/pygmt/pull/3218#issuecomment-2089229289.