### PR TITLE
pygmt.grd2cpt & pygmt.makecpt: Simplify the logic for dealing with CPT output

### DIFF
--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -183,13 +183,15 @@ def grd2cpt(grid, **kwargs):
     """
     if kwargs.get("W") is not None and kwargs.get("Ww") is not None:
         raise GMTInvalidInput("Set only categorical or cyclic to True, not both.")
+
+    if (output := kwargs.pop("H", None)) is not None:
+        if not isinstance(output, str) or output == "":
+            raise GMTInvalidInput("'output' should be a proper file name.")
+        kwargs["H"] = True
+
     with Session() as lib:
         with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
-            if kwargs.get("H") is None:  # if no output is set
-                arg_str = build_arg_list(kwargs, infile=vingrd)
-            else:  # if output is set
-                outfile, kwargs["H"] = kwargs["H"], True
-                if not outfile or not isinstance(outfile, str):
-                    raise GMTInvalidInput("'output' should be a proper file name.")
-                arg_str = build_arg_list(kwargs, infile=vingrd, outfile=outfile)
-            lib.call_module(module="grd2cpt", args=arg_str)
+            lib.call_module(
+                module="grd2cpt",
+                args=build_arg_list(kwargs, infile=vingrd, outfile=output),
+            )

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -185,8 +185,6 @@ def grd2cpt(grid, **kwargs):
         raise GMTInvalidInput("Set only categorical or cyclic to True, not both.")
 
     if (output := kwargs.pop("H", None)) is not None:
-        if not isinstance(output, str) or output == "":
-            raise GMTInvalidInput("'output' should be a proper file name.")
         kwargs["H"] = True
 
     with Session() as lib:

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -157,8 +157,6 @@ def makecpt(**kwargs):
         raise GMTInvalidInput("Set only categorical or cyclic to True, not both.")
 
     if (output := kwargs.pop("H", None)) is not None:
-        if not isinstance(output, str) or output == "":
-            raise GMTInvalidInput("'output' should be a proper file name.")
         kwargs["H"] = True
 
     with Session() as lib:

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -153,14 +153,13 @@ def makecpt(**kwargs):
         range. Note that ``cyclic=True`` cannot be set together with
         ``categorical=True``.
     """
+    if kwargs.get("W") is not None and kwargs.get("Ww") is not None:
+        raise GMTInvalidInput("Set only categorical or cyclic to True, not both.")
+
+    if (output := kwargs.pop("H", None)) is not None:
+        if not isinstance(output, str) or output == "":
+            raise GMTInvalidInput("'output' should be a proper file name.")
+        kwargs["H"] = True
+
     with Session() as lib:
-        if kwargs.get("W") is not None and kwargs.get("Ww") is not None:
-            raise GMTInvalidInput("Set only categorical or cyclic to True, not both.")
-        if kwargs.get("H") is None:  # if no output is set
-            arg_str = build_arg_list(kwargs)
-        else:  # if output is set
-            outfile, kwargs["H"] = kwargs.pop("H"), True
-            if not outfile or not isinstance(outfile, str):
-                raise GMTInvalidInput("'output' should be a proper file name.")
-            arg_str = build_arg_list(kwargs, outfile=outfile)
-        lib.call_module(module="makecpt", args=arg_str)
+        lib.call_module(module="makecpt", args=build_arg_list(kwargs, outfile=output))


### PR DESCRIPTION
Simplify:
```
        if kwargs.get("H") is None:  # if no output is set
            arg_str = build_arg_list(kwargs)
        else:  # if output is set
            outfile, kwargs["H"] = kwargs.pop("H"), True
            if not outfile or not isinstance(outfile, str):
                raise GMTInvalidInput("'output' should be a proper file name.")
            arg_str = build_arg_list(kwargs, outfile=outfile)
```
to 
```
    if (output := kwargs.pop("H", None)) is not None:
        if not isinstance(output, str) or output == "":
            raise GMTInvalidInput("'output' should be a proper file name.")
        kwargs["H"] = True
    arg_str = build_arg_list(kwargs, outfile=output)
```

It works because `outfile` in `build_arg_list` can be `None`.