### PR TITLE
POC + WIP: Track current PyGMT figure to avoid calling the `figure` module repeatly

### DIFF
--- a/pygmt/_state.py
+++ b/pygmt/_state.py
@@ -1,0 +1,9 @@
+"""
+Private dictionary to keep tracking of current PyGMT state.
+
+The feature is only meant for internal use by PyGMT and is experimental!
+"""
+
+_STATE = {
+    "current_figure": None,
+}

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -7,6 +7,8 @@ import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from pygmt._state import _STATE
+
 try:
     import IPython
 
@@ -100,15 +102,22 @@ class Figure:
 
         All plotting commands run afterward will append to this figure.
 
-        Unlike the command-line version (``gmt figure``), this method does not
-        trigger the generation of a figure file. An explicit call to
-        :meth:`pygmt.Figure.savefig` or :meth:`pygmt.Figure.psconvert` must be
-        made in order to get a file.
+        Unlike the command-line version (``gmt figure``), this method does not trigger
+        the generation of a figure file. An explicit call to
+        :meth:`pygmt.Figure.savefig` or :meth:`pygmt.Figure.psconvert` must be made in
+        order to get a file.
         """
-        # Passing format '-' tells pygmt.end to not produce any files.
-        fmt = "-"
+        # Activate the figure only if it's not already activated
+        if _STATE["current_figure"] == self._name:
+            return
+
         with Session() as lib:
+            # Passing format '-' tells pygmt.end to not produce any files.
+            fmt = "-"
             lib.call_module(module="figure", args=[self._name, fmt])
+
+        # Track the current activated figure name
+        _STATE["current_figure"] = self._name
 
     def _preprocess(self, **kwargs):
         """


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
