### PR TITLE
GeoPandas: Explicitly convert columns with overflow integers to avoid OverflowError with fiona 1.10

### DIFF
--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -153,6 +153,7 @@ def tempfile_from_geojson(geojson):
                     if dtype in {"int", "int64"}:
                         overflow = geojson[col].abs().max() > 2**31 - 1
                         schema["properties"][col] = "float" if overflow else "int32"
+                        geojson[col] = geojson[col].astype(schema["properties"][col])
                 ogrgmt_kwargs["schema"] = schema
             else:  # GeoPandas v1.x.
                 # The default engine "pyogrio" doesn't support the 'schema' parameter


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/GenericMappingTools/pygmt/pull/3420#issuecomment-2372635383 for context.

I opened a separate PR for this small fix, so that we can have an entry in the "Bug Fixes" category, and we can better focus on CI in PR #3420.