### PR TITLE
Let pygmt.show_versions show GDAL version

### DIFF
--- a/pygmt/_show_versions.py
+++ b/pygmt/_show_versions.py
@@ -96,6 +96,18 @@ def _check_ghostscript_version(gs_version: str) -> str | None:
     return None
 
 
+def _get_gdal_version():
+    """
+    Get GDAL version.
+    """
+    try:
+        from osgeo import gdal
+
+        return gdal.__version__
+    except ImportError:
+        return None
+
+
 def show_versions(file=sys.stdout):
     """
     Print various dependency versions which are useful when submitting bug reports.
@@ -120,6 +132,7 @@ def show_versions(file=sys.stdout):
     }
     deps = [Requirement(v).name for v in importlib.metadata.requires("pygmt")]
     gs_version = _get_ghostscript_version()
+    gdal_version = _get_gdal_version()
 
     lines = []
     lines.append("PyGMT information:")
@@ -128,6 +141,7 @@ def show_versions(file=sys.stdout):
     lines.extend([f"  {key}: {val}" for key, val in sys_info.items()])
     lines.append("Dependency information:")
     lines.extend([f"  {modname}: {_get_module_version(modname)}" for modname in deps])
+    lines.append(f"  gdal: {gdal_version}")
     lines.append(f"  ghostscript: {gs_version}")
     lines.append("GMT library information:")
     lines.extend([f"  {key}: {val}" for key, val in _get_clib_info().items()])


### PR DESCRIPTION
**Description of proposed changes**

Show GDAL version in `pygmt.show_versions`, addressing https://github.com/GenericMappingTools/pygmt/pull/3338#discussion_r1685579242.

```
>>> pygmt.show_versions()
PyGMT information:
  version: v0.12.1.dev87+g318a8c4af
System information:
  python: 3.12.4 | packaged by conda-forge | (main, Jun 17 2024, 10:11:10) [Clang 16.0.6 ]
  executable: /Users/seisman/opt/miniconda/envs/pygmt/bin/python3.12
  machine: macOS-14.5-x86_64-i386-64bit
Dependency information:
  numpy: 2.0.0
  pandas: 2.2.2
  xarray: 2024.6.0
  netCDF4: 1.7.1
  packaging: 24.1
  contextily: 1.6.0
  geopandas: 1.0.1
  IPython: 8.26.0
  rioxarray: 0.17.0
  gdal: 3.9.1
  ghostscript: 10.03.1
GMT library information:
  version: 6.5.0
  padding: 2
  share dir: /Users/seisman/opt/miniconda/envs/pygmt/share/gmt
  plugin dir: /Users/seisman/opt/miniconda/envs/pygmt/lib/gmt/plugins
  library path: /Users/seisman/opt/miniconda/envs/pygmt/lib/libgmt.dylib
  cores: 8
  grid layout: rows
  image layout:
  binary version: 6.5.0
```