### PR TITLE
CI: Set GMT_ENABLE_OPENMP to TRUE to enable OpenMP support on macOS

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -98,18 +98,13 @@ jobs:
       # https://github.com/GenericMappingTools/gmt/blob/6.5.0/ci/build-gmt.sh
       - name: Build GMT on Linux/macOS
         run: |
-          if [ "$RUNNER_OS" == "macOS" ]; then
-            GMT_ENABLE_OPENMP=FALSE
-          else
-            GMT_ENABLE_OPENMP=TRUE
-          fi
           cd gmt/
           mkdir build
           cd build
           cmake -G Ninja .. \
             -DCMAKE_INSTALL_PREFIX=${{ env.GMT_INSTALL_DIR }} \
             -DCMAKE_BUILD_TYPE=Release \
-            -DGMT_ENABLE_OPENMP=${GMT_ENABLE_OPENMP} \
+            -DGMT_ENABLE_OPENMP=TRUE \
             -DGMT_USE_THREADS=TRUE
           cmake --build .
           cmake --build . --target install


### PR DESCRIPTION
After upstream fix https://github.com/GenericMappingTools/gmt/pull/8494, now it's possible to enable OpenMP support on macOS.