### PR TITLE
Improve the geographic global xarray.DataArray grid used in grdimage tests

### DIFF
--- a/pygmt/tests/baseline/test_grdimage_over_dateline.png.dvc
+++ b/pygmt/tests/baseline/test_grdimage_over_dateline.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: cfd6484e1e2eddea0d4b56df54aabe05
-  size: 10854
+- md5: 89b79fd00e185ab840927dad11cb5ec5
+  size: 8393
   path: test_grdimage_over_dateline.png
+  hash: md5

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -39,7 +39,7 @@ def fixture_xrgrid():
     latitude = np.arange(-90, 91, 1)
     lon_grid, lat_grid = np.meshgrid(longitude, latitude)
     data = np.cos(np.deg2rad(lat_grid)) * np.sin(np.deg2rad(lon_grid))
-    # Consistent data points are North/South poles for all longitudes
+    # Consistent data points at the North/South poles for all longitudes
     data[0, :] = 0.0
     data[-1, :] = 0.0
     return xr.DataArray(

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -35,12 +35,13 @@ def fixture_xrgrid():
     """
     Create a sample xarray.DataArray grid for testing.
     """
-    longitude = np.arange(0, 360, 1)
-    latitude = np.arange(-89, 90, 1)
-    x = np.sin(np.deg2rad(longitude))
-    y = np.linspace(start=0, stop=1, num=179)
-    data = y[:, np.newaxis] * x
-
+    longitude = np.arange(0, 361, 1)
+    latitude = np.arange(-90, 91, 1)
+    lon_grid, lat_grid = np.meshgrid(longitude, latitude)
+    data = np.cos(np.deg2rad(lat_grid)) * np.sin(np.deg2rad(lon_grid))
+    # Consistent data points are North/South poles for all longitudes
+    data[0, :] = 0.0
+    data[-1, :] = 0.0
     return xr.DataArray(
         data,
         coords=[


### PR DESCRIPTION
**Description of proposed changes**

Originally proposed in https://github.com/GenericMappingTools/pygmt/pull/3358#issuecomment-2254832971. This PR updates the `xrgrid` to be a true global grid. The new grid comes from https://github.com/GenericMappingTools/pygmt/issues/390.

```python
import numpy as np
import xarray as xr


# The old xr.DataArray grid
longitude = np.arange(0, 360, 1)
latitude = np.arange(-89, 90, 1)
x = np.sin(np.deg2rad(longitude))
y = np.linspace(start=0, stop=1, num=179)
data = y[:, np.newaxis] * x

da1 = xr.DataArray(
    data,
    coords=[
        ("latitude", latitude, {"units": "degrees_north"}),
        ("longitude", longitude, {"units": "degrees_east"}),
    ],
    attrs={"actual_range": [-1, 1]},
)

# The new xr.DataArray grid
longitude = np.arange(0, 361, 1)
latitude = np.arange(-90, 91, 1)
lon_grid, lat_grid = np.meshgrid(longitude, latitude)
data = np.cos(np.deg2rad(lat_grid)) * np.sin(np.deg2rad(lon_grid))
# Consistent data points are North/South poles for all longitude
data[0, :] = 0.0
data[-1, :] = 0.0

da2 = xr.DataArray(
    data,
    coords=[
        ("latitude", latitude, {"units": "degrees_north"}),
        ("longitude", longitude, {"units": "degrees_east"}),
    ],
    attrs={"actual_range": [-1, 1]},
)

import pygmt
fig = pygmt.Figure()

fig.grdimage(da1, projection="H0/15c", region="g")
fig.shift_origin(xshift="w+2c")
fig.grdimage(da2, projection="H0/15c", region="g")
fig.show()
```

Left is old grid and right is the new grid:
![map](https://github.com/user-attachments/assets/e28e37ab-c2e0-4b26-8c3f-ffc3288f4c5d)

Pros of the new grids:

1. It's 0-360 range, and it's easy to get a 0-359 grid by grid slicing.
2. It has consistent data points in the North/South poles.
3. The `xrgrid` object is also used in `test_grdimage_grid_and_shading_with_xarray` but in that test we only add shading to a small region (i.e. `region="GL"`), so it's still unclear if adding a `xrgrid` shading grid to a global grid works or not. 