### PR TITLE
Replace rio.set_crs with rio.write_crs in load_tile_map function

### DIFF
--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -166,6 +166,6 @@ def load_tile_map(
 
     # If rioxarray is installed, set the coordinate reference system
     if hasattr(dataarray, "rio"):
-        dataarray = dataarray.rio.set_crs(input_crs="EPSG:3857")
+        dataarray = dataarray.rio.write_crs(input_crs="EPSG:3857")
 
     return dataarray

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -113,9 +113,10 @@ def load_tile_map(
     Frozen({'band': 3, 'y': 256, 'x': 512})
     >>> raster.coords  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     Coordinates:
-      * band    (band) uint8 ... 0 1 2
-      * y       (y) float64 ... -7.081e-10 -7.858e+04 ... -1.996e+07 ...
-      * x       (x) float64 ... -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
+      * band         (band) uint8 ... 0 1 2
+      * y            (y) float64 ... -7.081e-10 -7.858e+04 ... -1.996e+07 -2.004e+07
+      * x            (x) float64 ... -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
+        spatial_ref  int64 ... 0
     """
     if not _HAS_CONTEXTILY:
         raise ImportError(


### PR DESCRIPTION
**Description of proposed changes**

[Rioxarray 0.16.0](https://github.com/corteva/rioxarray/releases/tag/0.16.0) has deprecated the use of `set_crs` in favour of [`write_crs`](https://corteva.github.io/rioxarray/latest/rioxarray.html#rioxarray.rioxarray.XRasterBase.write_crs). Xref https://github.com/corteva/rioxarray/pull/793

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes `FutureWarning: It is recommended to use 'rio.write_crs()' instead. 'rio.set_crs()' will likelybe removed in a future release`


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
