### PR TITLE
Add pre-commit.ci configurations to enable auto updates of hooks

### DIFF
--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -42,6 +42,9 @@ jobs:
            make check
            pre-commit run --all-files
 
+      - name: Update pre-commit hooks
+        run: pre-commit autoupdate
+
       - name: Ensure example scripts have at least one code block separator
         run: |
           git ls-files 'examples/**/*.py' | xargs grep --files-without-match '# %%' > output.txt

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -12,6 +12,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  workflow_dispatch:
   # Schedule daily tests
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -42,6 +42,7 @@ jobs:
         run: |
           pre-commit autoupdate
           if [[ $(git ls-files -m) ]]; then git --no-pager diff HEAD; exit 1; fi
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
       - name: Formatting check (ruff + pre-commit)
         run: |

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -37,13 +37,15 @@ jobs:
           python -m pip install ruff pre-commit
           python -m pip list
 
+      - name: Check updates of pre-commit hooks
+        run: |
+          pre-commit autoupdate
+          if [[ $(git ls-files -m) ]]; then git --no-pager diff HEAD; exit 1; fi
+
       - name: Formatting check (ruff + pre-commit)
         run: |
            make check
            pre-commit run --all-files
-
-      - name: Update pre-commit hooks
-        run: pre-commit autoupdate
 
       - name: Ensure example scripts have at least one code block separator
         run: |

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -12,7 +12,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-  workflow_dispatch:
   # Schedule daily tests
   schedule:
     - cron: '0 0 * * *'
@@ -37,12 +36,6 @@ jobs:
         run: |
           python -m pip install ruff pre-commit
           python -m pip list
-
-      - name: Check updates of pre-commit hooks
-        run: |
-          pre-commit autoupdate
-          if [[ $(git ls-files -m) ]]; then git --no-pager diff HEAD; exit 1; fi
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
       - name: Formatting check (ruff + pre-commit)
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,8 @@ repos:
     - id: remove-crlf
     - id: chmod
       args: ['644']
+
+# https://pre-commit.ci/#configuration
+ci:
+  autofix_prs: false
+  autoupdate_schedule: quarterly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v4.5.0
   hooks:
     - id: check-added-large-files
     - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
     - id: check-added-large-files
     - id: check-yaml


### PR DESCRIPTION
**Description of proposed changes**

Run `pre-commit autoupdate` command in the Style Checks workflow, to check if there are new versions of pre-commit hooks. The workflow will fail if there are updates. Then we just need to open a PR to manually update the workflow.

Address https://github.com/GenericMappingTools/pygmt/pull/3374#discussion_r1730385091.