### PR TITLE
Add pytest conftest.py file to suppress warnings with NumPy 2.0

### DIFF
--- a/pygmt/conftest.py
+++ b/pygmt/conftest.py
@@ -8,4 +8,4 @@ from packaging.version import Version
 # Keep this until we require numpy to be >=2.0
 # Address https://github.com/GenericMappingTools/pygmt/issues/2628.
 if Version(np.__version__) >= Version("2.0.0.dev0+git20230726"):
-    np.set_printoptions(legacy="1.25")
+    np.set_printoptions(legacy="1.25")  # type: ignore[arg-type]

--- a/pygmt/conftest.py
+++ b/pygmt/conftest.py
@@ -1,0 +1,10 @@
+"""
+conftets.py for pytest.
+"""
+import numpy as np
+from packaging.version import Version
+
+# Keep this until we require numpy to be >=2.0
+# Address https://github.com/GenericMappingTools/pygmt/issues/2628.
+if Version(np.__version__) >= Version("2.0.0.dev0+git20230726"):
+    np.set_printoptions(legacy="1.25")

--- a/pygmt/conftest.py
+++ b/pygmt/conftest.py
@@ -1,5 +1,5 @@
 """
-conftets.py for pytest.
+conftest.py for pytest.
 """
 
 import numpy as np

--- a/pygmt/conftest.py
+++ b/pygmt/conftest.py
@@ -1,6 +1,7 @@
 """
 conftets.py for pytest.
 """
+
 import numpy as np
 from packaging.version import Version
 


### PR DESCRIPTION
Workaround from https://github.com/GenericMappingTools/pygmt/issues/2628#issuecomment-1688666672.

Fixes https://github.com/GenericMappingTools/pygmt/issues/2628.