### PR TITLE
Workaround for the pd.read_csv's index_col bug in pandas 3.0 dev version

### DIFF
--- a/pygmt/tests/test_grdhisteq.py
+++ b/pygmt/tests/test_grdhisteq.py
@@ -125,10 +125,9 @@ def test_compute_bins_outfile(grid, expected_df, region):
             header=None,
             names=["start", "stop", "bin_id"],
             dtype={"start": np.float32, "stop": np.float32, "bin_id": np.uint32},
-            index_col="bin_id",
         )
         pd.testing.assert_frame_equal(
-            left=temp_df, right=expected_df.set_index("bin_id")
+            left=temp_df.set_index("bin_id"), right=expected_df.set_index("bin_id")
         )
 
 


### PR DESCRIPTION
Address https://github.com/GenericMappingTools/pygmt/issues/3291.