### PR TITLE
GMT-Ghostscript incompatibility: Give recommendations and extend examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/4-release_checklist.md
@@ -23,7 +23,8 @@ assignees: ''
   - [ ] All tests pass in the ["GMT Dev Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_dev.yaml)
   - [ ] All tests pass in the ["Doctests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_doctests.yaml)
   - [ ] Deprecations and related tests are removed for this version by running `grep --include="*.py" -r 'remove_version="vX.Y.Z"' pygmt` from the base of the repository
-- [ ] Update warnings in `pygmt.show_versions()` and notes in [Common installation issues](https://www.pygmt.org/dev/install.html#not-working-transparency) regarding GMT-Ghostscript incompatibility
+- [ ] Update warnings in `pygmt.show_versions()` as well as notes in [Common installation issues](https://www.pygmt.org/dev/install.html#not-working-transparency)
+      and [Testing your install]((https://www.pygmt.org/dev/install.html#testing-your-install) regarding GMT-Ghostscript incompatibility
 - [ ] Reserve a DOI on [Zenodo](https://zenodo.org) by clicking on "New Version"
 - [ ] Review the ["PyGMT Team" page](https://www.pygmt.org/dev/team.html)
 - [ ] Finish up 'Changelog entry for v0.x.x' Pull Request:

--- a/.github/ISSUE_TEMPLATE/4-release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/4-release_checklist.md
@@ -23,7 +23,7 @@ assignees: ''
   - [ ] All tests pass in the ["GMT Dev Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_dev.yaml)
   - [ ] All tests pass in the ["Doctests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_doctests.yaml)
   - [ ] Deprecations and related tests are removed for this version by running `grep --include="*.py" -r 'remove_version="vX.Y.Z"' pygmt` from the base of the repository
-- [ ] Update warning in `pygmt.show_versions()` and note in [Common installation issues](https://www.pygmt.org/dev/install.html#common-installation-issues) regarding GMT Ghostscript incompatibility
+- [ ] Update warning in `pygmt.show_versions()` and note in [Common installation issues](https://www.pygmt.org/dev/install.html#common-installation-issues) regarding GMT-Ghostscript incompatibility
 - [ ] Reserve a DOI on [Zenodo](https://zenodo.org) by clicking on "New Version"
 - [ ] Review the ["PyGMT Team" page](https://www.pygmt.org/dev/team.html)
 - [ ] Finish up 'Changelog entry for v0.x.x' Pull Request:

--- a/.github/ISSUE_TEMPLATE/4-release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/4-release_checklist.md
@@ -23,6 +23,7 @@ assignees: ''
   - [ ] All tests pass in the ["GMT Dev Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_dev.yaml)
   - [ ] All tests pass in the ["Doctests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_doctests.yaml)
   - [ ] Deprecations and related tests are removed for this version by running `grep --include="*.py" -r 'remove_version="vX.Y.Z"' pygmt` from the base of the repository
+- [ ] Update warning in `pygmt.show_versions()` and note in [Common installation issues](https://www.pygmt.org/dev/install.html#common-installation-issues) regarding GMT Ghostscript incompatibility
 - [ ] Reserve a DOI on [Zenodo](https://zenodo.org) by clicking on "New Version"
 - [ ] Review the ["PyGMT Team" page](https://www.pygmt.org/dev/team.html)
 - [ ] Finish up 'Changelog entry for v0.x.x' Pull Request:

--- a/.github/ISSUE_TEMPLATE/4-release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/4-release_checklist.md
@@ -23,7 +23,7 @@ assignees: ''
   - [ ] All tests pass in the ["GMT Dev Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_dev.yaml)
   - [ ] All tests pass in the ["Doctests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_doctests.yaml)
   - [ ] Deprecations and related tests are removed for this version by running `grep --include="*.py" -r 'remove_version="vX.Y.Z"' pygmt` from the base of the repository
-- [ ] Update warning in `pygmt.show_versions()` and note in [Common installation issues](https://www.pygmt.org/dev/install.html#common-installation-issues) regarding GMT-ghostscript incompatibility
+- [ ] Update warning in `pygmt.show_versions()` and note in [Common installation issues](https://www.pygmt.org/dev/install.html#not-working-transparency) regarding GMT-ghostscript incompatibility
 - [ ] Reserve a DOI on [Zenodo](https://zenodo.org) by clicking on "New Version"
 - [ ] Review the ["PyGMT Team" page](https://www.pygmt.org/dev/team.html)
 - [ ] Finish up 'Changelog entry for v0.x.x' Pull Request:

--- a/.github/ISSUE_TEMPLATE/4-release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/4-release_checklist.md
@@ -23,7 +23,7 @@ assignees: ''
   - [ ] All tests pass in the ["GMT Dev Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_dev.yaml)
   - [ ] All tests pass in the ["Doctests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_doctests.yaml)
   - [ ] Deprecations and related tests are removed for this version by running `grep --include="*.py" -r 'remove_version="vX.Y.Z"' pygmt` from the base of the repository
-- [ ] Update warnings in `pygmt.show_versions()` and notes in [Common installation issues](https://www.pygmt.org/dev/install.html#not-working-transparency) regarding GMT-ghostscript incompatibility
+- [ ] Update warnings in `pygmt.show_versions()` and notes in [Common installation issues](https://www.pygmt.org/dev/install.html#not-working-transparency) regarding GMT-Ghostscript incompatibility
 - [ ] Reserve a DOI on [Zenodo](https://zenodo.org) by clicking on "New Version"
 - [ ] Review the ["PyGMT Team" page](https://www.pygmt.org/dev/team.html)
 - [ ] Finish up 'Changelog entry for v0.x.x' Pull Request:

--- a/.github/ISSUE_TEMPLATE/4-release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/4-release_checklist.md
@@ -23,7 +23,7 @@ assignees: ''
   - [ ] All tests pass in the ["GMT Dev Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_dev.yaml)
   - [ ] All tests pass in the ["Doctests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_doctests.yaml)
   - [ ] Deprecations and related tests are removed for this version by running `grep --include="*.py" -r 'remove_version="vX.Y.Z"' pygmt` from the base of the repository
-- [ ] Update warning in `pygmt.show_versions()` and note in [Common installation issues](https://www.pygmt.org/dev/install.html#not-working-transparency) regarding GMT-ghostscript incompatibility
+- [ ] Update warnings in `pygmt.show_versions()` and notes in [Common installation issues](https://www.pygmt.org/dev/install.html#not-working-transparency) regarding GMT-ghostscript incompatibility
 - [ ] Reserve a DOI on [Zenodo](https://zenodo.org) by clicking on "New Version"
 - [ ] Review the ["PyGMT Team" page](https://www.pygmt.org/dev/team.html)
 - [ ] Finish up 'Changelog entry for v0.x.x' Pull Request:

--- a/.github/ISSUE_TEMPLATE/4-release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/4-release_checklist.md
@@ -23,7 +23,7 @@ assignees: ''
   - [ ] All tests pass in the ["GMT Dev Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_dev.yaml)
   - [ ] All tests pass in the ["Doctests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_doctests.yaml)
   - [ ] Deprecations and related tests are removed for this version by running `grep --include="*.py" -r 'remove_version="vX.Y.Z"' pygmt` from the base of the repository
-- [ ] Update warning in `pygmt.show_versions()` and note in [Common installation issues](https://www.pygmt.org/dev/install.html#common-installation-issues) regarding GMT-Ghostscript incompatibility
+- [ ] Update warning in `pygmt.show_versions()` and note in [Common installation issues](https://www.pygmt.org/dev/install.html#common-installation-issues) regarding GMT-ghostscript incompatibility
 - [ ] Reserve a DOI on [Zenodo](https://zenodo.org) by clicking on "New Version"
 - [ ] Review the ["PyGMT Team" page](https://www.pygmt.org/dev/team.html)
 - [ ] Finish up 'Changelog entry for v0.x.x' Pull Request:

--- a/README.md
+++ b/README.md
@@ -79,11 +79,7 @@ fig.text(position="MC", text="PyGMT", font="60p,Helvetica-Bold,red@75")
 fig.show()
 ```
 
-You should see a global map with land and water masses colored in tan and lightblue, respectively. On top, there
-should be the semi-transparent text "PyGMT". If the semi-transparency does not show up, there is  probably an
-incompatibility between your GMT and ghostscript versions. For details, please run `pygmt.show_versions()` and
-see [Not working transparency](https://www.pygmt.org/dev/install.html#not-working-transparency).
-
+You should see a global map with land and water masses colored in tan and lightblue, respectively, with a semi-transparent text "PyGMT" on top. 
 For more examples, please have a look at the [Gallery](https://www.pygmt.org/latest/gallery/index.html) and
 [Tutorials](https://www.pygmt.org/latest/tutorials/index.html).
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ fig.text(position="MC", text="PyGMT", font="80p,Helvetica-Bold,red@75")
 fig.show()
 ```
 
-You should see a global map with land and water masses colored in tan and lightblue, respectively, with the
-semi-transparent text "PyGMT" on top. For more examples, please have a look at the
+You should see a global map with land and water masses colored in tan and lightblue, respectively. On top,
+there should be the semi-transparent text "PyGMT". For more examples, please have a look at the
 [Gallery](https://www.pygmt.org/latest/gallery/index.html) and
 [Tutorials](https://www.pygmt.org/latest/tutorials/index.html).
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ fig.text(position="MC", text="PyGMT", font="60p,Helvetica-Bold,red@75")
 fig.show()
 ```
 
-You should see a global map with land and water masses colored in tan and lightblue, respectively, with a semi-transparent text "PyGMT" on top. 
-For more examples, please have a look at the [Gallery](https://www.pygmt.org/latest/gallery/index.html) and
-[Tutorials](https://www.pygmt.org/latest/tutorials/index.html).
+You should see a global map with land and water masses colored in tan and lightblue, respectively, with a semi-transparent
+text "PyGMT" on top. For more examples, please have a look at the [Gallery](https://www.pygmt.org/latest/gallery/index.html)
+and [Tutorials](https://www.pygmt.org/latest/tutorials/index.html).
 
 ## Contacting us
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ or a [Jupyter notebook](https://docs.jupyter.org/en/latest/running.html), and tr
 import pygmt
 fig = pygmt.Figure()
 fig.coast(projection="N10c", region="g", frame=True, land="tan", water="lightblue")
-# Add a semi-transparent text element
 fig.text(position="MC", text="PyGMT", font="60p,Helvetica-Bold,red@75")
 fig.show()
 ```

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ or a [Jupyter notebook](https://docs.jupyter.org/en/latest/running.html), and tr
 ``` python
 import pygmt
 fig = pygmt.Figure()
-fig.coast(projection="N10c", region="g", frame=True, land="tan", water="lightblue")
-fig.text(position="MC", text="PyGMT", font="60p,Helvetica-Bold,red@75")
+fig.coast(projection="N15c", region="g", frame=True, land="tan", water="lightblue")
+fig.text(position="MC", text="PyGMT", font="80p,Helvetica-Bold,red@75")
 fig.show()
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ fig.text(position="MC", text="PyGMT", font="80p,Helvetica-Bold,red@75")
 fig.show()
 ```
 
-You should see a global map with land and water masses colored in tan and lightblue, respectively, with the semi-transparent
-text "PyGMT" on top. For more examples, please have a look at the [Gallery](https://www.pygmt.org/latest/gallery/index.html)
-and [Tutorials](https://www.pygmt.org/latest/tutorials/index.html).
+You should see a global map with land and water masses colored in tan and lightblue, respectively, with the
+semi-transparent text "PyGMT" on top. For more examples, please have a look at the
+[Gallery](https://www.pygmt.org/latest/gallery/index.html) and
+[Tutorials](https://www.pygmt.org/latest/tutorials/index.html).
 
 ## Contacting us
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ or a [Jupyter notebook](https://docs.jupyter.org/en/latest/running.html), and tr
 ``` python
 import pygmt
 fig = pygmt.Figure()
-fig.coast(projection="H10c", region="g", frame=True, land="gray")
+fig.coast(projection="N10c", region="g", frame=True, land="tan", water="lightblue")
+fig.text(position="MC", text="PyGMT", font="60p,Helvetica-Bold,red@75")
 fig.show()
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,15 @@ or a [Jupyter notebook](https://docs.jupyter.org/en/latest/running.html), and tr
 import pygmt
 fig = pygmt.Figure()
 fig.coast(projection="N10c", region="g", frame=True, land="tan", water="lightblue")
+# Add a semi-transparent text element
 fig.text(position="MC", text="PyGMT", font="60p,Helvetica-Bold,red@75")
 fig.show()
 ```
+
+You should see a global map with land and water masses colored in tan and lightblue, respectively. On top, there
+should be the semi-transparent text "PyGMT". If the semi-transparency does not show up, there is  probably an
+incompatibility between your GMT and ghostscript versions. For details, please run `pygmt.show_versions()` and
+see [Not working transparency](https://www.pygmt.org/dev/install.html#not-working-transparency).
 
 For more examples, please have a look at the [Gallery](https://www.pygmt.org/latest/gallery/index.html) and
 [Tutorials](https://www.pygmt.org/latest/tutorials/index.html).

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ fig.text(position="MC", text="PyGMT", font="60p,Helvetica-Bold,red@75")
 fig.show()
 ```
 
-You should see a global map with land and water masses colored in tan and lightblue, respectively, with a semi-transparent
+You should see a global map with land and water masses colored in tan and lightblue, respectively, with the semi-transparent
 text "PyGMT" on top. For more examples, please have a look at the [Gallery](https://www.pygmt.org/latest/gallery/index.html)
 and [Tutorials](https://www.pygmt.org/latest/tutorials/index.html).
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -295,6 +295,5 @@ and then import pygmt.
 It is known that some combinations of GMT and ghostscript versions cause issues, especially
 regarding transparency:
 
-- ghostscript 9.53-9.56: work
-- ghostscript 10.00-10.01: doesn't work
-- ghostscript 10.02-10.03: work, but requires GMT<=6.4
+- Use ghostscript 9.53-9.56 for GMT 6.3/6.4
+- Use ghostscript 10.03 or later for GMT 6.5

--- a/doc/install.md
+++ b/doc/install.md
@@ -242,7 +242,7 @@ fig.coast(projection="N15c", region="g", frame=True, land="tan", water="lightblu
 fig.text(position="MC", text="PyGMT", font="80p,Helvetica-Bold,red@75")
 fig.show()
 ```
-
+![pygmt-get-started](https://github.com/GenericMappingTools/pygmt/assets/3974108/f7f51484-8640-4b58-ae5b-6c71e7150f7a)
 You should see a global map with land and water masses colored in tan and lightblue, respectively. On top, there
 should be the semi-transparent text "PyGMT". If the semi-transparency does not show up, there is probably an
 incompatibility between your GMT and Ghostscript versions. For details, please run `pygmt.show_versions()` and

--- a/doc/install.md
+++ b/doc/install.md
@@ -244,7 +244,7 @@ fig.show()
 ```
 
 You should see a global map with land and water masses colored in tan and lightblue, respectively. On top, there
-should be the semi-transparent text "PyGMT". If the semi-transparency does not show up, there is  probably an
+should be the semi-transparent text "PyGMT". If the semi-transparency does not show up, there is probably an
 incompatibility between your GMT and ghostscript versions. For details, please run `pygmt.show_versions()` and
 see [Not working transparency](#not-working-transparency).
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -294,7 +294,8 @@ and then import pygmt.
 ### Not working transparency
 
 It is known that some combinations of GMT and Ghostscript versions cause issues, especially
-regarding transparency:
+regarding transparency. If transparency doesn't work in your figures, please
+check your GMT and Ghostscript versions. We recommend:
 
 - Use Ghostscript 9.53-9.56 for GMT 6.3/6.4
 - Use Ghostscript 10.03 or later for GMT 6.5

--- a/doc/install.md
+++ b/doc/install.md
@@ -238,8 +238,8 @@ import pygmt
 pygmt.show_versions()
 
 fig = pygmt.Figure()
-fig.coast(projection="N10c", region="g", frame=True, land="tan", water="lightblue")
-fig.text(position="MC", text="PyGMT", font="60p,Helvetica-Bold,red@75")
+fig.coast(projection="N15c", region="g", frame=True, land="tan", water="lightblue")
+fig.text(position="MC", text="PyGMT", font="80p,Helvetica-Bold,red@75")
 fig.show()
 ```
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -299,5 +299,5 @@ especially regarding transparency. If the transparency doesn't work in your figu
 please check your GMT and Ghostscript versions (you can run `pygmt.show_versions()`).
 We recommend:
 
-- Use Ghostscript 9.53-9.56 for GMT 6.3.0/6.4.0
-- Use Ghostscript 10.03 or later for GMT 6.5.0
+- Ghostscript 9.53-9.56 for GMT 6.3.0/6.4.0
+- Ghostscript 10.03 or later for GMT 6.5.0

--- a/doc/install.md
+++ b/doc/install.md
@@ -294,9 +294,10 @@ and then import pygmt.
 
 ### Not working transparency
 
-It is known that some combinations of GMT and Ghostscript versions cause issues, especially
-regarding transparency. If transparency doesn't work in your figures, please
-check your GMT and Ghostscript versions. We recommend:
+It is known that some combinations of GMT and Ghostscript versions cause issues,
+especially regarding transparency. If transparency doesn't work in your figures,
+please check your GMT and Ghostscript versions (you can run `pygmt.show_versions()`).
+We recommend:
 
-- Use Ghostscript 9.53-9.56 for GMT 6.3/6.4
-- Use Ghostscript 10.03 or later for GMT 6.5
+- Use Ghostscript 9.53-9.56 for GMT 6.3.0/6.4.0
+- Use Ghostscript 10.03 or later for GMT 6.5.0

--- a/doc/install.md
+++ b/doc/install.md
@@ -239,7 +239,6 @@ pygmt.show_versions()
 
 fig = pygmt.Figure()
 fig.coast(projection="N10c", region="g", frame=True, land="tan", water="lightblue")
-# Add a semi-transparent text element
 fig.text(position="MC", text="PyGMT", font="60p,Helvetica-Bold,red@75")
 fig.show()
 ```

--- a/doc/install.md
+++ b/doc/install.md
@@ -242,7 +242,8 @@ fig.coast(projection="N15c", region="g", frame=True, land="tan", water="lightblu
 fig.text(position="MC", text="PyGMT", font="80p,Helvetica-Bold,red@75")
 fig.show()
 ```
-![pygmt-get-started](https://github.com/GenericMappingTools/pygmt/assets/3974108/f7f51484-8640-4b58-ae5b-6c71e7150f7a)
+![pygmt-get-started](https://github.com/GenericMappingTools/pygmt/assets/3974108/f7f51484-8640-4b58-ae5b-6c71e7150f7a){.align-center width="70%"}
+
 You should see a global map with land and water masses colored in tan and lightblue, respectively. On top, there
 should be the semi-transparent text "PyGMT". If the semi-transparency does not show up, there is probably an
 incompatibility between your GMT and Ghostscript versions. For details, please run `pygmt.show_versions()` and

--- a/doc/install.md
+++ b/doc/install.md
@@ -295,7 +295,7 @@ and then import pygmt.
 ### Not working transparency
 
 It is known that some combinations of GMT and Ghostscript versions cause issues,
-especially regarding transparency. If transparency doesn't work in your figures,
+especially regarding transparency. If the transparency doesn't work in your figures,
 please check your GMT and Ghostscript versions (you can run `pygmt.show_versions()`).
 We recommend:
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -105,7 +105,7 @@ If you have [PyArrow](https://arrow.apache.org/docs/python/index.html) installed
 does have some initial support for `pandas.Series` and `pandas.DataFrame` objects with
 Apache Arrow-backed arrays. Specifically, only uint/int/float and date32/date64 dtypes
 are supported for now. Support for string Arrow dtypes is still a work in progress.
-For  more details, see [issue #2800](https://github.com/GenericMappingTools/pygmt/issues/2800).
+For more details, see [issue #2800](https://github.com/GenericMappingTools/pygmt/issues/2800).
 :::
 
 ## Installing GMT and other dependencies

--- a/doc/install.md
+++ b/doc/install.md
@@ -284,3 +284,13 @@ jupyter kernelspec list --json
 
 After that, you need to restart Jupyter, open your notebook, select the `pygmt` kernel
 and then import pygmt.
+
+
+### Not working transparency
+
+It is known that some combinations of GMT and ghostscript versions cause issues, especially
+regarding transparency:
+
+- ghostscript 9.53-9.56: work
+- ghostscript 10.00-10.01: doesn't work
+- ghostscript 10.02-10.03: work, but requires GMT<=6.4

--- a/doc/install.md
+++ b/doc/install.md
@@ -245,7 +245,7 @@ fig.show()
 
 You should see a global map with land and water masses colored in tan and lightblue, respectively. On top, there
 should be the semi-transparent text "PyGMT". If the semi-transparency does not show up, there is probably an
-incompatibility between your GMT and ghostscript versions. For details, please run `pygmt.show_versions()` and
+incompatibility between your GMT and Ghostscript versions. For details, please run `pygmt.show_versions()` and
 see [Not working transparency](#not-working-transparency).
 
 ## Common installation issues
@@ -292,8 +292,8 @@ and then import pygmt.
 
 ### Not working transparency
 
-It is known that some combinations of GMT and ghostscript versions cause issues, especially
+It is known that some combinations of GMT and Ghostscript versions cause issues, especially
 regarding transparency:
 
-- Use ghostscript 9.53-9.56 for GMT 6.3/6.4
-- Use ghostscript 10.03 or later for GMT 6.5
+- Use Ghostscript 9.53-9.56 for GMT 6.3/6.4
+- Use Ghostscript 10.03 or later for GMT 6.5

--- a/doc/install.md
+++ b/doc/install.md
@@ -244,10 +244,11 @@ fig.show()
 ```
 ![pygmt-get-started](https://github.com/GenericMappingTools/pygmt/assets/3974108/f7f51484-8640-4b58-ae5b-6c71e7150f7a){.align-center width="70%"}
 
-You should see a global map with land and water masses colored in tan and lightblue, respectively. On top, there
-should be the semi-transparent text "PyGMT". If the semi-transparency does not show up, there is probably an
-incompatibility between your GMT and Ghostscript versions. For details, please run `pygmt.show_versions()` and
-see [Not working transparency](#not-working-transparency).
+You should see a global map with land and water masses colored in tan and lightblue
+respectively. On top, there should be the semi-transparent text "PyGMT". If the
+semi-transparency does not show up, there is probably an incompatibility between your
+GMT and Ghostscript versions. For details, please run `pygmt.show_versions()` and see
+[Not working transparency](#not-working-transparency).
 
 ## Common installation issues
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -238,11 +238,16 @@ import pygmt
 pygmt.show_versions()
 
 fig = pygmt.Figure()
-fig.coast(region="g", frame=True, shorelines=1)
+fig.coast(projection="N10c", region="g", frame=True, land="tan", water="lightblue")
+# Add a semi-transparent text element
+fig.text(position="MC", text="PyGMT", font="60p,Helvetica-Bold,red@75")
 fig.show()
 ```
 
-If you see a global map with shorelines, then you're all set.
+You should see a global map with land and water masses colored in tan and lightblue, respectively. On top, there
+should be the semi-transparent text "PyGMT". If the semi-transparency does not show up, there is  probably an
+incompatibility between your GMT and ghostscript versions. For details, please run `pygmt.show_versions()` and
+see [Not working transparency](https://www.pygmt.org/dev/install.html#not-working-transparency).
 
 ## Common installation issues
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -246,7 +246,7 @@ fig.show()
 You should see a global map with land and water masses colored in tan and lightblue, respectively. On top, there
 should be the semi-transparent text "PyGMT". If the semi-transparency does not show up, there is  probably an
 incompatibility between your GMT and ghostscript versions. For details, please run `pygmt.show_versions()` and
-see [Not working transparency](https://www.pygmt.org/dev/install.html#not-working-transparency).
+see [Not working transparency](#not-working-transparency).
 
 ## Common installation issues
 


### PR DESCRIPTION
**Description of proposed changes**

The incompatibility of some GMT Ghostscript version combinations causes not working transparency.

This PR adds
- [x] a transprency element to the "Getting started" example
      **Preview**: https://github.com/GenericMappingTools/pygmt/tree/mention-gs-gmt-transprency?tab=readme-ov-file#getting-started
- [x] a transprency element to the "Testing your installation" example
      **Preview**: https://pygmt-dev--3249.org.readthedocs.build/en/3249/install.html#testing-your-install
- [x] a note to the "Commen installation issues" list
      **Preview**: https://pygmt-dev--3249.org.readthedocs.build/en/3249/install.html#common-installation-issues
- [x] a reminder to the "release checklist" issue template
      **Preview**: https://github.com/GenericMappingTools/pygmt/blob/mention-gs-gmt-transprency/.github/ISSUE_TEMPLATE/4-release_checklist.md

Related to
- PR #3244 
- Issue #3242

Fixes: https://github.com/GenericMappingTools/pygmt/issues/3242#issuecomment-2110485498

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
