### PR TITLE
Update minimum value on GEBCO grid

### DIFF
--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -82,7 +82,7 @@ def test_earth_relief_01d_with_region_gebco():
     assert data.gmt.registration == 0
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -5136.0, atol=1.0)
+    npt.assert_allclose(data.min(), -5118.0, atol=1.0)
     npt.assert_allclose(data.max(), 681.0, atol=1.0)
 
 


### PR DESCRIPTION
**Description of proposed changes**

GEBCO grid was updated to 2024 version at https://github.com/GenericMappingTools/gmtserver-admin/pull/265, and has a new minimum value of -5118.0

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Fixes the following CI error (e.g. at https://github.com/GenericMappingTools/pygmt/actions/runs/10361853098/job/28682875240#step:8:1436):

```python-traceback
=================================== FAILURES ===================================
___________________ test_earth_relief_01d_with_region_gebco ____________________
[gw1] linux -- Python 3.10.14 /home/runner/micromamba/envs/pygmt/bin/python3.10

    def test_earth_relief_01d_with_region_gebco():
        """
        Test loading low-resolution earth relief with 'region' with GEBCO data.
        """
        data = load_earth_relief(
            resolution="01d",
            region=[-10, 10, -5, 5],
            data_source="gebco",
        )
        assert data.shape == (11, 21)
        assert data.gmt.registration == 0
        npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
        npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
>       npt.assert_allclose(data.min(), -5136.0, atol=1.0)

../pygmt/tests/test_datasets_earth_relief.py:85: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

args = (<function assert_allclose.<locals>.compare at 0x7f444b3df0a0>, array(-5118.), array(-5136.))
kwds = {'equal_nan': True, 'err_msg': '', 'header': 'Not equal to tolerance rtol=1e-07, atol=1', 'verbose': True}

    @wraps(func)
    def inner(*args, **kwds):
        with self._recreate_cm():
>           return func(*args, **kwds)
E           AssertionError: 
E           Not equal to tolerance rtol=1e-07, atol=1
E           
E           Mismatched elements: 1 / 1 (100%)
E           Max absolute difference: 18.
E           Max relative difference: 0.00350467
E            x: array(-5118.)
E            y: array(-5136.)

../../../../micromamba/envs/pygmt/lib/python3.10/contextlib.py:79: AssertionError
```

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
