### PR TITLE
load_tile_map: Register the rio accessor by importing rioxarray so the returned raster has CRS

### DIFF
--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -123,8 +123,7 @@ def load_tile_map(
       * x            (x) float64 ... -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
         spatial_ref  int64 ... 0
     >>> # CRS is set only if rioxarray is available
-    >>> import importlib
-    >>> if importlib.util.find_spec("rioxarray"):
+    >>> if hasattr(dataarray, "rio"):
     ...     raster.rio.crs
     CRS.from_epsg(3857)
     """

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -3,6 +3,7 @@ Function to load raster tile maps from XYZ tile providers, and load as
 :class:`xarray.DataArray`.
 """
 
+import contextlib
 from typing import Literal
 
 from packaging.version import Version

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -18,10 +18,8 @@ except ImportError:
 
 try:
     import rioxarray  # rioxarray is needed to register the rio accessor  # noqa: F401
-
-    _HAS_RIOXARRAY = True
 except ImportError:
-    _HAS_RIOXARRAY = False
+    pass
 
 import numpy as np
 import xarray as xr

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -123,7 +123,7 @@ def load_tile_map(
       * x            (x) float64 ... -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
         spatial_ref  int64 ... 0
     >>> # CRS is set only if rioxarray is available
-    >>> if hasattr(dataarray, "rio"):
+    >>> if hasattr(raster, "rio"):
     ...     raster.rio.crs
     CRS.from_epsg(3857)
     """

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -16,6 +16,13 @@ except ImportError:
     TileProvider = None
     _HAS_CONTEXTILY = False
 
+try:
+    import rioxarray  # rioxarray is needed to register the rio accessor  # noqa: F401
+
+    _HAS_RIOXARRAY = True
+except ImportError:
+    _HAS_RIOXARRAY = False
+
 import numpy as np
 import xarray as xr
 
@@ -117,6 +124,11 @@ def load_tile_map(
       * y            (y) float64 ... -7.081e-10 -7.858e+04 ... -1.996e+07 -2.004e+07
       * x            (x) float64 ... -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
         spatial_ref  int64 ... 0
+    >>> # CRS is set only if rioxarray is available
+    >>> import importlib
+    >>> if importlib.util.find_spec("rioxarray"):
+    ...     raster.rio.crs
+    CRS.from_epsg(3857)
     """
     if not _HAS_CONTEXTILY:
         raise ImportError(

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -16,10 +16,9 @@ except ImportError:
     TileProvider = None
     _HAS_CONTEXTILY = False
 
-try:  # noqa: SIM105
-    import rioxarray  # rioxarray is needed to register the rio accessor  # noqa: F401
-except ImportError:
-    pass
+with contextlib.suppress(ImportError):
+    # rioxarray is needed to register the rio accessor
+    import rioxarray  # noqa: F401
 
 import numpy as np
 import xarray as xr

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -16,7 +16,7 @@ except ImportError:
     TileProvider = None
     _HAS_CONTEXTILY = False
 
-try:
+try:  # noqa: SIM105
     import rioxarray  # rioxarray is needed to register the rio accessor  # noqa: F401
 except ImportError:
     pass


### PR DESCRIPTION
**Description of proposed changes**

The `rio` accessor is only registered when rioxarray is imported. Currently, we import rioxarray in `Figure.tilemap` (https://github.com/GenericMappingTools/pygmt/blob/3a32169402b992e013d5a28006cb3fa8135f7d80/pygmt/src/tilemap.py#L12) but don't do it in `load_tile_map`. Thus, the raster returned by `load_tile_map` alone may have CRS set or not, depending on if a script imports `rioxarray` or not elsewhere.

This PR fixes the issue by importing the rioxarray package in `pygmt/datasets/tile_map.py` so that the `rio` accessor is always registered when rioxarray is installed.