### PR TITLE
Remove the non-official GMT wrappers from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,12 +186,6 @@ Other official wrappers for GMT:
 - [GMT.jl](https://github.com/GenericMappingTools/GMT.jl): A Julia wrapper for GMT.
 - [gmtmex](https://github.com/GenericMappingTools/gmtmex): A Matlab/Octave wrapper for GMT.
 
-Other non-official Python wrappers for GMT (not maintained):
-
-- [gmtpy](https://github.com/emolch/gmtpy) by [Sebastian Heimann](https://github.com/emolch)
-- [pygmt](https://github.com/ian-r-rose/pygmt) by [Ian Rose](https://github.com/ian-r-rose)
-- [PyGMT](https://github.com/glimmer-cism/PyGMT) by [Magnus Hagdorn](https://github.com/mhagdorn)
-
 <!-- doc-index-end-before -->
 
 ## Minimum supported versions


### PR DESCRIPTION
These non-official GMT wrappers have not been updated/maintained since the initiation of the official PyGMT project in 2017. 

It makes sense to mention these projects in 2017, but now is 2024. I prefer to remove them from README.