### PR TITLE
Remove CODE_OF_CONDUCT.md and use the organization-wide CODE OF CONDUCT file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,2 +1,0 @@
-All participants in the PyGMT community must abide by
-the [Generic Mapping Tools organization Code of Conduct](https://github.com/GenericMappingTools/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,6 @@ exclude .gitignore
 exclude .pre-commit-config.yaml
 exclude .readthedocs.yaml
 exclude AUTHORSHIP.md
-exclude CODE_OF_CONDUCT.md
 exclude CONTRIBUTING.md
 exclude Makefile
 exclude environment.yml

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Digital Object Identifier for the Zenodo archive](https://zenodo.org/badge/DOI/10.5281/3781524.svg)](https://doi.org/10.5281/zenodo.3781524)
 [![PyOpenSci](https://tinyurl.com/y22nb8up)](https://github.com/pyOpenSci/software-review/issues/43)
 [![GitHub license](https://img.shields.io/github/license/GenericMappingTools/pygmt?style=flat-square)](https://github.com/GenericMappingTools/pygmt/blob/main/LICENSE.txt)
-[![Contributor Code of Conduct](https://img.shields.io/badge/Contributor%20Covenant-v2.1%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
+[![Contributor Code of Conduct](https://img.shields.io/badge/Contributor%20Covenant-v2.1%20adopted-ff69b4.svg)](https://github.com/GenericMappingTools/.github/blob/main/CODE_OF_CONDUCT.md)
 
 <!-- doc-index-start-after -->
 


### PR DESCRIPTION
**Description of proposed changes**

Currently, `CODE_OF_CONDUCT.md` only contains a link to the org-wide CODE OF CONDUCT file (https://github.com/GenericMappingTools/.github/blob/main/CODE_OF_CONDUCT.md). If a repository doesn't have a CODE_OF_CONDUCT.md file, the organization-wide default file will be used and displayed (https://github.blog/changelog/2019-02-21-organization-wide-community-health-files/).

To view how the org-wide CODE_OF_CONDUCT file works, you can visit the [`try-gmt`](https://github.com/GenericMappingTools/try-gmt) repository:

<img width="949" alt="image" src="https://github.com/GenericMappingTools/pygmt/assets/3974108/bfc87ab8-91d3-4542-af20-05f0ed144ad2">

This PR removes the local `CODE_OF_CONDUCT.md` file.


xref:

1. https://github.blog/changelog/2019-02-21-organization-wide-community-health-files/
2. https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file