### PR TITLE
Refactor the data_kind and validate_data_input functions

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -34,10 +34,10 @@ from pygmt.exceptions import (
     GMTVersionError,
 )
 from pygmt.helpers import (
+    _validate_data_input,
     data_kind,
     tempfile_from_geojson,
     tempfile_from_image,
-    validate_data_input,
 )
 
 FAMILIES = [
@@ -1593,7 +1593,7 @@ class Session:
         <vector memory>: N = 3 <7/9> <4/6> <1/3>
         """
         kind = data_kind(data, required=required_data)
-        validate_data_input(
+        _validate_data_input(
             data=data,
             x=x,
             y=y,

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1592,9 +1592,7 @@ class Session:
         ...             print(fout.read().strip())
         <vector memory>: N = 3 <7/9> <4/6> <1/3>
         """
-        kind = data_kind(
-            data, x, y, z, required_z=required_z, required_data=required_data
-        )
+        kind = data_kind(data, required_data=required_data)
         validate_data_input(
             data=data,
             x=x,

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1592,7 +1592,7 @@ class Session:
         ...             print(fout.read().strip())
         <vector memory>: N = 3 <7/9> <4/6> <1/3>
         """
-        kind = data_kind(data, required_data=required_data)
+        kind = data_kind(data, required=required_data)
         validate_data_input(
             data=data,
             x=x,

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -37,6 +37,7 @@ from pygmt.helpers import (
     data_kind,
     tempfile_from_geojson,
     tempfile_from_image,
+    validate_data_input,
 )
 
 FAMILIES = [
@@ -1593,6 +1594,15 @@ class Session:
         """
         kind = data_kind(
             data, x, y, z, required_z=required_z, required_data=required_data
+        )
+        validate_data_input(
+            data=data,
+            x=x,
+            y=y,
+            z=z,
+            required_z=required_z,
+            required_data=required_data,
+            kind=kind,
         )
 
         if check_kind:

--- a/pygmt/helpers/__init__.py
+++ b/pygmt/helpers/__init__.py
@@ -15,6 +15,7 @@ from pygmt.helpers.tempfile import (
     unique_name,
 )
 from pygmt.helpers.utils import (
+    _validate_data_input,
     args_in_kwargs,
     build_arg_list,
     build_arg_string,
@@ -22,6 +23,5 @@ from pygmt.helpers.utils import (
     is_nonstr_iter,
     launch_external_viewer,
     non_ascii_to_octal,
-    validate_data_input,
 )
 from pygmt.helpers.validators import validate_output_table_type

--- a/pygmt/helpers/__init__.py
+++ b/pygmt/helpers/__init__.py
@@ -22,5 +22,6 @@ from pygmt.helpers.utils import (
     is_nonstr_iter,
     launch_external_viewer,
     non_ascii_to_octal,
+    validate_data_input,
 )
 from pygmt.helpers.validators import validate_output_table_type

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -130,9 +130,6 @@ def data_kind(
     * 1-D arrays x and y (and z, optionally)
     * an optional argument (None, bool, int or float) provided as 'data'
 
-    Arguments should be ``None`` if not used. If doesn't fit any of these
-    categories (or fits more than one), will raise an exception.
-
     Parameters
     ----------
     data : str, pathlib.PurePath, None, bool, xarray.DataArray or {table-like}
@@ -150,7 +147,6 @@ def data_kind(
 
     Examples
     --------
-
     >>> import numpy as np
     >>> import xarray as xr
     >>> import pathlib

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -169,7 +169,7 @@ def data_kind(
     >>> data_kind(data=xr.DataArray(np.random.rand(3, 4, 5)))
     'image'
     """
-    # determine the data kind
+    kind: Literal["arg", "file", "geojson", "grid", "image", "matrix", "vectors"]
     if isinstance(data, str | pathlib.PurePath) or (
         isinstance(data, list | tuple)
         and all(isinstance(_file, str | pathlib.PurePath) for _file in data)

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -19,7 +19,7 @@ from pygmt.encodings import charset
 from pygmt.exceptions import GMTInvalidInput
 
 
-def _validate_data_input(
+def validate_data_input(
     data=None, x=None, y=None, z=None, required_z=False, required_data=True, kind=None
 ):
     """
@@ -27,23 +27,23 @@ def _validate_data_input(
 
     Examples
     --------
-    >>> _validate_data_input(data="infile")
-    >>> _validate_data_input(x=[1, 2, 3], y=[4, 5, 6])
-    >>> _validate_data_input(x=[1, 2, 3], y=[4, 5, 6], z=[7, 8, 9])
-    >>> _validate_data_input(data=None, required_data=False)
-    >>> _validate_data_input()
+    >>> validate_data_input(data="infile")
+    >>> validate_data_input(x=[1, 2, 3], y=[4, 5, 6])
+    >>> validate_data_input(x=[1, 2, 3], y=[4, 5, 6], z=[7, 8, 9])
+    >>> validate_data_input(data=None, required_data=False)
+    >>> validate_data_input()
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: No input data provided.
-    >>> _validate_data_input(x=[1, 2, 3])
+    >>> validate_data_input(x=[1, 2, 3])
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Must provide both x and y.
-    >>> _validate_data_input(y=[4, 5, 6])
+    >>> validate_data_input(y=[4, 5, 6])
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Must provide both x and y.
-    >>> _validate_data_input(x=[1, 2, 3], y=[4, 5, 6], required_z=True)
+    >>> validate_data_input(x=[1, 2, 3], y=[4, 5, 6], required_z=True)
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Must provide x, y, and z.
@@ -51,11 +51,11 @@ def _validate_data_input(
     >>> import pandas as pd
     >>> import xarray as xr
     >>> data = np.arange(8).reshape((4, 2))
-    >>> _validate_data_input(data=data, required_z=True, kind="matrix")
+    >>> validate_data_input(data=data, required_z=True, kind="matrix")
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: data must provide x, y, and z columns.
-    >>> _validate_data_input(
+    >>> validate_data_input(
     ...     data=pd.DataFrame(data, columns=["x", "y"]),
     ...     required_z=True,
     ...     kind="matrix",
@@ -63,7 +63,7 @@ def _validate_data_input(
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: data must provide x, y, and z columns.
-    >>> _validate_data_input(
+    >>> validate_data_input(
     ...     data=xr.Dataset(pd.DataFrame(data, columns=["x", "y"])),
     ...     required_z=True,
     ...     kind="matrix",
@@ -71,15 +71,15 @@ def _validate_data_input(
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: data must provide x, y, and z columns.
-    >>> _validate_data_input(data="infile", x=[1, 2, 3])
+    >>> validate_data_input(data="infile", x=[1, 2, 3])
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Too much data. Use either data or x/y/z.
-    >>> _validate_data_input(data="infile", y=[4, 5, 6])
+    >>> validate_data_input(data="infile", y=[4, 5, 6])
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Too much data. Use either data or x/y/z.
-    >>> _validate_data_input(data="infile", z=[7, 8, 9])
+    >>> validate_data_input(data="infile", z=[7, 8, 9])
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Too much data. Use either data or x/y/z.
@@ -193,15 +193,6 @@ def data_kind(data=None, x=None, y=None, z=None, required_z=False, required_data
         kind = "matrix"
     else:
         kind = "vectors"
-    _validate_data_input(
-        data=data,
-        x=x,
-        y=y,
-        z=z,
-        required_z=required_z,
-        required_data=required_data,
-        kind=kind,
-    )
     return kind
 
 

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -115,7 +115,7 @@ def validate_data_input(
                 raise GMTInvalidInput("data must provide x, y, and z columns.")
 
 
-def data_kind(data=None, x=None, y=None, z=None, required_z=False, required_data=True):
+def data_kind(data=None, required_data=True):
     """
     Check what kind of data is provided to a module.
 
@@ -137,12 +137,6 @@ def data_kind(data=None, x=None, y=None, z=None, required_z=False, required_data
         Pass in either a file name or :class:`pathlib.Path` to an ASCII data
         table, an :class:`xarray.DataArray`, a 1-D/2-D
         {table-classes} or an option argument.
-    x/y : 1-D arrays or None
-        x and y columns as numpy arrays.
-    z : 1-D array or None
-        z column as numpy array. To be used optionally when x and y are given.
-    required_z : bool
-        State whether the 'z' column is required.
     required_data : bool
         Set to True when 'data' is required, or False when dealing with
         optional virtual files. [Default is True].
@@ -159,19 +153,19 @@ def data_kind(data=None, x=None, y=None, z=None, required_z=False, required_data
     >>> import numpy as np
     >>> import xarray as xr
     >>> import pathlib
-    >>> data_kind(data=None, x=np.array([1, 2, 3]), y=np.array([4, 5, 6]))
+    >>> data_kind(data=None)
     'vectors'
-    >>> data_kind(data=np.arange(10).reshape((5, 2)), x=None, y=None)
+    >>> data_kind(data=np.arange(10).reshape((5, 2)))
     'matrix'
-    >>> data_kind(data="my-data-file.txt", x=None, y=None)
+    >>> data_kind(data="my-data-file.txt")
     'file'
-    >>> data_kind(data=pathlib.Path("my-data-file.txt"), x=None, y=None)
+    >>> data_kind(data=pathlib.Path("my-data-file.txt"))
     'file'
-    >>> data_kind(data=None, x=None, y=None, required_data=False)
+    >>> data_kind(data=None, required_data=False)
     'arg'
-    >>> data_kind(data=2.0, x=None, y=None, required_data=False)
+    >>> data_kind(data=2.0, required_data=False)
     'arg'
-    >>> data_kind(data=True, x=None, y=None, required_data=False)
+    >>> data_kind(data=True, required_data=False)
     'arg'
     >>> data_kind(data=xr.DataArray(np.random.rand(4, 3)))
     'grid'

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -12,7 +12,7 @@ import time
 import warnings
 import webbrowser
 from collections.abc import Iterable, Sequence
-from typing import Any
+from typing import Any, Literal
 
 import xarray as xr
 from pygmt.encodings import charset
@@ -115,7 +115,9 @@ def validate_data_input(
                 raise GMTInvalidInput("data must provide x, y, and z columns.")
 
 
-def data_kind(data=None, required_data=True):
+def data_kind(
+    data: Any = None, required: bool = True
+) -> Literal["arg", "file", "geojson", "grid", "image", "matrix", "vectors"]:
     """
     Check what kind of data is provided to a module.
 
@@ -137,15 +139,14 @@ def data_kind(data=None, required_data=True):
         Pass in either a file name or :class:`pathlib.Path` to an ASCII data
         table, an :class:`xarray.DataArray`, a 1-D/2-D
         {table-classes} or an option argument.
-    required_data : bool
+    required
         Set to True when 'data' is required, or False when dealing with
         optional virtual files. [Default is True].
 
     Returns
     -------
-    kind : str
-        One of ``'arg'``, ``'file'``, ``'grid'``, ``image``, ``'geojson'``,
-        ``'matrix'``, or ``'vectors'``.
+    kind
+        The data kind.
 
     Examples
     --------
@@ -161,11 +162,11 @@ def data_kind(data=None, required_data=True):
     'file'
     >>> data_kind(data=pathlib.Path("my-data-file.txt"))
     'file'
-    >>> data_kind(data=None, required_data=False)
+    >>> data_kind(data=None, required=False)
     'arg'
-    >>> data_kind(data=2.0, required_data=False)
+    >>> data_kind(data=2.0, required=False)
     'arg'
-    >>> data_kind(data=True, required_data=False)
+    >>> data_kind(data=True, required=False)
     'arg'
     >>> data_kind(data=xr.DataArray(np.random.rand(4, 3)))
     'grid'
@@ -179,7 +180,7 @@ def data_kind(data=None, required_data=True):
     ):
         # One or more files
         kind = "file"
-    elif isinstance(data, bool | int | float) or (data is None and not required_data):
+    elif isinstance(data, bool | int | float) or (data is None and not required):
         kind = "arg"
     elif isinstance(data, xr.DataArray):
         kind = "image" if len(data.dims) == 3 else "grid"

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -19,7 +19,7 @@ from pygmt.encodings import charset
 from pygmt.exceptions import GMTInvalidInput
 
 
-def validate_data_input(
+def _validate_data_input(
     data=None, x=None, y=None, z=None, required_z=False, required_data=True, kind=None
 ):
     """
@@ -27,23 +27,23 @@ def validate_data_input(
 
     Examples
     --------
-    >>> validate_data_input(data="infile")
-    >>> validate_data_input(x=[1, 2, 3], y=[4, 5, 6])
-    >>> validate_data_input(x=[1, 2, 3], y=[4, 5, 6], z=[7, 8, 9])
-    >>> validate_data_input(data=None, required_data=False)
-    >>> validate_data_input()
+    >>> _validate_data_input(data="infile")
+    >>> _validate_data_input(x=[1, 2, 3], y=[4, 5, 6])
+    >>> _validate_data_input(x=[1, 2, 3], y=[4, 5, 6], z=[7, 8, 9])
+    >>> _validate_data_input(data=None, required_data=False)
+    >>> _validate_data_input()
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: No input data provided.
-    >>> validate_data_input(x=[1, 2, 3])
+    >>> _validate_data_input(x=[1, 2, 3])
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Must provide both x and y.
-    >>> validate_data_input(y=[4, 5, 6])
+    >>> _validate_data_input(y=[4, 5, 6])
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Must provide both x and y.
-    >>> validate_data_input(x=[1, 2, 3], y=[4, 5, 6], required_z=True)
+    >>> _validate_data_input(x=[1, 2, 3], y=[4, 5, 6], required_z=True)
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Must provide x, y, and z.
@@ -51,11 +51,11 @@ def validate_data_input(
     >>> import pandas as pd
     >>> import xarray as xr
     >>> data = np.arange(8).reshape((4, 2))
-    >>> validate_data_input(data=data, required_z=True, kind="matrix")
+    >>> _validate_data_input(data=data, required_z=True, kind="matrix")
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: data must provide x, y, and z columns.
-    >>> validate_data_input(
+    >>> _validate_data_input(
     ...     data=pd.DataFrame(data, columns=["x", "y"]),
     ...     required_z=True,
     ...     kind="matrix",
@@ -63,7 +63,7 @@ def validate_data_input(
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: data must provide x, y, and z columns.
-    >>> validate_data_input(
+    >>> _validate_data_input(
     ...     data=xr.Dataset(pd.DataFrame(data, columns=["x", "y"])),
     ...     required_z=True,
     ...     kind="matrix",
@@ -71,19 +71,19 @@ def validate_data_input(
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: data must provide x, y, and z columns.
-    >>> validate_data_input(data="infile", x=[1, 2, 3])
+    >>> _validate_data_input(data="infile", x=[1, 2, 3])
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Too much data. Use either data or x/y/z.
-    >>> validate_data_input(data="infile", y=[4, 5, 6])
+    >>> _validate_data_input(data="infile", y=[4, 5, 6])
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Too much data. Use either data or x/y/z.
-    >>> validate_data_input(data="infile", x=[1, 2, 3], y=[4, 5, 6])
+    >>> _validate_data_input(data="infile", x=[1, 2, 3], y=[4, 5, 6])
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Too much data. Use either data or x/y/z.
-    >>> validate_data_input(data="infile", z=[7, 8, 9])
+    >>> _validate_data_input(data="infile", z=[7, 8, 9])
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Too much data. Use either data or x/y/z.

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -79,6 +79,10 @@ def validate_data_input(
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTInvalidInput: Too much data. Use either data or x/y/z.
+    >>> validate_data_input(data="infile", x=[1, 2, 3], y=[4, 5, 6])
+    Traceback (most recent call last):
+        ...
+    pygmt.exceptions.GMTInvalidInput: Too much data. Use either data or x/y/z.
     >>> validate_data_input(data="infile", z=[7, 8, 9])
     Traceback (most recent call last):
         ...

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -119,16 +119,17 @@ def data_kind(
     data: Any = None, required: bool = True
 ) -> Literal["arg", "file", "geojson", "grid", "image", "matrix", "vectors"]:
     """
-    Check what kind of data is provided to a module.
+    Check the kind of data that is provided to a module.
 
-    Possible types:
+    The ``data`` argument can be in any type, but only following types are supported:
 
-    * a file name provided as 'data'
-    * a pathlib.PurePath object provided as 'data'
-    * an xarray.DataArray object provided as 'data'
-    * a 2-D matrix provided as 'data'
-    * 1-D arrays x and y (and z, optionally)
-    * an optional argument (None, bool, int or float) provided as 'data'
+    - a string or a :class:`pathlib.PurePath` object or a sequence of them, representing
+      a file name or a list of file names
+    - a 2-D or 3-D :class:`xarray.DataArray` object
+    - a 2-D matrix
+    - None, bool, int or float type representing an optional arguments
+    - a geo-like Python object that implements ``__geo_interface__`` (e.g.,
+      geopandas.GeoDataFrame or shapely.geometry)
 
     Parameters
     ----------

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -208,7 +208,7 @@ def plot(  # noqa: PLR0912
     """
     kwargs = self._preprocess(**kwargs)
 
-    kind = data_kind(data, x, y)
+    kind = data_kind(data)
     extra_arrays = []
     if kind == "vectors":  # Add more columns for vectors input
         # Parameters for vector styles

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -183,7 +183,7 @@ def plot3d(  # noqa: PLR0912
     """
     kwargs = self._preprocess(**kwargs)
 
-    kind = data_kind(data, x, y, z)
+    kind = data_kind(data)
     extra_arrays = []
 
     if kind == "vectors":  # Add more columns for vectors input

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -180,11 +180,11 @@ def text_(  # noqa: PLR0912
 
     # Ensure inputs are either textfiles, x/y/text, or position/text
     if position is None:
-        if (x is not None or y is not None) and textfiles is not None:
+        if any(v is not None for v in (x, y, text)) and textfiles is not None:
             raise GMTInvalidInput(
                 "Provide either position only, or x/y pairs, or textfiles."
             )
-        kind = data_kind(textfiles, x, y, text)
+        kind = data_kind(textfiles)
         if kind == "vectors" and text is None:
             raise GMTInvalidInput("Must provide text with x/y pairs")
     else:

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -4,18 +4,11 @@ Test the helper functions/classes/etc used in wrapping GMT.
 
 from pathlib import Path
 
-import numpy as np
 import pytest
 import xarray as xr
 from pygmt import Figure
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import (
-    GMTTempFile,
-    args_in_kwargs,
-    data_kind,
-    kwargs_to_strings,
-    unique_name,
-)
+from pygmt.helpers import GMTTempFile, args_in_kwargs, kwargs_to_strings, unique_name
 from pygmt.helpers.testing import load_static_earth_relief, skip_if_no
 
 
@@ -30,25 +23,6 @@ def test_load_static_earth_relief():
     assert data.max() == 981
     assert data.median() == 467
     assert isinstance(data, xr.DataArray)
-
-
-@pytest.mark.parametrize(
-    ("data", "x", "y"),
-    [
-        (None, None, None),
-        ("data.txt", np.array([1, 2]), np.array([4, 5])),
-        ("data.txt", np.array([1, 2]), None),
-        ("data.txt", None, np.array([4, 5])),
-        (None, np.array([1, 2]), None),
-        (None, None, np.array([4, 5])),
-    ],
-)
-def test_data_kind_fails(data, x, y):
-    """
-    Make sure data_kind raises exceptions when it should.
-    """
-    with pytest.raises(GMTInvalidInput):
-        data_kind(data=data, x=x, y=y)
 
 
 def test_unique_name():


### PR DESCRIPTION
**Description of proposed changes**

This PR is a subset of PR #2744. PR #2744 takes more time than I initially expected (Still not satisfied with the new `Session.virtualfile_in` API function), so better to refactor the `data_kind`/`validate_data_input` function in a separate PR (this PR).

As mentioned in PR #2744:

> The `data_kind` function does three things: (1) determines the kind of the input data, and (2) checks if the data/x/y/z combinations are valid; and (3) checks if the matrix-type data has 3 columns. 
> The `data_kind` function is called inside `Session.virtualfile_in`, but sometimes we need to know the input data kind when wrapping GMT modules, for example, in `Figure.plot` and `Figure.plot3d`. It means the `data_kind` function is called twice, which is not necessary.

This PR moves the `validate_data_input` function outside of the `data_kind`, and calls it in `Session.virtualfile_in` explicitly. In this way, each function only focuses on one single data. which makes the functions easier to maintain.

I also don't like the current function design of the `data_kind`/`validate_data_input` functions, but I prefer to refactor the function details in a separate PR, to make this PR smaller for reviewing.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
