### PR TITLE
clib: Improve Session.get_default docstring to clarify that GMT configuration parameters are supported

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -453,11 +453,12 @@ class Session:
 
         self.session_pointer = None
 
-    def get_default(self, name):
+    def get_default(self, name: str) -> str:
         """
-        Get the value of a GMT default parameter (library version, paths, etc).
+        Get the value of a GMT configuration parameter or a GMT API parameter.
 
-        Possible default parameter names include:
+        In addtional to the long list of GMT configuration parameters, following API
+        parameter names are also supported:
 
         * ``"API_VERSION"``: The GMT API version
         * ``"API_PAD"``: The grid padding setting
@@ -473,13 +474,14 @@ class Session:
 
         Parameters
         ----------
-        name : str
-            The name of the default parameter (e.g., ``"API_VERSION"``)
+        name
+            The name of the GMT configuration parameter (e.g., ``"PROJ_LENGTH_UNIT"``)
+            or a GMT API parameter (e.g., ``"API_VERSION"``).
 
         Returns
         -------
-        value : str
-            The default value for the parameter.
+        value
+            The current value for the parameter.
 
         Raises
         ------
@@ -493,15 +495,11 @@ class Session:
         )
 
         # Make a string buffer to get a return value
-        value = ctp.create_string_buffer(10000)
-
+        value = ctp.create_string_buffer(4096)
         status = c_get_default(self.session_pointer, name.encode(), value)
-
         if status != 0:
-            raise GMTCLibError(
-                f"Error getting default value for '{name}' (error code {status})."
-            )
-
+            msg = f"Error getting value for '{name}' (error code {status})."
+            raise GMTCLibError(msg)
         return value.value.decode()
 
     def get_common(self, option):

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -457,7 +457,7 @@ class Session:
         """
         Get the value of a GMT configuration parameter or a GMT API parameter.
 
-        In addition to the long list of GMT configuration parameters, following API
+        In addition to the long list of GMT configuration parameters, the following API
         parameter names are also supported:
 
         * ``"API_VERSION"``: The GMT API version

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -457,7 +457,7 @@ class Session:
         """
         Get the value of a GMT configuration parameter or a GMT API parameter.
 
-        In addtional to the long list of GMT configuration parameters, following API
+        In addition to the long list of GMT configuration parameters, following API
         parameter names are also supported:
 
         * ``"API_VERSION"``: The GMT API version

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -534,6 +534,7 @@ def test_get_default():
         assert lib.get_default("API_GRID_LAYOUT") in ["rows", "columns"]
         assert int(lib.get_default("API_CORES")) >= 1
         assert Version(lib.get_default("API_VERSION")) >= Version("6.3.0")
+        assert lib.get_default("PROJ_LENGTH_UNIT") == "cm"
 
 
 def test_get_default_fails():


### PR DESCRIPTION
**Description of proposed changes**

Just docstring changes to clarify that `Session.get_default` can also get the **current** value of GMT configuration settings. One test is also added.

Need to note that the API name `get_default` may make people think that it returns the **default** value, but that's not true. The **current** value of a GMT configuration parameter is returned! I don't add an extra test to verify it, because the `pygmt.config` method already rely on the return value:
https://github.com/GenericMappingTools/pygmt/blob/a4d2b8e12cf1d10e31645768db0aae4253a058a3/pygmt/src/config.py#L193-L199
