### PR TITLE
Enable ruff's literal-membership (PLR6201) rule and fix violations

### DIFF
--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -141,7 +141,7 @@ class GMTDataArrayAccessor:
 
     @registration.setter
     def registration(self, value):
-        if value not in (0, 1):
+        if value not in {0, 1}:
             raise GMTInvalidInput(
                 f"Invalid grid registration value: {value}, should be either "
                 "0 for Gridline registration or 1 for Pixel registration."
@@ -157,7 +157,7 @@ class GMTDataArrayAccessor:
 
     @gtype.setter
     def gtype(self, value):
-        if value not in (0, 1):
+        if value not in {0, 1}:
             raise GMTInvalidInput(
                 f"Invalid coordinate system type: {value}, should be "
                 "either 0 for Cartesian or 1 for Geographic."

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -944,7 +944,7 @@ class Session:
         )
 
         gmt_type = self._check_dtype_and_dim(vector, ndim=1)
-        if gmt_type in (self["GMT_TEXT"], self["GMT_DATETIME"]):
+        if gmt_type in {self["GMT_TEXT"], self["GMT_DATETIME"]}:
             if gmt_type == self["GMT_DATETIME"]:
                 vector = np.datetime_as_string(array_to_datetime(vector))
             vector_pointer = strings_to_ctypes_array(vector)
@@ -1622,7 +1622,7 @@ class Session:
         }[kind]
 
         # Ensure the data is an iterable (Python list or tuple)
