### PR TITLE
pygmt.set_display: Fix the bug that `method=None` doesn't reset to the default display method

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -48,8 +48,8 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     - ``"notebook"``: Inline PNG preview in the current notebook
     - ``"none"``: Disable image preview
 
-    The default display method is ``"notebook"`` in the Jupyter notebook environment, and
-    ``"external"`` in other cases.
+    The default display method is ``"notebook"`` in the Jupyter notebook environment,
+    and ``"external"`` in other cases.
 
     Setting environment variable **PYGMT_USE_EXTERNAL_DISPLAY** to ``"false"`` can
     disable image preview. It's useful when running the tests and building the
@@ -60,12 +60,12 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     method
         The default display method.
     """
-    if os.environ.get("PYGMT_USE_EXTERNAL_DISPLAY", "true").lower() == "false":
-        return "none"
     if _HAS_IPYTHON:
         get_ipython = IPython.get_ipython()
         if get_ipython and "IPKernelApp" in get_ipython.config:
             return "notebook"
+    if os.environ.get("PYGMT_USE_EXTERNAL_DISPLAY", "true").lower() == "false":
+        return "none"
     return "external"
 
 

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -27,14 +27,6 @@ from pygmt.helpers import (
     use_alias,
 )
 
-# A registry of all figures that have had "show" called in this session.
-# This is needed for the sphinx-gallery scraper in pygmt/sphinx_gallery.py
-SHOWED_FIGURES = []
-# Configurations for figure display.
-SHOW_CONFIG = {
-    "method": None,  # The image preview display method.
-}
-
 
 def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     """
@@ -67,6 +59,15 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     if os.environ.get("PYGMT_USE_EXTERNAL_DISPLAY", "true").lower() == "false":
         return "none"
     return "external"
+
+
+# A registry of all figures that have had "show" called in this session.
+# This is needed for the sphinx-gallery scraper in pygmt/sphinx_gallery.py
+SHOWED_FIGURES = []
+# Configurations for figure display.
+SHOW_CONFIG = {
+    "method": _get_default_display_method(),  # The image preview display method.
+}
 
 
 class Figure:
@@ -463,8 +464,6 @@ class Figure:
 
         # Set the display method
         if method is None:
-            if SHOW_CONFIG["method"] is None:
-                SHOW_CONFIG["method"] = _get_default_display_method()
             method = SHOW_CONFIG["method"]
 
         if method not in {"external", "notebook", "none"}:

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -32,7 +32,7 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     """
     Get the default method to display preview images.
 
-    The function checks the current environment and determine the most suitable method
+    The function checks the current environment and determines the most suitable method
     to display preview images when calling :meth:`pygmt.Figure.show`. Valid display
     methods are:
 
@@ -44,8 +44,8 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     and ``"external"`` in other cases.
 
     Setting environment variable **PYGMT_USE_EXTERNAL_DISPLAY** to ``"false"`` can
-    disable image preview. It's useful when running the tests and building the
-    documentation to avoid popping up windows.
+    disable image preview in external viewers. It's useful when running the tests and
+    building the documentation to avoid popping up windows.
 
     Returns
     -------

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -48,7 +48,7 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     - ``"notebook"``: Inline PNG preview in the current notebook
     - ``"none"``: Disable image preview
 
-    The default display method is ``"notebook"`` in Jupyter notebook environment, and
+    The default display method is ``"notebook"`` in the Jupyter notebook environment, and
     ``"external"`` in other cases.
 
     Setting environment variable **PYGMT_USE_EXTERNAL_DISPLAY** to ``"false"`` can

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -562,22 +562,20 @@ class Figure:
     )
 
 
-def set_display(method=None):
+def set_display(method: Literal["external", "notebook", "none", None] = None):
     """
     Set the display method when calling :meth:`pygmt.Figure.show`.
 
     Parameters
     ----------
-    method : str or None
+    method
         The method to display an image preview. Choose from:
 
         - ``"external"``: External PDF preview using the default PDF viewer
         - ``"notebook"``: Inline PNG preview in the current notebook
         - ``"none"``: Disable image preview
