### PR TITLE
CI: Test NumPy 2.0 in the GMT Tests workflow

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -75,7 +75,7 @@ jobs:
             xarray-version: '=2022.06'
             optional-packages: ''
           - python-version: '3.12'
-            numpy-version: '1.26'
+            numpy-version: '2.0'
             pandas-version: ''
             xarray-version: ''
             optional-packages: ' contextily geopandas ipython pyarrow rioxarray sphinx-gallery'


### PR DESCRIPTION
**Description of proposed changes**

Bumps [numpy](https://github.com/numpy/numpy) from 1.26 to 2.0. [NumPy 2.0.0](https://github.com/numpy/numpy/releases/tag/v2.0.0) was released on 17 Jun 2024.
- [Release notes](https://github.com/numpy/numpy/releases)
- [Changelog](https://numpy.org/doc/2.0/release/2.0.0-notes.html)
- [Commits](https://github.com/numpy/numpy/compare/v1.26.0...v2.0.0)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This is in line with PyGMT's policy on [SPEC0](https://scientific-python.org/specs/spec-0000/#support-window) at https://www.pygmt.org/v0.12.0/maintenance.html#dependencies-policy, xref https://github.com/GenericMappingTools/pygmt/issues/2863.

Note that the branch protection rules at [GenericMappingTools/pygmt/settings/branches](https://github.com/GenericMappingTools/pygmt/settings/branches) will need to be changed to use Python 3.12/Numpy 2.0 instead of Python 3.12/Numpy 1.26 before this Pull Request is merged.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Supersedes #2692

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash commands are:

- `/format`: automatically format and lint the code
