### PR TITLE
Remove the unused pygmt.print_clib_info function

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -203,7 +203,6 @@ Miscellaneous
     :toctree: generated
 
     which
-    print_clib_info
     show_versions
 
 .. currentmodule:: pygmt

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -77,21 +77,6 @@ _begin()
 _atexit.register(_end)
 
 
-def print_clib_info(file=sys.stdout):
-    """
-    Print information about the GMT shared library that we can find.
-
-    Includes the GMT version, default values for parameters, the path to the
-    ``libgmt`` shared library, and GMT directories.
-    """
-    from pygmt.clib import Session
-
-    print("GMT library information:", file=file)
-    with Session() as ses:
-        lines = [f"  {key}: {ses.info[key]}" for key in sorted(ses.info)]
-    print("\n".join(lines), file=file)
-
-
 def show_versions(file=sys.stdout):
     """
     Print various dependency versions which are useful when submitting bug reports.


### PR DESCRIPTION
**Description of proposed changes**

As mentioned in https://github.com/GenericMappingTools/pygmt/pull/3244#discussion_r1597542147:

> The pygmt.print_clib_info function was initially added in https://github.com/GenericMappingTools/pygmt/pull/176 but has been replaced by pygmt.show_versions in https://github.com/GenericMappingTools/pygmt/pull/466 (first appear in v0.1.2).

> In this PR, a new private function _get_clib_info is added which returns a dictionary instead of printing a long string.

> It's time to retire the print_clib_info function. Since it's rarely used, I think we can just remove it without a deprecation warning. Of course, we should do it in a separate PR so that at least we have a deprecation entry in the v0.13.0 changelog.

This PR removes the `print_clib.info` function.