### PR TITLE
Wrap the GMT API function GMT_Read_Data to read data into GMT data containers

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -309,6 +309,7 @@ Low level access (these are mostly used by the :mod:`pygmt.clib` package):
     clib.Session.put_matrix
     clib.Session.put_strings
     clib.Session.put_vector
+    clib.Session.read_data
     clib.Session.write_data
     clib.Session.open_virtualfile
     clib.Session.read_virtualfile

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -247,7 +247,9 @@ def as_c_contiguous(array):
     return array
 
 
-def sequence_to_ctypes_array(sequence: Sequence, ctype, size: int) -> ctp.Array | None:
+def sequence_to_ctypes_array(
+    sequence: Sequence | None, ctype, size: int
+) -> ctp.Array | None:
     """
     Convert a sequence of numbers into a ctypes array variable.
 

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1074,7 +1074,7 @@ class Session:
         infile: str,
         kind: Literal["dataset", "grid"],
         mode: str = "GMT_READ_NORMAL",
-        wesn: Sequence[float] | None = None,
+        region: Sequence[float] | None = None,
         data=None,
     ):
         """
@@ -1093,7 +1093,7 @@ class Session:
         mode
             How the data is to be read from the file. This option varies depending on
             the given family. See the GMT API documentation for details.
-        wesn
+        region
             Subregion of the data, in the form of [xmin, xmax, ymin, ymax, zmin, zmax].
             If ``None``, the whole data is read.
         data
@@ -1132,7 +1132,7 @@ class Session:
             self["GMT_IS_FILE"],  # Reading from a file
             self[geometry],
             self[mode],
-            sequence_to_ctypes_array(wesn, ctp.c_double, 6),
+            sequence_to_ctypes_array(region, ctp.c_double, 6),
             infile.encode(),
             data,
         )

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1121,9 +1121,9 @@ class Session:
         )
 
         # Determine the family and geometry from kind
-        family, geometry = {
-            "dataset": ("GMT_IS_DATASET", "GMT_IS_PLP"),
-            "grid": ("GMT_IS_GRID", "GMT_IS_SURFACE"),
+        family, geometry, dtype = {
+            "dataset": ("GMT_IS_DATASET", "GMT_IS_PLP", _GMT_DATASET),
+            "grid": ("GMT_IS_GRID", "GMT_IS_SURFACE", _GMT_GRID),
         }[kind]
 
         family_int = self._parse_constant(family, valid=FAMILIES, valid_modifiers=VIAS)
@@ -1141,7 +1141,7 @@ class Session:
             infile.encode(),
             data,
         )
-        return data_ptr
+        return ctp.cast(data_ptr, ctp.POINTER(dtype))
 
     def write_data(self, family, geometry, mode, wesn, output, data):
         """

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1125,7 +1125,7 @@ class Session:
             restype=ctp.c_void_p,  # data_ptr
         )
 
-        # Determine the family and geometry from kind
+        # Determine the family, geometry and data container from kind
         family, geometry, dtype = {
             "dataset": ("GMT_IS_DATASET", "GMT_IS_PLP", _GMT_DATASET),
             "grid": ("GMT_IS_GRID", "GMT_IS_SURFACE", _GMT_GRID),

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1100,7 +1100,9 @@ class Session:
             data geometry from the ``kind`` parameter.
         mode
             How the data is to be read from the file. This option varies depending on
-            the given family. See the GMT API documentation for details.
+            the given family. See the
+            :gmt-docs:`GMT API documentation <devdocs/api.html#import-from-a-file-stream-or-handle>`
+            for details.
         region
             Subregion of the data, in the form of [xmin, xmax, ymin, ymax, zmin, zmax].
             If ``None``, the whole data is read.

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1098,12 +1098,17 @@ class Session:
             If ``None``, the whole data is read.
         data
             ``None`` or the pointer returned by this function after a first call. It's
-            useful when reading grids in two steps (get a grid structure with a header,
-            then read the data).
+            useful when reading grids/images/cubes in two steps (get a grid/image/cube
+            structure with a header, then read the data).
 
         Returns
         -------
         Pointer to the data container, or ``None`` if there were errors.
+
+        Raises
+        ------
+        GMTCLibError
+            If the GMT API function fails to read the data.
         """
         c_read_data = self.get_libgmt_func(
             "GMT_Read_Data",
@@ -1136,6 +1141,8 @@ class Session:
             infile.encode(),
             data,
         )
