### PR TITLE
pygmt.show_versions: Remove _get_gdal_version and create a dictionary for dependency versions

### DIFF
--- a/pygmt/_show_versions.py
+++ b/pygmt/_show_versions.py
@@ -7,8 +7,13 @@ Adapted from :func:`rioxarray.show_versions` and :func:`pandas.show_versions`.
 import importlib
 import platform
 import shutil
+import subprocess
 import sys
 from importlib.metadata import version
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+from pygmt.clib import Session, __gmt_version__
 
 # Get semantic version through setuptools-scm
 __version__ = f'v{version("pygmt")}'  # e.g. v0.1.2.dev3+g0ab3cd78
@@ -19,8 +24,6 @@ def _get_clib_info() -> dict:
     """
     Return information about the GMT shared library.
     """
-    from pygmt.clib import Session
-
     with Session() as ses:
         return ses.info
 
@@ -47,8 +50,6 @@ def _get_ghostscript_version() -> str | None:
     """
     Get Ghostscript version.
     """
-    import subprocess
-
     match sys.platform:
         case "linux" | "darwin":
             cmds = ["gs"]
@@ -71,8 +72,6 @@ def _check_ghostscript_version(gs_version: str) -> str | None:
     """
     Check if the Ghostscript version is compatible with GMT versions.
     """
-    from packaging.version import Version
-
     match Version(gs_version):
         case v if v < Version("9.53"):
             return (
@@ -85,8 +84,6 @@ def _check_ghostscript_version(gs_version: str) -> str | None:
                 "Please consider upgrading to version v10.02 or later."
             )
         case v if v >= Version("10.02"):
-            from pygmt.clib import __gmt_version__
-
             if Version(__gmt_version__) < Version("6.5.0"):
                 return (
                     f"GMT v{__gmt_version__} doesn't support Ghostscript "
@@ -110,8 +107,6 @@ def show_versions(file=sys.stdout):
     It also warns users if the installed Ghostscript version has serious bugs or is
     incompatible with the installed GMT version.
     """
-
-    from packaging.requirements import Requirement
 
     sys_info = {
         "python": sys.version.replace("\n", " "),

--- a/pygmt/_show_versions.py
+++ b/pygmt/_show_versions.py
@@ -68,10 +68,13 @@ def _get_ghostscript_version() -> str | None:
     return None
 
 
-def _check_ghostscript_version(gs_version: str) -> str | None:
+def _check_ghostscript_version(gs_version: str | None) -> str | None:
     """
     Check if the Ghostscript version is compatible with GMT versions.
     """
+    if gs_version is None:
+        return None
+
     match Version(gs_version):
         case v if v < Version("9.53"):
             return (

--- a/pygmt/_show_versions.py
+++ b/pygmt/_show_versions.py
@@ -23,7 +23,7 @@ __commit__ = __version__.split("+g")[-1] if "+g" in __version__ else ""  # 0ab3c
 
 def _get_clib_info() -> dict[str, str]:
     """
-    Return information about the GMT shared library.
+    Get information about the GMT shared library.
     """
     with Session() as ses:
         return ses.info

--- a/pygmt/_show_versions.py
+++ b/pygmt/_show_versions.py
@@ -119,7 +119,7 @@ def show_versions(file: TextIO | None = sys.stdout):
     }
     dep_info = {
         Requirement(v).name: _get_module_version(Requirement(v).name)
-        for v in importlib.metadata.requires("pygmt")
+        for v in importlib.metadata.requires("pygmt")  # type: ignore[union-attr]
     }
     dep_info.update(
         {

--- a/pygmt/_show_versions.py
+++ b/pygmt/_show_versions.py
@@ -74,7 +74,7 @@ def _check_ghostscript_version(gs_version: str | None) -> str | None:
     Check if the Ghostscript version is compatible with GMT versions.
     """
     if gs_version is None:
-        return None
+        return "Ghostscript is not detected. Your installation may be broken."
 
     match Version(gs_version):
         case v if v < Version("9.53"):

--- a/pygmt/_show_versions.py
+++ b/pygmt/_show_versions.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 from importlib.metadata import version
+from typing import TextIO
 
 from packaging.requirements import Requirement
 from packaging.version import Version
@@ -20,7 +21,7 @@ __version__ = f'v{version("pygmt")}'  # e.g. v0.1.2.dev3+g0ab3cd78
 __commit__ = __version__.split("+g")[-1] if "+g" in __version__ else ""  # 0ab3cd78
 
 
-def _get_clib_info() -> dict:
+def _get_clib_info() -> dict[str, str]:
     """
     Return information about the GMT shared library.
     """
@@ -96,7 +97,7 @@ def _check_ghostscript_version(gs_version: str | None) -> str | None:
     return None
 
 
-def show_versions(file=sys.stdout):
+def show_versions(file: TextIO | None = sys.stdout):
     """
     Print various dependency versions which are useful when submitting bug reports.
 


### PR DESCRIPTION
**Description of proposed changes**

1. [Remove _get_gdal_version and create a dictionary for dependency versions](https://github.com/GenericMappingTools/pygmt/commit/b0115f4769d51e0cb3fce972d037ff1e98049f43) The private function was added in #3364.
2. [Move imports out of the functions](https://github.com/GenericMappingTools/pygmt/commit/cae8f80a1c7e55d3ca3da4b7c4ff7633189a902b)
3. [Check gs_version=None in _check_ghostscript_version](https://github.com/GenericMappingTools/pygmt/commit/be12ccab718a53fc5e23bb537fb77c627356dded) May fail to find ghostscript as shown in #3366.

```
>>> import pygmt

>>> pygmt.show_versions()
PyGMT information:
  version: v0.12.1.dev78+g9c13eb04b.d20240709
System information:
  python: 3.12.3 | packaged by conda-forge | (main, Apr 15 2024, 18:38:13) [GCC 12.3.0]
  executable: /home/seisman/opt/miniforge/envs/pygmt/bin/python3.12
  machine: Linux-6.9.9-200.fc40.x86_64-x86_64-with-glibc2.39
Dependency information:
  numpy: 2.0.0
  pandas: 2.2.2
  xarray: 2024.6.0
  netCDF4: 1.6.5
  packaging: 24.1
  contextily: 1.6.0
  geopandas: 1.0.0
  IPython: 8.25.0
  rioxarray: 0.15.6
  gdal: 3.9.0
  ghostscript: 10.03.1
GMT library information:
  version: 6.5.0
  padding: 2
  share dir: /home/seisman/opt/miniforge/envs/pygmt/share/gmt
  plugin dir: /home/seisman/opt/miniforge/envs/pygmt/lib/gmt/plugins
  library path: /home/seisman/opt/miniforge/envs/pygmt/lib/libgmt.so
  cores: 80
  grid layout: rows
  image layout:
  binary version: 6.5.0
```