### PR TITLE
Fix the tile_map doctest which has different output on Windows in the GMT Legacy Tests

### DIFF
--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -122,7 +122,7 @@ def load_tile_map(
       * band         (band) uint8 ... 1 2 3
       * y            (y) float64 ... -7.081e-10 -7.858e+04 ... -1.996e+07 -2.004e+07
       * x            (x) float64 ... -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
-        spatial_ref  int64 ... 0
+        spatial_ref  int... 0
     >>> # CRS is set only if rioxarray is available
     >>> if hasattr(raster, "rio"):
     ...     raster.rio.crs


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/GenericMappingTools/pygmt/actions/runs/10050492014/job/27778503913

```
================================== FAILURES ===================================
_______________ [doctest] pygmt.datasets.tile_map.load_tile_map _______________
111     >>> from pygmt.datasets import load_tile_map
112     >>> raster = load_tile_map(
113     ...     region=[-180.0, 180.0, -90.0, 0.0],  # West, East, South, North
114     ...     zoom=1,  # less detailed zoom level
115     ...     source=contextily.providers.OpenTopoMap,
116     ...     lonlat=True,  # bounding box coordinates are longitude/latitude
117     ... )
118     >>> raster.sizes
119     Frozen({'band': 3, 'y': 256, 'x': 512})
120     >>> raster.coords  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
Differences (unified diff with -expected +actual):
    @@ -1,5 +1,5 @@
     Coordinates:
    -  * band         (band) uint8 ... 1 2 3
    -  * y            (y) float64 ... -7.081e-10 -7.858e+04 ... -1.996e+07 -2.004e+07
    -  * x            (x) float64 ... -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
    -    spatial_ref  int64 ... 0
    +  * band         (band) uint8 3B 1 2 3
    +  * y            (y) float64 2kB -7.081e-10 -7.858e+04 ... -1.996e+07 -2.004e+07
    +  * x            (x) float64 4kB -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
    +    spatial_ref  int32 4B 0
```

Triggered a new CI run at https://github.com/GenericMappingTools/pygmt/actions/runs/10069565056.