### PR TITLE
CI: Bump to Ghostscript 10.03.1

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -94,7 +94,7 @@ jobs:
           create-args: >-
             python=3.12
             gmt=6.5.0
-            ghostscript=10.03.0
+            ghostscript=10.03.1
             numpy
             pandas
             xarray

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -119,7 +119,7 @@ jobs:
           create-args: >-
             python=${{ matrix.python-version }}${{ matrix.optional-packages }}
             gmt=6.5.0
-            ghostscript=10.03.0
+            ghostscript=10.03.1
             numpy=${{ matrix.numpy-version }}
             pandas${{ matrix.pandas-version }}
             xarray${{ matrix.xarray-version }}

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -75,7 +75,7 @@ jobs:
             ninja
             curl
             fftw
-            ghostscript=10.03.0
+            ghostscript=10.03.1
             glib
             hdf5
             libblas

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -6,7 +6,7 @@ dependencies:
     # Required dependencies
     - python=3.12
     - gmt=6.5.0
-    - ghostscript=10.03.0
+    - ghostscript=10.03.1
     - numpy
     - pandas
     - xarray

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
     - python=3.12
     # Required dependencies
     - gmt=6.5.0
-    - ghostscript=10.03.0
+    - ghostscript=10.03.1
     - numpy>=1.23
     - pandas>=1.5
     - xarray>=2022.06


### PR DESCRIPTION
Ghostscript 10.03.1 was released last week https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/tag/gs10031.

Edit: Waiting for https://github.com/conda-forge/ghostscript-feedstock/pull/33.