### PR TITLE
CI: Do not add the 'cores' parameters for GMT 6.3

### DIFF
--- a/pygmt/tests/test_grdfilter.py
+++ b/pygmt/tests/test_grdfilter.py
@@ -7,10 +7,15 @@ from pathlib import Path
 import numpy as np
 import pytest
 import xarray as xr
+from packaging.version import Version
 from pygmt import grdfilter, load_dataarray
+from pygmt.clib import __gmt_version__
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import load_static_earth_relief
+
+# GMT 6.3 on conda-forge doesn't have OpenMP enabled.
+cores = 2 if Version(__gmt_version__) > Version("6.3.0") else None
 
 
 @pytest.fixture(scope="module", name="grid")
@@ -46,7 +51,7 @@ def test_grdfilter_dataarray_in_dataarray_out(grid, expected_grid):
     Test grdfilter with an input DataArray, and output as DataArray.
     """
     result = grdfilter(
-        grid=grid, filter="g600", distance="4", region=[-53, -49, -20, -17], cores=2
+        grid=grid, filter="g600", distance="4", region=[-53, -49, -20, -17], cores=cores
     )
     # check information of the output grid
     assert isinstance(result, xr.DataArray)

--- a/pygmt/tests/test_grdlandmask.py
+++ b/pygmt/tests/test_grdlandmask.py
@@ -6,9 +6,14 @@ from pathlib import Path
 
 import pytest
 import xarray as xr
+from packaging.version import Version
 from pygmt import grdlandmask, load_dataarray
+from pygmt.clib import __gmt_version__
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import GMTTempFile
+
+# GMT 6.3 on conda-forge doesn't have OpenMP enabled.
+cores = 2 if Version(__gmt_version__) > Version("6.3.0") else None
 
 
 @pytest.fixture(scope="module", name="expected_grid")
@@ -50,7 +55,7 @@ def test_grdlandmask_no_outgrid(expected_grid):
     """
     Test grdlandmask with no set outgrid.
     """
-    result = grdlandmask(spacing=1, region=[125, 130, 30, 35], cores=2)
+    result = grdlandmask(spacing=1, region=[125, 130, 30, 35], cores=cores)
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
     assert result.gmt.gtype == 1  # Geographic grid

--- a/pygmt/tests/test_grdsample.py
+++ b/pygmt/tests/test_grdsample.py
@@ -6,9 +6,14 @@ from pathlib import Path
 
 import pytest
 import xarray as xr
+from packaging.version import Version
 from pygmt import grdsample, load_dataarray
+from pygmt.clib import __gmt_version__
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import load_static_earth_relief
+
+# GMT 6.3 on conda-forge doesn't have OpenMP enabled.
+cores = 2 if Version(__gmt_version__) > Version("6.3.0") else None
 
 
 @pytest.fixture(scope="module", name="grid")
@@ -75,7 +80,7 @@ def test_grdsample_dataarray_out(grid, expected_grid, region, spacing):
     """
     Test grdsample with no outgrid set and the spacing is changed.
     """
-    result = grdsample(grid=grid, spacing=spacing, region=region, cores=2)
+    result = grdsample(grid=grid, spacing=spacing, region=region, cores=cores)
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
     assert result.gmt.gtype == 1  # Geographic grid

--- a/pygmt/tests/test_sph2grd.py
+++ b/pygmt/tests/test_sph2grd.py
@@ -6,8 +6,13 @@ from pathlib import Path
 
 import numpy.testing as npt
 import pytest
+from packaging.version import Version
 from pygmt import sph2grd
+from pygmt.clib import __gmt_version__
 from pygmt.helpers import GMTTempFile
+
+# GMT 6.3 on conda-forge doesn't have OpenMP enabled.
+cores = 2 if Version(__gmt_version__) > Version("6.3.0") else None
 
 
 def test_sph2grd_outgrid():
@@ -27,7 +32,7 @@ def test_sph2grd_no_outgrid():
     """
     Test sph2grd with no set outgrid.
     """
-    temp_grid = sph2grd(data="@EGM96_to_36.txt", spacing=1, region="g", cores=2)
+    temp_grid = sph2grd(data="@EGM96_to_36.txt", spacing=1, region="g", cores=cores)
     assert temp_grid.dims == ("y", "x")
     assert temp_grid.gmt.gtype == 0  # Cartesian grid
     assert temp_grid.gmt.registration == 0  # Gridline registration


### PR DESCRIPTION
Four tests fail with GMT 6.3 because the GMT 6.3 package on conda-forge doesn't have OpenMP enabled.

This PR sets `cores` based on the GMT version so that tests can pass with GMT 6.3.