### PR TITLE
CI: Set PROJ_LIB in the Benchmarks workflow to fix the proj_create_from_database error

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -83,3 +83,4 @@ jobs:
             PYGMT_USE_EXTERNAL_DISPLAY="false" python -m pytest -r P --pyargs pygmt --codspeed
         env:
           GMT_LIBRARY_PATH: /usr/share/miniconda/lib/
+          PROJ_LIB: /usr/share/miniconda/share/proj


### PR DESCRIPTION
**Description of proposed changes**

In the "Benchmarks" workflow (e.g., https://github.com/GenericMappingTools/pygmt/actions/runs/9001470390/job/24727777928), we can see an error like:
```
  ERROR 1: PROJ: proj_create_from_database: Open of /usr/share/miniconda/share/proj failed
```
which is not seen in the Tests workflow (e.g., https://github.com/GenericMappingTools/pygmt/actions/runs/9039830454/job/24843235152).

Currently, the "Benchmarks" workflow is not affected by the error and still passes, but it fails in https://github.com/GenericMappingTools/pygmt/pull/3193. So, we should fix the error.

It's unclear what's happening exactly, but the solution is simple. We just need to set the `PROJ_LIB` environment variable. xref: https://gis.stackexchange.com/questions/364421/how-to-make-proj-work-via-anaconda-in-google-colab/370360#370360

After this patch, the error disappears. See https://github.com/GenericMappingTools/pygmt/actions/runs/9039893228/job/24843381919