### PR TITLE
Mark one x2sys_cross test as xfail in the GMT Legacy Tests workflow

### DIFF
--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -39,6 +39,10 @@ def fixture_tracks():
 
 
 @pytest.mark.usefixtures("mock_x2sys_home")
+@pytest.mark.xfail(
+    condition=Version(__gmt_version__) < Version("6.5.0"),
+    reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/8188",
+)
 def test_x2sys_cross_input_file_output_file():
     """
     Run x2sys_cross by passing in a filename, and output internal crossovers to an ASCII


### PR DESCRIPTION
Before: https://github.com/GenericMappingTools/pygmt/actions/runs/9457537860

After: https://github.com/GenericMappingTools/pygmt/actions/runs/9542988903

With this PR, now there are only four failures with GMT 6.3, because OpenMP is not enabled in this version.