### PR TITLE
Fix IPython package name from ipython to IPython

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dynamic = ["version"]
 all = [
     "contextily",
     "geopandas",
-    "ipython",
+    "IPython",  # 'ipython' is not the correct module name.
     "rioxarray",
 ]
 


### PR DESCRIPTION
`pygmt.show_versions()` gives `None` for ipython, because the module name should be `IPython`, not `ipython`.
```
PyGMT information:
  version: v0.12.1.dev14+g2a663f7b
System information:
  python: 3.12.3 | packaged by conda-forge | (main, Apr [15](https://github.com/GenericMappingTools/pygmt/actions/runs/9041785268/job/24847550903#step:7:16) 2024, 18:38:13) [GCC 12.3.0]
  executable: /home/runner/micromamba/envs/pygmt/bin/python
  machine: Linux-6.5.0-1018-azure-x86_64-with-glibc2.35
Dependency information:
  numpy: 1.26.4
  pandas: 2.2.2
  xarray: 2024.3.0
  netCDF4: 1.6.5
  packaging: 24.0
  contextily: 1.6.0
  geopandas: 0.14.4
  ipython: None
  rioxarray: 0.15.5
  ghostscript: 10.03.0
GMT library information:
  binary version: 6.5.0
  cores: 4
  grid layout: rows
  image layout: 
  library path: /home/runner/micromamba/envs/pygmt/lib/libgmt.so
  padding: 2
  plugin dir: /home/runner/micromamba/envs/pygmt/lib/gmt/plugins
  share dir: /home/runner/micromamba/envs/pygmt/share/gmt
  version: 6.5.0
```