### PR TITLE
Fix a failing test for legacy GMT versions

### DIFF
--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -209,4 +209,4 @@ def test_earth_relief_03s_default_registration():
     npt.assert_allclose(data.coords["lon"].data.min(), -10)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.8)
     npt.assert_allclose(data.min(), -2069.85, atol=0.5)
-    npt.assert_allclose(data.max(), -924.5, atol=0.5)
+    npt.assert_allclose(data.max(), -923.5, atol=0.5)


### PR DESCRIPTION
**Description of proposed changes**

As reported in #2511, GMT 6.5.0 has some known bugs working with 03s remote datasets. So, the values with GMT 6.4.0 should be taken as the correct values.

This PR fixes a value from `-924.5` (reported by GMT 6.5) to `-923.5` (reported by GMT 6.4), so that the test doesn't fail in the GMT Legacy Tests CI (see https://github.com/GenericMappingTools/pygmt/actions/runs/9541097742).

The GMT Tests CI is not affected because the test is already marked as xfail for GMT 6.5. 