### PR TITLE
CI: Add the dvc '--no-run-cache' option to avoid RunCacheNotSupported error

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -126,7 +126,7 @@ jobs:
             netCDF4
             packaging
             build
-            dvc<3.51
+            dvc
             make
             pip
             pytest

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -126,7 +126,7 @@ jobs:
             netCDF4
             packaging
             build
-            dvc
+            dvc<3.51
             make
             pip
             pytest

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -149,7 +149,7 @@ jobs:
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote
-        run: dvc pull --verbose && ls -lhR pygmt/tests/baseline/
+        run: dvc pull --no-run-cache --verbose && ls -lhR pygmt/tests/baseline/
 
       # Install the package that we want to test
       - name: Install the package

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -144,7 +144,7 @@ jobs:
           python -m pip install --pre --prefer-binary \
                         --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
                         'numpy<2' pandas xarray netCDF4 packaging \
-                        build contextily 'dvc<3.51' geopandas ipython pyarrow rioxarray \
+                        build contextily dvc geopandas ipython pyarrow rioxarray \
                         pytest pytest-cov pytest-doctestplus pytest-mpl pytest-rerunfailures pytest-xdist\
                         sphinx-gallery
 

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -144,7 +144,7 @@ jobs:
           python -m pip install --pre --prefer-binary \
                         --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
                         'numpy<2' pandas xarray netCDF4 packaging \
-                        build contextily dvc geopandas ipython pyarrow rioxarray \
+                        build contextily 'dvc<3.51' geopandas ipython pyarrow rioxarray \
                         pytest pytest-cov pytest-doctestplus pytest-mpl pytest-rerunfailures pytest-xdist\
                         sphinx-gallery
 

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -154,7 +154,7 @@ jobs:
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote
-        run: dvc pull --verbose && ls -lhR pygmt/tests/baseline/
+        run: dvc pull --no-run-cache --verbose && ls -lhR pygmt/tests/baseline/
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub


### PR DESCRIPTION
dvc 3.51 breaks with following error (https://github.com/GenericMappingTools/pygmt/actions/runs/9247930872/job/25437578302?pr=3182):
```
Run dvc pull --verbose && ls -lhR pygmt/tests/baseline/
  dvc pull --verbose && ls -lhR pygmt/tests/baseline/
  shell: /usr/bin/bash -l {0}
  env:
    OS: ubuntu-latest
    PYTHON: 3.10
    NUMPY: 1.[2](https://github.com/GenericMappingTools/pygmt/actions/runs/9247930872/job/25437578302?pr=3182#step:6:2)3
    MAMBA_ROOT_PREFIX: /home/runner/micromamba
    MAMBA_EXE: /home/runner/micromamba-bin/micromamba
    CONDARC: /home/runner/work/_temp/setup-micromamba/.condarc
2024-05-27 01:48:[3](https://github.com/GenericMappingTools/pygmt/actions/runs/9247930872/job/25437578302?pr=3182#step:6:3)4,944 DEBUG: v3.51.0 (conda), CPython 3.10.1[4](https://github.com/GenericMappingTools/pygmt/actions/runs/9247930872/job/25437578302?pr=3182#step:6:4) on Linux-6.[5](https://github.com/GenericMappingTools/pygmt/actions/runs/9247930872/job/25437578302?pr=3182#step:6:5).0-1021-azure-x86_[6](https://github.com/GenericMappingTools/pygmt/actions/runs/9247930872/job/25437578302?pr=3182#step:6:6)4-with-glibc2.35
2024-05-2[7](https://github.com/GenericMappingTools/pygmt/actions/runs/9247930872/job/25437578302?pr=3182#step:6:7) 01:48:34,944 DEBUG: command: /home/runner/micromamba/envs/pygmt/bin/dvc pull --verbose
2024-05-27 01:4[8](https://github.com/GenericMappingTools/pygmt/actions/runs/9247930872/job/25437578302?pr=3182#step:6:8):35,191 ERROR: failed to pull data from the cloud - run-cache is not supported for http filesystem: https://dagshub.com/GenericMappingTools/pygmt.dvc
Traceback (most recent call last):
  File "/home/runner/micromamba/envs/pygmt/lib/python3.10/site-packages/dvc/commands/data_sync.py", line 35, in run
    stats = self.repo.pull(
  File "/home/runner/micromamba/envs/pygmt/lib/python3.10/site-packages/dvc/repo/__init__.py", line 58, in wrapper
    return f(repo, *args, **kwargs)
  File "/home/runner/micromamba/envs/pygmt/lib/python3.10/site-packages/dvc/repo/pull.py", line 30, in pull
    processed_files_count = self.fetch(
  File "/home/runner/micromamba/envs/pygmt/lib/python3.10/site-packages/dvc/repo/__init__.py", line 58, in wrapper
    return f(repo, *args, **kwargs)
  File "/home/runner/micromamba/envs/pygmt/lib/python3.10/site-packages/dvc/repo/fetch.py", line 138, in fetch
    self.stage_cache.pull(remote)
  File "/home/runner/micromamba/envs/pygmt/lib/python3.10/site-packages/dvc/stage/cache.py", line 2[9](https://github.com/GenericMappingTools/pygmt/actions/runs/9247930872/job/25437578302?pr=3182#step:6:9)0, in pull
    return self.transfer(odb, self.repo.cache.legacy)
  File "/home/runner/micromamba/envs/pygmt/lib/python3.[10](https://github.com/GenericMappingTools/pygmt/actions/runs/9247930872/job/25437578302?pr=3182#step:6:10)/site-packages/dvc/stage/cache.py", line 248, in transfer
    raise RunCacheNotSupported(message)
dvc.stage.cache.RunCacheNotSupported: run-cache is not supported for http filesystem: https://dagshub.com/GenericMappingTools/pygmt.dvc

2024-05-27 01:48:35,195 DEBUG: Analytics is enabled.
2024-05-27 01:48:35,229 DEBUG: Trying to spawn ['daemon', 'analytics', '/tmp/tmpv7kiuswp', '-v']
2024-05-27 01:48:35,233 DEBUG: Spawned ['daemon', 'analytics', '/tmp/tmpv7kiuswp', '-v'] with pid 2[14](https://github.com/GenericMappingTools/pygmt/actions/runs/9247930872/job/25437578302?pr=3182#step:6:15)7
```