### PR TITLE
geopandas: Use io.StringIO to read geojson data and handle compatibility with geopandas v0.x and v1.x

### DIFF
--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -2,6 +2,7 @@
 Utilities for dealing with temporary file management.
 """
 
+import io
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
@@ -154,14 +155,8 @@ def tempfile_from_geojson(geojson):
             # Other 'geo' formats which implement __geo_interface__
             import json
 
-            import fiona
-
-            with fiona.Env():
-                jsontext = json.dumps(geojson.__geo_interface__)
-                # Do Input/Output via Fiona virtual memory
-                with fiona.io.MemoryFile(file_or_bytes=jsontext.encode()) as memfile:
-                    geoseries = gpd.GeoSeries.from_file(filename=memfile)
-                    geoseries.to_file(**ogrgmt_kwargs)
+            jsontext = json.dumps(geojson.__geo_interface__)
+            gpd.read_file(io.StringIO(jsontext)).to_file(**ogrgmt_kwargs)
 
         yield tmpfile.name
 


### PR DESCRIPTION
**Description of proposed changes**

1. For a geojson object with the `__geo_interface__`, read it via `gdf.read_file` by wrapping the geojson object into a `io.StringIO` object
2. Backward-compatible with geopandas v0.x (default engine is `fiona`) and v1.x (default engine is `pyogrio`).

Supersede #3237, so closes #3237. 

This PR should fix the errors seen at https://github.com/GenericMappingTools/pygmt/issues/3180#issuecomment-2081801690. So also closes #3231.

