### PR TITLE
CI: Simplify the step for downloading GMT cached files

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -62,11 +62,8 @@ jobs:
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub
         run: |
-          gh run download -n gmt-cache -D gmt-cache
-          # Move downloaded files to ~/.gmt directory and list them
-          mkdir -p ~/.gmt
-          mv gmt-cache/* ~/.gmt
-          rmdir gmt-cache
+          # Download cached files to ~/.gmt directory and list them
+          gh run download -n gmt-cache -D ~/.gmt/
           # Change modification times of the two files, so GMT won't refresh it
           touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
           ls -lhR ~/.gmt

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Download remote data from GitHub
         run: |
           # Download cached files to ~/.gmt directory and list them
-          gh run download -n gmt-cache -D ~/.gmt/
+          gh run download --name gmt-cache --dir ~/.gmt/
           # Change modification times of the two files, so GMT won't refresh it
           touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
           ls -lhR ~/.gmt

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -113,11 +113,8 @@ jobs:
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub
         run: |
-          gh run download -n gmt-cache -D gmt-cache
-          # Move downloaded files to ~/.gmt directory and list them
-          mkdir -p ~/.gmt
-          mv gmt-cache/* ~/.gmt
-          rmdir gmt-cache
+          # Download cached files to ~/.gmt directory and list them
+          gh run download -n gmt-cache -D ~/.gmt/
           # Change modification times of the two files, so GMT won't refresh it
           touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
           ls -lhR ~/.gmt

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Download remote data from GitHub
         run: |
           # Download cached files to ~/.gmt directory and list them
-          gh run download -n gmt-cache -D ~/.gmt/
+          gh run download --name gmt-cache --dir ~/.gmt/
           # Change modification times of the two files, so GMT won't refresh it
           touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
           ls -lhR ~/.gmt

--- a/.github/workflows/ci_doctests.yaml
+++ b/.github/workflows/ci_doctests.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Download remote data from GitHub
         run: |
           # Download cached files to ~/.gmt directory and list them
-          gh run download -n gmt-cache -D ~/.gmt/
+          gh run download --name gmt-cache --dir ~/.gmt/
           # Change modification times of the two files, so GMT won't refresh it
           touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
           ls -lhR ~/.gmt

--- a/.github/workflows/ci_doctests.yaml
+++ b/.github/workflows/ci_doctests.yaml
@@ -72,11 +72,8 @@ jobs:
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub
         run: |
-          gh run download -n gmt-cache -D gmt-cache
-          # Move downloaded files to ~/.gmt directory and list them
-          mkdir -p ~/.gmt
-          mv gmt-cache/* ~/.gmt
-          rmdir gmt-cache
+          # Download cached files to ~/.gmt directory and list them
+          gh run download -n gmt-cache -D ~/.gmt/
           # Change modification times of the two files, so GMT won't refresh it
           touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
           ls -lhR ~/.gmt

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -130,7 +130,7 @@ jobs:
       - name: Download remote data from GitHub
         run: |
           # Download files to ~/.gmt directory and list them
-          gh run download -n gmt-cache -D ~/.gmt/
+          gh run download --name gmt-cache --dir ~/.gmt/
           # Change modification times of the two files, so GMT won't refresh it
           touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
           ls -lhR ~/.gmt

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -129,11 +129,8 @@ jobs:
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub
         run: |
-          gh run download -n gmt-cache -D gmt-cache
-          # Move downloaded files to ~/.gmt directory and list them
-          mkdir -p ~/.gmt
-          mv gmt-cache/* ~/.gmt
-          rmdir gmt-cache
+          # Download files to ~/.gmt directory and list them
+          gh run download -n gmt-cache -D ~/.gmt/
           # Change modification times of the two files, so GMT won't refresh it
           touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
           ls -lhR ~/.gmt

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -136,11 +136,8 @@ jobs:
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub
         run: |
-          gh run download -n gmt-cache -D gmt-cache
-          # Move downloaded files to ~/.gmt directory and list them
-          mkdir -p ~/.gmt
-          mv gmt-cache/* ~/.gmt
-          rmdir gmt-cache
+          # Download cached files to ~/.gmt directory and list them
+          gh run download -n gmt-cache -D ~/.gmt/
           # Change modification times of the two files, so GMT won't refresh it
           touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
           ls -lhR ~/.gmt

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -137,7 +137,7 @@ jobs:
       - name: Download remote data from GitHub
         run: |
           # Download cached files to ~/.gmt directory and list them
-          gh run download -n gmt-cache -D ~/.gmt/
+          gh run download --name gmt-cache --dir ~/.gmt/
           # Change modification times of the two files, so GMT won't refresh it
           touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
           ls -lhR ~/.gmt

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -84,14 +84,12 @@ jobs:
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub
         run: |
-          gh run download -n gmt-cache -D gmt-cache
-          # Move downloaded files to ~/.gmt directory and list them
-          mkdir -p ~/.gmt
-          mv gmt-cache/* ~/.gmt
-          rmdir gmt-cache
+          # Download cached files to ~/.gmt directory and list them
+          gh run download -n gmt-cache -D ~/.gmt/
           # Change modification times of the two files, so GMT won't refresh it
           # The two files are in the `~/.gmt/server` directory for GMT<=6.4, and
           # in the `~/.gmt` directory for GMT>=6.5.
+          mkdir -p ~/.gmt/server/
           mv ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt ~/.gmt/server/
           touch ~/.gmt/server/gmt_data_server.txt ~/.gmt/server/gmt_hash_server.txt
           ls -lhR ~/.gmt

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Download remote data from GitHub
         run: |
           # Download cached files to ~/.gmt directory and list them
-          gh run download -n gmt-cache -D ~/.gmt/
+          gh run download --name gmt-cache --dir ~/.gmt/
           # Change modification times of the two files, so GMT won't refresh it
           # The two files are in the `~/.gmt/server` directory for GMT<=6.4, and
           # in the `~/.gmt` directory for GMT>=6.5.


### PR DESCRIPTION
**Description of proposed changes**

`gh run download` can download artifacts into the specified directory like `~/.gmt` so we don't need intermediate directory anymore.

Patches #3188.