### PR TITLE
CI: Bump to ubuntu-24.04 and mambaforge-23.11 in ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "mambaforge-22.9"
+    python: "mambaforge-23.11"
   jobs:
     post_checkout:
       # Cancel building pull requests when there aren't changes related to docs.


### PR DESCRIPTION
**Description of proposed changes**

Bump ReadTheDocs os version from `ubuntu-22.04` to `ubuntu-24.04`, and mambaforge version from `22.9` to `23.11`.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

References:
- https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os
- https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Supersedes #3268


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
