### PR TITLE
SPEC 0: Set minimum supported versions to pandas>=2.0 and xarray>=2023.04

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -71,7 +71,7 @@ jobs:
         include:
           - python-version: '3.10'
             numpy-version: '1.24'
-            pandas-version: '=1.5'
+            pandas-version: '=2.0'
             xarray-version: '=2022.09'
             optional-packages: ''
           - python-version: '3.12'

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -72,7 +72,7 @@ jobs:
           - python-version: '3.10'
             numpy-version: '1.24'
             pandas-version: '=2.0'
-            xarray-version: '=2022.09'
+            xarray-version: '=2022.11'
             optional-packages: ''
           - python-version: '3.12'
             numpy-version: '2.1'

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -72,7 +72,7 @@ jobs:
           - python-version: '3.10'
             numpy-version: '1.24'
             pandas-version: '=2.0'
-            xarray-version: '=2023.03'
+            xarray-version: '=2023.04'
             optional-packages: ''
           - python-version: '3.12'
             numpy-version: '2.1'

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -72,7 +72,7 @@ jobs:
           - python-version: '3.10'
             numpy-version: '1.24'
             pandas-version: '=2.0'
-            xarray-version: '=2022.11'
+            xarray-version: '=2023.03'
             optional-packages: ''
           - python-version: '3.12'
             numpy-version: '2.1'

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
     - ghostscript=10.04.0
     - numpy>=1.24
     - pandas>=2.0
-    - xarray>=2022.09
+    - xarray>=2022.11
     - netCDF4
     - packaging
     # Optional dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
     - gmt=6.5.0
     - ghostscript=10.04.0
     - numpy>=1.24
-    - pandas>=1.5
+    - pandas>=2.0
     - xarray>=2022.09
     - netCDF4
     - packaging

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
     - ghostscript=10.04.0
     - numpy>=1.24
     - pandas>=2.0
-    - xarray>=2023.03
+    - xarray>=2023.04
     - netCDF4
     - packaging
     # Optional dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
     - ghostscript=10.04.0
     - numpy>=1.24
     - pandas>=2.0
-    - xarray>=2022.11
+    - xarray>=2023.03
     - netCDF4
     - packaging
     # Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.24",
-    "pandas>=1.5",
+    "pandas>=2.0",
     "xarray>=2022.09",
     "netCDF4",
     "packaging",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.24",
     "pandas>=2.0",
-    "xarray>=2022.11",
+    "xarray>=2023.03",
     "netCDF4",
     "packaging",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.24",
     "pandas>=2.0",
-    "xarray>=2022.09",
+    "xarray>=2022.11",
     "netCDF4",
     "packaging",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.24",
     "pandas>=2.0",
-    "xarray>=2023.03",
+    "xarray>=2023.04",
     "netCDF4",
     "packaging",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Required packages
 numpy>=1.24
 pandas>=2.0
-xarray>=2023.03
+xarray>=2023.04
 netCDF4
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Required packages
 numpy>=1.24
 pandas>=2.0
-xarray>=2022.11
+xarray>=2023.03
 netCDF4
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Required packages
 numpy>=1.24
-pandas>=1.5
+pandas>=2.0
 xarray>=2022.09
 netCDF4
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Required packages
 numpy>=1.24
 pandas>=2.0
-xarray>=2022.09
+xarray>=2022.11
 netCDF4
 packaging


### PR DESCRIPTION
**Description of proposed changes**

Following [SPEC0](https://scientific-python.org/specs/spec-0000/), we should drop pandas 1.5 and xarray 2022.09 support in 2024 Q3, but now we have dependency conflicts.

```
  error    libmamba Could not solve for environment specs
      The following packages are incompatible
      ├─ pandas =2.0 is requested and can be installed;
      └─ xarray =2022.11 is not installable because it requires
         └─ pandas >=1.3,<2a0, which conflicts with any installable versions previously reported.
  critical libmamba Could not solve for environment specs
```

Following https://github.com/pydata/xarray/issues/7716#issuecomment-1510434058, xarray 2023.04 works with pandas 2.0. Then we must decide whether to merge this PR now (violating the SPEC0 policy) or wait until April 2025.

I prefer to wait until April 2025, so adding this PR to milestone v0.16.0.

Previous pandas version bump at #3043.