### PR TITLE
CI: Fix the Check Links workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -69,6 +69,7 @@ jobs:
     - name: Create Issue From File
       if: env.lychee_exit_code != 0
       run: |
+        cd repository/
         title="Link Checker Report on ${{ steps.date.outputs.date }}"
         gh issue create --title "$title" --body-file ./lychee/out.md
       env:


### PR DESCRIPTION
The Check Links workflow fails https://github.com/GenericMappingTools/pygmt/actions/runs/9243225468/job/25427089107, because `gh` command needs to run in a git repository, so `cd repository` first.