### PR TITLE
Move pygmt.show_versions function to _show_versions.py

### DIFF
--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -19,15 +19,10 @@ Here are just a few of the things that PyGMT does well:
 """
 
 import atexit as _atexit
-import sys
-from importlib.metadata import version
-
-# Get semantic version through setuptools-scm
-__version__ = f'v{version("pygmt")}'  # e.g. v0.1.2.dev3+g0ab3cd78
-__commit__ = __version__.split("+g")[-1] if "+g" in __version__ else ""  # 0ab3cd78
 
 # Import modules to make the high-level GMT Python API
 from pygmt import datasets
+from pygmt._show_versions import __commit__, __version__, show_versions
 from pygmt.accessors import GMTDataArrayAccessor
 from pygmt.figure import Figure, set_display
 from pygmt.io import load_dataarray
@@ -75,122 +70,3 @@ from pygmt.src import (
 _begin()
 # Tell Python to run _end when shutting down
 _atexit.register(_end)
-
-
-def show_versions(file=sys.stdout):
-    """
-    Print various dependency versions which are useful when submitting bug reports.
-
-    This includes information about:
-
-    - PyGMT itself
-    - System information (Python version, Operating System)
-    - Core dependency versions (NumPy, Pandas, Xarray, etc)
-    - GMT library information
-
-    It also warns users if the installed Ghostscript version has serious bugs or is
-    incompatible with the installed GMT version.
-    """
-
-    import importlib
-    import platform
-    import shutil
-    import subprocess
-
-    from packaging.requirements import Requirement
-    from packaging.version import Version
-
-    def _get_clib_info() -> dict:
-        """
-        Return information about the GMT shared library.
-        """
-        from pygmt.clib import Session
-
-        with Session() as ses:
-            return ses.info
-
-    def _get_module_version(modname: str) -> str | None:
-        """
-        Get version information of a Python module.
-        """
-        try:
-            module = (
-                sys.modules[modname]
-                if modname in sys.modules
-                else importlib.import_module(modname)
-            )
-
-            try:
-                return module.__version__
-            except AttributeError:
-                return module.version
-        except ImportError:
-            return None
-
-    def _get_ghostscript_version() -> str | None:
-        """
-        Get Ghostscript version.
-        """
-        match sys.platform:
-            case os_name if os_name.startswith(("linux", "darwin", "freebsd")):
-                cmds = ["gs"]
-            case "win32":
-                cmds = ["gswin64c.exe", "gswin32c.exe"]
-            case _:
-                return None
-
-        for gs_cmd in cmds:
-            if (gsfullpath := shutil.which(gs_cmd)) is not None:
-                return subprocess.check_output(
-                    [gsfullpath, "--version"], universal_newlines=True
-                ).strip()
-        return None
-
-    def _check_ghostscript_version(gs_version: str) -> str | None:
-        """
-        Check if the Ghostscript version is compatible with GMT versions.
-        """
-        match Version(gs_version):
-            case v if v < Version("9.53"):
-                return (
-                    f"Ghostscript v{gs_version} is too old and may have serious bugs. "
-                    "Please consider upgrading your Ghostscript."
-                )
-            case v if Version("10.00") <= v < Version("10.02"):
-                return (
-                    f"Ghostscript v{gs_version} has known bugs. "
-                    "Please consider upgrading to version v10.02 or later."
-                )
-            case v if v >= Version("10.02"):
-                from pygmt.clib import __gmt_version__
-
-                if Version(__gmt_version__) < Version("6.5.0"):
-                    return (
-                        f"GMT v{__gmt_version__} doesn't support Ghostscript "
-                        "v{gs_version}. Please consider upgrading to GMT>=6.5.0 or "
-                        "downgrading to Ghostscript v9.56."
-                    )
-        return None
-
-    sys_info = {
-        "python": sys.version.replace("\n", " "),
-        "executable": sys.executable,
-        "machine": platform.platform(),
-    }
-    deps = [Requirement(v).name for v in importlib.metadata.requires("pygmt")]
-    gs_version = _get_ghostscript_version()
-
-    lines = []
-    lines.append(f"PyGMT information:\n  version: {__version__}")
-    lines.append("System information:")
-    lines.extend([f"  {key}: {val}" for key, val in sys_info.items()])
-    lines.append("Dependency information:")
-    lines.extend([f"  {modname}: {_get_module_version(modname)}" for modname in deps])
-    lines.append(f"  ghostscript: {gs_version}")
-    lines.append("GMT library information:")
-    lines.extend([f"  {key}: {val}" for key, val in _get_clib_info().items()])
-
-    if warnmsg := _check_ghostscript_version(gs_version):
-        lines.append(f"WARNING:\n  {warnmsg}")
-
-    print("\n".join(lines), file=file)

--- a/pygmt/__init__.py
+++ b/pygmt/__init__.py
@@ -114,10 +114,11 @@ def show_versions(file=sys.stdout):
         Get version information of a Python module.
         """
         try:
-            if modname in sys.modules:
-                module = sys.modules[modname]
-            else:
-                module = importlib.import_module(modname)
+            module = (
+                sys.modules[modname]
+                if modname in sys.modules
+                else importlib.import_module(modname)
+            )
 
             try:
                 return module.__version__
