### PR TITLE
Remove unused CSS classes for style.css

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -48,38 +48,6 @@ p {
     font-size: 4em;
 }
 
-.api-module {
-	margin-bottom: 80px;
-}
-
-.youtube-embed {
-    max-width: 600px;
-    margin-bottom: 24px;
-}
-
-.video-container {
-    position:relative;
-    padding-bottom:56.25%;
-    padding-top:30px;
-    height:0;
-    overflow:hidden;
-}
-
-.video-container iframe, .video-container object, .video-container embed {
-    position:absolute;
-    top:0;
-    left:0;
-    width:100%;
-    height:100%;
-}
-
-/*.wy-menu-vertical header, .wy-menu-vertical p.caption {*/
-    /*font-size: 90%;*/
-    /*font-weight: bold;*/
-    /*color: #eeeeee;*/
-    /*letter-spacing: 0.12em;*/
-/*}*/
-
 .wy-nav-content {
     max-width: 1000px;
 }
@@ -137,22 +105,6 @@ html.writer-html5 .rst-content dl.field-list {
     }
 }
 
-/* Style for the copy button */
-/* Safe to remove for sphinx-copybutton>0.3.1
- * https://github.com/executablebooks/sphinx-copybutton/pull/107
- */
-a.copybtn {
-    position: absolute;
-    top: .2em;
-    right: .2em;
-    width: 1.3em;
-    height: 1.3em;
-    opacity: .3;
-    transition: opacity 0.5s;
-    border: none;
-    user-select: none;
-}
-
 /* Atkinson Hyperlegible regular */
 @font-face {
     font-family: "Atkinson Hyperlegible";
@@ -189,9 +141,6 @@ a.copybtn {
 .sphx-glr-thumbcontainer {
     border: solid #d6d6d6 1px!important;
     text-align: center!important;
-}
-
-.sphx-glr-thumbcontainer {
     min-height: 240px!important;
     min-width: 180px!important;
 }


### PR DESCRIPTION
This PR removes some CSS classes no longer used in our documentation. These classes are found by building the documentation locally and grep the class names in the generated HTML files.

**Preview**: https://pygmt-dev--3453.org.readthedocs.build/en/3453/

Check the blame to know when/why these styles were added: https://github.com/GenericMappingTools/pygmt/blame/main/doc/_static/style.css