### PR TITLE
CI: Bump to mambaforge-22.9 in ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-22.9"
   jobs:
     post_checkout:
       # Cancel building pull requests when there aren't changes related to docs.


### PR DESCRIPTION
**Description of proposed changes**

`mambaforge-22.9` is the latest version available on ReadTheDocs.

xref: https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python
