### PR TITLE
Fix "sphinx-gallery" to "sphinx_gallery" when importing

### DIFF
--- a/pygmt/tests/test_sphinx_gallery.py
+++ b/pygmt/tests/test_sphinx_gallery.py
@@ -9,7 +9,7 @@ import pytest
 from pygmt.figure import SHOWED_FIGURES, Figure
 from pygmt.sphinx_gallery import PyGMTScraper
 
-pytest.importorskip("sphinx-gallery", reason="Requires sphinx-gallery to be installed")
+pytest.importorskip("sphinx_gallery", reason="Requires sphinx-gallery to be installed")
 pytest.importorskip("IPython", reason="Requires IPython to be installed")
 
 


### PR DESCRIPTION
**Description of proposed changes**

The `PyGMTScraper` class has the lowest code coverage because tests in `pygmt/tests/test_sphinx_gallery.py` are skipped, due to a typo of the sphinx-gallery package name.

The package name is sphinx-gallery, but when importing, we should use sphinx_gallery.

With this patch, the code coverage increases by 0.32%.

Patches #2567.