+        if data_ptr is None:
+            raise GMTCLibError(f"Failed to read dataset from '{infile}'.")
         return ctp.cast(data_ptr, ctp.POINTER(dtype))
 
     def write_data(self, family, geometry, mode, wesn, output, data):

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -10,6 +10,7 @@ import ctypes as ctp
 import pathlib
 import sys
 import warnings
+from collections.abc import Sequence
 from typing import Literal
 
 import numpy as np
@@ -1067,6 +1068,77 @@ class Session:
         )
         if status != 0:
             raise GMTCLibError(f"Failed to put matrix of type {matrix.dtype}.")
+
+    def read_data(
+        self,
+        family: str,
+        geometry: str,
+        mode: str,
+        wesn: Sequence[float] | None,
+        infile: str,
+        data=None,
+    ):
+        """
+        Read a data file into a GMT data container.
+
+        Wraps ``GMT_Read_Data`` but only allows reading from a file, so the ``method``
+        ``method`` argument is omitted.
+
+        Parameters
+        ----------
+        family
+            A valid GMT data family name (e.g., ``"GMT_IS_DATASET"``). See the
+            ``FAMILIES`` attribute for valid names.
+        geometry
+            A valid GMT data geometry name (e.g., ``"GMT_IS_POINT"``). See the
+            ``GEOMETRIES`` attribute for valid names.
+        mode
+            How the data is to be read from the file. This option varies depending on
+            the given family. See the GMT API documentation for details.
+        wesn
+            Subregion of the data, in the form of [xmin, xmax, ymin, ymax, zmin, zmax].
+            If ``None``, the whole data is read.
+        input
+            The input file name.
+        data
+            ``None`` or the pointer returned by this function after a first call. It's
+            useful when reading grids in two steps (get a grid structure with a header,
+            then read the data).
+
+        Returns
+        -------
+        Pointer to the data container, or ``None`` if there were errors.
+        """
+        c_read_data = self.get_libgmt_func(
+            "GMT_Read_Data",
+            argtypes=[
+                ctp.c_void_p,
+                ctp.c_uint,
+                ctp.c_uint,
+                ctp.c_uint,
+                ctp.c_uint,
+                ctp.POINTER(ctp.c_double),
+                ctp.c_char_p,
+                ctp.c_void_p,
+            ],
+            restype=ctp.c_void_p,
+        )
+
+        family_int = self._parse_constant(family, valid=FAMILIES, valid_modifiers=VIAS)
+        geometry_int = self._parse_constant(geometry, valid=GEOMETRIES)
+        method = self["GMT_IS_FILE"]  # Reading from a file.
+
+        data_ptr = c_read_data(
+            self.session_pointer,
+            family_int,
+            method,
+            geometry_int,
+            self[mode],
+            sequence_to_ctypes_array(wesn, ctp.c_double, 6),
+            infile.encode(),
+            data,
+        )
+        return data_ptr
 
     def write_data(self, family, geometry, mode, wesn, output, data):
         """

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1073,7 +1073,7 @@ class Session:
         self,
         infile: str,
         kind: Literal["dataset", "grid"],
-        mode: str | None = None,
+        mode: str = "GMT_READ_NORMAL",
         wesn: Sequence[float] | None = None,
         data=None,
     ):
@@ -1088,8 +1088,8 @@ class Session:
         input
             The input file name.
         kind
-            The data kind of the input file. Currently, valid values are ``"dataset"``
-            and ``"grid"``.
+            The data kind of the input file. Valid values are ``"dataset"`` and
+            ``"grid"``.
         mode
             How the data is to be read from the file. This option varies depending on
             the given family. See the GMT API documentation for details.
@@ -1131,7 +1131,7 @@ class Session:
             self[family],
             self["GMT_IS_FILE"],  # Reading from a file
             self[geometry],
-            self["GMT_READ_NORMAL"] if mode is None else self[mode],
+            self[mode],
             sequence_to_ctypes_array(wesn, ctp.c_double, 6),
             infile.encode(),
             data,

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1085,7 +1085,7 @@ class Session:
 
         Parameters
         ----------
-        input
+        infile
             The input file name.
         kind
             The data kind of the input file. Valid values are ``"dataset"`` and

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1102,7 +1102,8 @@ class Session:
             How the data is to be read from the file. This option varies depending on
             the given family. See the
             :gmt-docs:`GMT API documentation <devdocs/api.html#import-from-a-file-stream-or-handle>`
-            for details.
+            for details. Default is ``GMT_READ_NORMAL`` which corresponds to the default
+            read mode value of 0 in the ``GMT_enum_read`` enum.
         region
             Subregion of the data, in the form of [xmin, xmax, ymin, ymax, zmin, zmax].
             If ``None``, the whole data is read.

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1126,17 +1126,12 @@ class Session:
             "grid": ("GMT_IS_GRID", "GMT_IS_SURFACE", _GMT_GRID),
         }[kind]
 
-        family_int = self._parse_constant(family, valid=FAMILIES, valid_modifiers=VIAS)
-        geometry_int = self._parse_constant(geometry, valid=GEOMETRIES)
-        method_int = self["GMT_IS_FILE"]  # Reading from a file
-        mode_int = self["GMT_READ_NORMAL"] if mode is None else self[mode]
-
         data_ptr = c_read_data(
             self.session_pointer,
-            family_int,
-            method_int,
-            geometry_int,
-            mode_int,
+            self[family],
+            self["GMT_IS_FILE"],  # Reading from a file
+            self[geometry],
+            self["GMT_READ_NORMAL"] if mode is None else self[mode],
             sequence_to_ctypes_array(wesn, ctp.c_double, 6),
             infile.encode(),
             data,

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1071,6 +1071,8 @@ class Session:
         self,
         infile: str,
         kind: Literal["dataset", "grid"],
+        family: str | None = None,
+        geometry: str | None = None,
         mode: str = "GMT_READ_NORMAL",
         region: Sequence[float] | None = None,
         data=None,
@@ -1088,6 +1090,14 @@ class Session:
         kind
             The data kind of the input file. Valid values are ``"dataset"`` and
             ``"grid"``.
+        family
+            A valid GMT data family name (e.g., ``"GMT_IS_DATASET"``). See the
+            ``FAMILIES`` attribute for valid names. If ``None``, will determine the data
+            family from the ``kind`` parameter.
+        geometry
+            A valid GMT data geometry name (e.g., ``"GMT_IS_POINT"``). See the
+            ``GEOMETRIES`` attribute for valid names. If ``None``, will determine the
+            data geometry from the ``kind`` parameter.
         mode
             How the data is to be read from the file. This option varies depending on
             the given family. See the GMT API documentation for details.
@@ -1124,10 +1134,14 @@ class Session:
         )
 
         # Determine the family, geometry and data container from kind
-        family, geometry, dtype = {
+        _family, _geometry, dtype = {
             "dataset": ("GMT_IS_DATASET", "GMT_IS_PLP", _GMT_DATASET),
             "grid": ("GMT_IS_GRID", "GMT_IS_SURFACE", _GMT_GRID),
         }[kind]
+        if family is None:
+            family = _family
+        if geometry is None:
+            geometry = _geometry
 
         data_ptr = c_read_data(
             self.session_pointer,

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1119,7 +1119,7 @@ class Session:
         ------
         GMTCLibError
             If the GMT API function fails to read the data.
-        """
+        """  # noqa: W505
         c_read_data = self.get_libgmt_func(
             "GMT_Read_Data",
             argtypes=[

--- a/pygmt/tests/test_clib_read_data.py
+++ b/pygmt/tests/test_clib_read_data.py
@@ -1,0 +1,145 @@
+"""
+Test the Session.read_data method.
+"""
+
+import ctypes as ctp
+from pathlib import Path
+
+import numpy as np
+from pygmt.clib import Session
+from pygmt.datatypes import _GMT_DATASET, _GMT_GRID
+from pygmt.helpers import GMTTempFile
+
+
+def test_clib_read_data_dataset():
+    """
+    Test the Session.read_data method for datasets.
+
+    The test is adapted from the doctest in the _GMT_DATASET class.
+    """
+    with GMTTempFile(suffix=".txt") as tmpfile:
+        # Prepare the sample data file
+        with Path(tmpfile.name).open(mode="w", encoding="utf-8") as fp:
+            print("# x y z name", file=fp)
+            print(">", file=fp)
+            print("1.0 2.0 3.0 TEXT1 TEXT23", file=fp)
+            print("4.0 5.0 6.0 TEXT4 TEXT567", file=fp)
+            print(">", file=fp)
+            print("7.0 8.0 9.0 TEXT8 TEXT90", file=fp)
+            print("10.0 11.0 12.0 TEXT123 TEXT456789", file=fp)
+
+        with Session() as lib:
+            data_ptr = lib.read_data(
+                "GMT_IS_DATASET",
+                "GMT_IS_PLP",
+                "GMT_READ_NORMAL",
+                None,
+                tmpfile.name,
+                None,
+            )
+            ds = ctp.cast(data_ptr, ctp.POINTER(_GMT_DATASET)).contents
+
+            assert ds.n_tables == 1
+            assert ds.n_segments == 2
+            assert ds.n_columns == 3
+
+            tbl = ds.table[0].contents
+            assert tbl.min[: tbl.n_columns] == [1.0, 2.0, 3.0]
+            assert tbl.max[: tbl.n_columns] == [10.0, 11.0, 12.0]
+
+
+def test_clib_read_data_grid():
+    """
+    Test the Session.read_data method for grids.
+
+    The test is adapted from the doctest in the _GMT_GRID class.
+    """
+    with Session() as lib:
+        data_ptr = lib.read_data(
+            "GMT_IS_GRID",
+            "GMT_IS_SURFACE",
+            "GMT_CONTAINER_AND_DATA",
+            None,
+            "@static_earth_relief.nc",
+            None,
+        )
+        grid = ctp.cast(data_ptr, ctp.POINTER(_GMT_GRID)).contents
+        header = grid.header.contents
+        assert header.n_rows == 14
+        assert header.n_columns == 8
+        assert header.n_bands == 1
+        assert header.wesn[:] == [-55.0, -47.0, -24.0, -10.0]
+        assert header.z_min == 190.0
+        assert header.z_max == 981.0
+
+        assert grid.data  # The data is read
+        data = np.reshape(grid.data[: header.mx * header.my], (header.my, header.mx))
+        data = data[
+            header.pad[2] : header.my - header.pad[3],
+            header.pad[0] : header.mx - header.pad[1],
+        ]
+        assert data[3][4] == 250.0
+
+
+def test_clib_read_data_grid_two_steps():
+    """
+    Test the Session.read_data method for grids in two steps, first reading the header
+    and then the data.
+
+    The test is adapted from the doctest in the _GMT_GRID class.
+    """
+    family, geometry = "GMT_IS_GRID", "GMT_IS_SURFACE"
+    infile = "@static_earth_relief.nc"
+    with Session() as lib:
+        # Read the header first
+        data_ptr = lib.read_data(
+            family, geometry, "GMT_CONTAINER_ONLY", None, infile, None
+        )
+        grid = ctp.cast(data_ptr, ctp.POINTER(_GMT_GRID)).contents
+        header = grid.header.contents
+        assert header.n_rows == 14
+        assert header.n_columns == 8
+        assert header.n_bands == 1
+        assert header.wesn[:] == [-55.0, -47.0, -24.0, -10.0]
+        assert header.z_min == 190.0
+        assert header.z_max == 981.0
+
+        assert not grid.data  # The data is not read yet
+
+        # Read the data
+        data_ptr = lib.read_data(
+            family, geometry, "GMT_DATA_ONLY", None, infile, data_ptr
+        )
+        grid = ctp.cast(data_ptr, ctp.POINTER(_GMT_GRID)).contents
+
+        assert grid.data  # The data is read
+        header = grid.header.contents
+        data = np.reshape(grid.data[: header.mx * header.my], (header.my, header.mx))
+        data = data[
+            header.pad[2] : header.my - header.pad[3],
+            header.pad[0] : header.mx - header.pad[1],
+        ]
+        assert data[3][4] == 250.0
+
+
+def test_clib_read_data_image_as_grid():
+    """
+    Test the Session.read_data method for images.
+    """
+    with Session() as lib:
+        data_ptr = lib.read_data(
+            "GMT_IS_GRID",
+            "GMT_IS_SURFACE",
+            "GMT_CONTAINER_AND_DATA",
+            None,
+            "@earth_day_01d_p",
+            None,
+        )
+        image = ctp.cast(data_ptr, ctp.POINTER(_GMT_GRID)).contents
+        header = image.header.contents
+        assert header.n_rows == 180
+        assert header.n_columns == 360
+        assert header.n_bands == 1
+        assert header.wesn[:] == [-180.0, 180.0, -90.0, 90.0]
+
+        assert image.data

--- a/pygmt/tests/test_clib_read_data.py
+++ b/pygmt/tests/test_clib_read_data.py
@@ -4,9 +4,21 @@ Test the Session.read_data method.
 
 from pathlib import Path
 
-import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
 from pygmt.clib import Session
 from pygmt.helpers import GMTTempFile
+from pygmt.io import load_dataarray
+from pygmt.src import which
+
+
+@pytest.fixture(scope="module", name="expected_xrgrid")
+def fixture_expected_xrgrid():
+    """
+    The expected xr.DataArray object for the static_earth_relief.nc file.
+    """
+    return load_dataarray(which("@static_earth_relief.nc"))
 
 
 def test_clib_read_data_dataset():
@@ -27,49 +39,42 @@ def test_clib_read_data_dataset():
             print("10.0 11.0 12.0 TEXT123 TEXT456789", file=fp)
 
         with Session() as lib:
-            data_ptr = lib.read_data(tmpfile.name, kind="dataset")
-            ds = data_ptr.contents
+            ds = lib.read_data(tmpfile.name, kind="dataset").contents
+            df = ds.to_dataframe(header=0)
+            expected_df = pd.DataFrame(
+                data={
+                    "x": [1.0, 4.0, 7.0, 10.0],
+                    "y": [2.0, 5.0, 8.0, 11.0],
+                    "z": [3.0, 6.0, 9.0, 12.0],
+                    "name": pd.Series(
+                        [
+                            "TEXT1 TEXT23",
+                            "TEXT4 TEXT567",
+                            "TEXT8 TEXT90",
+                            "TEXT123 TEXT456789",
+                        ],
+                        dtype=pd.StringDtype(),
+                    ),
+                }
+            )
+            pd.testing.assert_frame_equal(df, expected_df)
 
-            assert ds.n_tables == 1
-            assert ds.n_segments == 2
-            assert ds.n_columns == 3
 
-            tbl = ds.table[0].contents
-            assert tbl.min[: tbl.n_columns] == [1.0, 2.0, 3.0]
-            assert tbl.max[: tbl.n_columns] == [10.0, 11.0, 12.0]
-
-
-def test_clib_read_data_grid():
+def test_clib_read_data_grid(expected_xrgrid):
     """
     Test the Session.read_data method for grids.
 
     The test is adapted from the doctest in the _GMT_GRID class.
     """
     with Session() as lib:
-        data_ptr = lib.read_data(
-            "@static_earth_relief.nc",
-            kind="grid",
-            mode="GMT_CONTAINER_AND_DATA",
-        )
-        grid = data_ptr.contents
-        header = grid.header.contents
-        assert header.n_rows == 14
-        assert header.n_columns == 8
-        assert header.n_bands == 1
-        assert header.wesn[:] == [-55.0, -47.0, -24.0, -10.0]
-        assert header.z_min == 190.0
-        assert header.z_max == 981.0
-
-        assert grid.data  # The data is read
-        data = np.reshape(grid.data[: header.mx * header.my], (header.my, header.mx))
-        data = data[
-            header.pad[2] : header.my - header.pad[3],
-            header.pad[0] : header.mx - header.pad[1],
-        ]
-        assert data[3][4] == 250.0
+        grid = lib.read_data("@static_earth_relief.nc", kind="grid").contents
+        xrgrid = grid.to_dataarray()
+        xr.testing.assert_equal(xrgrid, expected_xrgrid)
+        # Explicitely check n_bands
+        assert grid.header.contents.n_bands == 1
 
 
-def test_clib_read_data_grid_two_steps():
+def test_clib_read_data_grid_two_steps(expected_xrgrid):
     """
     Test the Session.read_data method for grids in two steps, first reading the header
     and then the data.
