### PR TITLE
PYGMT_USE_EXTERNAL_DISPLAY should NOT disable image display in Jupyter notebook environment

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -48,8 +48,8 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     - ``"notebook"``: Inline PNG preview in the current notebook
     - ``"none"``: Disable image preview
 
-    The default display method is ``"notebook"`` in the Jupyter notebook environment, and
-    ``"external"`` in other cases.
+    The default display method is ``"notebook"`` in the Jupyter notebook environment,
+    and ``"external"`` in other cases.
 
     Setting environment variable **PYGMT_USE_EXTERNAL_DISPLAY** to ``"false"`` can
     disable image preview. It's useful when running the tests and building the
@@ -60,12 +60,12 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     method
         The default display method.
     """
-    if os.environ.get("PYGMT_USE_EXTERNAL_DISPLAY", "true").lower() == "false":
-        return "none"
     if _HAS_IPYTHON:
         get_ipython = IPython.get_ipython()
         if get_ipython and "IPKernelApp" in get_ipython.config:
             return "notebook"
+    if os.environ.get("PYGMT_USE_EXTERNAL_DISPLAY", "true").lower() == "false":
+        return "none"
     return "external"
 
 

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -27,14 +27,6 @@ from pygmt.helpers import (
     use_alias,
 )
 
-# A registry of all figures that have had "show" called in this session.
-# This is needed for the sphinx-gallery scraper in pygmt/sphinx_gallery.py
-SHOWED_FIGURES = []
-# Configurations for figure display.
-SHOW_CONFIG = {
-    "method": None,  # The image preview display method.
-}
-
 
 def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     """
@@ -67,6 +59,15 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     if os.environ.get("PYGMT_USE_EXTERNAL_DISPLAY", "true").lower() == "false":
         return "none"
     return "external"
+
+
+# A registry of all figures that have had "show" called in this session.
+# This is needed for the sphinx-gallery scraper in pygmt/sphinx_gallery.py
+SHOWED_FIGURES = []
+# Configurations for figure display.
+SHOW_CONFIG = {
+    "method": _get_default_display_method(),  # The image preview display method.
+}
 
 
 class Figure:
@@ -463,8 +464,6 @@ class Figure:
 
         # Set the display method
         if method is None:
-            if SHOW_CONFIG["method"] is None:
-                SHOW_CONFIG["method"] = _get_default_display_method()
             method = SHOW_CONFIG["method"]
 
         if method not in {"external", "notebook", "none"}:

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -32,7 +32,7 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     """
     Get the default method to display preview images.
 
-    The function checks the current environment and determine the most suitable method
+    The function checks the current environment and determines the most suitable method
     to display preview images when calling :meth:`pygmt.Figure.show`. Valid display
     methods are:
 
@@ -44,8 +44,8 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     and ``"external"`` in other cases.
 
     Setting environment variable **PYGMT_USE_EXTERNAL_DISPLAY** to ``"false"`` can
-    disable image preview. It's useful when running the tests and building the
-    documentation to avoid popping up windows.
+    disable image preview in external viewers. It's useful when running the tests and
+    building the documentation to avoid popping up windows.
 
     Returns
     -------

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -48,7 +48,7 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     - ``"notebook"``: Inline PNG preview in the current notebook
     - ``"none"``: Disable image preview
 
-    The default display method is ``"notebook"`` in Jupyter notebook environment, and
+    The default display method is ``"notebook"`` in the Jupyter notebook environment, and
     ``"external"`` in other cases.
 
     Setting environment variable **PYGMT_USE_EXTERNAL_DISPLAY** to ``"false"`` can

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -52,12 +52,13 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
     method
         The default display method.
     """
-    if _HAS_IPYTHON:
-        get_ipython = IPython.get_ipython()
-        if get_ipython and "IPKernelApp" in get_ipython.config:
-            return "notebook"
+    # Check if an IPython kernel is running.
+    if _HAS_IPYTHON and (ipy := IPython.get_ipython()) and "IPKernelApp" in ipy.config:
+        return "notebook"
+    # Check if the environment variable PYGMT_USE_EXTERNAL_DISPLAY is set to "false".
     if os.environ.get("PYGMT_USE_EXTERNAL_DISPLAY", "true").lower() == "false":
         return "none"
+    # Fallback to using the external viewer.
     return "external"
 
 

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -402,10 +402,11 @@ class TestGetDefaultDisplayMethod:
     Test the _get_default_display_method function.
     """
 
-    def test_default_display_method(self):
+    def test_default_display_method(self, monkeypatch):
         """
         The default display method is "external" as tests are not run in IPython.
         """
+        monkeypatch.setenv("PYGMT_USE_EXTERNAL_DISPLAY", "true")
         assert _get_default_display_method() == "external"
 
     def test_disable_external_display(self, monkeypatch):
@@ -415,6 +416,7 @@ class TestGetDefaultDisplayMethod:
         monkeypatch.setenv("PYGMT_USE_EXTERNAL_DISPLAY", "false")
         assert _get_default_display_method() == "none"
 
+    @pytest.mark.skipif(not _HAS_IPYTHON, reason="Run when IPython is installed")
     def test_notebook_display(self, monkeypatch):
         """
         The default display method is "notebook" when IPython instance is available.

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -430,9 +430,11 @@ class TestGetDefaultDisplayMethod:
             def __init__(self):
                 self.config = {"IPKernelApp": True}
 
+        # Mock IPython.get_ipython() to return a MockIPython instance.
         mock_ipython = MockIPython()
-
         monkeypatch.setattr(IPython, "get_ipython", lambda: mock_ipython)
+
+        # Default display method should be "notebook" when an IPython kernel is running.
         assert _get_default_display_method() == "notebook"
 
         # PYGMT_USE_EXTERNAL_DISPLAY should not affect notebook display.

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -404,14 +404,14 @@ class TestGetDefaultDisplayMethod:
 
     def test_default_display_method(self, monkeypatch):
         """
-        The default display method is "external" as tests are not run in IPython.
+        Default display method is "external" if PYGMT_USE_EXTERNAL_DISPLAY is undefined.
         """
-        monkeypatch.setenv("PYGMT_USE_EXTERNAL_DISPLAY", "true")
+        monkeypatch.delenv("PYGMT_USE_EXTERNAL_DISPLAY", raising=False)
         assert _get_default_display_method() == "external"
 
     def test_disable_external_display(self, monkeypatch):
         """
-        Set PYGMT_USE_EXTERNAL_DISPLAY to "false" should disable external display.
+        Setting PYGMT_USE_EXTERNAL_DISPLAY to "false" should disable external display.
         """
         monkeypatch.setenv("PYGMT_USE_EXTERNAL_DISPLAY", "false")
         assert _get_default_display_method() == "none"
@@ -419,7 +419,7 @@ class TestGetDefaultDisplayMethod:
     @pytest.mark.skipif(not _HAS_IPYTHON, reason="Run when IPython is installed")
     def test_notebook_display(self, monkeypatch):
         """
-        The default display method is "notebook" when IPython instance is available.
+        Default display method is "notebook" when an IPython kernel is running.
         """
 
         class MockIPython:


### PR DESCRIPTION
**Description of proposed changes**

See #3416 for the bug report. 

The environment variable `PYGMT_USE_EXTERNAL_DISPLAY` should only disable images previews when the display method is `"external"`. Otherwise, images won't be shown in notebook environment.

Changes in this PR was cherry-picked from PR #3396.

I've built the documentation locally, and can confirm that the issue #3416 can be fixed by this PR.

Closes #3416.