### PR TITLE
Updating External Resources: Add tutorial in Portuguese and using PyGMT in Google Colab

### DIFF
--- a/doc/external_resources.md
+++ b/doc/external_resources.md
@@ -13,7 +13,7 @@ to submit a pull request with your recommended addition to the
 :::::{grid} 1 2 2 3
 
 ::::{grid-item-card} 2024 PyGMT Webinar using Google Colab (in Portuguese)
-:link: [[https://www.generic-mapping-tools.org/egu22pygmt](https://github.com/andrebelem/Oficina_PyGMT)/](https://github.com/andrebelem/Oficina_PyGMT)
+:link: https://github.com/andrebelem/Oficina_PyGMT
 :text-align: center
 :margin: 0 3 0 0
 


### PR DESCRIPTION
**This is an update for External Resources**

- a PyGMT webinar conducted in Portuguese

As suggested in the [forum](https://forum.generic-mapping-tools.org/t/pygmt-very-short-course-in-portuguese/5028), I am applying to include this webinar in Portuguese for PyGMT.

**Preview**: https://pygmt-dev--3360.org.readthedocs.build/en/3360/external_resources.html
