### PR TITLE
Gallery example "Velocity arrows and confidence ellipses": Improve argument passed to "spec"

### DIFF
--- a/examples/gallery/seismology/velo_arrow_ellipse.py
+++ b/examples/gallery/seismology/velo_arrow_ellipse.py
@@ -30,12 +30,12 @@ df = pd.DataFrame(
 fig.velo(
     data=df,
     region=[-10, 8, -10, 6],
-    pen="0.6p,red",
-    uncertaintyfill="lightblue1",
-    line=True,
-    spec="e0.2/0.39+f18",
-    frame=["WSne", "2g2f"],
     projection="x0.8c",
+    frame=["WSne", "2g2f"],
+    spec="e0.2/0.39+f18",
+    uncertaintyfill="lightblue1",
+    pen="0.6p,red",
+    line=True,
     vector="0.3c+p1p+e+gred",
 )
 

--- a/examples/gallery/seismology/velo_arrow_ellipse.py
+++ b/examples/gallery/seismology/velo_arrow_ellipse.py
@@ -33,7 +33,7 @@ fig.velo(
     pen="0.6p,red",
     uncertaintyfill="lightblue1",
     line=True,
-    spec="e0.2/0.39/18",
+    spec="e0.2/0.39+f18",
     frame=["WSne", "2g2f"],
     projection="x0.8c",
     vector="0.3c+p1p+e+gred",

--- a/examples/gallery/seismology/velo_arrow_ellipse.py
+++ b/examples/gallery/seismology/velo_arrow_ellipse.py
@@ -2,12 +2,12 @@
 Velocity arrows and confidence ellipses
 =======================================
 
-The :meth:`pygmt.Figure.velo` method can be used to plot mean velocity arrows
-and confidence ellipses. The example below plots red velocity arrows with
-light-blue confidence ellipses outlined in red with the east_velocity x
-north_velocity used for the station names. Note that the velocity arrows are
-scaled by 0.2 and the 39% confidence limit will give an ellipse which fits
-inside a rectangle of dimension east_sigma by north_sigma.
+The :meth:`pygmt.Figure.velo` method can be used to plot mean velocity arrows and
+confidence ellipses. The example below plots red velocity arrows with lightblue
+confidence ellipses outlined in red with the east_velocity x north_velocity used for
+the station names. Note that the velocity arrows are scaled by 0.2 and the 39%
+confidence limit will give an ellipse which fits inside a rectangle of dimension
+east_sigma by north_sigma.
 """
 
 # %%


### PR DESCRIPTION
**Description of proposed changes**

For `Figure.velo`, the font size of the text label is set by appending "+f" to the `spec` (**S**) parameter (please see https://www.pygmt.org/dev/api/generated/pygmt.Figure.velo.html#pygmt.Figure.velo or https://docs.generic-mapping-tools.org/6.5/supplements/geodesy/velo.html#s):
> e[velscale/]confidence[+ffont]

However, in the gallery example "Velocity arrows and confidence ellipses" the argument passed to `spec` is `spec="e0.2/0.39/18"` (which seems to work). This PR updates the gallery example to use the syntax stated in the documentation.

Furthermore, I updated the line length to 81 characters and sorted the parameters.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
