### PR TITLE
Rename test_init.py to test_show_versions.py

### DIFF
--- a/pygmt/tests/test_show_versions.py
+++ b/pygmt/tests/test_show_versions.py
@@ -1,5 +1,5 @@
 """
-Test functions in __init__.
+Test the pygmt.show_versions function.
 """
 
 import io


### PR DESCRIPTION
**Description of proposed changes**

`show_versions()` was moved to a separate file in #3277. We should also move the test.

This PR rename `pygmt/tests/test_init.py` to `pygmt/tests/test_show_versions.py` and fix the docstring.