@@ -131,9 +132,7 @@ def show_versions(file=sys.stdout):
         Get Ghostscript version.
         """
         match sys.platform:
-            case "linux" | "darwin":
-                cmds = ["gs"]
-            case os_name if os_name.startswith("freebsd"):
+            case os_name if os_name.startswith(("linux", "darwin", "freebsd")):
                 cmds = ["gs"]
             case "win32":
                 cmds = ["gswin64c.exe", "gswin32c.exe"]
@@ -182,8 +181,7 @@ def show_versions(file=sys.stdout):
     gs_version = _get_ghostscript_version()
 
     lines = []
-    lines.append("PyGMT information:")
-    lines.append(f"  version: {__version__}")
+    lines.append(f"PyGMT information:\n  version: {__version__}")
     lines.append("System information:")
     lines.extend([f"  {key}: {val}" for key, val in sys_info.items()])
     lines.append("Dependency information:")
@@ -193,7 +191,6 @@ def show_versions(file=sys.stdout):
     lines.extend([f"  {key}: {val}" for key, val in _get_clib_info().items()])
 
     if warnmsg := _check_ghostscript_version(gs_version):
-        lines.append("WARNING:")
-        lines.append(f"  {warnmsg}")
+        lines.append(f"WARNING:\n  {warnmsg}")
 
     print("\n".join(lines), file=file)

--- a/pygmt/_show_versions.py
+++ b/pygmt/_show_versions.py
@@ -1,0 +1,139 @@
+"""
+Utility methods to print system info for debugging.
+
+Adapted from :func:`rioxarray.show_versions` and :func:`pandas.show_versions`.
+"""
+
+import importlib
+import platform
+import shutil
+import sys
+from importlib.metadata import version
+
+# Get semantic version through setuptools-scm
+__version__ = f'v{version("pygmt")}'  # e.g. v0.1.2.dev3+g0ab3cd78
+__commit__ = __version__.split("+g")[-1] if "+g" in __version__ else ""  # 0ab3cd78
+
+
+def _get_clib_info() -> dict:
+    """
+    Return information about the GMT shared library.
+    """
+    from pygmt.clib import Session
+
+    with Session() as ses:
+        return ses.info
+
+
+def _get_module_version(modname: str) -> str | None:
+    """
+    Get version information of a Python module.
+    """
+    try:
+        if modname in sys.modules:
+            module = sys.modules[modname]
+        else:
+            module = importlib.import_module(modname)
+
+        try:
+            return module.__version__
+        except AttributeError:
+            return module.version
+    except ImportError:
+        return None
+
+
+def _get_ghostscript_version() -> str | None:
+    """
+    Get Ghostscript version.
+    """
+    import subprocess
+
+    match sys.platform:
+        case "linux" | "darwin":
+            cmds = ["gs"]
+        case os_name if os_name.startswith("freebsd"):
+            cmds = ["gs"]
+        case "win32":
+            cmds = ["gswin64c.exe", "gswin32c.exe"]
+        case _:
+            return None
+
+    for gs_cmd in cmds:
+        if (gsfullpath := shutil.which(gs_cmd)) is not None:
+            return subprocess.check_output(
+                [gsfullpath, "--version"], universal_newlines=True
+            ).strip()
+    return None
+
+
+def _check_ghostscript_version(gs_version: str) -> str | None:
+    """
+    Check if the Ghostscript version is compatible with GMT versions.
+    """
+    from packaging.version import Version
+
+    match Version(gs_version):
+        case v if v < Version("9.53"):
+            return (
+                f"Ghostscript v{gs_version} is too old and may have serious bugs. "
+                "Please consider upgrading your Ghostscript."
+            )
+        case v if Version("10.00") <= v < Version("10.02"):
+            return (
+                f"Ghostscript v{gs_version} has known bugs. "
+                "Please consider upgrading to version v10.02 or later."
+            )
+        case v if v >= Version("10.02"):
+            from pygmt.clib import __gmt_version__
+
+            if Version(__gmt_version__) < Version("6.5.0"):
+                return (
+                    f"GMT v{__gmt_version__} doesn't support Ghostscript "
+                    "v{gs_version}. Please consider upgrading to GMT>=6.5.0 or "
+                    "downgrading to Ghostscript v9.56."
+                )
+    return None
+
+
+def show_versions(file=sys.stdout):
+    """
+    Print various dependency versions which are useful when submitting bug reports.
+
+    This includes information about:
+
+    - PyGMT itself
+    - System information (Python version, Operating System)
+    - Core dependency versions (NumPy, Pandas, Xarray, etc)
+    - GMT library information
+
+    It also warns users if the installed Ghostscript version has serious bugs or is
+    incompatible with the installed GMT version.
+    """
+
+    from packaging.requirements import Requirement
+
+    sys_info = {
+        "python": sys.version.replace("\n", " "),
+        "executable": sys.executable,
+        "machine": platform.platform(),
+    }
+    deps = [Requirement(v).name for v in importlib.metadata.requires("pygmt")]
+    gs_version = _get_ghostscript_version()
+
+    lines = []
+    lines.append("PyGMT information:")
+    lines.append(f"  version: {__version__}")
+    lines.append("System information:")
+    lines.extend([f"  {key}: {val}" for key, val in sys_info.items()])
+    lines.append("Dependency information:")
+    lines.extend([f"  {modname}: {_get_module_version(modname)}" for modname in deps])
+    lines.append(f"  ghostscript: {gs_version}")
+    lines.append("GMT library information:")
+    lines.extend([f"  {key}: {val}" for key, val in _get_clib_info().items()])
+
+    if warnmsg := _check_ghostscript_version(gs_version):
+        lines.append("WARNING:")
+        lines.append(f"  {warnmsg}")
+
+    print("\n".join(lines), file=file)


### PR DESCRIPTION
**Description of proposed changes**

Move `pygmt.show_versions()` function from `__init__.py` to `_show_versions.py` because it got too long after #3244, and ruff v0.4.6 introduced a minor change in https://github.com/astral-sh/ruff/pull/11521 that counts every branch in the match statement as a single statement, causing `pygmt.show_versions()` to exceed the 50 statement limit.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Reference:
- https://docs.astral.sh/ruff/rules/too-many-statements

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #3276


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