-        - ``None``: Reset to the default display method
-
-        The default display method is ``"external"`` in Python consoles or
-        ``"notebook"`` in Jupyter notebooks.
+        - ``None``: Reset to the default display method, which is either ``"external"``
+          in Python consoles or ``"notebook"`` in Jupyter notebooks.
 
     Examples
     --------
@@ -600,10 +598,13 @@ def set_display(method=None):
     >>> pygmt.set_display(method=None)
     >>> fig.show()  # again, will show a PNG image in the current notebook
     """
-    if method in {"notebook", "external", "none"}:
-        SHOW_CONFIG["method"] = method
-    elif method is not None:
-        raise GMTInvalidInput(
-            f"Invalid display mode '{method}', "
-            "should be either 'notebook', 'external', 'none' or None."
-        )
+    match method:
+        case "external" | "notebook" | "none":
+            SHOW_CONFIG["method"] = method  # type: ignore[assignment]
+        case None:
+            SHOW_CONFIG["method"] = _get_default_display_method()  # type: ignore[assignment]
+        case _:
+            raise GMTInvalidInput(
+                f"Invalid display method '{method}'. Valid values are 'external',"
+                "'notebook', 'none' or None."
+            )

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -52,12 +52,13 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     method
         The default display method.
     """
-    if _HAS_IPYTHON:
-        get_ipython = IPython.get_ipython()
-        if get_ipython and "IPKernelApp" in get_ipython.config:
-            return "notebook"
+    # Check if an IPython kernel is running.
+    if _HAS_IPYTHON and (ipy := IPython.get_ipython()) and "IPKernelApp" in ipy.config:
+        return "notebook"
+    # Check if the environment variable PYGMT_USE_EXTERNAL_DISPLAY is set to "false".
     if os.environ.get("PYGMT_USE_EXTERNAL_DISPLAY", "true").lower() == "false":
         return "none"
+    # Fallback to using the external viewer.
     return "external"
 
 

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -11,7 +11,7 @@ import numpy.testing as npt
 import pytest
 from pygmt import Figure, set_display
 from pygmt.exceptions import GMTError, GMTInvalidInput
-from pygmt.figure import _get_default_display_method
+from pygmt.figure import SHOW_CONFIG, _get_default_display_method
 from pygmt.helpers import GMTTempFile
 
 try:
@@ -373,12 +373,28 @@ def test_figure_display_external():
     fig.show(method="external")
 
 
-def test_figure_set_display_invalid():
+class TestSetDisplay:
     """
-    Test to check if an error is raised when an invalid method is passed to set_display.
+    Test the pygmt.set_display method.
     """
-    with pytest.raises(GMTInvalidInput):
-        set_display(method="invalid")
+
+    def test_set_display(self):
+        """
+        Test pygmt.set_display.
+        """
+        current_method = SHOW_CONFIG["method"]
+        for method in ("notebook", "external", "none"):
+            set_display(method=method)
+            assert SHOW_CONFIG["method"] == method
+        set_display(method=None)
+        assert SHOW_CONFIG["method"] == current_method
+
+    def test_invalid_method(self):
+        """
+        Test if an error is raised when an invalid method is passed.
+        """
+        with pytest.raises(GMTInvalidInput):
+            set_display(method="invalid")
 
 
 def test_figure_unsupported_xshift_yshift():

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -402,10 +402,11 @@ class TestGetDefaultDisplayMethod:
     Test the _get_default_display_method function.
     """
 
-    def test_default_display_method(self):
+    def test_default_display_method(self, monkeypatch):
         """
         The default display method is "external" as tests are not run in IPython.
         """
+        monkeypatch.setenv("PYGMT_USE_EXTERNAL_DISPLAY", "true")
         assert _get_default_display_method() == "external"
 
     def test_disable_external_display(self, monkeypatch):
@@ -415,6 +416,7 @@ class TestGetDefaultDisplayMethod:
         monkeypatch.setenv("PYGMT_USE_EXTERNAL_DISPLAY", "false")
         assert _get_default_display_method() == "none"
 
+    @pytest.mark.skipif(not _HAS_IPYTHON, reason="Run when IPython is installed")
     def test_notebook_display(self, monkeypatch):
         """
         The default display method is "notebook" when IPython instance is available.

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -430,9 +430,11 @@ class TestGetDefaultDisplayMethod:
             def __init__(self):
                 self.config = {"IPKernelApp": True}
 
