### PR TITLE
pygmt.dataset.load_*: Add type hints for the 'region' parameter

### DIFF
--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -5,20 +5,19 @@ and load as :class:`xarray.DataArray`.
 The grids are available in various resolutions.
 """
 
+from collections.abc import Sequence
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
-from pygmt.helpers import kwargs_to_strings
 
 __doctest_skip__ = ["load_earth_age"]
 
 
-@kwargs_to_strings(region="sequence")
 def load_earth_age(
     resolution: Literal[
         "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
     ] = "01d",
-    region=None,
+    region: Sequence[float] | None = None,
     registration: Literal["gridline", "pixel"] = "gridline",
 ):
     r"""
@@ -56,13 +55,10 @@ def load_earth_age(
     resolution
         The grid resolution. The suffix ``d`` and ``m`` stand for arc-degrees and
         arc-minutes.
-
-    region : str or list
-        The subregion of the grid to load, in the form of a list
-        [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
-        Required for grids with resolutions higher than 5
-        arc-minutes (i.e., ``"05m"``).
-
+    region
+        The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
+        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
+        (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration.

--- a/pygmt/datasets/earth_age.py
+++ b/pygmt/datasets/earth_age.py
@@ -17,7 +17,7 @@ def load_earth_age(
     resolution: Literal[
         "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
     ] = "01d",
-    region: Sequence[float] | None = None,
+    region: Sequence[float] | str | None = None,
     registration: Literal["gridline", "pixel"] = "gridline",
 ):
     r"""
@@ -57,8 +57,8 @@ def load_earth_age(
         arc-minutes.
     region
         The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
-        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
-        (i.e., ``"05m"``).
+        *ymin*, *ymax*] or an ISO country code. Required for grids with resolutions
+        higher than 5 arc-minutes (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration.

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -17,7 +17,7 @@ def load_earth_free_air_anomaly(
     resolution: Literal[
         "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
     ] = "01d",
-    region: Sequence[float] | None = None,
+    region: Sequence[float] | str | None = None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
     r"""
@@ -57,8 +57,8 @@ def load_earth_free_air_anomaly(
         arc-minutes.
     region
         The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
-        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
-        (i.e., ``"05m"``).
+        *ymin*, *ymax*] or an ISO country code. Required for grids with resolutions
+        higher than 5 arc-minutes (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means

--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -5,20 +5,19 @@ and load as :class:`xarray.DataArray`.
 The grids are available in various resolutions.
 """
 
+from collections.abc import Sequence
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
-from pygmt.helpers import kwargs_to_strings
 
 __doctest_skip__ = ["load_earth_free_air_anomaly"]
 
 
-@kwargs_to_strings(region="sequence")
 def load_earth_free_air_anomaly(
     resolution: Literal[
         "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
     ] = "01d",
-    region=None,
+    region: Sequence[float] | None = None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
     r"""
@@ -56,13 +55,10 @@ def load_earth_free_air_anomaly(
     resolution
         The grid resolution. The suffix ``d`` and ``m`` stand for arc-degrees and
         arc-minutes.
-
-    region : str or list
-        The subregion of the grid to load, in the form of a list
-        [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
-        Required for grids with resolutions higher than 5
-        arc-minutes (i.e., ``"05m"``).
-
+    region
+        The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
+        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
+        (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -5,20 +5,19 @@ as :class:`xarray.DataArray`.
 The grids are available in various resolutions.
 """
 
+from collections.abc import Sequence
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
-from pygmt.helpers import kwargs_to_strings
 
 __doctest_skip__ = ["load_earth_geoid"]
 
 
-@kwargs_to_strings(region="sequence")
 def load_earth_geoid(
     resolution: Literal[
         "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
     ] = "01d",
-    region=None,
+    region: Sequence[float] | None = None,
     registration: Literal["gridline", "pixel"] = "gridline",
 ):
     r"""
@@ -49,13 +48,10 @@ def load_earth_geoid(
     resolution
         The grid resolution. The suffix ``d`` and ``m`` stand for arc-degrees and
         arc-minutes.
-
-    region : str or list
-        The subregion of the grid to load, in the form of a list
-        [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
-        Required for grids with resolutions higher than 5
-        arc-minutes (i.e., ``"05m"``).
-
+    region
+        The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
+        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
+        (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration.

--- a/pygmt/datasets/earth_geoid.py
+++ b/pygmt/datasets/earth_geoid.py
@@ -17,7 +17,7 @@ def load_earth_geoid(
     resolution: Literal[
         "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
     ] = "01d",
-    region: Sequence[float] | None = None,
+    region: Sequence[float] | str | None = None,
     registration: Literal["gridline", "pixel"] = "gridline",
 ):
     r"""
@@ -50,8 +50,8 @@ def load_earth_geoid(
         arc-minutes.
     region
         The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
-        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
-        (i.e., ``"05m"``).
+        *ymin*, *ymax*] or an ISO country code. Required for grids with resolutions
+        higher than 5 arc-minutes (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration.

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -5,21 +5,20 @@ load as :class:`xarray.DataArray`.
 The grids are available in various resolutions.
 """
 
+from collections.abc import Sequence
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import kwargs_to_strings
 
 __doctest_skip__ = ["load_earth_magnetic_anomaly"]
 
 
-@kwargs_to_strings(region="sequence")
 def load_earth_magnetic_anomaly(
     resolution: Literal[
         "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m"
     ] = "01d",
-    region=None,
+    region: Sequence[float] | None = None,
     registration: Literal["gridline", "pixel", None] = None,
     data_source: Literal["emag2", "emag2_4km", "wdmam"] = "emag2",
 ):
@@ -70,20 +69,16 @@ def load_earth_magnetic_anomaly(
         The grid resolution. The suffix ``d`` and ``m`` stand for arc-degrees and
         arc-minutes. The resolution ``"02m"`` is not available for
         ``data_source="wdmam"``.
-
-    region : str or list
-        The subregion of the grid to load, in the form of a list
-        [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
-        Required for grids with resolutions higher than 5
-        arc-minutes (i.e., ``"05m"``).
-
+    region
+        The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
+        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
+        (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means
         ``"gridline"`` for all resolutions except ``"02m"`` for
         ``data_source="emag2"`` or ``data_source="emag2_4km"``, which are
         ``"pixel"`` only.
-
     data_source
         Select the source of the magnetic anomaly data. Available options are:
 

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -18,7 +18,7 @@ def load_earth_magnetic_anomaly(
     resolution: Literal[
         "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m"
     ] = "01d",
-    region: Sequence[float] | None = None,
+    region: Sequence[float] | str | None = None,
     registration: Literal["gridline", "pixel", None] = None,
     data_source: Literal["emag2", "emag2_4km", "wdmam"] = "emag2",
 ):
@@ -71,8 +71,8 @@ def load_earth_magnetic_anomaly(
         ``data_source="wdmam"``.
     region
         The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
-        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
-        (i.e., ``"05m"``).
+        *ymin*, *ymax*] or an ISO country code. Required for grids with resolutions
+        higher than 5 arc-minutes (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -29,7 +29,7 @@ def load_earth_mask(
         "30s",
         "15s",
     ] = "01d",
-    region: Sequence[float] | None = None,
+    region: Sequence[float] | str | None = None,
     registration: Literal["gridline", "pixel"] = "gridline",
 ):
     r"""
@@ -62,7 +62,7 @@ def load_earth_mask(
         arc-minutes, and arc-seconds.
     region
         The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
-        *ymin*, *ymax*].
+        *ymin*, *ymax*] or an ISO country code.
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration.

--- a/pygmt/datasets/earth_mask.py
+++ b/pygmt/datasets/earth_mask.py
@@ -5,15 +5,14 @@ Function to download the GSHHG Earth Mask dataset from the GMT data server, and 
 The grids are available in various resolutions.
 """
 
+from collections.abc import Sequence
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
-from pygmt.helpers import kwargs_to_strings
 
 __doctest_skip__ = ["load_earth_mask"]
 
 
-@kwargs_to_strings(region="sequence")
 def load_earth_mask(
     resolution: Literal[
         "01d",
@@ -30,7 +29,7 @@ def load_earth_mask(
         "30s",
         "15s",
     ] = "01d",
-    region=None,
+    region: Sequence[float] | None = None,
     registration: Literal["gridline", "pixel"] = "gridline",
 ):
     r"""
@@ -61,11 +60,9 @@ def load_earth_mask(
     resolution
         The grid resolution. The suffix ``d``, ``m``, and ``s`` stand for arc-degrees,
         arc-minutes, and arc-seconds.
-
-    region : str or list
-        The subregion of the grid to load, in the form of a list
-        [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
-
+    region
+        The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
+        *ymin*, *ymax*].
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration.

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -5,16 +5,15 @@ Function to download the Earth relief datasets from the GMT data server, and loa
 The grids are available in various resolutions.
 """
 
+from collections.abc import Sequence
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import kwargs_to_strings
 
 __doctest_skip__ = ["load_earth_relief"]
 
 
-@kwargs_to_strings(region="sequence")
 def load_earth_relief(
     resolution: Literal[
         "01d",
@@ -33,10 +32,10 @@ def load_earth_relief(
         "03s",
         "01s",
     ] = "01d",
-    region=None,
+    region: Sequence[float] | None = None,
     registration: Literal["gridline", "pixel", None] = None,
     data_source: Literal["igpp", "gebco", "gebcosi", "synbath"] = "igpp",
-    use_srtm=False,
+    use_srtm: bool = False,
 ):
     r"""
     Load the Earth relief datasets (topography and bathymetry) in various resolutions.
@@ -77,19 +76,15 @@ def load_earth_relief(
     resolution
         The grid resolution. The suffix ``d``, ``m`` and ``s`` stand for arc-degrees,
         arc-minutes, and arc-seconds.
-
-    region : str or list
-        The subregion of the grid to load, in the form of a list
-        [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
-        Required for Earth relief grids with resolutions higher than 5
-        arc-minutes (i.e., ``"05m"``).
-
+    region
+        The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
+        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
+        (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means
         ``"gridline"`` for all resolutions except ``"15s"`` which is
         ``"pixel"`` only.
-
     data_source
         Select the source for the Earth relief data. Available options are:
 
@@ -102,7 +97,6 @@ def load_earth_relief(
           inferred relief via altimetric gravity. See
           :gmt-datasets:`earth-gebco.html`.
         - ``"gebcosi"``: GEBCO Earth Relief that gives sub-ice (si) elevations.
-
     use_srtm : bool
         By default, the land-only SRTM tiles from NASA are used to generate the
         ``"03s"`` and ``"01s"`` grids, and the missing ocean values are filled

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -32,7 +32,7 @@ def load_earth_relief(
         "03s",
         "01s",
     ] = "01d",
-    region: Sequence[float] | None = None,
+    region: Sequence[float] | str | None = None,
     registration: Literal["gridline", "pixel", None] = None,
     data_source: Literal["igpp", "gebco", "gebcosi", "synbath"] = "igpp",
     use_srtm: bool = False,
@@ -78,8 +78,8 @@ def load_earth_relief(
         arc-minutes, and arc-seconds.
     region
         The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
-        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
-        (i.e., ``"05m"``).
+        *ymin*, *ymax*] or an ISO country code. Required for grids with resolutions
+        higher than 5 arc-minutes (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -97,7 +97,7 @@ def load_earth_relief(
           inferred relief via altimetric gravity. See
           :gmt-datasets:`earth-gebco.html`.
         - ``"gebcosi"``: GEBCO Earth Relief that gives sub-ice (si) elevations.
-    use_srtm : bool
+    use_srtm
         By default, the land-only SRTM tiles from NASA are used to generate the
         ``"03s"`` and ``"01s"`` grids, and the missing ocean values are filled
         by up-sampling the SRTM15 tiles which have a resolution of 15

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -5,20 +5,19 @@ server, and load as :class:`xarray.DataArray`.
 The grids are available in various resolutions.
 """
 
+from collections.abc import Sequence
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
-from pygmt.helpers import kwargs_to_strings
 
 __doctest_skip__ = ["load_earth_vertical_gravity_gradient"]
 
 
-@kwargs_to_strings(region="sequence")
 def load_earth_vertical_gravity_gradient(
     resolution: Literal[
         "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
     ] = "01d",
-    region=None,
+    region: Sequence[float] | None = None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
     r"""
@@ -56,13 +55,10 @@ def load_earth_vertical_gravity_gradient(
     resolution
         The grid resolution. The suffix ``d`` and ``m`` stand for arc-degrees and
         arc-minutes.
-
-    region : str or list
-        The subregion of the grid to load, in the form of a list
-        [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
-        Required for grids with resolutions higher than 5
-        arc-minutes (i.e., ``"05m"``).
-
+    region
+        The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
+        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
+        (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means

--- a/pygmt/datasets/earth_vertical_gravity_gradient.py
+++ b/pygmt/datasets/earth_vertical_gravity_gradient.py
@@ -17,7 +17,7 @@ def load_earth_vertical_gravity_gradient(
     resolution: Literal[
         "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
     ] = "01d",
-    region: Sequence[float] | None = None,
+    region: Sequence[float] | str | None = None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
     r"""
@@ -57,8 +57,8 @@ def load_earth_vertical_gravity_gradient(
         arc-minutes.
     region
         The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
-        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
-        (i.e., ``"05m"``).
+        *ymin*, *ymax*] or an ISO country code. Required for grids with resolutions
+        higher than 5 arc-minutes (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means

--- a/pygmt/datasets/mars_relief.py
+++ b/pygmt/datasets/mars_relief.py
@@ -5,15 +5,14 @@ Function to download the Mars relief dataset from the GMT data server, and load 
 The grids are available in various resolutions.
 """
 
+from collections.abc import Sequence
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
-from pygmt.helpers import kwargs_to_strings
 
 __doctest_skip__ = ["load_mars_relief"]
 
 
-@kwargs_to_strings(region="sequence")
 def load_mars_relief(
     resolution: Literal[
         "01d",
@@ -31,7 +30,7 @@ def load_mars_relief(
         "15s",
         "12s",
     ] = "01d",
-    region=None,
+    region: Sequence[float] | None = None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
     r"""
@@ -68,10 +67,10 @@ def load_mars_relief(
     resolution
         The grid resolution. The suffix ``d``, ``m`` and ``s`` stand for arc-degrees,
         arc-minutes and arc-seconds.
-    region : str or list
-        The subregion of the grid to load, in the form of a list
-        [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*. Required for
-        grids with resolutions higher than 5 arc-minutes (i.e., ``"05m"``).
+    region
+        The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
+        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
+        (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means

--- a/pygmt/datasets/mars_relief.py
+++ b/pygmt/datasets/mars_relief.py
@@ -30,7 +30,7 @@ def load_mars_relief(
         "15s",
         "12s",
     ] = "01d",
-    region: Sequence[float] | None = None,
+    region: Sequence[float] | str | None = None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
     r"""
@@ -69,8 +69,8 @@ def load_mars_relief(
         arc-minutes and arc-seconds.
     region
         The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
-        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
-        (i.e., ``"05m"``).
+        *ymin*, *ymax*] or an ISO country code. Required for grids with resolutions
+        higher than 5 arc-minutes (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means

--- a/pygmt/datasets/mercury_relief.py
+++ b/pygmt/datasets/mercury_relief.py
@@ -5,15 +5,14 @@ Function to download the Mercury relief dataset from the GMT data server, and lo
 The grids are available in various resolutions.
 """
 
+from collections.abc import Sequence
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
-from pygmt.helpers import kwargs_to_strings
 
 __doctest_skip__ = ["load_mercury_relief"]
 
 
-@kwargs_to_strings(region="sequence")
 def load_mercury_relief(
     resolution: Literal[
         "01d",
@@ -29,7 +28,7 @@ def load_mercury_relief(
         "01m",
         "56s",
     ] = "01d",
-    region=None,
+    region: Sequence[float] | None = None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
     r"""
@@ -66,10 +65,10 @@ def load_mercury_relief(
     resolution
         The grid resolution. The suffix ``d``, ``m`` and ``s`` stand for arc-degrees,
         arc-minutes and arc-seconds.
-    region : str or list
-        The subregion of the grid to load, in the form of a list
-        [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*. Required for
-        grids with resolutions higher than 5 arc-minutes (i.e., ``"05m"``).
+    region
+        The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
+        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
+        (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means

--- a/pygmt/datasets/mercury_relief.py
+++ b/pygmt/datasets/mercury_relief.py
@@ -28,7 +28,7 @@ def load_mercury_relief(
         "01m",
         "56s",
     ] = "01d",
-    region: Sequence[float] | None = None,
+    region: Sequence[float] | str | None = None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
     r"""
@@ -67,8 +67,8 @@ def load_mercury_relief(
         arc-minutes and arc-seconds.
     region
         The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
-        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
-        (i.e., ``"05m"``).
+        *ymin*, *ymax*] or an ISO country code. Required for grids with resolutions
+        higher than 5 arc-minutes (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means

--- a/pygmt/datasets/moon_relief.py
+++ b/pygmt/datasets/moon_relief.py
@@ -30,7 +30,7 @@ def load_moon_relief(
         "15s",
         "14s",
     ] = "01d",
-    region: Sequence[float] | None = None,
+    region: Sequence[float] | str | None = None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
     r"""
@@ -69,8 +69,8 @@ def load_moon_relief(
         arc-minutes and arc-seconds.
     region
         The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
-        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
-        (i.e., ``"05m"``).
+        *ymin*, *ymax*] or an ISO country code. Required for grids with resolutions
+        higher than 5 arc-minutes (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means

--- a/pygmt/datasets/moon_relief.py
+++ b/pygmt/datasets/moon_relief.py
@@ -5,15 +5,14 @@ Function to download the Moon relief dataset from the GMT data server, and load 
 The grids are available in various resolutions.
 """
 
+from collections.abc import Sequence
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
-from pygmt.helpers import kwargs_to_strings
 
 __doctest_skip__ = ["load_moon_relief"]
 
 
-@kwargs_to_strings(region="sequence")
 def load_moon_relief(
     resolution: Literal[
         "01d",
@@ -31,7 +30,7 @@ def load_moon_relief(
         "15s",
         "14s",
     ] = "01d",
-    region=None,
+    region: Sequence[float] | None = None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
     r"""
@@ -68,10 +67,10 @@ def load_moon_relief(
     resolution
         The grid resolution. The suffix ``d``, ``m`` and ``s`` stand for arc-degrees,
         arc-minutes and arc-seconds.
-    region : str or list
-        The subregion of the grid to load, in the form of a list
-        [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*. Required for
-        grids with resolutions higher than 5 arc-minutes (i.e., ``"05m"``).
+    region
+        The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
+        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
+        (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means

--- a/pygmt/datasets/pluto_relief.py
+++ b/pygmt/datasets/pluto_relief.py
@@ -5,15 +5,14 @@ Function to download the Pluto relief dataset from the GMT data server, and load
 The grids are available in various resolutions.
 """
 
+from collections.abc import Sequence
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
-from pygmt.helpers import kwargs_to_strings
 
 __doctest_skip__ = ["load_pluto_relief"]
 
 
-@kwargs_to_strings(region="sequence")
 def load_pluto_relief(
     resolution: Literal[
         "01d",
@@ -29,7 +28,7 @@ def load_pluto_relief(
         "01m",
         "52s",
     ] = "01d",
-    region=None,
+    region: Sequence[float] | None = None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
     r"""
@@ -66,10 +65,10 @@ def load_pluto_relief(
     resolution
         The grid resolution. The suffix ``d``, ``m`` and ``s`` stand for arc-degrees,
         arc-minutes and arc-seconds.
-    region : str or list
-        The subregion of the grid to load, in the form of a list
-        [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*. Required for
-        grids with resolutions higher than 5 arc-minutes (i.e., ``"05m"``).
+    region
+        The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
+        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
+        (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means

--- a/pygmt/datasets/pluto_relief.py
+++ b/pygmt/datasets/pluto_relief.py
@@ -28,7 +28,7 @@ def load_pluto_relief(
         "01m",
         "52s",
     ] = "01d",
-    region: Sequence[float] | None = None,
+    region: Sequence[float] | str | None = None,
     registration: Literal["gridline", "pixel", None] = None,
 ):
     r"""
@@ -67,8 +67,8 @@ def load_pluto_relief(
         arc-minutes and arc-seconds.
     region
         The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
-        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
-        (i.e., ``"05m"``).
+        *ymin*, *ymax*] or an ISO country code. Required for grids with resolutions
+        higher than 5 arc-minutes (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration. Default is ``None``, means

--- a/pygmt/datasets/venus_relief.py
+++ b/pygmt/datasets/venus_relief.py
@@ -17,7 +17,7 @@ def load_venus_relief(
     resolution: Literal[
         "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
     ] = "01d",
-    region: Sequence[float] | None = None,
+    region: Sequence[float] | str | None = None,
     registration: Literal["gridline", "pixel"] = "gridline",
 ):
     r"""
@@ -56,8 +56,8 @@ def load_venus_relief(
         arc-minutes.
     region
         The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
-        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
-        (i.e., ``"05m"``).
+        *ymin*, *ymax*] or an ISO country code. Required for grids with resolutions
+        higher than 5 arc-minutes (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration.

--- a/pygmt/datasets/venus_relief.py
+++ b/pygmt/datasets/venus_relief.py
@@ -5,20 +5,19 @@ Function to download the Venus relief dataset from the GMT data server, and load
 The grids are available in various resolutions.
 """
 
+from collections.abc import Sequence
 from typing import Literal
 
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
-from pygmt.helpers import kwargs_to_strings
 
 __doctest_skip__ = ["load_venus_relief"]
 
 
-@kwargs_to_strings(region="sequence")
 def load_venus_relief(
     resolution: Literal[
         "01d", "30m", "20m", "15m", "10m", "06m", "05m", "04m", "03m", "02m", "01m"
     ] = "01d",
-    region=None,
+    region: Sequence[float] | None = None,
     registration: Literal["gridline", "pixel"] = "gridline",
 ):
     r"""
@@ -55,10 +54,10 @@ def load_venus_relief(
     resolution
         The grid resolution. The suffix ``d`` and ``m`` stand for arc-degrees and
         arc-minutes.
-    region : str or list
-        The subregion of the grid to load, in the form of a list
-        [*xmin*, *xmax*, *ymin*, *ymax*] or a string *xmin/xmax/ymin/ymax*.
-        Required for grids with resolutions higher than 5 arc-minutes (i.e., ``"05m"``).
+    region
+        The subregion of the grid to load, in the form of a sequence [*xmin*, *xmax*,
+        *ymin*, *ymax*]. Required for grids with resolutions higher than 5 arc-minutes
+        (i.e., ``"05m"``).
     registration
         Grid registration type. Either ``"pixel"`` for pixel registration or
         ``"gridline"`` for gridline registration.


### PR DESCRIPTION
**Description of proposed changes**
 
In the previous version, `region` can be either a list or a string, but a string like `region="0/10/0/20"` is not Pythonic and a tuple like `region=(0, 10, 0, 20)` is also accepted.

This PR adds type hints to the `region` parameter of `load_*` functions. The `region` parameter must be a `Sequence` type (list, tuple, or array). A string type is still supported but no longer documented/recommended.

**Preview**: https://pygmt-dev--3272.org.readthedocs.build/en/3272/api/generated/pygmt.datasets.load_earth_age.html#pygmt.datasets.load_earth_age