@@ -92,19 +97,11 @@ def test_clib_read_data_grid_two_steps():
         assert not grid.data  # The data is not read yet
 
         # Read the data
-        data_ptr = lib.read_data(
-            infile, kind="grid", mode="GMT_DATA_ONLY", data=data_ptr
-        )
-        grid = data_ptr.contents
-
-        assert grid.data  # The data is read
-        header = grid.header.contents
-        data = np.reshape(grid.data[: header.mx * header.my], (header.my, header.mx))
-        data = data[
-            header.pad[2] : header.my - header.pad[3],
-            header.pad[0] : header.mx - header.pad[1],
-        ]
-        assert data[3][4] == 250.0
+        lib.read_data(infile, kind="grid", mode="GMT_DATA_ONLY", data=data_ptr)
+        xrgrid = data_ptr.contents.to_dataarray()
+        xr.testing.assert_equal(xrgrid, expected_xrgrid)
+        # Explicitely check n_bands
+        assert grid.header.contents.n_bands == 1
 
 
 def test_clib_read_data_image_as_grid():

--- a/pygmt/tests/test_clib_read_data.py
+++ b/pygmt/tests/test_clib_read_data.py
@@ -120,7 +120,7 @@ def test_clib_read_data_grid_actual_image():
 
         if _HAS_RIOXARRAY:  # Full check if rioxarray is installed.
             xrimage = image.to_dataarray()
