### PR TITLE
GMT_IMAGE: Remove 'nan_value' from the doctest since it depends on GMT versions

### DIFF
--- a/pygmt/datatypes/image.py
+++ b/pygmt/datatypes/image.py
@@ -18,7 +18,7 @@ class _GMT_IMAGE(ctp.Structure):  # noqa: N801
     >>> from pygmt.clib import Session
     >>> with Session() as lib:
     ...     with lib.virtualfile_out(kind="image") as voutimg:
-    ...         lib.call_module("read", ["@earth_day_01d", voutimg, "-Ti"])
+    ...         lib.call_module("read", ["@earth_day_01d_p", voutimg, "-Ti"])
     ...         # Read the image from the virtual file
     ...         image = lib.read_virtualfile(vfname=voutimg, kind="image").contents
     ...         # The image header
@@ -34,7 +34,7 @@ class _GMT_IMAGE(ctp.Structure):  # noqa: N801
     ...         print(header.nm, header.size, header.complex_mode)
     ...         print(header.type, header.n_bands, header.mx, header.my)
     ...         print(header.pad[:])
-    ...         print(header.mem_layout, header.nan_value, header.xy_off)
+    ...         print(header.mem_layout, header.xy_off)
     ...         # Image-specific attributes.
     ...         print(image.type, image.n_indexed_colors)
     ...         # The x and y coordinates
@@ -58,7 +58,7 @@ class _GMT_IMAGE(ctp.Structure):  # noqa: N801
     64800 66976 0
     0 3 364 184
     [2, 2, 2, 2]
-    b'BRPa' 0.0 0.5
+    b'BRPa' 0.5
     1 0
     >>> x
     [-179.5, -178.5, ..., 178.5, 179.5]


### PR DESCRIPTION
**Description of proposed changes**

In the "GMT Legacy Tests" workflow, we have one failure:

```
=================================== FAILURES ===================================
__________________ [doctest] pygmt.datatypes.image._GMT_IMAGE __________________
012 
013     GMT image data structure.
014 
015     Examples
016     --------
017     >>> import numpy as np
018     >>> from pygmt.clib import Session
019     >>> with Session() as lib:
Differences (unified diff with -expected +actual):
    @@ -9,4 +9,4 @@
     0 3 364 184
     [2, 2, 2, 2]
    -b'BRPa' 0.0 0.5
    +b'BRPa' nan 0.5
     1 0

/home/runner/work/pygmt/pygmt/pygmt/datatypes/image.py:19: DocTestFailure
----------------------------- Captured stderr call -----------------------------
Warning: sion [WARNING]: Remote dataset given to a data processing module but no registration was specified - default to gridline registration (if available)
```

The `image.nan_value` is 0.0 in GMT 6.5 and is `nan` in old versions. It's likely related to upstream changes in https://github.com/GenericMappingTools/gmt/pull/7827, but I guess we don't care.

This PR remove `header.nan_value` from the doctest so it passes for GMT 6.3-6.5. I also change `@earth_day_01d` to `@earth_day_01d_p` to silent the warning.

Triggered CI runs at: https://github.com/GenericMappingTools/pygmt/actions/runs/10287846021