### PR TITLE
doc: Simplify the "minimum required versions" page using MyST customized URL schemes

### DIFF
--- a/doc/minversions.md
+++ b/doc/minversions.md
@@ -1,7 +1,7 @@
 ---
 myst:
   # Customized URI schemes that are converted to external links
-  # Reference:
+  # References:
   # - https://myst-parser.readthedocs.io/en/latest/syntax/cross-referencing.html#customising-external-url-resolution
   # - https://myst-parser.readthedocs.io/en/latest/configuration.html#frontmatter-local-configuration
   url_schemes:

--- a/doc/minversions.md
+++ b/doc/minversions.md
@@ -1,3 +1,20 @@
+---
+myst:
+  # Customized URI schemes that are converted to external links
+  # Reference:
+  # - https://myst-parser.readthedocs.io/en/latest/syntax/cross-referencing.html#customising-external-url-resolution
+  # - https://myst-parser.readthedocs.io/en/latest/configuration.html#frontmatter-local-configuration
+  url_schemes:
+    http: null
+    https: null
+    tag:
+      url: "https://github.com/GenericMappingTools/pygmt/releases/tag/{{path}}"
+      title: "{{path}}"
+    doc:
+      url: "https://www.pygmt.org/{{path}}"
+      title: "Docs"
+---
+
 # Minimum Supported Versions
 
 PyGMT has adopted [SPEC 0](https://scientific-python.org/specs/spec-0000/) alongside the
@@ -12,64 +29,26 @@ after their initial release.
 
 | PyGMT Version | GMT | Python | NumPy | Pandas | Xarray |
 |---|---|---|---|---|---|
-| [Dev][]* [[Docs][Docs Dev]] | {{ requires.gmt }} | {{ requires.python }} | {{ requires.numpy }} | {{ requires.pandas }} | {{ requires.xarray }} |
-| [v0.12.0][] [[Docs][Docs v0.12.0]] | >=6.3.0 | >=3.10 | >=1.23 | >=1.5 | >=2022.06 |
-| [v0.11.0][] [[Docs][Docs v0.11.0]] | >=6.3.0 | >=3.9 | >=1.23 |  |  |
-| [v0.10.0][] [[Docs][Docs v0.10.0]] | >=6.3.0 | >=3.9 | >=1.22 |  |  |
-| [v0.9.0][] [[Docs][Docs v0.9.0]] | >=6.3.0 | >=3.8 | >=1.21 |  |  |
-| [v0.8.0][] [[Docs][Docs v0.8.0]] | >=6.3.0 | >=3.8 | >=1.20 |  |  |
-| [v0.7.0][] [[Docs][Docs v0.7.0]] | >=6.3.0 | >=3.8 | >=1.20 |  |  |
-| [v0.6.1][] [[Docs][Docs v0.6.1]] | >=6.3.0 | >=3.8 | >=1.19 |  |  |
-| [v0.6.0][] [[Docs][Docs v0.6.0]] | >=6.3.0 | >=3.8 | >=1.19 |  |  |
-| [v0.5.0][] [[Docs][Docs v0.5.0]] | >=6.2.0 | >=3.7 | >=1.18 |  |  |
-| [v0.4.1][] [[Docs][Docs v0.4.1]] | >=6.2.0 | >=3.7 | >=1.17 |  |  |
-| [v0.4.0][] [[Docs][Docs v0.4.0]] | >=6.2.0 | >=3.7 | >=1.17 |  |  |
-| [v0.3.1][] [[Docs][Docs v0.3.1]] | >=6.1.1 | >=3.7 |  |  |  |
-| [v0.3.0][] [[Docs][Docs v0.3.0]] | >=6.1.1 | >=3.7 |  |  |  |
-| [v0.2.1][] [[Docs][Docs v0.2.1]] | >=6.1.1 | >=3.6 |  |  |  |
-| [v0.2.0][] [[Docs][Docs v0.2.0]] | >=6.1.1 | 3.6 - 3.8 |  |  |  |
-| [v0.1.2][] [[Docs][Docs v0.1.2]] | >=6.0.0 | 3.6 - 3.8 |  |  |  |
-| [v0.1.1][] [[Docs][Docs v0.1.1]] | >=6.0.0 | 3.6 - 3.8 |  |  |  |
-| [v0.1.0][] [[Docs][Docs v0.1.0]] | >=6.0.0 | 3.6 - 3.8 |  |  |  |
+| [Dev][]* [<doc:dev>] | {{ requires.gmt }} | {{ requires.python }} | {{ requires.numpy }} | {{ requires.pandas }} | {{ requires.xarray }} |
+| <tag:v0.12.0> [<doc:v0.12.0>] | >=6.3.0 | >=3.10 | >=1.23 | >=1.5 | >=2022.06 |
+| <tag:v0.11.0> [<doc:v0.11.0>] | >=6.3.0 | >=3.9 | >=1.23 |  |  |
+| <tag:v0.10.0> [<doc:v0.10.0>] | >=6.3.0 | >=3.9 | >=1.22 |  |  |
+| <tag:v0.9.0> [<doc:v0.9.0>] | >=6.3.0 | >=3.8 | >=1.21 |  |  |
+| <tag:v0.8.0> [<doc:v0.8.0>] | >=6.3.0 | >=3.8 | >=1.20 |  |  |
+| <tag:v0.7.0> [<doc:v0.7.0>] | >=6.3.0 | >=3.8 | >=1.20 |  |  |
+| <tag:v0.6.1> [<doc:v0.6.1>] | >=6.3.0 | >=3.8 | >=1.19 |  |  |
+| <tag:v0.6.0> [<doc:v0.6.0>] | >=6.3.0 | >=3.8 | >=1.19 |  |  |
+| <tag:v0.5.0> [<doc:v0.5.0>] | >=6.2.0 | >=3.7 | >=1.18 |  |  |
+| <tag:v0.4.1> [<doc:v0.4.1>] | >=6.2.0 | >=3.7 | >=1.17 |  |  |
+| <tag:v0.4.0> [<doc:v0.4.0>] | >=6.2.0 | >=3.7 | >=1.17 |  |  |
+| <tag:v0.3.1> [<doc:v0.3.1>] | >=6.1.1 | >=3.7 |  |  |  |
+| <tag:v0.3.0> [<doc:v0.3.0>] | >=6.1.1 | >=3.7 |  |  |  |
+| <tag:v0.2.1> [<doc:v0.2.1>] | >=6.1.1 | >=3.6 |  |  |  |
+| <tag:v0.2.0> [<doc:v0.2.0>] | >=6.1.1 | 3.6 - 3.8 |  |  |  |
+| <tag:v0.1.2> [<doc:v0.1.2>] | >=6.0.0 | 3.6 - 3.8 |  |  |  |
+| <tag:v0.1.1> [<doc:v0.1.1>] | >=6.0.0 | 3.6 - 3.8 |  |  |  |
+| <tag:v0.1.0> [<doc:v0.1.0>] | >=6.0.0 | 3.6 - 3.8 |  |  |  |
 
 *Dev reflects the main branch and is for the upcoming release.
 
 [Dev]: https://github.com/GenericMappingTools/pygmt/milestones
-[v0.12.0]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.12.0
-[v0.11.0]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.11.0
-[v0.10.0]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.10.0
-[v0.9.0]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.9.0
-[v0.8.0]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.8.0
-[v0.7.0]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.7.0
-[v0.6.1]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.6.1
-[v0.6.0]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.6.0
-[v0.5.0]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.5.0
-[v0.4.1]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.4.1
-[v0.4.0]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.4.0
-[v0.3.1]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.3.1
-[v0.3.0]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.3.0
-[v0.2.1]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.2.1
-[v0.2.0]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.2.0
-[v0.1.2]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.1.2
-[v0.1.1]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.1.1
-[v0.1.0]: https://github.com/GenericMappingTools/pygmt/releases/tag/v0.1.0
-
-[Docs Dev]: https://www.pygmt.org/dev
-[Docs v0.12.0]: https://www.pygmt.org/v0.12.0
-[Docs v0.11.0]: https://www.pygmt.org/v0.11.0
-[Docs v0.10.0]: https://www.pygmt.org/v0.10.0
-[Docs v0.9.0]: https://www.pygmt.org/v0.9.0
-[Docs v0.8.0]: https://www.pygmt.org/v0.8.0
-[Docs v0.7.0]: https://www.pygmt.org/v0.7.0
-[Docs v0.6.1]: https://www.pygmt.org/v0.6.1
-[Docs v0.6.0]: https://www.pygmt.org/v0.6.0
-[Docs v0.5.0]: https://www.pygmt.org/v0.5.0
-[Docs v0.4.1]: https://www.pygmt.org/v0.4.1
-[Docs v0.4.0]: https://www.pygmt.org/v0.4.0
-[Docs v0.3.1]: https://www.pygmt.org/v0.3.1
-[Docs v0.3.0]: https://www.pygmt.org/v0.3.0
-[Docs v0.2.1]: https://www.pygmt.org/v0.2.1
-[Docs v0.2.0]: https://www.pygmt.org/v0.2.0
-[Docs v0.1.2]: https://www.pygmt.org/v0.1.2
-[Docs v0.1.1]: https://www.pygmt.org/v0.1.1
-[Docs v0.1.0]: https://www.pygmt.org/v0.1.0


### PR DESCRIPTION
**Description of proposed changes**

MyST supports customized URLs.

References:

- https://myst-parser.readthedocs.io/en/latest/syntax/cross-referencing.html#customising-external-url-resolution
- https://myst-parser.readthedocs.io/en/latest/configuration.html#frontmatter-local-configuration

**Preview**: https://pygmt-dev--3383.org.readthedocs.build/en/3383/minversions.html

This page doesn't change but the markdown file is much shorter!
