### PR TITLE
Determine the minimum required versions of dependencies from package metadata for docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,18 +3,25 @@ Sphinx documentation configuration file.
 """
 
 import datetime
-from importlib.metadata import metadata
+import importlib
 
-# ruff: isort: off
-from sphinx_gallery.sorting import ExplicitOrder, ExampleTitleSortKey
-from pygmt.clib import required_gmt_version
+from packaging.requirements import Requirement
 from pygmt import __commit__, __version__
+from pygmt.clib import required_gmt_version
 from pygmt.sphinx_gallery import PyGMTScraper
+from sphinx_gallery.sorting import ExampleTitleSortKey, ExplicitOrder
 
-# ruff: isort: on
-
-requires_python = metadata("pygmt")["Requires-Python"]
-requires_gmt = f">={required_gmt_version}"
+# Dictionary for dependency name and minimum required version.
+requirements = {
+    Requirement(requirement).name: str(Requirement(requirement).specifier)
+    for requirement in importlib.metadata.requires("pygmt")
+}
+requirements.update(
+    {
+        "python": importlib.metadata.metadata("pygmt")["Requires-Python"],
+        "gmt": f">={required_gmt_version}",
+    }
+)
 
 extensions = [
     "myst_parser",
@@ -51,8 +58,7 @@ myst_enable_extensions = [
 ]
 # These enable substitutions using {{ key }} in the Markdown files
 myst_substitutions = {
-    "requires_python": requires_python,
-    "requires_gmt": requires_gmt,
+    "requires": requirements,
 }
 
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -59,7 +59,7 @@ development version.
 
 ## Which Python?
 
-PyGMT is tested to run on Python {{ requires_python }}.
+PyGMT is tested to run on Python {{ requires.python }}.
 
 We recommend using the [Miniforge](https://github.com/conda-forge/miniforge#miniforge3)
 Python distribution to ensure you have all dependencies installed and
@@ -69,7 +69,7 @@ your computer and doesn't interfere with any other Python installations on your 
 
 ## Which GMT?
 
-PyGMT requires Generic Mapping Tools (GMT) {{ requires_gmt }} since there are many
+PyGMT requires Generic Mapping Tools (GMT) {{ requires.gmt }} since there are many
 changes being made to GMT itself in response to the development of PyGMT.
 
 Compiled conda packages of GMT for Linux, macOS and Windows are provided through

--- a/doc/minversions.md
+++ b/doc/minversions.md
@@ -12,7 +12,7 @@ after their initial release.
 
 | PyGMT Version | GMT | Python | NumPy | Pandas | Xarray |
 |---|---|---|---|---|---|
-| [Dev][]* [[Docs][Docs Dev]] | >=6.3.0 | >=3.10 | >=1.24 | >=1.5 | >=2022.09 |
+| [Dev][]* [[Docs][Docs Dev]] | {{ requires.gmt }} | {{ requires.python }} | {{ requires.numpy }} | {{ requires.pandas }} | {{ requires.xarray }} |
 | [v0.12.0][] [[Docs][Docs v0.12.0]] | >=6.3.0 | >=3.10 | >=1.23 | >=1.5 | >=2022.06 |
 | [v0.11.0][] [[Docs][Docs v0.11.0]] | >=6.3.0 | >=3.9 | >=1.23 |  |  |
 | [v0.10.0][] [[Docs][Docs v0.10.0]] | >=6.3.0 | >=3.9 | >=1.22 |  |  |


### PR DESCRIPTION
**Description of proposed changes**

It's possible to determine the minimum required versions from the package metadata using codes like below. So that we don't have to update the `doc/minversions.md` file everytime we bump the minimum required versions (e.g., #3372). 
```python
>>> import importlib
>>> from packaging.requirements import Requirement
>>> requirements = {
...:     Requirement(requirement).name: str(Requirement(requirement).specifier)
...:     for requirement in importlib.metadata.requires("pygmt")
...: }
...: requirements.update(
...:     {
...:         "python": importlib.metadata.metadata("pygmt")["Requires-Python"],
...:         #"gmt": f">={required_gmt_version}",
...:     }
...: )

>> requirements
{'numpy': '>=1.24',
 'pandas': '>=1.5',
 'xarray': '>=2022.09',
 'netCDF4': '',
 'packaging': '',
 'contextily': '',
 'geopandas': '',
 'IPython': '',
 'rioxarray': '',
 'python': '>=3.10'}
```

This PR uses the same codes to determine the minimum required versions and store in the `requirements` dictionary, which can be used in the documentation using syntax like ``{{ requires.python }}``.

**Preview**:

- https://pygmt-dev--3380.org.readthedocs.build/en/3380/minversions.html
- https://pygmt-dev--3380.org.readthedocs.build/en/3380/install.html#which-python