+        # Mock IPython.get_ipython() to return a MockIPython instance.
         mock_ipython = MockIPython()
-
         monkeypatch.setattr(IPython, "get_ipython", lambda: mock_ipython)
+
+        # Default display method should be "notebook" when an IPython kernel is running.
         assert _get_default_display_method() == "notebook"
 
         # PYGMT_USE_EXTERNAL_DISPLAY should not affect notebook display.

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -404,14 +404,14 @@ class TestGetDefaultDisplayMethod:
 
     def test_default_display_method(self, monkeypatch):
         """
-        The default display method is "external" as tests are not run in IPython.
+        Default display method is "external" if PYGMT_USE_EXTERNAL_DISPLAY is undefined.
         """
-        monkeypatch.setenv("PYGMT_USE_EXTERNAL_DISPLAY", "true")
+        monkeypatch.delenv("PYGMT_USE_EXTERNAL_DISPLAY", raising=False)
         assert _get_default_display_method() == "external"
 
     def test_disable_external_display(self, monkeypatch):
         """
-        Set PYGMT_USE_EXTERNAL_DISPLAY to "false" should disable external display.
+        Setting PYGMT_USE_EXTERNAL_DISPLAY to "false" should disable external display.
         """
         monkeypatch.setenv("PYGMT_USE_EXTERNAL_DISPLAY", "false")
         assert _get_default_display_method() == "none"
@@ -419,7 +419,7 @@ class TestGetDefaultDisplayMethod:
     @pytest.mark.skipif(not _HAS_IPYTHON, reason="Run when IPython is installed")
     def test_notebook_display(self, monkeypatch):
         """
-        The default display method is "notebook" when IPython instance is available.
+        Default display method is "notebook" when an IPython kernel is running.
         """
 
         class MockIPython:

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -380,14 +380,17 @@ class TestSetDisplay:
 
     def test_set_display(self):
         """
-        Test pygmt.set_display.
+        Test if pygmt.set_display updates the SHOW_CONFIG variable correctly.
         """
-        current_method = SHOW_CONFIG["method"]
+        default_method = SHOW_CONFIG["method"]  # Current default method
+
         for method in ("notebook", "external", "none"):
             set_display(method=method)
             assert SHOW_CONFIG["method"] == method
+
+        # Setting method to None should revert it to the default method.
         set_display(method=None)
-        assert SHOW_CONFIG["method"] == current_method
+        assert SHOW_CONFIG["method"] == default_method
 
     def test_invalid_method(self):
         """


### PR DESCRIPTION
**Description of proposed changes**

`pygmt.set_display(method=None)` should revert the display method to the default value, but it doens't work. Here is a minimal example to reproduce the issue:
```python
In [1]: import pygmt
In [2]: fig = pygmt.Figure()
In [3]: fig.basemap(region=[0, 10, 0, 10], projection="X4c/4c", frame=True)
In [4]: fig.show()  # Display the image in an external viewer
In [5]: pygmt.set_display(method="none")  # Disable image preview 
In [6]: fig.show()  # Image is not displayed
In [7]: pygmt.set_display(method=None)   # Should revert to the default display method
In [8]: fig.show()  # Image is not displayed. WRONG!
```
In the last `fig.show()` call, the image should be displayed, but it doesn't. It's because `method=None` is ignored in `pygmt.set_display`. 

This PR fixes the bug and does some refactorings.

- 24092848061522523847d8cce1234cf091e07586: Add the `_get_default_display_method` function so that the same logic of codes can be called when `method=None` is used.
- 6bd742e6aa2c0bb48e2b7b9adaa056cff06d96d2: Refactor `set_display` to fix the bug.

Ideally, we should add a test to check if `SHOW_CONFIG["method"]` matches the value in `pygmt.set_display(method="XXX")`. However, `SHOW_CONFIG` is a global variable, changing its value will affect other tests. So, no test is added.