### PR TITLE
CI: Temporarily pin geopandas<1.0 in the Docs workflow

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -101,7 +101,8 @@ jobs:
             netCDF4
             packaging
             contextily
-            geopandas
+            geopandas=0.14
+            pyogrio=0.9
             ipython
             rioxarray
             build

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -101,7 +101,7 @@ jobs:
             netCDF4
             packaging
             contextily
-            geopandas=0.14
+            geopandas=1.0
             pyogrio=0.9
             ipython
             rioxarray

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -101,8 +101,7 @@ jobs:
             netCDF4
             packaging
             contextily
-            geopandas=1.0
-            pyogrio=0.9
+            geopandas<1.0
             ipython
             rioxarray
             build

--- a/examples/gallery/lines/roads.py
+++ b/examples/gallery/lines/roads.py
@@ -17,7 +17,8 @@ import pygmt
 
 # Read shapefile data using geopandas
 gdf = gpd.read_file(
-    "http://www2.census.gov/geo/tiger/TIGER2015/PRISECROADS/tl_2015_15_prisecroads.zip"
+    "http://www2.census.gov/geo/tiger/TIGER2015/PRISECROADS/tl_2015_15_prisecroads.zip",
+    engine="pyogrio"
 )
 # The dataset contains different road types listed in the RTTYP column,
 # here we select the following ones to plot:

--- a/examples/gallery/lines/roads.py
+++ b/examples/gallery/lines/roads.py
@@ -17,8 +17,7 @@ import pygmt
 
 # Read shapefile data using geopandas
 gdf = gpd.read_file(
-    "http://www2.census.gov/geo/tiger/TIGER2015/PRISECROADS/tl_2015_15_prisecroads.zip",
-    engine="pyogrio"
+    "http://www2.census.gov/geo/tiger/TIGER2015/PRISECROADS/tl_2015_15_prisecroads.zip"
 )
 # The dataset contains different road types listed in the RTTYP column,
 # here we select the following ones to plot:


### PR DESCRIPTION
In 45ff5a4feb5a32177ab03c7f3b62dcc825526cb3, I set the parameter `engine="pyogrio"` so that geopandas would use pyogrio instead of fiona.

- geopandas 0.14 + pyogrio 0.9 works (https://github.com/GenericMappingTools/pygmt/actions/runs/9678856324/job/26703528256?pr=3304)
- geopandas 1.0 + pyogrio 0.9 fails (https://github.com/GenericMappingTools/pygmt/actions/runs/9678923611/job/26703733741?pr=3304)

The conda environments diff a little:
```diff
diff gpd-0.14.txt gpd-1.0.txt
61d60
<     fiona                          1.9.6         py312h32ad294_3          conda-forge
76,77c75,76
<     geopandas                      0.14.4        pyhd8ed1ab_0             conda-forge
<     geopandas-base                 0.14.4        pyha770c72_0             conda-forge
---
>     geopandas                      1.0.0         pyhd8ed1ab_0             conda-forge
>     geopandas-base                 1.0.0         pyha770c72_0             conda-forge
144d142
<     libspatialindex                2.0.0         he02047a_0               conda-forge
220d217
<     rtree                          1.2.0         py312h3ed4c40_1          conda-forge
```
So it's likely something wrong with geopandas 1.0, but not sure why I can't reproduce it locally. The Tests workflow also have geopandas 1.0 installed but all tests pass (see https://github.com/GenericMappingTools/pygmt/actions/runs/9671820457/job/26701186881).

Maybe we just need to wait for a few days and see if there are any upstream fixes/changes. This PR pins geopandas<1.0 in the Docs workflow so that the Docs build passes.

Address #3301