### PR TITLE
Run codespell via pre-commit instead of in Makefile

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/4-release_checklist.md
@@ -17,7 +17,6 @@ assignees: ''
 
 **Before release**:
 - [ ] Check [SPEC 0](https://scientific-python.org/specs/spec-0000/) to see if we need to bump the minimum supported versions of GMT, Python and core package dependencies (NumPy/Pandas/Xarray)
-- [ ] Run `make codespell` to check common misspellings. If there are any, either fix them or add them to `ignore-words-list` in `pyproject.toml`
 - [ ] Check to ensure that:
   - [ ] All tests pass in the ["GMT Legacy Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_legacy.yaml)
   - [ ] All tests pass in the ["GMT Dev Tests" workflow](https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_tests_dev.yaml)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.3.0
+  hooks:
+  - id: codespell
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.6.0
   hooks:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ help:
 	@echo "  test_no_images run the test suite (including all doctests) but skip image comparisons"
 	@echo "  format         run ruff to automatically format the code"
 	@echo "  check          run ruff to check code style and quality"
-	@echo "  codespell      run codespell to check common misspellings"
 	@echo "  typecheck      run mypy for static type check"
 	@echo "  clean          clean up build and generated files"
 	@echo "  distclean      clean up build and generated files, including project metadata files"
@@ -66,9 +65,6 @@ format:
 check:
 	ruff check $(FORMAT_FILES)
 	ruff format --check $(FORMAT_FILES)
-
-codespell:
-	@codespell
 
 typecheck:
 	mypy ${PROJECT}

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,6 @@ dependencies:
     - make
     - pip
     # Dev dependencies (style checks)
-    - codespell
     - pre-commit
     - ruff>=0.3.0
     # Dev dependencies (unit testing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,12 @@ local_scheme = "node-and-date"
 fallback_version = "999.999.999+unknown"
 
 [tool.codespell]
-ignore-words-list = "astroid,oints,reenable,tripel,trough"
+ignore-words-list = [
+    "astroid",
+    "oints",
+    "tripel",
+    "trough",
+]
 
 [tool.coverage.run]
 omit = ["*/tests/*", "*pygmt/__init__.py"]


### PR DESCRIPTION
**Description of proposed changes**

Let `codespell` be ran more regularly in the Style Checks CI instead of irregularly during releases. The `make codespell` command is removed, as codespell will be ran with pre-commit here:

https://github.com/GenericMappingTools/pygmt/blob/d7560fa097819c7717a75dac85db1953da6ce430/.github/workflows/style_checks.yaml#L40-L43

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

References:
- https://github.com/codespell-project/codespell/tree/v2.3.0?tab=readme-ov-file#pre-commit-hook

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Supersedes #2673, see also #2671


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
