### PR TITLE
Enable ruff's unspecified-encoding (PLW1514) rule and fix violations

### DIFF
--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -247,7 +247,7 @@ def plot(  # noqa: PLR0912
             kwargs["S"] = "s0.2c"
         elif kind == "file" and str(data).endswith(".gmt"):  # OGR_GMT file
             try:
-                with Path(which(data)).open(encoding="locale") as file:
+                with Path(which(data)).open(encoding="utf-8") as file:
                     line = file.readline()
                 if "@GMULTIPOINT" in line or "@GPOINT" in line:
                     kwargs["S"] = "s0.2c"

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -247,7 +247,7 @@ def plot(  # noqa: PLR0912
             kwargs["S"] = "s0.2c"
         elif kind == "file" and str(data).endswith(".gmt"):  # OGR_GMT file
             try:
-                with Path(which(data)).open() as file:
+                with Path(which(data)).open(encoding="locale") as file:
                     line = file.readline()
                 if "@GMULTIPOINT" in line or "@GPOINT" in line:
                     kwargs["S"] = "s0.2c"

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -223,7 +223,7 @@ def plot3d(  # noqa: PLR0912
             kwargs["S"] = "u0.2c"
         elif kind == "file" and str(data).endswith(".gmt"):  # OGR_GMT file
             try:
-                with Path(which(data)).open(encoding="locale") as file:
+                with Path(which(data)).open(encoding="utf-8") as file:
                     line = file.readline()
                 if "@GMULTIPOINT" in line or "@GPOINT" in line:
                     kwargs["S"] = "u0.2c"

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -223,7 +223,7 @@ def plot3d(  # noqa: PLR0912
             kwargs["S"] = "u0.2c"
         elif kind == "file" and str(data).endswith(".gmt"):  # OGR_GMT file
             try:
-                with Path(which(data)).open() as file:
+                with Path(which(data)).open(encoding="locale") as file:
                     line = file.readline()
                 if "@GMULTIPOINT" in line or "@GPOINT" in line:
                     kwargs["S"] = "u0.2c"

--- a/pygmt/tests/test_datatypes_dataset.py
+++ b/pygmt/tests/test_datatypes_dataset.py
@@ -57,7 +57,7 @@ def test_dataset():
     Test the basic functionality of GMT_DATASET.
     """
     with GMTTempFile(suffix=".txt") as tmpfile:
-        with Path(tmpfile.name).open(mode="w", encoding="locale") as fp:
+        with Path(tmpfile.name).open(mode="w", encoding="utf-8") as fp:
             print(">", file=fp)
             print("1.0 2.0 3.0 TEXT1 TEXT23", file=fp)
             print("4.0 5.0 6.0 TEXT4 TEXT567", file=fp)
@@ -75,7 +75,7 @@ def test_dataset_empty():
     Make sure that an empty DataFrame is returned if a file contains no data.
     """
     with GMTTempFile(suffix=".txt") as tmpfile:
-        with Path(tmpfile.name).open(mode="w", encoding="locale") as fp:
+        with Path(tmpfile.name).open(mode="w", encoding="utf-8") as fp:
             print("# This is a comment line.", file=fp)
 
         df = dataframe_from_gmt(tmpfile.name)
@@ -89,7 +89,7 @@ def test_dataset_header():
     Test parsing column names from dataset header.
     """
     with GMTTempFile(suffix=".txt") as tmpfile:
-        with Path(tmpfile.name).open(mode="w", encoding="locale") as fp:
+        with Path(tmpfile.name).open(mode="w", encoding="utf-8") as fp:
             print("# lon lat z text", file=fp)
             print("1.0 2.0 3.0 TEXT1 TEXT23", file=fp)
             print("4.0 5.0 6.0 TEXT4 TEXT567", file=fp)
@@ -109,7 +109,7 @@ def test_dataset_header_greater_than_nheaders():
     Test passing a header line number that is greater than the number of header lines.
     """
     with GMTTempFile(suffix=".txt") as tmpfile:
-        with Path(tmpfile.name).open(mode="w", encoding="locale") as fp:
+        with Path(tmpfile.name).open(mode="w", encoding="utf-8") as fp:
             print("# lon lat z text", file=fp)
             print("1.0 2.0 3.0 TEXT1 TEXT23", file=fp)
             print("4.0 5.0 6.0 TEXT4 TEXT567", file=fp)
@@ -127,7 +127,7 @@ def test_dataset_header_too_many_names():
     Test passing a header line with more column names than the number of columns.
     """
     with GMTTempFile(suffix=".txt") as tmpfile:
-        with Path(tmpfile.name).open(mode="w", encoding="locale") as fp:
+        with Path(tmpfile.name).open(mode="w", encoding="utf-8") as fp:
             print("# lon lat z text1 text2", file=fp)
             print("1.0 2.0 3.0 TEXT1 TEXT23", file=fp)
             print("4.0 5.0 6.0 TEXT4 TEXT567", file=fp)

--- a/pygmt/tests/test_datatypes_dataset.py
+++ b/pygmt/tests/test_datatypes_dataset.py
@@ -57,7 +57,7 @@ def test_dataset():
     Test the basic functionality of GMT_DATASET.
     """
     with GMTTempFile(suffix=".txt") as tmpfile:
-        with Path(tmpfile.name).open(mode="w") as fp:
+        with Path(tmpfile.name).open(mode="w", encoding="locale") as fp:
             print(">", file=fp)
             print("1.0 2.0 3.0 TEXT1 TEXT23", file=fp)
             print("4.0 5.0 6.0 TEXT4 TEXT567", file=fp)
@@ -75,7 +75,7 @@ def test_dataset_empty():
     Make sure that an empty DataFrame is returned if a file contains no data.
     """
     with GMTTempFile(suffix=".txt") as tmpfile:
-        with Path(tmpfile.name).open(mode="w") as fp:
+        with Path(tmpfile.name).open(mode="w", encoding="locale") as fp:
             print("# This is a comment line.", file=fp)
 
         df = dataframe_from_gmt(tmpfile.name)
@@ -89,7 +89,7 @@ def test_dataset_header():
     Test parsing column names from dataset header.
     """
     with GMTTempFile(suffix=".txt") as tmpfile:
-        with Path(tmpfile.name).open(mode="w") as fp:
+        with Path(tmpfile.name).open(mode="w", encoding="locale") as fp:
             print("# lon lat z text", file=fp)
             print("1.0 2.0 3.0 TEXT1 TEXT23", file=fp)
             print("4.0 5.0 6.0 TEXT4 TEXT567", file=fp)
@@ -109,7 +109,7 @@ def test_dataset_header_greater_than_nheaders():
     Test passing a header line number that is greater than the number of header lines.
     """
     with GMTTempFile(suffix=".txt") as tmpfile:
-        with Path(tmpfile.name).open(mode="w") as fp:
+        with Path(tmpfile.name).open(mode="w", encoding="locale") as fp:
             print("# lon lat z text", file=fp)
             print("1.0 2.0 3.0 TEXT1 TEXT23", file=fp)
             print("4.0 5.0 6.0 TEXT4 TEXT567", file=fp)
@@ -127,7 +127,7 @@ def test_dataset_header_too_many_names():
     Test passing a header line with more column names than the number of columns.
     """
     with GMTTempFile(suffix=".txt") as tmpfile:
-        with Path(tmpfile.name).open(mode="w") as fp:
+        with Path(tmpfile.name).open(mode="w", encoding="locale") as fp:
             print("# lon lat z text1 text2", file=fp)
             print("1.0 2.0 3.0 TEXT1 TEXT23", file=fp)
             print("4.0 5.0 6.0 TEXT4 TEXT567", file=fp)

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -132,7 +132,9 @@ def test_gmttempfile_read():
     Make sure GMTTempFile.read() works.
     """
     with GMTTempFile() as tmpfile:
-        Path(tmpfile.name).write_text("in.dat: N = 2\t<1/3>\t<2/4>\n")
+        Path(tmpfile.name).write_text(
+            "in.dat: N = 2\t<1/3>\t<2/4>\n", encoding="locale"
+        )
         assert tmpfile.read() == "in.dat: N = 2 <1/3> <2/4>\n"
         assert tmpfile.read(keep_tabs=True) == "in.dat: N = 2\t<1/3>\t<2/4>\n"
 

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -132,9 +132,7 @@ def test_gmttempfile_read():
     Make sure GMTTempFile.read() works.
     """
     with GMTTempFile() as tmpfile:
-        Path(tmpfile.name).write_text(
-            "in.dat: N = 2\t<1/3>\t<2/4>\n", encoding="locale"
-        )
+        Path(tmpfile.name).write_text("in.dat: N = 2\t<1/3>\t<2/4>\n", encoding="utf-8")
         assert tmpfile.read() == "in.dat: N = 2 <1/3> <2/4>\n"
         assert tmpfile.read(keep_tabs=True) == "in.dat: N = 2\t<1/3>\t<2/4>\n"
 

--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -97,7 +97,7 @@ T so we may have to adjust the box height to get the right size box.
 """
 
     with GMTTempFile() as specfile:
-        Path(specfile.name).write_text(specfile_contents)
+        Path(specfile.name).write_text(specfile_contents, encoding="locale")
         fig = Figure()
         fig.basemap(projection="x6i", region=[0, 1, 0, 1], frame=True)
         fig.legend(specfile.name, position="JTM+jCM+w5i")

--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -97,7 +97,7 @@ T so we may have to adjust the box height to get the right size box.
 """
 
     with GMTTempFile() as specfile:
-        Path(specfile.name).write_text(specfile_contents, encoding="locale")
+        Path(specfile.name).write_text(specfile_contents, encoding="utf-8")
         fig = Figure()
         fig.basemap(projection="x6i", region=[0, 1, 0, 1], frame=True)
         fig.legend(specfile.name, position="JTM+jCM+w5i")

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -74,7 +74,7 @@ def test_meca_spec_single_focalmecha_file():
     fig = Figure()
     fig.basemap(region=[-1, 1, 4, 6], projection="M8c", frame=2)
     with GMTTempFile() as temp:
-        Path(temp.name).write_text("0 5 0 0 90 0 5")
+        Path(temp.name).write_text("0 5 0 0 90 0 5", encoding="locale")
         fig.meca(spec=temp.name, convention="aki", scale="2.5c")
     return fig
 

--- a/pygmt/tests/test_meca.py
+++ b/pygmt/tests/test_meca.py
@@ -74,7 +74,7 @@ def test_meca_spec_single_focalmecha_file():
     fig = Figure()
     fig.basemap(region=[-1, 1, 4, 6], projection="M8c", frame=2)
     with GMTTempFile() as temp:
-        Path(temp.name).write_text("0 5 0 0 90 0 5", encoding="locale")
+        Path(temp.name).write_text("0 5 0 0 90 0 5", encoding="utf-8")
         fig.meca(spec=temp.name, convention="aki", scale="2.5c")
     return fig
 

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -487,7 +487,7 @@ def test_plot_ogrgmt_file_multipoint_default_style(func):
 # FEATURE_DATA
 1 2
         """
-        Path(tmpfile.name).write_text(gmt_file, encoding="locale")
+        Path(tmpfile.name).write_text(gmt_file, encoding="utf-8")
         fig = Figure()
         fig.plot(
             data=func(tmpfile.name), region=[0, 2, 1, 3], projection="X2c", frame=True
@@ -506,7 +506,7 @@ def test_plot_ogrgmt_file_multipoint_non_default_style():
 # FEATURE_DATA
 1 2
         """
-        Path(tmpfile.name).write_text(gmt_file, encoding="locale")
+        Path(tmpfile.name).write_text(gmt_file, encoding="utf-8")
         fig = Figure()
         fig.plot(
             data=tmpfile.name,

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -487,7 +487,7 @@ def test_plot_ogrgmt_file_multipoint_default_style(func):
 # FEATURE_DATA
 1 2
         """
-        Path(tmpfile.name).write_text(gmt_file)
+        Path(tmpfile.name).write_text(gmt_file, encoding="locale")
         fig = Figure()
         fig.plot(
             data=func(tmpfile.name), region=[0, 2, 1, 3], projection="X2c", frame=True
@@ -506,7 +506,7 @@ def test_plot_ogrgmt_file_multipoint_non_default_style():
 # FEATURE_DATA
 1 2
         """
-        Path(tmpfile.name).write_text(gmt_file)
+        Path(tmpfile.name).write_text(gmt_file, encoding="locale")
         fig = Figure()
         fig.plot(
             data=tmpfile.name,

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -444,7 +444,7 @@ def test_plot3d_ogrgmt_file_multipoint_default_style(func):
 >
 1 1 2
 1.5 1.5 1"""
-        Path(tmpfile.name).write_text(gmt_file)
+        Path(tmpfile.name).write_text(gmt_file, encoding="locale")
         fig = Figure()
         fig.plot3d(
             data=func(tmpfile.name),
@@ -469,7 +469,7 @@ def test_plot3d_ogrgmt_file_multipoint_non_default_style():
 >
 1 1 2
 1.5 1.5 1"""
-        Path(tmpfile.name).write_text(gmt_file)
+        Path(tmpfile.name).write_text(gmt_file, encoding="locale")
         fig = Figure()
         fig.plot3d(
             data=tmpfile.name,

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -444,7 +444,7 @@ def test_plot3d_ogrgmt_file_multipoint_default_style(func):
 >
 1 1 2
 1.5 1.5 1"""
-        Path(tmpfile.name).write_text(gmt_file, encoding="locale")
+        Path(tmpfile.name).write_text(gmt_file, encoding="utf-8")
         fig = Figure()
         fig.plot3d(
             data=func(tmpfile.name),
@@ -469,7 +469,7 @@ def test_plot3d_ogrgmt_file_multipoint_non_default_style():
 >
 1 1 2
 1.5 1.5 1"""
-        Path(tmpfile.name).write_text(gmt_file, encoding="locale")
+        Path(tmpfile.name).write_text(gmt_file, encoding="utf-8")
         fig = Figure()
         fig.plot3d(
             data=tmpfile.name,

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -299,7 +299,9 @@ def test_text_angle_font_justify_from_textfile():
     """
     fig = Figure()
     with GMTTempFile(suffix=".txt") as tempfile:
-        Path(tempfile.name).write_text("114 0.5 30 22p,Helvetica-Bold,black LM BORNEO")
+        Path(tempfile.name).write_text(
+            "114 0.5 30 22p,Helvetica-Bold,black LM BORNEO", encoding="locale"
+        )
         fig.text(
             region=[113, 117.5, -0.5, 3],
             projection="M5c",

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -300,7 +300,7 @@ def test_text_angle_font_justify_from_textfile():
     fig = Figure()
     with GMTTempFile(suffix=".txt") as tempfile:
         Path(tempfile.name).write_text(
-            "114 0.5 30 22p,Helvetica-Bold,black LM BORNEO", encoding="locale"
+            "114 0.5 30 22p,Helvetica-Bold,black LM BORNEO", encoding="utf-8"
         )
         fig.text(
             region=[113, 117.5, -0.5, 3],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ extend-select = [
     "D213",     # Summary lines should be positioned on the second physical line of the docstring.
     "D410",     # A blank line after section headings.
     "PLR6201",  # Use a set literal when testing for membership
+    "PLW1514",  # {function_name} in text mode without explicit encoding argument
 ]
 ignore = [
     "D200",     # One-line docstring should fit on one line


### PR DESCRIPTION
**Description of proposed changes**

Enable ruff's [unspecified-encoding (PLW1514) rule](https://docs.astral.sh/ruff/rules/unspecified-encoding/) to check for uses of `open` and related calls without an explicit `encoding` argument. Note that this is a preview mode feature.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This lint rule tells us to consider using the `encoding` parameter to enforce a specific encoding. [PEP 597](https://peps.python.org/pep-0597/) recommends using `encoding="locale"` on Python 3.10 and later, though we could also use `encoding="utf-8"` perhaps.

For this PR, we went for setting `encoding="utf-8"`

References:
- https://docs.astral.sh/ruff/rules/unspecified-encoding/
- https://peps.python.org/pep-0597/#prepare-to-change-the-default-encoding-to-utf-8

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses https://github.com/GenericMappingTools/pygmt/issues/2741#issuecomment-2212728325


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