-        if kind in ("geojson", "grid", "image", "file", "arg"):
+        if kind in {"geojson", "grid", "image", "file", "arg"}:
             if kind == "image" and data.dtype != "uint8":
                 msg = (
                     f"Input image has dtype: {data.dtype} which is unsupported, "
@@ -1849,7 +1849,7 @@ class Session:
         # _GMT_DATASET).
         if kind is None:  # Return the ctypes void pointer
             return pointer
-        if kind in ["image", "cube"]:
+        if kind in {"image", "cube"}:
             raise NotImplementedError(f"kind={kind} is not supported yet.")
         dtype = {"dataset": _GMT_DATASET, "grid": _GMT_GRID}[kind]
         return ctp.cast(pointer, ctp.POINTER(dtype))

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -387,7 +387,7 @@ def _load_remote_dataset(
     if registration is None:
         # Use gridline registration unless only pixel registration is available
         registration = "gridline" if "gridline" in resinfo.registrations else "pixel"
-    elif registration in ("pixel", "gridline"):
+    elif registration in {"pixel", "gridline"}:
         if registration not in resinfo.registrations:
             raise GMTInvalidInput(
                 f"{registration} registration is not available for the "

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -236,7 +236,7 @@ class Figure:
             kwargs["A"] = ""
 
         prefix = kwargs.get("F")
-        if prefix in ["", None, False, True]:
+        if prefix in {"", None, False, True}:
             raise GMTInvalidInput(
                 "The 'prefix' parameter must be specified with a valid value."
             )
@@ -363,7 +363,7 @@ class Figure:
             kwargs["Qg"] = 2
 
         if worldfile:
-            if ext in ["eps", "kml", "pdf", "tiff"]:
+            if ext in {"eps", "kml", "pdf", "tiff"}:
                 raise GMTInvalidInput(
                     f"Saving a world file is not supported for '{ext}' format."
                 )
@@ -444,7 +444,7 @@ class Figure:
         if method is None:
             method = SHOW_CONFIG["method"]
 
-        if method not in ["external", "notebook", "none"]:
+        if method not in {"external", "notebook", "none"}:
             raise GMTInvalidInput(
                 f"Invalid display method '{method}', "
                 "should be either 'notebook', 'external', or 'none'."
@@ -583,7 +583,7 @@ def set_display(method=None):
     >>> pygmt.set_display(method=None)
     >>> fig.show()  # again, will show a PNG image in the current notebook
     """
-    if method in ["notebook", "external", "none"]:
+    if method in {"notebook", "external", "none"}:
         SHOW_CONFIG["method"] = method
     elif method is not None:
         raise GMTInvalidInput(

--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -148,7 +148,7 @@ def tempfile_from_geojson(geojson):
                 geojson = geojson.reset_index(drop=False)
                 schema = gpd.io.file.infer_schema(geojson)
                 for col, dtype in schema["properties"].items():
-                    if dtype in ("int", "int64"):
+                    if dtype in {"int", "int64"}:
                         overflow = geojson[col].abs().max() > 2**31 - 1
                         schema["properties"][col] = "float" if overflow else "int32"
                 ogrgmt_kwargs["schema"] = schema
@@ -156,7 +156,7 @@ def tempfile_from_geojson(geojson):
                 # The default engine "pyogrio" doesn't support the 'schema' parameter
                 # but we can change the dtype directly.
                 for col in geojson.columns:
-                    if geojson[col].dtype in ("int", "int64", "Int64"):
+                    if geojson[col].dtype in {"int", "int64", "Int64"}:
                         overflow = geojson[col].abs().max() > 2**31 - 1
                         dtype = "float" if overflow else "int32"
                         geojson[col] = geojson[col].astype(dtype)

--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -156,7 +156,7 @@ def tempfile_from_geojson(geojson):
                 # The default engine "pyogrio" doesn't support the 'schema' parameter
                 # but we can change the dtype directly.
                 for col in geojson.columns:
-                    if geojson[col].dtype in {"int", "int64", "Int64"}:
+                    if geojson[col].dtype.name in {"int", "int64", "Int64"}:
                         overflow = geojson[col].abs().max() > 2**31 - 1
                         dtype = "float" if overflow else "int32"
                         geojson[col] = geojson[col].astype(dtype)

--- a/pygmt/helpers/validators.py
+++ b/pygmt/helpers/validators.py
@@ -49,7 +49,7 @@ def validate_output_table_type(
     ...     assert len(w) == 1
     'file'
     """
-    if output_type not in ["file", "numpy", "pandas"]:
+    if output_type not in {"file", "numpy", "pandas"}:
         raise GMTInvalidInput(
             "Must specify 'output_type' either as 'file', 'numpy', or 'pandas'."
         )

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -95,7 +95,7 @@ def convention_code(convention, component="full"):
                 f"Invalid component '{component}' for convention '{convention}'."
             )
         return codes2[convention][component]
-    if convention in ["a", "c", "m", "d", "z", "p", "x", "y", "t"]:
+    if convention in {"a", "c", "m", "d", "z", "p", "x", "y", "t"}:
         return convention
     raise GMTInvalidInput(f"Invalid convention '{convention}'.")
 

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -146,7 +146,7 @@ def tilemap(
 
     # Only set region if no_clip is None or False, so that plot is clipped to exact
     # bounding box region
-    if kwargs.get("N") in [None, False]:
+    if kwargs.get("N") in {None, False}:
         kwargs["R"] = "/".join(str(coordinate) for coordinate in region)
 
     with Session() as lib:

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -529,7 +529,7 @@ def test_get_default():
     Make sure get_default works without crashing and gives reasonable results.
     """
     with clib.Session() as lib:
-        assert lib.get_default("API_GRID_LAYOUT") in ["rows", "columns"]
+        assert lib.get_default("API_GRID_LAYOUT") in {"rows", "columns"}
         assert int(lib.get_default("API_CORES")) >= 1
         assert Version(lib.get_default("API_VERSION")) >= Version("6.3.0")
         assert lib.get_default("PROJ_LENGTH_UNIT") == "cm"

--- a/pygmt/tests/test_clib_loading.py
+++ b/pygmt/tests/test_clib_loading.py
@@ -131,7 +131,7 @@ class TestLibgmtBrokenLibs:
         # libname is a loaded GMT library
         return self.loaded_libgmt
 
-    @pytest.fixture()
+    @pytest.fixture
     def _mock_ctypes(self, monkeypatch):
         """
         Patch the ctypes.CDLL function.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,8 +121,9 @@ select = [
     "YTT",  # flake8-2020
 ]
 extend-select = [
-    "D213",  # Summary lines should be positioned on the second physical line of the docstring.
-    "D410",  # A blank line after section headings.
+    "D213",     # Summary lines should be positioned on the second physical line of the docstring.
+    "D410",     # A blank line after section headings.
+    "PLR6201",  # Use a set literal when testing for membership
 ]
 ignore = [
     "D200",     # One-line docstring should fit on one line
@@ -140,6 +141,8 @@ ignore = [
     "S603",     # Allow method calls that initiate a subprocess without a shell
     "SIM117",   # Allow nested `with` statements
 ]
+preview = true
+explicit-preview-rules = true
 
 [tool.ruff.lint.isort]
 known-third-party = ["pygmt"]


### PR DESCRIPTION
**Description of proposed changes**

Enable ruff's [literal membership (PLR6201) rule](https://docs.astral.sh/ruff/rules/literal-membership/) to ensure a set literal is used when testing for membership. Note that this is a preview mode feature.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This offers a bit of a speed/performance improvement, as Python's peephole optimizer will optimize set membership tests (by converting the set to a frozenset), making it faster than tuple or list membership tests.

Example speed tests on my machine, about a 4.5x speedup using set `{}` compared to tuple `()` or list `[]`:

```
$ python -m timeit -s 'convention="t"' 'convention in {"a", "c", "m", "d", "z", "p", "x", "y", "t"}'
50000000 loops, best of 5: 9.52 nsec per loop

$ python -m timeit -s 'convention="t"' 'convention in ("a", "c", "m", "d", "z", "p", "x", "y", "t")'
5000000 loops, best of 5: 42.4 nsec per loop

$ python -m timeit -s 'convention="t"' 'convention in ["a", "c", "m", "d", "z", "p", "x", "y", "t"]'
5000000 loops, best of 5: 42.4 nsec per loop
```

References:
- https://docs.python.org/3/whatsnew/3.2.html#optimizations
- https://docs.astral.sh/ruff/rules/literal-membership/
- https://docs.astral.sh/ruff/preview/#selecting-single-preview-rules

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses https://github.com/GenericMappingTools/pygmt/issues/2741#issuecomment-2212728325


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code