### PR TITLE
clib.Session: Refactor the __getitem__ special method to avoid calling API function GMT_Get_Enum repeatedly

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -91,6 +91,8 @@ DTYPES = {
     np.datetime64: "GMT_DATETIME",
     np.timedelta64: "GMT_LONG",
 }
+# Dictionary for storing the values of GMT constants.
+GMT_ENUMS = {}
 
 # Load the GMT library outside the Session class to avoid repeated loading.
 _libgmt = load_libgmt()
@@ -239,23 +241,41 @@ class Session:
         """
         self.destroy()
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> int:
         """
-        Get the value of a GMT constant (C enum) from gmt_resources.h.
-
-        Used to set configuration values for other API calls. Wraps
-        ``GMT_Get_Enum``.
+        Get the value of a GMT constant.
 
         Parameters
         ----------
-        name : str
-            The name of the constant (e.g., ``"GMT_SESSION_EXTERNAL"``)
+        name
+            The name of the constant (e.g., ``"GMT_SESSION_EXTERNAL"``).
 
         Returns
         -------
-        constant : int
-            Integer value of the constant. Do not rely on this value because it
-            might change.
+        value
+            Integer value of the constant. Do not rely on this value because it might
+            change.
+        """
+        if name not in GMT_ENUMS:
+            GMT_ENUMS[name] = self.get_enum(name)
+        return GMT_ENUMS[name]
+
+    def get_enum(self, name: str) -> int:
+        """
+        Get the value of a GMT constant (C enum) from gmt_resources.h.
+
+        Used to set configuration values for other API calls. Wraps ``GMT_Get_Enum``.
+
+        Parameters
+        ----------
+        name
+            The name of the constant (e.g., ``"GMT_SESSION_EXTERNAL"``).
+
+        Returns
+        -------
+        value
+            Integer value of the constant. Do not rely on this value because it might
+            change.
 
         Raises
         ------
@@ -266,18 +286,15 @@ class Session:
             "GMT_Get_Enum", argtypes=[ctp.c_void_p, ctp.c_char_p], restype=ctp.c_int
         )
 
-        # The C lib introduced the void API pointer to GMT_Get_Enum so that
-        # it's consistent with other functions. It doesn't use the pointer so
-        # we can pass in None (NULL pointer). We can't give it the actual
-        # pointer because we need to call GMT_Get_Enum when creating a new API
-        # session pointer (chicken-and-egg type of thing).
+        # The C lib introduced the void API pointer to GMT_Get_Enum so that it's
+        # consistent with other functions. It doesn't use the pointer so we can pass
+        # in None (NULL pointer). We can't give it the actual pointer because we need
+        # to call GMT_Get_Enum when creating a new API session pointer (chicken-and-egg
+        # type of thing).
         session = None
-
         value = c_get_enum(session, name.encode())
-
         if value is None or value == -99999:
             raise GMTCLibError(f"Constant '{name}' doesn't exist in libgmt.")
-
         return value
 
     def get_libgmt_func(self, name, argtypes=None, restype=None):

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -286,7 +286,7 @@ class Session:
             "GMT_Get_Enum", argtypes=[ctp.c_void_p, ctp.c_char_p], restype=ctp.c_int
         )
 
-        # The C lib introduced the void API pointer to GMT_Get_Enum so that it's
+        # The C library introduced the void API pointer to GMT_Get_Enum so that it's
         # consistent with other functions. It doesn't use the pointer so we can pass
         # in None (NULL pointer). We can't give it the actual pointer because we need
         # to call GMT_Get_Enum when creating a new API session pointer (chicken-and-egg

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -92,7 +92,7 @@ DTYPES = {
     np.timedelta64: "GMT_LONG",
 }
 # Dictionary for storing the values of GMT constants.
-GMT_ENUMS = {}
+GMT_CONSTANTS = {}
 
 # Load the GMT library outside the Session class to avoid repeated loading.
 _libgmt = load_libgmt()
