### PR TITLE
RFC: grdhisteq.compute_bins: use int64 dtype for bin_id column instead of uint32

### DIFF
--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -243,7 +243,7 @@ class grdhisteq:  # noqa: N801
                 dtype={
                     "start": np.float32,
                     "stop": np.float32,
-                    "bin_id": np.uint32,
+                    "bin_id": np.int64,
                 },
                 index_col="bin_id" if output_type == "pandas" else None,
             )

--- a/pygmt/tests/test_grdhisteq.py
+++ b/pygmt/tests/test_grdhisteq.py
@@ -53,7 +53,7 @@ def fixture_expected_df():
     return pd.DataFrame(
         data=np.array([[345.5, 519.5, 0], [519.5, 726.5, 1]]),
         columns=["start", "stop", "bin_id"],
-    ).astype({"start": np.float32, "stop": np.float32, "bin_id": np.uint32})
+    ).astype({"start": np.float32, "stop": np.float32, "bin_id": np.int64})
 
 
 def test_equalize_grid_outgrid_file(grid, expected_grid, region):


### PR DESCRIPTION
**Description of proposed changes**

Change to follow the pandas 3.0 default RangeIndex column's dtype.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

For context, the `uint32` dtype was originally set in the initial implementation of `grdhisteq.compute_bins` at https://github.com/GenericMappingTools/pygmt/pull/1433#discussion_r818920375.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #3291


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
