### PR TITLE
load_tile_map: Fix the raster band indexing, should start from 1

### DIFF
--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -113,7 +113,7 @@ def load_tile_map(
     Frozen({'band': 3, 'y': 256, 'x': 512})
     >>> raster.coords  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     Coordinates:
-      * band         (band) uint8 ... 0 1 2
+      * band         (band) uint8 ... 1 2 3
       * y            (y) float64 ... -7.081e-10 -7.858e+04 ... -1.996e+07 -2.004e+07
       * x            (x) float64 ... -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
         spatial_ref  int64 ... 0
@@ -122,8 +122,7 @@ def load_tile_map(
         raise ImportError(
             "Package `contextily` is required to be installed to use this function. "
             "Please use `python -m pip install contextily` or "
-            "`mamba install -c conda-forge contextily` "
-            "to install the package."
+            "`mamba install -c conda-forge contextily` to install the package."
         )
 
     contextily_kwargs = {}
@@ -158,7 +157,7 @@ def load_tile_map(
     dataarray = xr.DataArray(
         data=rgb_image,
         coords={
-            "band": np.array(object=[0, 1, 2], dtype=np.uint8),  # Red, Green, Blue
+            "band": np.array(object=[1, 2, 3], dtype=np.uint8),  # Red, Green, Blue
             "y": np.linspace(start=top, stop=bottom, num=rgb_image.shape[1]),
             "x": np.linspace(start=left, stop=right, num=rgb_image.shape[2]),
         },


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/GenericMappingTools/pygmt/pull/3115#discussion_r1667889781 for context. 

In the GDAL world, the raster band starts from 1 (xref https://gdal.org/doxygen/classGDALDataset.html#ad96adcf07f2979ad176e37a7f8638fb6), but we incorrectly return bands 0, 1, 2 in the `load_tile_map` function.