### PR TITLE
CI: Set environment cache key based on current week of year to avoid outdated cache in the "Setup Micromamba" step

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -74,6 +74,10 @@ jobs:
           # fetch all history so that setuptools-scm works
           fetch-depth: 0
 
+      - name: Get current week number of year
+        id: date
+        run: echo "date=$(date +%Y-W%W)" >> $GITHUB_OUTPUT  # e.g., 2024-W19
+
       # Install Micromamba with conda-forge dependencies
       - name: Setup Micromamba
         uses: mamba-org/setup-micromamba@v1.8.1
@@ -85,6 +89,8 @@ jobs:
               - nodefaults
           cache-downloads: false
           cache-environment: true
+          # environment cache is persistent in one week.
+          cache-environment-key: micromamba-environment-${{ steps.date.outputs.date }}
           create-args: >-
             python=3.12
             gmt=6.5.0

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -89,7 +89,7 @@ jobs:
               - nodefaults
           cache-downloads: false
           cache-environment: true
-          # environment cache is persistent in one week.
+          # environment cache is persistent for one week.
           cache-environment-key: micromamba-environment-${{ steps.date.outputs.date }}
           create-args: >-
             python=3.12

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -112,7 +112,7 @@ jobs:
               - nodefaults
           cache-downloads: false
           cache-environment: true
-          # environment cache is persistent in one week.
+          # environment cache is persistent for one week.
           cache-environment-key: micromamba-environment-${{ steps.date.outputs.date }}
           create-args: >-
             python=${{ matrix.python-version }}${{ matrix.optional-packages }}

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -106,7 +106,7 @@ jobs:
             channels:
               - conda-forge
               - nodefaults
-          cache-downloads: false
+          cache-downloads: true
           cache-environment: false
           create-args: >-
             python=${{ matrix.python-version }}${{ matrix.optional-packages }}

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -107,7 +107,7 @@ jobs:
               - conda-forge
               - nodefaults
           cache-downloads: false
-          cache-environment: true
+          cache-environment: false
           create-args: >-
             python=${{ matrix.python-version }}${{ matrix.optional-packages }}
             gmt=6.5.0

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -97,9 +97,9 @@ jobs:
           # fetch all history so that setuptools-scm works
           fetch-depth: 0
 
-      - name: Get current date
+      - name: Get current week number of year
         id: date
-        run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +%Y-W%W)" >> $GITHUB_OUTPUT  # e.g., 2024-W19
 
       # Install Micromamba with conda-forge dependencies
       - name: Setup Micromamba
@@ -112,7 +112,7 @@ jobs:
               - nodefaults
           cache-downloads: false
           cache-environment: true
-          # environment cache is persistent on the same day.
+          # environment cache is persistent in one week.
           cache-environment-key: micromamba-environment-${{ steps.date.outputs.date }}
           create-args: >-
             python=${{ matrix.python-version }}${{ matrix.optional-packages }}

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -97,6 +97,10 @@ jobs:
           # fetch all history so that setuptools-scm works
           fetch-depth: 0
 
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+
       # Install Micromamba with conda-forge dependencies
       - name: Setup Micromamba
         uses: mamba-org/setup-micromamba@v1.8.1
@@ -106,8 +110,10 @@ jobs:
             channels:
               - conda-forge
               - nodefaults
-          cache-downloads: true
-          cache-environment: false
+          cache-downloads: false
+          cache-environment: true
+          # environment cache is persistent on the same day.
+          cache-environment-key: micromamba-environment-${{ steps.date.outputs.date }}
           create-args: >-
             python=${{ matrix.python-version }}${{ matrix.optional-packages }}
             gmt=6.5.0

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -52,6 +52,10 @@ jobs:
           # fetch all history so that setuptools-scm works
           fetch-depth: 0
 
+      - name: Get current week number of year
+        id: date
+        run: echo "date=$(date +%Y-W%W)" >> $GITHUB_OUTPUT  # e.g., 2024-W19
+
       # Install Micromamba with conda-forge dependencies
       - name: Setup Micromamba
         uses: mamba-org/setup-micromamba@v1.8.1
@@ -63,6 +67,8 @@ jobs:
               - nodefaults
           cache-downloads: false
           cache-environment: true
+          # environment cache is persistent in one week.
+          cache-environment-key: micromamba-environment-${{ steps.date.outputs.date }}
           create-args: >-
             python=3.12
             cmake

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -67,7 +67,7 @@ jobs:
               - nodefaults
           cache-downloads: false
           cache-environment: true
-          # environment cache is persistent in one week.
+          # environment cache is persistent for one week.
           cache-environment-key: micromamba-environment-${{ steps.date.outputs.date }}
           create-args: >-
             python=3.12

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -58,8 +58,6 @@ jobs:
             channels:
               - conda-forge
               - nodefaults
-          cache-downloads: false
-          cache-environment: true
           create-args: >-
             python=3.10
             gmt=${{ matrix.gmt_version }}


### PR DESCRIPTION
Take the [latest run](https://github.com/GenericMappingTools/pygmt/actions/runs/8979469426) of the "Tests" workflow on the main branch as an example. The "Setup Micromamba" step in the "Ubuntu + Python 3.10" job uses the cache with key `micromamba-environment--linux-64-pygmt-args-4fc7725-root-dcc80ee`, which was cached last month as shown here (https://github.com/GenericMappingTools/pygmt/actions/caches).

<img width="1270" alt="image" src="https://github.com/GenericMappingTools/pygmt/assets/3974108/32f39838-009e-42e5-bb24-91402489cb04">

The setup-micromamba action says (https://github.com/mamba-org/setup-micromamba#caching):

> Note that the specified cache key is only the prefix of the real cache key. setup-micromamba will append a hash of the environment file and the custom-args as well as the environment name and OS to the cache key.

And GitHub says (https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy):

> GitHub will remove any cache entries that have not been accessed in over 7 days.

So, the cached environment won't be refreshed unless we make changes to the packages listed in the `create-args` argument. We're using outdated packages in our workflows, which explains why sometimes we see old packages installed in CI.

**The solution is to define the cache key based on the current date.** 

We can define the cache key like `micromamba-environment-2024-05-07`, which means the cache will expire on the next day so the first CI run on the next day will be slower since the cache is missing. I feel one day is a little too short for PyGMT, so in this PR, the cache key is defined like `micromamba-environment-2024-W19`, in which `2024-W19` means the 19th week of 2024. The cache will persist for one week.

Patches #2946.
