### PR TITLE
Revert "Allow validate_output_table_type to specify the supported output types (#3191)"

### DIFF
--- a/pygmt/helpers/validators.py
+++ b/pygmt/helpers/validators.py
@@ -3,16 +3,13 @@ Functions to check if given arguments are valid.
 """
 
 import warnings
-from collections.abc import Sequence
 from typing import Literal
 
 from pygmt.exceptions import GMTInvalidInput
 
 
 def validate_output_table_type(
-    output_type: Literal["pandas", "numpy", "file"],
-    valid_types: Sequence[str] = ("pandas", "numpy", "file"),
-    outfile: str | None = None,
+    output_type: Literal["pandas", "numpy", "file"], outfile: str | None = None
 ) -> Literal["pandas", "numpy", "file"]:
     """
     Check if the ``output_type`` and ``outfile`` parameters are valid.
@@ -20,10 +17,8 @@ def validate_output_table_type(
     Parameters
     ----------
     output_type
-        Desired output type of tabular data. Default valid values are ``"pandas"``,
-        ``"numpy"`` and ``"file"``, but can be configured by parameter ``valid_types``.
-    valid_types
-        Tuple of valid desired output types.
+        Desired output type of tabular data. Valid values are ``"pandas"``,
+        ``"numpy"`` and ``"file"``.
     outfile
         File name for saving the result data. Required if ``output_type`` is ``"file"``.
         If specified, ``output_type`` will be forced to be ``"file"``.
@@ -41,32 +36,23 @@ def validate_output_table_type(
     'numpy'
     >>> validate_output_table_type(output_type="file", outfile="output-fname.txt")
     'file'
-    >>> validate_output_table_type(output_type="pandas", valid_types=("pandas", "file"))
-    'pandas'
     >>> validate_output_table_type(output_type="invalid-type")
     Traceback (most recent call last):
         ...
-    pygmt.exceptions.GMTInvalidInput: Must specify 'output_type' as 'pandas', ...
+    pygmt.exceptions.GMTInvalidInput: Must specify 'output_type' either as 'file', ...
     >>> validate_output_table_type("file", outfile=None)
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Must specify 'outfile' for output_type='file'.
-    >>> validate_output_table_type(output_type="numpy", valid_types=("pandas", "file"))
-    Traceback (most recent call last):
-        ...
-    pygmt.exceptions.GMTInvalidInput: Must specify 'output_type' as 'pandas', or 'file'.
     >>> with warnings.catch_warnings(record=True) as w:
     ...     validate_output_table_type("pandas", outfile="not-none.txt")
     ...     assert len(w) == 1
     'file'
     """
-    if output_type not in valid_types:
-        msg = (
-            "Must specify 'output_type' as "
-            + ", ".join(f"'{v}'" for v in valid_types[:-1])
-            + f", or '{valid_types[-1]}'."
+    if output_type not in ["file", "numpy", "pandas"]:
+        raise GMTInvalidInput(
+            "Must specify 'output_type' either as 'file', 'numpy', or 'pandas'."
         )
-        raise GMTInvalidInput(msg)
     if output_type == "file" and outfile is None:
         raise GMTInvalidInput("Must specify 'outfile' for output_type='file'.")
     if output_type != "file" and outfile is not None:

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -233,7 +233,7 @@ class triangulate:  # noqa: N801
         ``triangulate`` is a Cartesian or small-geographic area operator and is
         unaware of periodic or polar boundary conditions.
         """
-        output_type = validate_output_table_type(output_type, outfile=outfile)
+        output_type = validate_output_table_type(output_type, outfile)
 
         with Session() as lib:
             with (

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -233,7 +233,7 @@ class triangulate:  # noqa: N801
         ``triangulate`` is a Cartesian or small-geographic area operator and is
         unaware of periodic or polar boundary conditions.
         """
-        output_type = validate_output_table_type(output_type, outfile)
+        output_type = validate_output_table_type(output_type, outfile=outfile)
 
         with Session() as lib:
             with (


### PR DESCRIPTION
This reverts commit a4d2b8e12cf1d10e31645768db0aae4253a058a3.

No longer needed after https://github.com/GenericMappingTools/pygmt/pull/3182#discussion_r1591706209.