### PR TITLE
CI: Remove pytest-xdist and pytest-rerunfailures options from addopts and only add them in CI jobs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -69,9 +69,9 @@ jobs:
             pytest
             pytest-codspeed
             pytest-mpl
-            pytest-rerunfailures 
+            pytest-rerunfailures
             pytest-xdist
-            
+
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub
         run: |
@@ -93,4 +93,4 @@ jobs:
         with:
           # 'bash -el -c' is needed to use the custom shell.
           # See https://github.com/CodSpeedHQ/action/issues/65.
-          run: bash -el -c "python -c \"import pygmt; pygmt.show_versions()\"; PYGMT_USE_EXTERNAL_DISPLAY=false python -m pytest -r P --pyargs pygmt --codspeed"
+          run: bash -el -c "python -c \"import pygmt; pygmt.show_versions()\"; PYGMT_USE_EXTERNAL_DISPLAY=false python -m pytest -r P -n auto --reruns 2 --pyargs pygmt --codspeed"

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -157,7 +157,7 @@ jobs:
 
       # Run the regular tests
       - name: Run tests
-        run: make test PYTEST_EXTRA="-r P"
+        run: make test PYTEST_EXTRA="-r P -n auto --reruns 2"
 
       # Upload diff images on test failure
       - name: Upload diff images if any test fails

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -178,7 +178,7 @@ jobs:
 
       # Run the tests
       - name: Test with pytest
-        run: make test PYTEST_EXTRA="-r P"
+        run: make test PYTEST_EXTRA="-r P -n auto --reruns 2"
         env:
           GMT_LIBRARY_PATH: ${{ runner.temp }}/gmt-install-dir/lib
 

--- a/environment.yml
+++ b/environment.yml
@@ -32,8 +32,6 @@ dependencies:
     - pytest-cov
     - pytest-doctestplus
     - pytest-mpl
-    - pytest-rerunfailures
-    - pytest-xdist
     # Dev dependencies (building documentation)
     - myst-parser
     - panel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ max-args=10
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--verbose --durations=0 --durations-min=0.2 --doctest-modules --mpl --mpl-results-path=results -n auto --reruns 2"
+addopts = "--verbose --durations=0 --durations-min=0.2 --doctest-modules --mpl --mpl-results-path=results"
 markers = [
     "benchmark: mark a test with custom benchmark settings.",
 ]


### PR DESCRIPTION
**Description of proposed changes**

In PR #3193, pytest-xdist and pytest-rerunfailures were added to speed up the CI jobs. They work well but also cause some troubles:

1. Options `-n auto --reruns 2` are added to `addopts`, so pytest-xdist and pytest-rerunfailures are required in local environments.
2. In local environments, I (maybe also others) usually don't run the full tests and only run a few specific tests, but `pytest-xdist`'s `-n auto` option always initializes multiple workers, which takes more time when running a single test. 

This PR removes the options `-n auto --reruns 2` from `pyproject.toml` and add the options to the workflows if needed. 