### PR TITLE
Figure.grdcontour: Remove the deprecated syntax for the 'annotation' parameter

### DIFF
--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -2,8 +2,6 @@
 grdcontour - Plot a contour figure.
 """
 
-import warnings
-
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_list,
@@ -139,20 +137,6 @@ def grdcontour(self, grid, **kwargs):
     >>> fig.show()
     """
     kwargs = self._preprocess(**kwargs)
-
-    # Backward compatibility with the old syntax for the annotation parameter, e.g.,
-    # [100, "e", "f10p", "gred"].
-    if is_nonstr_iter(kwargs.get("A")) and any(
-        i[0] in "acdefgijlLnoprtuvwx=" for i in kwargs["A"] if isinstance(i, str)
-    ):
-        msg = (
-            "Argument of the parameter 'annotation'/'A' is using the old, deprecated "
-            "syntax. Please refer to the PyGMT documentation for the new syntax. "
-            "The warning will be removed in v0.14.0 and the old syntax will no longer "
-            "be supported. "
-        )
-        warnings.warn(msg, category=FutureWarning, stacklevel=2)
-        kwargs["A"] = "+".join(f"{item}" for item in kwargs["A"])
 
     # Specify levels for the annotation and levels parameters.
     # One level is converted to a string with a trailing comma to separate it from

--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -45,23 +45,6 @@ def test_grdcontour_one_level(grid):
     return fig
 
 
-@pytest.mark.mpl_image_compare(filename="test_grdcontour_one_level.png")
-def test_grdcontour_old_annotations(grid):
-    """
-    Test the old syntax for the annotation parameter using "sequence_plus".
-    Modified from the "test_grdcontour_one_level()" test. Can be removed in v0.14.0.
-    """
-    fig = Figure()
-    fig.grdcontour(
-        grid=grid,
-        levels=[400],
-        annotation=["570,", "gwhite"],
-        projection="M10c",
-        frame=True,
-    )
-    return fig
-
-
 @pytest.mark.mpl_image_compare
 def test_grdcontour_multiple_levels(grid):
     """


### PR DESCRIPTION
**Description of proposed changes**

It was marked as deprecated in https://github.com/GenericMappingTools/pygmt/pull/3116.