### PR TITLE
POC: Handle __geo_interface__ objects using pyogrio instead of fiona

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -76,7 +76,7 @@ jobs:
             numpy-version: '1.26'
             pandas-version: ''
             xarray-version: ''
-            optional-packages: ' contextily geopandas ipython pyarrow rioxarray sphinx-gallery'
+            optional-packages: ' contextily geopandas ipython pyarrow pyogrio rioxarray sphinx-gallery'
 
     timeout-minutes: 30
     defaults:

--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -154,14 +154,12 @@ def tempfile_from_geojson(geojson):
             # Other 'geo' formats which implement __geo_interface__
             import json
 
-            import fiona
+            import pyogrio
 
-            with fiona.Env():
-                jsontext = json.dumps(geojson.__geo_interface__)
-                # Do Input/Output via Fiona virtual memory
-                with fiona.io.MemoryFile(file_or_bytes=jsontext.encode()) as memfile:
-                    geoseries = gpd.GeoSeries.from_file(filename=memfile)
-                    geoseries.to_file(**ogrgmt_kwargs)
+            jsontext = json.dumps(geojson.__geo_interface__)
+            # Do Input/Output via Pyogrio (GDAL) virtual memory
+            geodataframe = pyogrio.read_dataframe(jsontext)
+            geodataframe.to_file(**ogrgmt_kwargs)
 
         yield tmpfile.name
 


### PR DESCRIPTION
**Description of proposed changes**

Save objects that implement `__geo_interface__` (e.g. shapely geometries) to a temporary OGR_GMT file via pyogrio and geopandas instead of fiona.

Note that this would mean that users must have `geopandas` installed, and cannot just install `fiona`.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes error seen at https://github.com/GenericMappingTools/pygmt/issues/3180#issuecomment-2081801690, Addresses #3231


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