-            expected_xrimage = xr.open_dataarray(which("@earth_day_01d_p"))
+            expected_xrimage = xr.open_dataarray(which("@earth_day_01d_p"), engine="rasterio")
             assert expected_xrimage.band.size == 3  # 3-band image.
             xr.testing.assert_equal(
                 xrimage,

--- a/pygmt/tests/test_clib_read_data.py
+++ b/pygmt/tests/test_clib_read_data.py
@@ -2,12 +2,10 @@
 Test the Session.read_data method.
 """
 
-import ctypes as ctp
 from pathlib import Path
 
 import numpy as np
 from pygmt.clib import Session
-from pygmt.datatypes import _GMT_DATASET, _GMT_GRID
 from pygmt.helpers import GMTTempFile
 
 
@@ -30,7 +28,7 @@ def test_clib_read_data_dataset():
 
         with Session() as lib:
             data_ptr = lib.read_data(tmpfile.name, kind="dataset")
-            ds = ctp.cast(data_ptr, ctp.POINTER(_GMT_DATASET)).contents
+            ds = data_ptr.contents
 
             assert ds.n_tables == 1
             assert ds.n_segments == 2
@@ -53,7 +51,7 @@ def test_clib_read_data_grid():
             kind="grid",
             mode="GMT_CONTAINER_AND_DATA",
         )
-        grid = ctp.cast(data_ptr, ctp.POINTER(_GMT_GRID)).contents
+        grid = data_ptr.contents
         header = grid.header.contents
         assert header.n_rows == 14
         assert header.n_columns == 8
@@ -82,7 +80,7 @@ def test_clib_read_data_grid_two_steps():
     with Session() as lib:
         # Read the header first
         data_ptr = lib.read_data(infile, kind="grid", mode="GMT_CONTAINER_ONLY")
-        grid = ctp.cast(data_ptr, ctp.POINTER(_GMT_GRID)).contents
+        grid = data_ptr.contents
         header = grid.header.contents
         assert header.n_rows == 14
         assert header.n_columns == 8
@@ -97,7 +95,7 @@ def test_clib_read_data_grid_two_steps():
         data_ptr = lib.read_data(
             infile, kind="grid", mode="GMT_DATA_ONLY", data=data_ptr
         )
-        grid = ctp.cast(data_ptr, ctp.POINTER(_GMT_GRID)).contents
+        grid = data_ptr.contents
 
         assert grid.data  # The data is read
         header = grid.header.contents
@@ -117,7 +115,7 @@ def test_clib_read_data_image_as_grid():
         data_ptr = lib.read_data(
             "@earth_day_01d_p", kind="grid", mode="GMT_CONTAINER_AND_DATA"
         )
-        image = ctp.cast(data_ptr, ctp.POINTER(_GMT_GRID)).contents
+        image = data_ptr.contents
         header = image.header.contents
         assert header.n_rows == 180
         assert header.n_columns == 360

--- a/pygmt/tests/test_clib_read_data.py
+++ b/pygmt/tests/test_clib_read_data.py
@@ -29,14 +29,7 @@ def test_clib_read_data_dataset():
             print("10.0 11.0 12.0 TEXT123 TEXT456789", file=fp)
 
         with Session() as lib:
-            data_ptr = lib.read_data(
-                "GMT_IS_DATASET",
-                "GMT_IS_PLP",
-                "GMT_READ_NORMAL",
-                None,
-                tmpfile.name,
-                None,
-            )
+            data_ptr = lib.read_data(tmpfile.name, kind="dataset")
             ds = ctp.cast(data_ptr, ctp.POINTER(_GMT_DATASET)).contents
 
             assert ds.n_tables == 1
@@ -56,12 +49,9 @@ def test_clib_read_data_grid():
     """
     with Session() as lib:
         data_ptr = lib.read_data(
-            "GMT_IS_GRID",
-            "GMT_IS_SURFACE",
-            "GMT_CONTAINER_AND_DATA",
-            None,
             "@static_earth_relief.nc",
-            None,
+            kind="grid",
+            mode="GMT_CONTAINER_AND_DATA",
         )
         grid = ctp.cast(data_ptr, ctp.POINTER(_GMT_GRID)).contents
         header = grid.header.contents
@@ -88,13 +78,10 @@ def test_clib_read_data_grid_two_steps():
 
     The test is adapted from the doctest in the _GMT_GRID class.
     """
-    family, geometry = "GMT_IS_GRID", "GMT_IS_SURFACE"
     infile = "@static_earth_relief.nc"
     with Session() as lib:
         # Read the header first
-        data_ptr = lib.read_data(
-            family, geometry, "GMT_CONTAINER_ONLY", None, infile, None
-        )
+        data_ptr = lib.read_data(infile, kind="grid", mode="GMT_CONTAINER_ONLY")
         grid = ctp.cast(data_ptr, ctp.POINTER(_GMT_GRID)).contents
         header = grid.header.contents
         assert header.n_rows == 14
@@ -108,7 +95,7 @@ def test_clib_read_data_grid_two_steps():
 
         # Read the data
         data_ptr = lib.read_data(
-            family, geometry, "GMT_DATA_ONLY", None, infile, data_ptr
+            infile, kind="grid", mode="GMT_DATA_ONLY", data=data_ptr
         )
         grid = ctp.cast(data_ptr, ctp.POINTER(_GMT_GRID)).contents
 
@@ -128,12 +115,7 @@ def test_clib_read_data_image_as_grid():
     """
     with Session() as lib:
         data_ptr = lib.read_data(
-            "GMT_IS_GRID",
-            "GMT_IS_SURFACE",
-            "GMT_CONTAINER_AND_DATA",
-            None,
-            "@earth_day_01d_p",
-            None,
+            "@earth_day_01d_p", kind="grid", mode="GMT_CONTAINER_AND_DATA"
         )
         image = ctp.cast(data_ptr, ctp.POINTER(_GMT_GRID)).contents
         header = image.header.contents

--- a/pygmt/tests/test_clib_read_data.py
+++ b/pygmt/tests/test_clib_read_data.py
@@ -120,7 +120,9 @@ def test_clib_read_data_grid_actual_image():
 
         if _HAS_RIOXARRAY:  # Full check if rioxarray is installed.
             xrimage = image.to_dataarray()
-            expected_xrimage = xr.open_dataarray(which("@earth_day_01d_p"), engine="rasterio")
+            expected_xrimage = xr.open_dataarray(
+                which("@earth_day_01d_p"), engine="rasterio"
+            )
             assert expected_xrimage.band.size == 3  # 3-band image.
             xr.testing.assert_equal(
                 xrimage,

--- a/pygmt/tests/test_clib_read_data.py
+++ b/pygmt/tests/test_clib_read_data.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 from pygmt.clib import Session
+from pygmt.exceptions import GMTCLibError
 from pygmt.helpers import GMTTempFile
 from pygmt.io import load_dataarray
 from pygmt.src import which
@@ -127,3 +128,12 @@ def test_clib_read_data_grid_actual_image():
                 .drop_vars(["band", "spatial_ref"])
                 .sortby("y"),
             )
+
+
+def test_clib_read_data_fails():
+    """
+    Test that the Session.read_data method raises an exception if there are errors.
+    """
+    with Session() as lib:
+        with pytest.raises(GMTCLibError):
+            lib.read_data("not-exsits.txt", kind="dataset")

--- a/pygmt/tests/test_clib_read_data.py
+++ b/pygmt/tests/test_clib_read_data.py
@@ -74,7 +74,7 @@ def test_clib_read_data_grid(expected_xrgrid):
         grid = lib.read_data("@static_earth_relief.nc", kind="grid").contents
         xrgrid = grid.to_dataarray()
         xr.testing.assert_equal(xrgrid, expected_xrgrid)
-        assert grid.header.contents.n_bands == 1  # Explicitely check n_bands
+        assert grid.header.contents.n_bands == 1  # Explicitly check n_bands
 
 
 def test_clib_read_data_grid_two_steps(expected_xrgrid):
@@ -93,7 +93,7 @@ def test_clib_read_data_grid_two_steps(expected_xrgrid):
         assert header.wesn[:] == [-55.0, -47.0, -24.0, -10.0]
         assert header.z_min == 190.0
         assert header.z_max == 981.0
-        assert header.n_bands == 1  # Explicitely check n_bands
+        assert header.n_bands == 1  # Explicitly check n_bands
         assert not grid.data  # The data is not read yet
 
         # Read the data
@@ -115,7 +115,7 @@ def test_clib_read_data_grid_actual_image():
         assert header.n_rows == 180
         assert header.n_columns == 360
         assert header.wesn[:] == [-180.0, 180.0, -90.0, 90.0]
-        # Explicitely check n_bands. Only one band is read for 3-band images.
+        # Explicitly check n_bands. Only one band is read for 3-band images.
         assert header.n_bands == 1
 
         if _HAS_RIOXARRAY:  # Full check if rioxarray is installed.


### PR DESCRIPTION
**Description of proposed changes**

See #3318 for the motivations. 

This PR wraps the GMT API functions `GMT_Read_Data` for reading data file into GMT data containers. Currently, only `GMT_DATASET` and `GMT_GRID` are supported, other data containers will be supported later.

The first two commits 5a56ba8ad2c314df7a00b597a3684b1710fc0318 and 7ccf641299b4900457257741bf2571ebe4d387ca are cherry-picked from PR #3318.

**Preview** at https://pygmt-dev--3324.org.readthedocs.build/en/3324/api/generated/pygmt.clib.Session.read_data.html

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [x] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
