### PR TITLE
Gallery example "vector styles": Fix typos

### DIFF
--- a/examples/gallery/lines/vector_styles.py
+++ b/examples/gallery/lines/vector_styles.py
@@ -11,7 +11,7 @@ See also the :doc:`Vector attributes example </gallery/lines/vector_heads_tails>
 import numpy as np
 import pygmt
 
-# create a plot with coast, Mercator projection (M) over the continental US
+# Create a plot with coast, Mercator projection (M) over the continental US
 fig = pygmt.Figure()
 fig.coast(
     region=[-127, -64, 24, 53],
@@ -28,8 +28,8 @@ x = np.linspace(-116, -116, 12)  # x vector coordinates
 y = np.linspace(33.5, 42.5, 12)  # y vector coordinates
 direction = np.zeros(x.shape)  # direction of vectors
 length = np.linspace(0.5, 2.4, 12)  # length of vectors
-# Cartesian vectors (v) with red fill and pen (+g, +p), vector head at
-# end (+e), and 40 degree angle (+a) with no indentation for vector head (+h)
+# Cartesian vectors (v) with red fill and pen (+g, +p), vector head at the
+# end (+e), and 40 degree angle (+a) with no indentation for the vector head (+h)
 style = "v0.2c+e+a40+gred+h0+p1p,red"
 fig.plot(x=x, y=y, style=style, pen="1p,red", direction=[direction, length])
 fig.text(text="CARTESIAN", x=-112, y=44.2, font="13p,Helvetica-Bold,red", fill="white")
@@ -44,7 +44,7 @@ startdir = np.full(num, 90)  # start direction in degrees
 stopdir = 180 + 40 * np.arange(0, num)  # stop direction in degrees
 # data for circular vectors
 data = np.column_stack([x, y, radius, startdir, stopdir])
-arcstyle = "m0.5c+ea"  # Circular vector (m) with an arrow at end
+arcstyle = "m0.5c+ea"  # Circular vector (m) with an arrow at the end
 fig.plot(data=data, style=arcstyle, fill="red3", pen="1.5p,black")
 fig.text(text="CIRCULAR", x=-95, y=44.2, font="13p,Helvetica-Bold,black", fill="white")
 
@@ -54,7 +54,7 @@ NYC = [-74.0060, 40.7128]
 CHI = [-87.6298, 41.8781]
 SEA = [-122.3321, 47.6062]
 NO = [-90.0715, 29.9511]
-# `=` means geographic vectors.
+# '=' means geographic vectors.
 # With the modifier '+s', the input data should contain coordinates of start
 # and end points
 style = "=0.5c+s+e+a30+gblue+h0.5+p1p,blue"

--- a/examples/gallery/lines/vector_styles.py
+++ b/examples/gallery/lines/vector_styles.py
@@ -2,9 +2,9 @@
 Cartesian, circular, and geographic vectors
 ===========================================
 
-The :meth:`pygmt.Figure.plot` method can plot Cartesian, circular, and
-geographic vectors. The ``style`` parameter controls vector attributes.
-See also the :doc:`Vector attributes example </gallery/lines/vector_heads_tails>`.
+The :meth:`pygmt.Figure.plot` method can plot Cartesian, circular, and geographic
+vectors. The ``style`` parameter controls vector attributes. See also the
+:doc:`Vector attributes example </gallery/lines/vector_heads_tails>`.
 """
 
 # %%
@@ -28,8 +28,8 @@ x = np.linspace(-116, -116, 12)  # x vector coordinates
 y = np.linspace(33.5, 42.5, 12)  # y vector coordinates
 direction = np.zeros(x.shape)  # direction of vectors
 length = np.linspace(0.5, 2.4, 12)  # length of vectors
-# Cartesian vectors (v) with red fill and pen (+g, +p), vector head at the
-# end (+e), and 40 degree angle (+a) with no indentation for the vector head (+h)
+# Cartesian vectors (v) with red fill and pen (+g, +p), vector head at the end (+e), and
+# 40 degree angle (+a) with no indentation for the vector head (+h)
 style = "v0.2c+e+a40+gred+h0+p1p,red"
 fig.plot(x=x, y=y, style=style, pen="1p,red", direction=[direction, length])
 fig.text(text="CARTESIAN", x=-112, y=44.2, font="13p,Helvetica-Bold,red", fill="white")
@@ -54,9 +54,8 @@ NYC = [-74.0060, 40.7128]
 CHI = [-87.6298, 41.8781]
 SEA = [-122.3321, 47.6062]
 NO = [-90.0715, 29.9511]
-# '=' means geographic vectors.
-# With the modifier '+s', the input data should contain coordinates of start
-# and end points
+# '=' means geographic vectors. With the modifier '+s', the input data should contain
+# coordinates of start and end points
 style = "=0.5c+s+e+a30+gblue+h0.5+p1p,blue"
 data = np.array([NYC + CHI, NYC + SEA, NYC + NO])
 fig.plot(data=data, style=style, pen="1.0p,blue")


### PR DESCRIPTION
**Description of proposed changes**

This PR offers some improvements of the comments in the Gallery example "Cartesian, circular, and geographic vectors".

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
