### PR TITLE
Team Gallery page: Restructure in three subsections

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/4-release_checklist.md
@@ -24,6 +24,7 @@ assignees: ''
   - [ ] All tests pass in the ["Doctests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_doctests.yaml)
   - [ ] Deprecations and related tests are removed for this version by running `grep --include="*.py" -r 'remove_version="vX.Y.Z"' pygmt` from the base of the repository
 - [ ] Reserve a DOI on [Zenodo](https://zenodo.org) by clicking on "New Version"
+- [ ] Review the ["PyGMT Team" page](https://www.pygmt.org/dev/team.html)
 - [ ] Finish up 'Changelog entry for v0.x.x' Pull Request:
   - [ ] Add a new entry in `doc/_static/version_switch.js` for documentation switcher
   - [ ] Update `CITATION.cff` and BibTeX at https://github.com/GenericMappingTools/pygmt#citing-pygmt

--- a/doc/team.md
+++ b/doc/team.md
@@ -40,7 +40,7 @@ the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 
 ## Active Maintainers
 
-:::::{grid} 2 3 3 4
+:::::{grid} 2 3 3 5
 
 ::::{grid-item-card} Dongdong Tian
 :margin: 0 3 0 0
@@ -87,7 +87,7 @@ the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 
 ## Distinguished Contributors
 
-:::::{grid} 2 3 3 4
+:::::{grid} 2 3 3 5
 
 ::::{grid-item-card} Max Jones
 :margin: 0 3 0 0

--- a/doc/team.md
+++ b/doc/team.md
@@ -10,7 +10,7 @@ Distinguished Contributors are recognized for their substantial contributions to
 which may include code, documentation, pull request review, triaging, forum responses,
 community building and engagement, outreach, and inclusion and diversity. Maintainers
 are recognized for their responsibilities in maintaining the project, as detailed in
-{doc}`maintenance`.
+the {doc}`maintenance`.
 
 New Distinguished Contributors and Active Maintainers are selected and voted by current
 Active Maintainers before each release. Maintainers that are inactive for more than one

--- a/doc/team.md
+++ b/doc/team.md
@@ -17,10 +17,10 @@ the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 
 ## Founders
 
-:::::{grid} 2 3 3 5
+:::::{grid} 5
 
 ::::{grid-item-card} Leonardo Uieda
-:margin: 0 3 0 0
+:padding: 1
 :text-align: center
 :img-top: https://avatars.githubusercontent.com/u/290082?v=4
 
@@ -28,7 +28,7 @@ the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 ::::
 
 ::::{grid-item-card} Paul Wessel
-:margin: 0 3 0 0
+:padding: 1
 :text-align: center
 :img-top: https://avatars.githubusercontent.com/u/26473567?v=4
 
@@ -40,10 +40,10 @@ the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 
 ## Active Maintainers
 
-:::::{grid} 2 3 3 5
+:::::{grid} 5
 
 ::::{grid-item-card} Dongdong Tian
-:margin: 0 3 0 0
+:padding: 1
 :text-align: center
 :img-top: https://avatars.githubusercontent.com/u/3974108?v=4
 
@@ -51,7 +51,7 @@ the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 ::::
 
 ::::{grid-item-card} Wei Ji Leong
-:margin: 0 3 0 0
+:padding: 1
 :text-align: center
 :img-top: https://avatars.githubusercontent.com/u/23487320?v=4
 
@@ -59,7 +59,7 @@ the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 ::::
 
 ::::{grid-item-card} Michael Grund
-:margin: 0 3 0 0
+:padding: 1
 :text-align: center
 :img-top: https://avatars.githubusercontent.com/u/23025878?v=4
 
@@ -67,7 +67,7 @@ the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 ::::
 
 ::::{grid-item-card} Will Schlitzer
-:margin: 0 3 0 0
+:padding: 1
 :text-align: center
 :img-top: https://avatars.githubusercontent.com/u/29518865?v=4
 
@@ -75,7 +75,7 @@ the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 ::::
 
 ::::{grid-item-card} Yvonne Fröhlich
-:margin: 0 3 0 0
+:padding: 1
 :text-align: center
 :img-top: https://avatars.githubusercontent.com/u/94163266?v=4
 
@@ -87,10 +87,10 @@ the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 
 ## Distinguished Contributors
 
-:::::{grid} 2 3 3 5
+:::::{grid} 5
 
 ::::{grid-item-card} Max Jones
-:margin: 0 3 0 0
+:padding: 1
 :text-align: center
 :img-top: https://avatars.githubusercontent.com/u/14077947?v=4
 
@@ -98,7 +98,7 @@ the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 ::::
 
 ::::{grid-item-card} Jiayuan Yao
-:margin: 0 3 0 0
+:padding: 1
 :text-align: center
 :img-top: https://avatars.githubusercontent.com/u/50591376?v=4
 
@@ -106,7 +106,7 @@ the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 ::::
 
 ::::{grid-item-card} Liam Toney
-:margin: 0 3 0 0
+:padding: 1
 :text-align: center
 :img-top: https://avatars.githubusercontent.com/u/38269494?v=4
 

--- a/doc/team.md
+++ b/doc/team.md
@@ -17,7 +17,7 @@ the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 
 ## Founders
 
-:::::{grid} 2 3 3 4
+:::::{grid} 2 3 3 5
 
 ::::{grid-item-card} Leonardo Uieda
 :margin: 0 3 0 0

--- a/doc/team.md
+++ b/doc/team.md
@@ -1,9 +1,7 @@
 # PyGMT Team
 
 We are an international team dedicated to building a Pythonic API for the Generic Mapping
-Tools (GMT). Our goal is to improve GMT's accessibility for new and experienced users by
-creating user-friendly interfaces with the GMT C API, supporting rich display in Jupyter
-notebooks, and integrating with the PyData ecosystem.
+Tools (GMT).
 
 All are welcome to become involved with the PyGMT project! For more information about how
 to get involved, see the {doc}`contributing`.

--- a/doc/team.md
+++ b/doc/team.md
@@ -6,13 +6,15 @@ Tools (GMT).
 All are welcome to become involved with the PyGMT project! For more information about how
 to get involved, see the {doc}`contributing`.
 
-PyGMT Distinguished Contributors are recognized for their substantial contributions to PyGMT,
+Distinguished Contributors are recognized for their substantial contributions to PyGMT,
 which may include code, documentation, pull request review, triaging, forum responses,
-community building and engagement, outreach, and inclusion and diversity. New Distinguished
-Contributors are selected twice per year by those listed below. Distinguished Contributors
-include current or inactive contributors and inactive maintainers, so is not meant as a means
-of conveying responsibilities. Distinguished Contributors who are also active maintainers of
-the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
+community building and engagement, outreach, and inclusion and diversity. Maintainers
+are recognized for their responsibilities in maintaining the project, as detailed in
+{doc}`maintenance`.
+
+New Distinguished Contributors and Active Maintainers are selected and voted by current
+Active Maintainers before each release. Maintainers that are inactive for more than one
+year will be moved to Distinguished Contributors.
 
 
 ## Founders

--- a/doc/team.md
+++ b/doc/team.md
@@ -1,26 +1,46 @@
-# Team Gallery
+# PyGMT Team
 
-We are an international team dedicated to building a Pythonic API for the
-Generic Mapping Tools (GMT). Our goal is to improve GMT's accessibility for
-new and experienced users by creating user-friendly interfaces with the GMT
-C API, supporting rich display in Jupyter notebooks, and integrating with
-the PyData ecosystem.
+We are an international team dedicated to building a Pythonic API for the Generic Mapping
+Tools (GMT). Our goal is to improve GMT's accessibility for new and experienced users by
+creating user-friendly interfaces with the GMT C API, supporting rich display in Jupyter
+notebooks, and integrating with the PyData ecosystem.
 
-All are welcome to become involved with the PyGMT project! For more information
-about how to get involved, see the {doc}`contributing`.
+All are welcome to become involved with the PyGMT project! For more information about how
+to get involved, see the {doc}`contributing`.
 
-## Distinguished Contributors
+PyGMT Distinguished Contributors are recognized for their substantial contributions to PyGMT,
+which may include code, documentation, pull request review, triaging, forum responses,
+community building and engagement, outreach, and inclusion and diversity. New Distinguished
+Contributors are selected twice per year by those listed below. Distinguished Contributors
+include current or inactive contributors and inactive maintainers, so is not meant as a means
+of conveying responsibilities. Distinguished Contributors who are also active maintainers of
+the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 
-PyGMT Distinguished Contributors are recognized for their substantial
-contributions to PyGMT, which may include code, documentation, pull request
-review, triaging, forum responses, community building and engagement,
-outreach, and inclusion and diversity. New Distinguished Contributors are
-selected twice per year by those listed below.
 
-Distinguished Contributors is not meant as a means of conveying
-responsibilities. Distinguished Contributors who are also active maintainers of
-the PyGMT project and have responsibilities detailed in the
-{doc}`maintenance` have 'Maintainer' listed below their names.
+## Founders
+
+:::::{grid} 2 3 3 4
+
+::::{grid-item-card} Leonardo Uieda
+:margin: 0 3 0 0
+:text-align: center
+:img-top: https://avatars.githubusercontent.com/u/290082?v=4
+
+[@leouieda](https://github.com/leouieda)
+::::
+
+::::{grid-item-card} Paul Wessel
+:margin: 0 3 0 0
+:text-align: center
+:img-top: https://avatars.githubusercontent.com/u/26473567?v=4
+
+[@PaulWessel](https://github.com/PaulWessel)
+::::
+
+:::::
+
+
+## Active Maintainers
 
 :::::{grid} 2 3 3 4
 
@@ -30,8 +50,53 @@ the PyGMT project and have responsibilities detailed in the
 :img-top: https://avatars.githubusercontent.com/u/3974108?v=4
 
 [@seisman](https://github.com/seisman)
-+++
-{bdg-primary}`Maintainer`
+::::
+
+::::{grid-item-card} Wei Ji Leong
+:margin: 0 3 0 0
+:text-align: center
+:img-top: https://avatars.githubusercontent.com/u/23487320?v=4
+
+[@weiji14](https://github.com/weiji14)
+::::
+
+::::{grid-item-card} Michael Grund
+:margin: 0 3 0 0
+:text-align: center
+:img-top: https://avatars.githubusercontent.com/u/23025878?v=4
+
+[@michaelgrund](https://github.com/michaelgrund)
+::::
+
+::::{grid-item-card} Will Schlitzer
+:margin: 0 3 0 0
+:text-align: center
+:img-top: https://avatars.githubusercontent.com/u/29518865?v=4
+
+[@willschlitzer](https://github.com/willschlitzer)
+::::
+
+::::{grid-item-card} Yvonne Fröhlich
+:margin: 0 3 0 0
+:text-align: center
+:img-top: https://avatars.githubusercontent.com/u/94163266?v=4
+
+[@yvonnefroehlich](https://github.com/yvonnefroehlich)
+::::
+
+:::::
+
+
+## Inactive Maintainers
+
+:::::{grid} 2 3 3 4
+
+::::{grid-item-card} Max Jones
+:margin: 0 3 0 0
+:text-align: center
+:img-top: https://avatars.githubusercontent.com/u/14077947?v=4
+
+[@maxrjones](https://github.com/maxrjones)
 ::::
 
 ::::{grid-item-card} Jiayuan Yao
@@ -42,16 +107,6 @@ the PyGMT project and have responsibilities detailed in the
 [@core-man](https://github.com/core-man)
 ::::
 
-::::{grid-item-card} Leonardo Uieda
-:margin: 0 3 0 0
-:text-align: center
-:img-top: https://avatars.githubusercontent.com/u/290082?v=4
-
-[@leouieda](https://github.com/leouieda)
-+++
-{bdg-success}`Founder`
-::::
-
 ::::{grid-item-card} Liam Toney
 :margin: 0 3 0 0
 :text-align: center
@@ -60,61 +115,5 @@ the PyGMT project and have responsibilities detailed in the
 [@liamtoney](https://github.com/liamtoney)
 ::::
 
-::::{grid-item-card} Max Jones
-:margin: 0 3 0 0
-:text-align: center
-:img-top: https://avatars.githubusercontent.com/u/14077947?v=4
-
-[@maxrjones](https://github.com/maxrjones)
-::::
-
-::::{grid-item-card} Michael Grund
-:margin: 0 3 0 0
-:text-align: center
-:img-top: https://avatars.githubusercontent.com/u/23025878?v=4
-
-[@michaelgrund](https://github.com/michaelgrund)
-+++
-{bdg-primary}`Maintainer`
-::::
-
-::::{grid-item-card} Paul Wessel
-:margin: 0 3 0 0
-:text-align: center
-:img-top: https://avatars.githubusercontent.com/u/26473567?v=4
-
-[@PaulWessel](https://github.com/PaulWessel)
-+++
-{bdg-success}`Founder`
-::::
-
-::::{grid-item-card} Wei Ji Leong
-:margin: 0 3 0 0
-:text-align: center
-:img-top: https://avatars.githubusercontent.com/u/23487320?v=4
-
-[@weiji14](https://github.com/weiji14)
-+++
-{bdg-primary}`Maintainer`
-::::
-
-::::{grid-item-card} Will Schlitzer
-:margin: 0 3 0 0
-:text-align: center
-:img-top: https://avatars.githubusercontent.com/u/29518865?v=4
-
-[@willschlitzer](https://github.com/willschlitzer)
-+++
-{bdg-primary}`Maintainer`
-::::
-
-::::{grid-item-card} Yvonne Fröhlich
-:margin: 0 3 0 0
-:text-align: center
-:img-top: https://avatars.githubusercontent.com/u/94163266?v=4
-
-[@yvonnefroehlich](https://github.com/yvonnefroehlich)
-+++
-{bdg-primary}`Maintainer`
-::::
 :::::
+

--- a/doc/team.md
+++ b/doc/team.md
@@ -87,7 +87,7 @@ the PyGMT project have responsibilities detailed in the {doc}`maintenance`.
 :::::
 
 
-## Inactive Maintainers
+## Distinguished Contributors
 
 :::::{grid} 2 3 3 4
 


### PR DESCRIPTION
**Description of proposed changes**

This PR updates the Team Gallery page:

- [x] Change title to PyGMT Team
- [x] Strucutre involved people in the three subsections "Founders", "Active Maintainers", "Distinguished Contributors"
- [x] Add policy reagarding removing a maintainer  - where?
- [x] Add reminder in the Release checklist issue template

**Preview**: https://pygmt-dev--3240.org.readthedocs.build/en/3240/team.html

Fixes #1212 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
