### PR TITLE
CI: Replace conda-incubator/setup-miniconda with mamba-org/setup-micromamba in the Benchmarks workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -39,25 +39,36 @@ jobs:
           # fetch all history so that setuptools-scm works
           fetch-depth: 0
 
-      # Install Miniconda with conda-forge dependencies
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3.0.4
-        with:
-          auto-activate-base: true
-          activate-environment: ""  # base environment
-          channels: conda-forge,nodefaults
-          channel-priority: strict
+      - name: Get current week number of year
+        id: date
+        run: echo "date=$(date +%Y-W%W)" >> $GITHUB_OUTPUT  # e.g., 2024-W19
 
-      # Install GMT and dependencies from conda-forge
-      - name: Install dependencies
-        run: |
-          # $CONDA is an environment variable pointing to the root of the miniconda directory
-          # Preprend $CONDA/bin to $PATH so that conda's python is used over system python
-          echo $CONDA/bin >> $GITHUB_PATH
-          conda install --solver=libmamba gmt=6.5.0 python=3.12 \
-                        numpy pandas xarray netCDF4 packaging \
-                        geopandas pyarrow pytest pytest-mpl
-          python -m pip install -U pytest-codspeed setuptools
+      # Install Micromamba with conda-forge dependencies
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@v1.8.1
+        with:
+          environment-name: pygmt
+          condarc: |
+            channels:
+              - conda-forge
+              - nodefaults
+          cache-downloads: false
+          cache-environment: true
+          # environment cache is persistent for one week.
+          cache-environment-key: micromamba-environment-${{ steps.date.outputs.date }}
+          create-args: >-
+            gmt=6.5.0
+            python=3.12
+            numpy
+            pandas
+            xarray
+            netCDF4
+            packaging
+            geopandas
+            pyarrow
+            pytest
+            pytest-codspeed
+            pytest-mpl
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub
@@ -78,9 +89,6 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v2.4.1
         with:
-          run: |
-            python -c "import pygmt; pygmt.show_versions()"
-            PYGMT_USE_EXTERNAL_DISPLAY="false" python -m pytest -r P --pyargs pygmt --codspeed
-        env:
-          GMT_LIBRARY_PATH: /usr/share/miniconda/lib/
-          PROJ_LIB: /usr/share/miniconda/share/proj
+          # 'bash -el -c' is needed to use the custom shell.
+          # See https://github.com/CodSpeedHQ/action/issues/65.
+          run: bash -el -c "python -c \"import pygmt; pygmt.show_versions()\"; PYGMT_USE_EXTERNAL_DISPLAY=false python -m pytest -r P --pyargs pygmt --codspeed"


### PR DESCRIPTION
**Description of proposed changes**

Use `mamba-org/setup-micromamba` instead of `conda-incubator/setup-miniconda` so the workflow is consistent with all other workflows.

The tricky thing is that CodSpeedHQ/action doesn't support using the custom shell, so we need a workaround as mentioned in https://github.com/CodSpeedHQ/action/issues/65.

Patches https://github.com/GenericMappingTools/pygmt/pull/2908. 

This PR also removes the `PROJ_LIB` setting added in #3241, since it's no longer needed.