### PR TITLE
Document the supported 35 standard Postscript fonts in the Technical Reference section

### DIFF
--- a/doc/techref/fonts.md
+++ b/doc/techref/fonts.md
@@ -1,10 +1,7 @@
 # Supported Fonts
 
-PyGMT (and GMT) supports the standard 35 PostScript fonts.
-
-## Standard PostScript Fonts
-
-The table below lists the standard 35 PostScript fonts that are supported by GMT and PyGMT.
+PyGMT supports the standard 35 PostScript fonts. The table below lists the 35 fonts with
+font number and the font name.
 
 | Font Number | Font Name                  | Font Number | Font Name                  |
 |-------------|----------------------------|-------------|----------------------------|
@@ -27,12 +24,13 @@ The table below lists the standard 35 PostScript fonts that are supported by GMT
 | 16          | AvantGarde-DemiOblique     | 33          | ZapfChancery-MediumItalic  |
 |             |                            | 34          | ZapfDingbats               |
 
+The figure below shows a visual sample for each font.
 
-The table shows the font number, the font name, and a sample of the font.
+![Standard PostScript Fonts](https://docs.generic-mapping-tools.org/dev/_images/GMT_App_G.png){.align-center width="80%"}
 
-![Standard PostScript Fonts](https://docs.generic-mapping-tools.org/dev/_images/GMT_App_G.png)
+For the special fonts Symbol (12) and ZapfDingbats (34), see the {doc}`/techref/encodings`
+for the character set.
 
-For the special fonts Symbol (12) and ZapfDingbats (34), see the {doc}`/techref/encodings` for the character set.
-
-When specifying fonts in GMT, you can either give the entire font name or
-just the font number listed in this table. For example, to use the Helvetica font, you can use either `Helvetica` or `0`.
+When specifying fonts in GMT, you can either give the entire font name or just the font
+number listed in this table. For example, to use the Helvetica font, you can use either
+`Helvetica` or `0`.

--- a/doc/techref/fonts.md
+++ b/doc/techref/fonts.md
@@ -1,6 +1,6 @@
 # Supported Fonts
 
-PyGMT supports the standard 35 PostScript fonts. The table below lists the 35 fonts with
+PyGMT supports the 35 standard PostScript fonts. The table below lists the 35 fonts with
 font number and the font name.
 
 | Font Number | Font Name                  | Font Number | Font Name                  |

--- a/doc/techref/fonts.md
+++ b/doc/techref/fonts.md
@@ -1,33 +1,31 @@
 # Supported Fonts
 
 PyGMT supports the 35 standard PostScript fonts. The table below lists them with their
-font numbers and font names. When specifying fonts in PyGMT, you can either give the 
-entire font name or just the font number. For example, to use the font "Helvetica", you
-can use either `"Helvetica"` or `"0"`.
-For the special fonts "Symbol" (12) and "ZapfDingbats" (34), see the {doc}`/techref/encodings`
-for the character set.
+font numbers and font names. When specifying fonts in PyGMT, you can either give the
+font name or just the font number. For example, to use the font "Helvetica", you can use
+either `"Helvetica"` or `"0"`. For the special fonts "Symbol" (**12**) and
+"ZapfDingbats" (**34**), see the {doc}`/techref/encodings` for the character set.
 The image below the table shows a visual sample for each font.
 
-| Font Number | Font Name                  | Font Number | Font Name                  |
-|-------------|----------------------------|-------------|----------------------------|
-| 0           | Helvetica                  | 17          | Bookman-Demi               |
-| 1           | Helvetica-Bold             | 18          | Bookman-DemiItalic         |
-| 2           | Helvetica-Oblique          | 19          | Bookman-Light              |
-| 3           | Helvetica-BoldOblique      | 20          | Bookman-LightItalic        |
-| 4           | Times-Roman                | 21          | Helvetica-Narrow           |
-| 5           | Times-Bold                 | 22          | Helvetica-Narrow-Bold      |
-| 6           | Times-Italic               | 23          | Helvetica-Narrow-Oblique   |
-| 7           | Times-BoldItalic           | 24          | Helvetica-Narrow-BoldOblique |
-| 8           | Courier                    | 25          | NewCenturySchlbk-Roman     |
-| 9           | Courier-Bold               | 26          | NewCenturySchlbk-Italic    |
-| 10          | Courier-Oblique            | 27          | NewCenturySchlbk-Bold      |
-| 11          | Courier-BoldOblique        | 28          | NewCenturySchlbk-BoldItalic|
-| 12          | Symbol                     | 29          | Palatino-Roman             |
-| 13          | AvantGarde-Book            | 30          | Palatino-Italic            |
-| 14          | AvantGarde-BookOblique     | 31          | Palatino-Bold              |
-| 15          | AvantGarde-Demi            | 32          | Palatino-BoldItalic        |
-| 16          | AvantGarde-DemiOblique     | 33          | ZapfChancery-MediumItalic  |
-|             |                            | 34          | ZapfDingbats               |
+| Font No. | Font Name              | Font No. | Font Name                    |
+|----------|------------------------|----------|------------------------------|
+| 0        | Helvetica              | 17       | Bookman-Demi                 |
+| 1        | Helvetica-Bold         | 18       | Bookman-DemiItalic           |
+| 2        | Helvetica-Oblique      | 19       | Bookman-Light                |
+| 3        | Helvetica-BoldOblique  | 20       | Bookman-LightItalic          |
+| 4        | Times-Roman            | 21       | Helvetica-Narrow             |
+| 5        | Times-Bold             | 22       | Helvetica-Narrow-Bold        |
+| 6        | Times-Italic           | 23       | Helvetica-Narrow-Oblique     |
+| 7        | Times-BoldItalic       | 24       | Helvetica-Narrow-BoldOblique |
+| 8        | Courier                | 25       | NewCenturySchlbk-Roman       |
+| 9        | Courier-Bold           | 26       | NewCenturySchlbk-Italic      |
+| 10       | Courier-Oblique        | 27       | NewCenturySchlbk-Bold        |
+| 11       | Courier-BoldOblique    | 28       | NewCenturySchlbk-BoldItalic  |
+| 12       | Symbol                 | 29       | Palatino-Roman               |
+| 13       | AvantGarde-Book        | 30       | Palatino-Italic              |
+| 14       | AvantGarde-BookOblique | 31       | Palatino-Bold                |
+| 15       | AvantGarde-Demi        | 32       | Palatino-BoldItalic          |
+| 16       | AvantGarde-DemiOblique | 33       | ZapfChancery-MediumItalic    |
+|          |                        | 34       | ZapfDingbats                 |
 
-![Standard PostScript Fonts](https://docs.generic-mapping-tools.org/dev/_images/GMT_App_G.png){.align-left width="80%"}
-
+![Standard PostScript Fonts](https://docs.generic-mapping-tools.org/dev/_images/GMT_App_G.png){width="80%"}

--- a/doc/techref/fonts.md
+++ b/doc/techref/fonts.md
@@ -1,7 +1,12 @@
 # Supported Fonts
 
-PyGMT supports the 35 standard PostScript fonts. The table below lists the 35 fonts with
-font number and the font name.
+PyGMT supports the 35 standard PostScript fonts. The table below lists them with their
+font numbers and font names. When specifying fonts in PyGMT, you can either give the 
+entire font name or just the font number. For example, to use the font "Helvetica", you
+can use either `"Helvetica"` or `"0"`.
+For the special fonts "Symbol" (12) and "ZapfDingbats" (34), see the {doc}`/techref/encodings`
+for the character set.
+The image below the table shows a visual sample for each font.
 
 | Font Number | Font Name                  | Font Number | Font Name                  |
 |-------------|----------------------------|-------------|----------------------------|
@@ -24,13 +29,5 @@ font number and the font name.
 | 16          | AvantGarde-DemiOblique     | 33          | ZapfChancery-MediumItalic  |
 |             |                            | 34          | ZapfDingbats               |
 
-The figure below shows a visual sample for each font.
+![Standard PostScript Fonts](https://docs.generic-mapping-tools.org/dev/_images/GMT_App_G.png){.align-left width="80%"}
 
-![Standard PostScript Fonts](https://docs.generic-mapping-tools.org/dev/_images/GMT_App_G.png){.align-center width="80%"}
-
-For the special fonts Symbol (12) and ZapfDingbats (34), see the {doc}`/techref/encodings`
-for the character set.
-
-When specifying fonts in GMT, you can either give the entire font name or just the font
-number listed in this table. For example, to use the Helvetica font, you can use either
-`Helvetica` or `0`.

--- a/doc/techref/fonts.md
+++ b/doc/techref/fonts.md
@@ -1,0 +1,15 @@
+# Supported Fonts
+
+PyGMT (and GMT) supports the standard 35 PostScript fonts.
+
+## Standard PostScript Fonts
+
+The table below lists the standard 35 PostScript fonts that are supported by GMT and PyGMT.
+The table shows the font number, the font name, and a sample of the font.
+
+![Standard PostScript Fonts](https://docs.generic-mapping-tools.org/dev/reference/postscript-fonts.html)
+
+For the special fonts Symbol (12) and ZapfDingbats (34), see the :doc:`/techref/encodings` for the character set.
+
+When specifying fonts in GMT, you can either give the entire font name or
+just the font number listed in this table. For example, to use the Helvetica font, you can use either `Helvetica` or `0`.

--- a/doc/techref/fonts.md
+++ b/doc/techref/fonts.md
@@ -6,43 +6,27 @@ PyGMT (and GMT) supports the standard 35 PostScript fonts.
 
 The table below lists the standard 35 PostScript fonts that are supported by GMT and PyGMT.
 
-| Font Number | Font Name                  |
-|-------------|----------------------------|
-| 0           | Helvetica                  |
-| 1           | Helvetica-Bold             |
-| 2           | Helvetica-Oblique          |
-| 3           | Helvetica-BoldOblique      |
-| 4           | Times-Roman                |
-| 5           | Times-Bold                 |
-| 6           | Times-Italic               |
-| 7           | Times-BoldItalic           |
-| 8           | Courier                    |
-| 9           | Courier-Bold               |
-| 10          | Courier-Oblique            |
-| 11          | Courier-BoldOblique        |
-| 12          | Symbol                     |
-| 13          | AvantGarde-Book            |
-| 14          | AvantGarde-BookOblique     |
-| 15          | AvantGarde-Demi            |
-| 16          | AvantGarde-DemiOblique     |
-| 17          | Bookman-Demi               |
-| 18          | Bookman-DemiItalic         |
-| 19          | Bookman-Light              |
-| 20          | Bookman-LightItalic        |
-| 21          | Helvetica-Narrow           |
-| 22          | Helvetica-Narrow-Bold      |
-| 23          | Helvetica-Narrow-Oblique   |
-| 24          | Helvetica-Narrow-BoldOblique |
-| 25          | NewCenturySchlbk-Roman     |
-| 26          | NewCenturySchlbk-Italic    |
-| 27          | NewCenturySchlbk-Bold      |
-| 28          | NewCenturySchlbk-BoldItalic |
-| 29          | Palatino-Roman             |
-| 30          | Palatino-Italic            |
-| 31          | Palatino-Bold              |
-| 32          | Palatino-BoldItalic        |
-| 33          | ZapfChancery-MediumItalic  |
-| 34          | ZapfDingbats               |
+| Font Number | Font Name                  | Font Number | Font Name                  |
+|-------------|----------------------------|-------------|----------------------------|
+| 0           | Helvetica                  | 17          | Bookman-Demi               |
+| 1           | Helvetica-Bold             | 18          | Bookman-DemiItalic         |
+| 2           | Helvetica-Oblique          | 19          | Bookman-Light              |
+| 3           | Helvetica-BoldOblique      | 20          | Bookman-LightItalic        |
+| 4           | Times-Roman                | 21          | Helvetica-Narrow           |
+| 5           | Times-Bold                 | 22          | Helvetica-Narrow-Bold      |
+| 6           | Times-Italic               | 23          | Helvetica-Narrow-Oblique   |
+| 7           | Times-BoldItalic           | 24          | Helvetica-Narrow-BoldOblique |
+| 8           | Courier                    | 25          | NewCenturySchlbk-Roman     |
+| 9           | Courier-Bold               | 26          | NewCenturySchlbk-Italic    |
+| 10          | Courier-Oblique            | 27          | NewCenturySchlbk-Bold      |
+| 11          | Courier-BoldOblique        | 28          | NewCenturySchlbk-BoldItalic|
+| 12          | Symbol                     | 29          | Palatino-Roman             |
+| 13          | AvantGarde-Book            | 30          | Palatino-Italic            |
+| 14          | AvantGarde-BookOblique     | 31          | Palatino-Bold              |
+| 15          | AvantGarde-Demi            | 32          | Palatino-BoldItalic        |
+| 16          | AvantGarde-DemiOblique     | 33          | ZapfChancery-MediumItalic  |
+|             |                            | 34          | ZapfDingbats               |
+
 
 The table shows the font number, the font name, and a sample of the font.
 

--- a/doc/techref/fonts.md
+++ b/doc/techref/fonts.md
@@ -32,7 +32,7 @@ The table shows the font number, the font name, and a sample of the font.
 
 ![Standard PostScript Fonts](https://docs.generic-mapping-tools.org/dev/_images/GMT_App_G.png)
 
-For the special fonts Symbol (12) and ZapfDingbats (34), see the :doc:`/techref/encodings` for the character set.
+For the special fonts Symbol (12) and ZapfDingbats (34), see the {doc}`/techref/encodings` for the character set.
 
 When specifying fonts in GMT, you can either give the entire font name or
 just the font number listed in this table. For example, to use the Helvetica font, you can use either `Helvetica` or `0`.

--- a/doc/techref/fonts.md
+++ b/doc/techref/fonts.md
@@ -28,4 +28,4 @@ The image below the table shows a visual sample for each font.
 | 16       | AvantGarde-DemiOblique | 33       | ZapfChancery-MediumItalic    |
 |          |                        | 34       | ZapfDingbats                 |
 
-![Standard PostScript Fonts](https://docs.generic-mapping-tools.org/dev/_images/GMT_App_G.png){width="80%"}
+![Standard PostScript Fonts](https://docs.generic-mapping-tools.org/dev/_images/GMT_App_G.png){width="67.5%"}

--- a/doc/techref/fonts.md
+++ b/doc/techref/fonts.md
@@ -46,7 +46,7 @@ The table below lists the standard 35 PostScript fonts that are supported by GMT
 
 The table shows the font number, the font name, and a sample of the font.
 
-![Standard PostScript Fonts](https://docs.generic-mapping-tools.org/dev/reference/postscript-fonts.html)
+![Standard PostScript Fonts](https://docs.generic-mapping-tools.org/dev/_images/GMT_App_G.png)
 
 For the special fonts Symbol (12) and ZapfDingbats (34), see the :doc:`/techref/encodings` for the character set.
 

--- a/doc/techref/fonts.md
+++ b/doc/techref/fonts.md
@@ -5,6 +5,45 @@ PyGMT (and GMT) supports the standard 35 PostScript fonts.
 ## Standard PostScript Fonts
 
 The table below lists the standard 35 PostScript fonts that are supported by GMT and PyGMT.
+
+| Font Number | Font Name                  |
+|-------------|----------------------------|
+| 0           | Helvetica                  |
+| 1           | Helvetica-Bold             |
+| 2           | Helvetica-Oblique          |
+| 3           | Helvetica-BoldOblique      |
+| 4           | Times-Roman                |
+| 5           | Times-Bold                 |
+| 6           | Times-Italic               |
+| 7           | Times-BoldItalic           |
+| 8           | Courier                    |
+| 9           | Courier-Bold               |
+| 10          | Courier-Oblique            |
+| 11          | Courier-BoldOblique        |
+| 12          | Symbol                     |
+| 13          | AvantGarde-Book            |
+| 14          | AvantGarde-BookOblique     |
+| 15          | AvantGarde-Demi            |
+| 16          | AvantGarde-DemiOblique     |
+| 17          | Bookman-Demi               |
+| 18          | Bookman-DemiItalic         |
+| 19          | Bookman-Light              |
+| 20          | Bookman-LightItalic        |
+| 21          | Helvetica-Narrow           |
+| 22          | Helvetica-Narrow-Bold      |
+| 23          | Helvetica-Narrow-Oblique   |
+| 24          | Helvetica-Narrow-BoldOblique |
+| 25          | NewCenturySchlbk-Roman     |
+| 26          | NewCenturySchlbk-Italic    |
+| 27          | NewCenturySchlbk-Bold      |
+| 28          | NewCenturySchlbk-BoldItalic |
+| 29          | Palatino-Roman             |
+| 30          | Palatino-Italic            |
+| 31          | Palatino-Bold              |
+| 32          | Palatino-BoldItalic        |
+| 33          | ZapfChancery-MediumItalic  |
+| 34          | ZapfDingbats               |
+
 The table shows the font number, the font name, and a sample of the font.
 
 ![Standard PostScript Fonts](https://docs.generic-mapping-tools.org/dev/reference/postscript-fonts.html)

--- a/doc/techref/index.md
+++ b/doc/techref/index.md
@@ -9,5 +9,6 @@ visit the {gmt-docs}`GMT Technical Reference <reference.html>`.
 :maxdepth: 1
 
 projections.md
+fonts.md
 encodings.md
 ```

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -2,20 +2,18 @@ r"""
 Text symbols
 ============
 
-The :meth:`pygmt.Figure.plot` method allows to plot text symbols. Text is
-normally placed with the :meth:`pygmt.Figure.text` method but there are times
-we wish to treat a character or even a string as a plottable symbol.
-A text symbol can be drawn by passing **l**\ *size*\ **+t**\ *string* to
-the ``style`` parameter where *size* defines the size of the text symbol
-(note: the size is only approximate; no individual scaling is done for
-different characters) and *string* can be a letter or a text string
-(less than 256 characters). Optionally, you can append
-**+f**\ *font,outlinecolor* to select a particular font [Default is
-:gmt-term:`FONT_ANNOT_PRIMARY`] and outline color [Default is black] as well
-as **+j**\ *justify* to change the justification [Default is CM]. For all supported
-fonts see :doc:`/techref/fonts`. The fill color of the text symbols can be set with
-the ``fill`` parameter, and the outline width can be customized with the ``pen``
-parameter.
+The :meth:`pygmt.Figure.plot` method allows to plot text symbols. Text is normally
+placed with the :meth:`pygmt.Figure.text` method but there are times we wish to treat a
+character or even a string as a plottable symbol. A text symbol can be drawn by passing
+**l**\ *size*\ **+t**\ *string* to the ``style`` parameter where *size* defines the size
+of the text symbol (note: the size is only approximate; no individual scaling is done
+for different characters) and *string* can be a letter or a text string (less than 256
+characters). Optionally, you can append **+f**\ *font,outlinecolor* to select a
+particular font [Default is :gmt-term:`FONT_ANNOT_PRIMARY`] and outline color [Default
+is black] as well as **+j**\ *justify* to change the justification [Default is CM]. For
+all supported fonts see :doc:`/techref/fonts`. The fill color of the text symbols can be
+set with the ``fill`` parameter, and the outline width can be customized with the
+``pen`` parameter.
 """
 
 # %%

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -12,9 +12,10 @@ different characters) and *string* can be a letter or a text string
 (less than 256 characters). Optionally, you can append
 **+f**\ *font,outlinecolor* to select a particular font [Default is
 :gmt-term:`FONT_ANNOT_PRIMARY`] and outline color [Default is black] as well
-as **+j**\ *justify* to change the justification [Default is CM]. The fill
-color of the text symbols can be set with the ``fill`` parameter, and the
-outline width can be customized with the ``pen`` parameter.
+as **+j**\ *justify* to change the justification [Default is CM]. For all supported
+fonts see :doc:`/techref/fonts`. The fill color of the text symbols can be set with
+the ``fill`` parameter, and the outline width can be customized with the ``pen``
+parameter.
 """
 
 # %%

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -15,8 +15,6 @@ different characters) and *string* can be a letter or a text string
 as **+j**\ *justify* to change the justification [Default is CM]. The fill
 color of the text symbols can be set with the ``fill`` parameter, and the
 outline width can be customized with the ``pen`` parameter.
-For all supported octal codes and fonts see :doc:`/techref/encodings` and
-:doc:`/techref/fonts`.
 """
 
 # %%

--- a/examples/gallery/symbols/text_symbols.py
+++ b/examples/gallery/symbols/text_symbols.py
@@ -15,9 +15,8 @@ different characters) and *string* can be a letter or a text string
 as **+j**\ *justify* to change the justification [Default is CM]. The fill
 color of the text symbols can be set with the ``fill`` parameter, and the
 outline width can be customized with the ``pen`` parameter.
-For all supported octal codes and fonts see the GMT Technical Reference
-:gmt-docs:`reference/octal-codes.html` and
-:gmt-docs:`reference/postscript-fonts.html`.
+For all supported octal codes and fonts see :doc:`/techref/encodings` and
+:doc:`/techref/fonts`.
 """
 
 # %%

--- a/examples/tutorials/basics/text.py
+++ b/examples/tutorials/basics/text.py
@@ -31,9 +31,9 @@ fig.show()
 # There are several optional parameters to adjust the text label:
 #
 # * ``font``: Sets the size, family/weight, and color of the font for the text.
-#   A list of all recognized fonts can be found at
-#   :gmt-docs:`PostScript Fonts Used by GMT <reference/postscript-fonts.html>`,
-#   including details of how to use non-default fonts.
+#   A list of all recognized fonts can be found at :doc:`/techref/fonts`.
+#   For details of how to use non-default fonts, refer to
+#   :gmt-docs:`PostScript Fonts Used by GMT <reference/postscript-fonts.html>`.
 # * ``angle``: Specifies the rotation of the text. It is measured counter-clockwise
 #   from the horizontal in degrees.
 # * ``justify``: Defines the anchor point of the bounding box for the text. It is


### PR DESCRIPTION
**Description of proposed changes**

Add the table of standard 35 postscript fonts to the Technical Reference, so that we don't have to visit the GMT documentation.

**Preview**:

- https://pygmt-dev--3378.org.readthedocs.build/en/3378/techref/fonts.html
- https://pygmt-dev--3378.org.readthedocs.build/en/3378/gallery/symbols/text_symbols.html
- https://pygmt-dev--3378.org.readthedocs.build/en/3378/tutorials/basics/text.html

xref: #2834