### PR TITLE
CI: Pin ghostscript<10 for GMT 6.3/6.4 in the GMT Legacy Tests workflow

### DIFF
--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -61,6 +61,7 @@ jobs:
           create-args: >-
             python=3.10
             gmt=${{ matrix.gmt_version }}
+            ghostscript<10
             numpy
             pandas<2
             xarray


### PR DESCRIPTION
The "GMT Legacy Tests" workflow failed recently (https://github.com/GenericMappingTools/pygmt/actions/runs/11004729295) with errors:
```
FAILED ../pygmt/tests/test_show_versions.py::test_show_versions - AssertionError: assert 'WARNING:' not in 'PyGMT infor...ipt v9.56.\n'
  
  'WARNING:' is contained here:
    PyGMT information:
      version: v0.13.1.dev19+gf7110e22
    System information:
      python: 3.10.14 | packaged by conda-forge | (main, Mar 20 2024, 12:45:18) [GCC 12.3.0]
      executable: /home/runner/micromamba/envs/pygmt/bin/python3.10
      machine: Linux-5.15.0-1071-azure-x86_64-with-glibc2.31
    Dependency information:
      numpy: 1.26.4
      pandas: 1.5.3
      xarray: 2024.3.0
      netCDF4: 1.6.5
      packaging: 24.1
      contextily: 1.6.2
      geopandas: 1.0.1
      IPython: 8.27.0
      rioxarray: 0.17.0
      gdal: 3.8.5
      ghostscript: 10.04.0
    GMT library information:
      version: 6.4.0
      padding: 2
      share dir: /home/runner/micromamba/envs/pygmt/share/gmt
      plugin dir: /home/runner/micromamba/envs/pygmt/lib/gmt/plugins
      library path: /home/runner/micromamba/envs/pygmt/lib/libgmt.so
      cores: 4
      grid layout: rows
      image layout: 
      binary version: 6.4.0
    WARNING:
      GMT v6.4.0 doesn't support Ghostscript v10.04.0. Please consider upgrading to GMT>=6.5.0 or downgrading to Ghostscript v9.56.
```
It's because GMT 6.4.0 doesn't work well with gs 10.x. This PR pins gs<10 in the GMT Legacy Tests workflow.

Manually triggered workflow runs at: https://github.com/GenericMappingTools/pygmt/actions/runs/11010355746