### PR TITLE
Fix typo in AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,7 +6,7 @@ with [Paul Wessel](https://www.soest.hawaii.edu/wessel) at the University of
 Hawaiʻi at Mānoa.
 
 The following people have contributed code and/or documentation to the project
-(alphabetical by name) and are considered to be "PyGMT Developers":
+(alphabetically by name) and are considered to be "PyGMT Developers":
 
 * [Abhishek Anant](https://twitter.com/itsabhianant) | [0000-0002-5751-2010](https://orcid.org/0000-0002-5751-2010) | Unaffiliated
 * [Andre L. Belem](https://github.com/andrebelem) | [0000-0002-8865-6180](https://orcid.org/0000-0002-8865-6180) | Fluminense Federal University, Brazil

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ research using the following BibTeX:
                   Ziebarth, Malte and
                   Quinn, Jamie and
                   Wessel, Paul},
-  title        = {PyGMT: A Python interface for the Generic Mapping Tools},
+  title        = {{PyGMT: A Python interface for the Generic Mapping Tools}},
   month        = may,
   year         = 2024,
   publisher    = {Zenodo},

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ research using the following BibTeX:
                   Ziebarth, Malte and
                   Quinn, Jamie and
                   Wessel, Paul},
-  title        = {{PyGMT: A Python interface for the Generic Mapping Tools}},
+  title        = {PyGMT: A Python interface for the Generic Mapping Tools},
   month        = may,
   year         = 2024,
   publisher    = {Zenodo},


### PR DESCRIPTION
**Description of proposed changes**

I am wondering if the BibTeX entry (https://github.com/GenericMappingTools/pygmt?tab=readme-ov-file#citing-pygmt) also works with single curly braces (https://de.overleaf.com/learn/latex/Bibliography_management_with_bibtex#Enter_\(\mathrm{Bib\TeX}\).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