@@ -256,9 +256,9 @@ class Session:
             Integer value of the constant. Do not rely on this value because it might
             change.
         """
-        if name not in GMT_ENUMS:
-            GMT_ENUMS[name] = self.get_enum(name)
-        return GMT_ENUMS[name]
+        if name not in GMT_CONSTANTS:
+            GMT_CONSTANTS[name] = self.get_enum(name)
+        return GMT_CONSTANTS[name]
 
     def get_enum(self, name: str) -> int:
         """

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -65,15 +65,13 @@ def mock(session, func, returns=None, mock_func=None):
 
 def test_getitem():
     """
-    Test that I can get correct constants from the C lib.
+    Test getting the GMT constants from the C library.
     """
-    ses = clib.Session()
-    assert ses["GMT_SESSION_EXTERNAL"] != -99999
-    assert ses["GMT_MODULE_CMD"] != -99999
-    assert ses["GMT_PAD_DEFAULT"] != -99999
-    assert ses["GMT_DOUBLE"] != -99999
-    with pytest.raises(GMTCLibError):
-        ses["A_WHOLE_LOT_OF_JUNK"]
+    with clib.Session() as lib:
+        for name in ["GMT_SESSION_EXTERNAL", "GMT_MODULE_CMD", "GMT_DOUBLE"]:
+            assert lib[name] != -99999
+        with pytest.raises(GMTCLibError):
+            lib["A_WHOLE_LOT_OF_JUNK"]
 
 
 def test_create_destroy_session():


### PR DESCRIPTION
The `__getitem__` method is a magic method that makes the `Session` class behave like a dictionary so that we can access the value of GMT constants like `self["GMT_IS_DATASET"]`. `self["GMT_IS_DATSET"]` is translated to the statement `self.__get_item__("GMT_IS_DATASET")`, which then calls the GMT C API function `GMT_Get_Enum`. 

Currently, the `__getitem__` method calls the `GMT_Get_Enum` function everytime a constant is accessed, so it's not efficient. To check how many times constants are accessed, I've added a print statement in the `__getitem__` method. 
```
In [1]: import pygmt
__getitem__ GMT_PAD_DEFAULT
__getitem__ GMT_SESSION_EXTERNAL
__getitem__ GMT_PAD_DEFAULT
__getitem__ GMT_SESSION_EXTERNAL

In [2]: fig = pygmt.Figure()
__getitem__ GMT_PAD_DEFAULT
__getitem__ GMT_SESSION_EXTERNAL

In [3]: fig.basemap(region=[0, 10, 0, 10], projection="X10c", frame=True)
__getitem__ GMT_PAD_DEFAULT
__getitem__ GMT_SESSION_EXTERNAL
__getitem__ GMT_PAD_DEFAULT
__getitem__ GMT_SESSION_EXTERNAL

In [4]: fig.show()
__getitem__ GMT_PAD_DEFAULT
__getitem__ GMT_SESSION_EXTERNAL
__getitem__ GMT_PAD_DEFAULT
__getitem__ GMT_SESSION_EXTERNAL
```
As you can see, even in the simplest script, `GMT_PAD_DEFAULT` and `GMT_SESSION_EXTERNAL` are called 7 times each.

This PR refactors the `__getitem__` method by storing the values of GMT constants in the `GMT_CONSTANTS` dictionary. When a constant is accessed for the first time, `GMT_Get_Enum` is called to the get its value and the value is stored in `GMT_CONSTANTS`. When the constant is accessed later, it will get the value from the `GMT_CONSTANTS` dictionary directly.

Below is a simple benchmark showing the performance improvement. 

Main branch:
```
In [1]: from pygmt.clib import Session

In [2]: with Session() as lib:
   ...:     %timeit lib["GMT_IS_FILE"]
   ...:
848 ns ± 2.14 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
This branch:
```
In [1]: from pygmt.clib import Session

In [2]: with Session() as lib:
   ...:     %timeit lib["GMT_IS_FILE"]
   ...:
66 ns ± 0.0665 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```
From the benchmark result, we can conclude that:

- Accessing a constant for the first time takes about 850 ns
- Accessing the same constant from the `GMT_CONSTANTS` dictionary takes about 66 ns, which is 10x faster

This PR doesn't affect our "Benchmarks" workflow, because in our tests, `__get_item__` is usually called a few times (like 10), so the execution time may decrease by only 10 ms, which has minor effects on the "Benchmarks" results.