### PR TITLE
CI: Use macos-12 in the GMT Legacy Tests workflow

### DIFF
--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
         gmt_version: ['6.3', '6.4']
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
**Description of proposed changes**

macos-11 will be removed on 6/28/2024.

https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/