### PR TITLE
CI: Always upload code coverage reports to codecov

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -160,7 +160,7 @@ jobs:
       # Upload diff images on test failure
       - name: Upload diff images if any test fails
         uses: actions/upload-artifact@v4
-        if: ${{ failure() }}
+        if: failure()
         with:
           name: artifact-${{ runner.os }}-${{ matrix.python-version }}
           path: tmp-test-dir-with-unique-name
@@ -168,6 +168,7 @@ jobs:
       # Upload coverage to Codecov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.3.1
+        if: success() || failure()
         with:
           use_oidc: true
           file: ./coverage.xml # optional


### PR DESCRIPTION
**Description of proposed changes**

The "Upload coverage to codecov" step is by default skipped if any tests fail (e.g., https://github.com/GenericMappingTools/pygmt/actions/runs/9050958726/job/24866916947), then we may see a coverage decrease like:
<img width="818" alt="image" src="https://github.com/GenericMappingTools/pygmt/assets/3974108/d7cf67fe-c679-4a16-a494-20577ced864d">

This PR adds `if: success() || failure()` to the step so that it always runs no matter if tests pass or fail. The solution is from https://stackoverflow.com/a/58859404.