### PR TITLE
Patch the callback print function to suppress the UnicodeDecodeError

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -379,10 +379,14 @@ class Session:
             We'll capture the messages and print them to stderr so that they will show
             up on the Jupyter notebook.
             """
-            message = message.decode().strip()
+            # Have to use try..except due to upstream GMT bug in GMT <= 6.5.0.
+            # See https://github.com/GenericMappingTools/pygmt/issues/3205.
+            try:
+                message = message.decode().strip()
+            except UnicodeDecodeError:
+                return 0
             self._error_log.append(message)
-            # flush to make sure the messages are printed even if we have a
-            # crash.
+            # Flush to make sure the messages are printed even if we have a crash.
             print(message, file=sys.stderr, flush=True)  # noqa: T201
             return 0
 


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/GenericMappingTools/pygmt/issues/3205 for the original issue and https://github.com/GenericMappingTools/gmt/pull/8461 for the upstream fix.

We can do nothing for old GMT versions but the UnicodeDecodeError error in debugging messages looks scaring. So at least we should catch the exception to suppress the error.

No `UnicodeDecodeError` error after this PR:

```
In [1]: import pygmt

In [2]: pygmt.config(GMT_VERBOSE="d")
gmtset [DEBUG]: gmtlib_get_graphics_item: Fig: 0 Subplot: 2 Panel: () Inset: 0
Out[2]: <pygmt.src.config.config at 0x13c8b8e90>

In [3]: fig = pygmt.Figure()
pygmt-session [DEBUG]: Exit:  gmt_reload_settings
pygmt-session [DEBUG]: Enter: gmtlib_plot_C_format
pygmt-session [DEBUG]: Exit:  gmtlib_plot_C_format
pygmt-session [DEBUG]: Enter: gmtinit_get_history
pygmt-session [DEBUG]: gmtlib_get_graphics_item: Fig: 0 Subplot: 2 Panel: () Inset: 0
pygmt-session [DEBUG]: Initialize FFTW with 8 threads.
pygmt-session [DEBUG]: GMT_Create_Session initialized GMT structure
pygmt-session [DEBUG]: Shared Library # 0 (core). Path = /Users/seisman/opt/miniconda/envs/pygmt/lib/libgmt.dylib
pygmt-session [DEBUG]: Loading GMT plugins from: /Users/seisman/opt/miniconda/envs/pygmt/lib/gmt/plugins
pygmt-session [DEBUG]: Shared Library # 1 (supplements). Path = /Users/seisman/opt/miniconda/envs/pygmt/lib/gmt/plugins/supplements.so
pygmt-session [DEBUG]: GMT now running in modern mode [Session ID = 13594]
pygmt-session [DEBUG]: Revised options: 03e3017e1ead48cc8d003fcbd5e98b9f -
figure [DEBUG]: No figure file /Users/seisman/.gmt/sessions/gmt_session.13594/gmt.figures - nothing to do
figure [DEBUG]: New figure: 1	03e3017e1ead48cc8d003fcbd5e98b9f	-
```
