### PR TITLE
build_arg_list: Raise an exception if an invalid output file name is given

### DIFF
--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -350,7 +350,13 @@ def build_arg_list(
             gmt_args = [str(infile), *gmt_args]
         else:
             gmt_args = [str(_file) for _file in infile] + gmt_args
-    if outfile:
+    if outfile is not None:
+        if (
+            not isinstance(outfile, str | pathlib.PurePath)
+            or str(outfile) in {"", ".", ".."}
+            or str(outfile).endswith(("/", "\\"))
+        ):
+            raise GMTInvalidInput(f"Invalid output file name '{outfile}'.")
         gmt_args.append(f"->{outfile}")
     return gmt_args
 

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -12,6 +12,7 @@ from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     GMTTempFile,
     args_in_kwargs,
+    build_arg_list,
     data_kind,
     kwargs_to_strings,
     unique_name,
@@ -135,6 +136,17 @@ def test_gmttempfile_read():
         Path(tmpfile.name).write_text("in.dat: N = 2\t<1/3>\t<2/4>\n", encoding="utf-8")
         assert tmpfile.read() == "in.dat: N = 2 <1/3> <2/4>\n"
         assert tmpfile.read(keep_tabs=True) == "in.dat: N = 2\t<1/3>\t<2/4>\n"
+
+
+@pytest.mark.parametrize(
+    "outfile", [123, "", ".", "..", "path/to/dir/", Path(), Path("..")]
+)
+def test_build_arg_list_invalid_output(outfile):
+    """
+    Test that build_arg_list raises an exception when output file name is invalid.
+    """
+    with pytest.raises(GMTInvalidInput):
+        build_arg_list({}, outfile=outfile)
 
 
 def test_args_in_kwargs():

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -139,7 +139,7 @@ def test_gmttempfile_read():
 
 
 @pytest.mark.parametrize(
-    "outfile", [123, "", ".", "..", "path/to/dir/", Path(), Path("..")]
+    "outfile", [123, "", ".", "..", "path/to/dir/", r"path\to\dir\", Path(), Path(".."), ]
 )
 def test_build_arg_list_invalid_output(outfile):
     """

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -139,7 +139,8 @@ def test_gmttempfile_read():
 
 
 @pytest.mark.parametrize(
-    "outfile", [123, "", ".", "..", "path/to/dir/", r"path\to\dir\", Path(), Path(".."), ]
+    "outfile",
+    [123, "", ".", "..", "path/to/dir/", "path\\to\\dir\\", Path(), Path("..")],
 )
 def test_build_arg_list_invalid_output(outfile):
     """


### PR DESCRIPTION
**Description of proposed changes**

When working on PR #3334, I realized that we didn't check if the `outfile` parameter passed to `build_arg_list` is valid or not. Some invalid values are `""`, `"."`, `".."` or a string ending with `/` or `\`.

This PR enhances the `build_arg_list` function to check if the `outfile` argument is valid. We can't check all cases but at least we can raise an exception for a few common cases.

This PR will further simplify #3334.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
