### PR TITLE
CI: Use ubuntu-24.04 in the GMT Dev Tests workflow

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-2022]
+        os: [ubuntu-24.04, macos-14, windows-2022]
         gmt_git_ref: [master]
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
**Description of proposed changes**

https://github.blog/changelog/2024-05-14-github-hosted-runners-public-beta-of-ubuntu-24-04-is-now-available/
