### PR TITLE
pygmt.datasets.load_*: Add autocompletion support for the 'resolution' parameter

### DIFF
--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -15,7 +15,9 @@ __doctest_skip__ = ["load_earth_age"]
 
 @kwargs_to_strings(region="sequence")
 def load_earth_age(
-    resolution="01d",
+    resolution: Literal[
+        "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
+    ] = "01d",
     region=None,
     registration: Literal["gridline", "pixel"] = "gridline",
 ):
@@ -51,11 +53,9 @@ def load_earth_age(
 
     Parameters
     ----------
-    resolution : str
-        The grid resolution. The suffix ``d`` and ``m`` stand for
-        arc-degrees and arc-minutes. It can be ``"01d"``, ``"30m"``,
-        ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``,
-        ``"03m"``, ``"02m"``, or ``"01m"``.
+    resolution
+        The grid resolution. The suffix ``d`` and ``m`` stand for arc-degrees and
+        arc-minutes.
 
     region : str or list
         The subregion of the grid to load, in the form of a list

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -15,7 +15,9 @@ __doctest_skip__ = ["load_earth_free_air_anomaly"]
 
 @kwargs_to_strings(region="sequence")
 def load_earth_free_air_anomaly(
-    resolution="01d",
+    resolution: Literal[
+        "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
+    ] = "01d",
     region=None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
@@ -51,11 +53,9 @@ def load_earth_free_air_anomaly(
 
     Parameters
     ----------
-    resolution : str
-        The grid resolution. The suffix ``d`` and ``m`` stand for
-        arc-degrees and arc-minutes. It can be ``"01d"``, ``"30m"``,
-        ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``,
-        ``"03m"``, ``"02m"``, or ``"01m"``.
+    resolution
+        The grid resolution. The suffix ``d`` and ``m`` stand for arc-degrees and
+        arc-minutes.
 
     region : str or list
         The subregion of the grid to load, in the form of a list

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -15,7 +15,9 @@ __doctest_skip__ = ["load_earth_geoid"]
 
 @kwargs_to_strings(region="sequence")
 def load_earth_geoid(
-    resolution="01d",
+    resolution: Literal[
+        "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
+    ] = "01d",
     region=None,
     registration: Literal["gridline", "pixel"] = "gridline",
 ):
@@ -44,11 +46,9 @@ def load_earth_geoid(
 
     Parameters
     ----------
-    resolution : str
-        The grid resolution. The suffix ``d`` and ``m`` stand for
-        arc-degrees and arc-minutes. It can be ``"01d"``, ``"30m"``,
-        ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``,
-        ``"03m"``, ``"02m"``, or ``"01m"``.
+    resolution
+        The grid resolution. The suffix ``d`` and ``m`` stand for arc-degrees and
+        arc-minutes.
 
     region : str or list
         The subregion of the grid to load, in the form of a list

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -68,7 +68,7 @@ def load_earth_magnetic_anomaly(
     ----------
     resolution
         The grid resolution. The suffix ``d`` and ``m`` stand for arc-degrees and
-        arc-minutes. The ``"02m"`` resolution is not available for
+        arc-minutes. The resolution ``"02m"`` is not available for
         ``data_source="wdmam"``.
 
     region : str or list

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -16,7 +16,9 @@ __doctest_skip__ = ["load_earth_magnetic_anomaly"]
 
 @kwargs_to_strings(region="sequence")
 def load_earth_magnetic_anomaly(
-    resolution="01d",
+    resolution: Literal[
+        "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m"
+    ] = "01d",
     region=None,
     registration: Literal["gridline", "pixel", None] = None,
     data_source: Literal["emag2", "emag2_4km", "wdmam"] = "emag2",
@@ -64,11 +66,9 @@ def load_earth_magnetic_anomaly(
 
     Parameters
     ----------
-    resolution : str
-        The grid resolution. The suffix ``d`` and ``m`` stand for
-        arc-degrees and arc-minutes. It can be ``"01d"``, ``"30m"``,
-        ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``,
-        ``"03m"``, or ``"02m"``. The ``"02m"`` resolution is not available for
+    resolution
+        The grid resolution. The suffix ``d`` and ``m`` stand for arc-degrees and
+        arc-minutes. The ``"02m"`` resolution is not available for
         ``data_source="wdmam"``.
 
     region : str or list

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -15,7 +15,21 @@ __doctest_skip__ = ["load_earth_mask"]
 
 @kwargs_to_strings(region="sequence")
 def load_earth_mask(
-    resolution="01d",
+    resolution: Literal[
+        "01d",
+        "30m",
+        "20m",
+        "15m",
+        "10m",
+        "06m",
+        "05m",
+        "04m",
+        "03m",
+        "02m",
+        "01m",
+        "30s",
+        "15s",
+    ] = "01d",
     region=None,
     registration: Literal["gridline", "pixel"] = "gridline",
 ):
@@ -44,11 +58,9 @@ def load_earth_mask(
 
     Parameters
     ----------
-    resolution : str
-        The grid resolution. The suffix ``d``, ``m``, and ``s`` stand for
-        arc-degrees, arc-minutes, and arc-seconds. It can be ``"01d"``,
-        ``"30m"``, ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``,
-        ``"04m"``, ``"03m"``, ``"02m"``, ``"01m"``, ``"30s"``, or ``"15s"``.
+    resolution
+        The grid resolution. The suffix ``d``, ``m``, and ``s`` stand for arc-degrees,
+        arc-minutes, and arc-seconds.
 
     region : str or list
         The subregion of the grid to load, in the form of a list

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -16,7 +16,23 @@ __doctest_skip__ = ["load_earth_relief"]
 
 @kwargs_to_strings(region="sequence")
 def load_earth_relief(
-    resolution="01d",
+    resolution: Literal[
+        "01d",
+        "30m",
+        "20m",
+        "15m",
+        "10m",
+        "06m",
+        "05m",
+        "04m",
+        "03m",
+        "02m",
+        "01m",
+        "30s",
+        "15s",
+        "03s",
+        "01s",
+    ] = "01d",
     region=None,
     registration: Literal["gridline", "pixel", None] = None,
     data_source: Literal["igpp", "gebco", "gebcosi", "synbath"] = "igpp",
@@ -58,12 +74,9 @@ def load_earth_relief(
 
     Parameters
     ----------
-    resolution : str
-        The grid resolution. The suffix ``d``, ``m`` and ``s`` stand for
-        arc-degrees, arc-minutes, and arc-seconds. It can be ``"01d"``,
-        ``"30m"``, ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``,
-        ``"04m"``, ``"03m"``, ``"02m"``, ``"01m"``, ``"30s"``, ``"15s"``,
-        ``"03s"``, or ``"01s"``.
+    resolution
+        The grid resolution. The suffix ``d``, ``m`` and ``s`` stand for arc-degrees,
+        arc-minutes, and arc-seconds.
 
     region : str or list
         The subregion of the grid to load, in the form of a list

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -15,7 +15,9 @@ __doctest_skip__ = ["load_earth_vertical_gravity_gradient"]
 
 @kwargs_to_strings(region="sequence")
 def load_earth_vertical_gravity_gradient(
-    resolution="01d",
+    resolution: Literal[
+        "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
+    ] = "01d",
     region=None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
@@ -51,11 +53,9 @@ def load_earth_vertical_gravity_gradient(
 
     Parameters
     ----------
-    resolution : str
-        The grid resolution. The suffix ``d`` and ``m`` stand for
-        arc-degrees and arc-minutes. It can be ``"01d"``, ``"30m"``,
-        ``"20m"``, ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``,
-        ``"03m"``, ``"02m"``, or ``"01m"``.
+    resolution
+        The grid resolution. The suffix ``d`` and ``m`` stand for arc-degrees and
+        arc-minutes.
 
     region : str or list
         The subregion of the grid to load, in the form of a list

--- a/pygmt/datasets/mars_relief.py
+++ b/pygmt/datasets/mars_relief.py
@@ -15,7 +15,22 @@ __doctest_skip__ = ["load_mars_relief"]
 
 @kwargs_to_strings(region="sequence")
 def load_mars_relief(
-    resolution="01d",
+    resolution: Literal[
+        "01d",
+        "30m",
+        "20m",
+        "15m",
+        "10m",
+        "06m",
+        "05m",
+        "04m",
+        "03m",
+        "02m",
+        "01m",
+        "30s",
+        "15s",
+        "12s",
+    ] = "01d",
     region=None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
@@ -50,11 +65,9 @@ def load_mars_relief(
 
     Parameters
     ----------
-    resolution : str
+    resolution
         The grid resolution. The suffix ``d``, ``m`` and ``s`` stand for arc-degrees,
-        arc-minutes and arc-seconds. It can be ``"01d"``, ``"30m"``, ``"20m"``,
-        ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``, ``"03m"``, ``"02m"``,
-        ``"01m"``, ``"30s"``, ``"15s"``, and ``"12s"``.
+        arc-minutes and arc-seconds.
     region : str or list
         The subregion of the grid to load, in the form of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*. Required for

--- a/pygmt/datasets/mercury_relief.py
+++ b/pygmt/datasets/mercury_relief.py
@@ -15,7 +15,20 @@ __doctest_skip__ = ["load_mercury_relief"]
 
 @kwargs_to_strings(region="sequence")
 def load_mercury_relief(
-    resolution="01d",
+    resolution: Literal[
+        "01d",
+        "30m",
+        "20m",
+        "15m",
+        "10m",
+        "06m",
+        "05m",
+        "04m",
+        "03m",
+        "02m",
+        "01m",
+        "56s",
+    ] = "01d",
     region=None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
@@ -50,11 +63,9 @@ def load_mercury_relief(
 
     Parameters
     ----------
-    resolution : str
+    resolution
         The grid resolution. The suffix ``d``, ``m`` and ``s`` stand for arc-degrees,
-        arc-minutes and arc-seconds. It can be ``"01d"``, ``"30m"``, ``"20m"``,
-        ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``, ``"03m"``, ``"02m"``,
-        ``"01m"``, and ``"56s"``.
+        arc-minutes and arc-seconds.
     region : str or list
         The subregion of the grid to load, in the form of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*. Required for

--- a/pygmt/datasets/moon_relief.py
+++ b/pygmt/datasets/moon_relief.py
@@ -15,7 +15,22 @@ __doctest_skip__ = ["load_moon_relief"]
 
 @kwargs_to_strings(region="sequence")
 def load_moon_relief(
-    resolution="01d",
+    resolution: Literal[
+        "01d",
+        "30m",
+        "20m",
+        "15m",
+        "10m",
+        "06m",
+        "05m",
+        "04m",
+        "03m",
+        "02m",
+        "01m",
+        "30s",
+        "15s",
+        "14s",
+    ] = "01d",
     region=None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
@@ -50,11 +65,9 @@ def load_moon_relief(
 
     Parameters
     ----------
-    resolution : str
+    resolution
         The grid resolution. The suffix ``d``, ``m`` and ``s`` stand for arc-degrees,
-        arc-minutes and arc-seconds. It can be ``"01d"``, ``"30m"``, ``"20m"``,
-        ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``, ``"03m"``, ``"02m"``,
-        ``"01m"``, ``"30s"``, ``"15s"``, and ``"14s"``.
+        arc-minutes and arc-seconds.
     region : str or list
         The subregion of the grid to load, in the form of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*. Required for

--- a/pygmt/datasets/pluto_relief.py
+++ b/pygmt/datasets/pluto_relief.py
@@ -15,7 +15,20 @@ __doctest_skip__ = ["load_pluto_relief"]
 
 @kwargs_to_strings(region="sequence")
 def load_pluto_relief(
-    resolution="01d",
+    resolution: Literal[
+        "01d",
+        "30m",
+        "20m",
+        "15m",
+        "10m",
+        "06m",
+        "05m",
+        "04m",
+        "03m",
+        "02m",
+        "01m",
+        "52s",
+    ] = "01d",
     region=None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
@@ -50,11 +63,9 @@ def load_pluto_relief(
 
     Parameters
     ----------
-    resolution : str
+    resolution
         The grid resolution. The suffix ``d``, ``m`` and ``s`` stand for arc-degrees,
-        arc-minutes and arc-seconds. It can be ``"01d"``, ``"30m"``, ``"20m"``,
-        ``"15m"``, ``"10m"``, ``"06m"``, ``"05m"``, ``"04m"``, ``"03m"``, ``"02m"``,
-        ``"01m"``, and ``"52s"``.
+        arc-minutes and arc-seconds.
     region : str or list
         The subregion of the grid to load, in the form of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*. Required for

--- a/pygmt/datasets/venus_relief.py
+++ b/pygmt/datasets/venus_relief.py
@@ -15,7 +15,9 @@ __doctest_skip__ = ["load_venus_relief"]
 
 @kwargs_to_strings(region="sequence")
 def load_venus_relief(
-    resolution="01d",
+    resolution: Literal[
+        "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
+    ] = "01d",
     region=None,
     registration: Literal["gridline", "pixel"] = "gridline",
 ):
@@ -50,10 +52,9 @@ def load_venus_relief(
 
     Parameters
     ----------
-    resolution : str
+    resolution
         The grid resolution. The suffix ``d`` and ``m`` stand for arc-degrees and
-        arc-minutes. It can be ``"01d"``, ``"30m"``, ``"20m"``, ``"15m"``, ``"10m"``,
-        ``"06m"``, ``"05m"``, ``"04m"``, ``"03m"``, ``"02m"``, and ``"01m"``.
+        arc-minutes.
     region : str or list
         The subregion of the grid to load, in the form of a list
         [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.


### PR DESCRIPTION
**Description of proposed changes**

This PR adds type hints to the `resolution` parameter of the `load_**` functions, so that editors can autocomplete the `resolution` parameter.

**Preview**:https://pygmt-dev--3260.org.readthedocs.build/en/3260/api/generated/pygmt.datasets.load_earth_relief.html

<img width="874" alt="image" src="https://github.com/GenericMappingTools/pygmt/assets/3974108/c11ac777-fc97-4961-a65d-1608afa98987">

- Pros: autocompletion for the `resolution` parameter.
- Cons: The function definition is much longer.

@GenericMappingTools/pygmt-maintainers What do you think?