### PR TITLE
CI: Fix the name of the 'build' package to 'python-build' on conda-forge

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -58,7 +58,7 @@ jobs:
             xarray
             netCDF4
             packaging
-            build
+            python-build
 
       # Install the package that we want to test
       - name: Install the package

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -104,9 +104,9 @@ jobs:
             geopandas<1.0
             ipython
             rioxarray
-            build
             make
             pip
+            python-build
             myst-nb
             panel
             sphinx

--- a/.github/workflows/ci_doctests.yaml
+++ b/.github/workflows/ci_doctests.yaml
@@ -62,9 +62,9 @@ jobs:
             ipython
             pyarrow
             rioxarray
-            build
             make
             pip
+            python-build
             pytest
             pytest-doctestplus
             pytest-mpl

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -125,10 +125,10 @@ jobs:
             xarray${{ matrix.xarray-version }}
             netCDF4
             packaging
-            build
             dvc
             make
             pip
+            python-build
             pytest
             pytest-cov
             pytest-doctestplus

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -72,9 +72,9 @@ jobs:
             pyarrow
             rioxarray
             sphinx-gallery
-            build
             make
             pip
+            python-build
             pytest
             pytest-doctestplus
             pytest-mpl

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -18,9 +18,9 @@ dependencies:
     - ipython
     - rioxarray
     # Development dependencies (general)
-    - build
     - make
     - pip
+    - python-build  # Package name is "build" on PyPI and "python-build" on conda-forge.
     # Dev dependencies (building documentation)
     - myst-nb
     - panel

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -20,7 +20,7 @@ dependencies:
     # Development dependencies (general)
     - make
     - pip
-    - python-build  # Package name is "build" on PyPI and "python-build" on conda-forge.
+    - python-build
     # Dev dependencies (building documentation)
     - myst-nb
     - panel

--- a/environment.yml
+++ b/environment.yml
@@ -18,11 +18,11 @@ dependencies:
     - ipython
     - rioxarray
     # Development dependencies (general)
-    - build
     - dvc
     - jupyter
     - make
     - pip
+    - python-build  # Package name is "build" on PyPI and "python-build" on conda-forge.
     # Dev dependencies (style checks)
     - codespell
     - pre-commit

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
     - jupyter
     - make
     - pip
-    - python-build  # Package name is "build" on PyPI and "python-build" on conda-forge.
+    - python-build
     # Dev dependencies (style checks)
     - codespell
     - pre-commit


### PR DESCRIPTION
**Description of proposed changes**

Our Docs workflow suddenly failed (https://github.com/GenericMappingTools/pygmt/actions/runs/10502290769/job/29093673041) with following errors:

```
  error    libmamba Could not solve for environment specs
      The following package could not be installed
      └─ build does not exist (perhaps a typo or a missing channel).
  critical libmamba Could not solve for environment specs
```
It turns out the [`build`](https://github.com/pypa/build) package has the name `build` on PyPI (https://pypi.org/project/build/), but has the name `python-build` on conda-forge (https://anaconda.org/conda-forge/python-build).

The `build` package also exists on conda-forge (https://anaconda.org/conda-forge/build) but it's no longer maintained and has a very old version (v0.7.0). Xref: https://github.com/conda-forge/build-feedstock/issues/2

Aslo xref: https://conda-forge.org/news/2024/08/21/remove-build/