### PR TITLE
CI: Remove the deprecated lychee option and specify the report file name in the Check Links workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -37,10 +37,10 @@ jobs:
       id: lychee
       uses: lycheeverse/lychee-action@v1.10.0
       with:
+        output: /tmp/lychee-out.md
         # 429: Too many requests
         args: >
           --accept 429
-          --exclude-mail
           --exclude "^https://doi.org/10.5281/zenodo$"
           --exclude "^https://zenodo.org/badge/DOI/$"
           --exclude "^https://zenodo.org/badge/DOI/10.5281/zenodo$"
@@ -71,6 +71,6 @@ jobs:
       run: |
         cd repository/
         title="Link Checker Report on ${{ steps.date.outputs.date }}"
-        gh issue create --title "$title" --body-file ./lychee/out.md
+        gh issue create --title "$title" --body-file /tmp/lychee-out.md
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The "Check Links" workflow fails (https://github.com/GenericMappingTools/pygmt/actions/runs/9535958882), because:

- We check out the repository and documentation into separate subdirectories
- `gh` only works for a git repository, so we need to change into the `repository` directory
- The lychee action is run in the github workspace directory.
 
Thus, the lychee output file `lychee/out.md` is also relative to the workspace directory. When running `gh issue create`, we should use the path `../lychee/out.md`, but it's not readable.

In this PR, we explicitly set `output: /tmp/lychee-out.md` so that we can use the full path.

The workflow also reports a warning:
```
[WARN ] WARNING: `--exclude-mail` is deprecated and will soon be removed; E-Mail is no longer checked by default. Use `--include-mail` to enable E-Mail checking.
```