### PR TITLE
clib: Improve docstrings, comments, type hints and codes of some Session methods

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -263,7 +263,7 @@ class Session:
 
     def get_enum(self, name: str) -> int:
         """
-        Get the value of a GMT constant (C enum) from gmt_resources.h.
+        Get the value of a GMT constant (C enum) from ``gmt_resources.h``.
 
         Used to set configuration values for other API calls. Wraps ``GMT_Get_Enum``.
 

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1871,8 +1871,7 @@ class Session:
         Parameters
         ----------
         vfname
-            The virtual file name that stores the result data. Required for ``"pandas"``
-            and ``"numpy"`` output type.
+            The virtual file name that stores the result data.
         output_type
             Desired output type of the result data.
 
@@ -1929,44 +1928,37 @@ class Session:
         ...                 assert result is None
         ...                 assert Path(outtmp.name).stat().st_size > 0
         ...
-        ...     # strings output
+        ...     # strings, numpy and pandas outputs
         ...     with Session() as lib:
         ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
         ...             lib.call_module("read", [tmpfile.name, vouttbl, "-Td"])
+        ...
+        ...             # strings output
         ...             outstr = lib.virtualfile_to_dataset(
         ...                 vfname=vouttbl, output_type="strings"
         ...             )
-        ...     assert isinstance(outstr, np.ndarray)
-        ...     assert outstr.dtype.kind in ("S", "U")
+        ...             assert isinstance(outstr, np.ndarray)
+        ...             assert outstr.dtype.kind in ("S", "U")
         ...
-        ...     # numpy output
-        ...     with Session() as lib:
-        ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
-        ...             lib.call_module("read", [tmpfile.name, vouttbl, "-Td"])
+        ...             # numpy output
         ...             outnp = lib.virtualfile_to_dataset(
         ...                 vfname=vouttbl, output_type="numpy"
         ...             )
-        ...     assert isinstance(outnp, np.ndarray)
+        ...             assert isinstance(outnp, np.ndarray)
         ...
-        ...     # pandas output
-        ...     with Session() as lib:
-        ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
-        ...             lib.call_module("read", [tmpfile.name, vouttbl, "-Td"])
+        ...             # pandas output
         ...             outpd = lib.virtualfile_to_dataset(
         ...                 vfname=vouttbl, output_type="pandas"
         ...             )
-        ...     assert isinstance(outpd, pd.DataFrame)
+        ...             assert isinstance(outpd, pd.DataFrame)
         ...
-        ...     # pandas output with specified column names
-        ...     with Session() as lib:
-        ...         with lib.virtualfile_out(kind="dataset") as vouttbl:
-        ...             lib.call_module("read", [tmpfile.name, vouttbl, "-Td"])
+        ...             # pandas output with specified column names
         ...             outpd2 = lib.virtualfile_to_dataset(
         ...                 vfname=vouttbl,
         ...                 output_type="pandas",
         ...                 column_names=["col1", "col2", "col3", "coltext"],
         ...             )
-        ...     assert isinstance(outpd2, pd.DataFrame)
+        ...             assert isinstance(outpd2, pd.DataFrame)
         >>> outstr
         array(['TEXT1 TEXT23', 'TEXT4 TEXT567', 'TEXT8 TEXT90',
            'TEXT123 TEXT456789'], dtype='<U18')

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1802,6 +1802,12 @@ class Session:
             Cast the data into a GMT data container. Valid values are ``"dataset"``,
             ``"grid"`` and ``None``. If ``None``, will return a ctypes void pointer.
 
+        Returns
+        -------
+        pointer
+            Pointer to the GMT data container. If ``kind`` is None, returns a ctypes
+            void pointer instead.
+
         Examples
         --------
         >>> from pathlib import Path
@@ -1832,10 +1838,6 @@ class Session:
         ...         data_pointer = lib.read_virtualfile(voutgrd, kind="grid")
         ...         assert isinstance(data_pointer, ctp.POINTER(_GMT_GRID))
 
-        Returns
-        -------
-        Pointer to the GMT data container. If ``kind`` is None, returns a ctypes void
-        pointer instead.
         """
         c_read_virtualfile = self.get_libgmt_func(
             "GMT_Read_VirtualFile",

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1805,7 +1805,7 @@ class Session:
         Returns
         -------
         pointer
-            Pointer to the GMT data container. If ``kind`` is None, returns a ctypes
+            Pointer to the GMT data container. If ``kind`` is ``None``, returns a ctypes
             void pointer instead.
 
         Examples
@@ -2095,7 +2095,7 @@ class Session:
         >>> print(", ".join([f"{x:.2f}" for x in region]))
         -164.71, -154.81, 18.91, 23.58
 
-        The country codes can have an extra argument that rounds the region a multiple
+        The country codes can have an extra argument that rounds the region to a multiple
         of the argument (for example, ``"US.HI+r5"`` will round the region to multiples
         of 5):
 

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -2057,7 +2057,7 @@ class Session:
         ...         result = lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)
         ...         assert isinstance(result, xr.DataArray)
         """
-        if outgrid is not None:
+        if outgrid is not None:  # Already written to file, so return None
             return None
         if kind is None:  # Inquire the data family from the virtualfile
             family = self.inquire_virtualfile(vfname)

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -10,6 +10,7 @@ import ctypes as ctp
 import pathlib
 import sys
 import warnings
+from collections.abc import Generator
 from typing import Literal
 
 import numpy as np
@@ -1698,7 +1699,7 @@ class Session:
     @contextlib.contextmanager
     def virtualfile_out(
         self, kind: Literal["dataset", "grid"] = "dataset", fname: str | None = None
-    ):
+    ) -> Generator[str, None, None]:
         r"""
         Create a virtual file or an actual file for storing output data.
 
@@ -1718,7 +1719,7 @@ class Session:
 
         Yields
         ------
-        vfile : str
+        vfile
             Name of the virtual file or the actual file.
 
         Examples

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -2095,7 +2095,7 @@ class Session:
         >>> print(", ".join([f"{x:.2f}" for x in region]))
         -164.71, -154.81, 18.91, 23.58
 
-        The country codes can have an extra argument that rounds the region to a multiple
+        The country codes can have an extra argument that rounds the region to multiples
         of the argument (for example, ``"US.HI+r5"`` will round the region to multiples
         of 5):
 

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -375,7 +375,7 @@ class Session:
             # destroyed
             raise GMTCLibError(
                 "Failed to create a GMT API session: There is a currently open session."
-                " Must destroy it fist."
+                " Must destroy it first."
             )
         # If the exception is raised, this means that there is no open session
         # and we're free to create a new one.


### PR DESCRIPTION
Following methods are updated minorly:

- `Session.get_common`
- `Session.extract_region`
- `Session.virtualfile_to_raster`
- `Session.virtualfile_to_dataset`
- `Session.virtualfile_out`

**Preview**: https://pygmt-dev--3327.org.readthedocs.build/en/3327/api/index.html