### PR TITLE
Mention breaking change regarding extra quotation marks around text strings in changelog v0.12.0

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -101,7 +101,7 @@
 
 ### Enhancements
 
-* **Breaking**: (Unneeded) extra quotation marks around text strings (containing white spaces) are now considered as part of the text string ([#3132](https://github.com/GenericMappingTools/pygmt/pull/3132), [#3457](https://github.com/GenericMappingTools/pygmt/issues/3457))
+* **Breaking**: (Unneeded) extra quotation marks around text strings (containing whitespaces) are now considered as part of the text string ([#3132](https://github.com/GenericMappingTools/pygmt/pull/3132), [#3457](https://github.com/GenericMappingTools/pygmt/issues/3457))
 * pygmt.project: Add 'output_type' parameter for output in pandas/numpy/file formats ([#3110](https://github.com/GenericMappingTools/pygmt/pull/3110))
 * pygmt.grdtrack: Add 'output_type' parameter for output in pandas/numpy/file formats ([#3106](https://github.com/GenericMappingTools/pygmt/pull/3106))
 * pygmt.blockm*: Add 'output_type' parameter for output in pandas/numpy/file formats ([#3103](https://github.com/GenericMappingTools/pygmt/pull/3103))

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -101,7 +101,7 @@
 
 ### Enhancements
 
-* **Breaking**: (Unneeded) extra quotation marks around text strings (containing whitespaces) are now considered as part of the text string ([#3132](https://github.com/GenericMappingTools/pygmt/pull/3132), [#3457](https://github.com/GenericMappingTools/pygmt/issues/3457))
+* **Breaking**: (Unneeded) extra double quotes around text strings (containing whitespaces) are now considered as part of the text string ([#3132](https://github.com/GenericMappingTools/pygmt/pull/3132), [#3457](https://github.com/GenericMappingTools/pygmt/issues/3457))
 * pygmt.project: Add 'output_type' parameter for output in pandas/numpy/file formats ([#3110](https://github.com/GenericMappingTools/pygmt/pull/3110))
 * pygmt.grdtrack: Add 'output_type' parameter for output in pandas/numpy/file formats ([#3106](https://github.com/GenericMappingTools/pygmt/pull/3106))
 * pygmt.blockm*: Add 'output_type' parameter for output in pandas/numpy/file formats ([#3103](https://github.com/GenericMappingTools/pygmt/pull/3103))

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -101,6 +101,7 @@
 
 ### Enhancements
 
+* **Breaking**: (Unneeded) extra quotation marks around text strings (containing white spaces) are now considered as part of the text string ([#3132](https://github.com/GenericMappingTools/pygmt/pull/3132), [#3457](https://github.com/GenericMappingTools/pygmt/issues/3457))
 * pygmt.project: Add 'output_type' parameter for output in pandas/numpy/file formats ([#3110](https://github.com/GenericMappingTools/pygmt/pull/3110))
 * pygmt.grdtrack: Add 'output_type' parameter for output in pandas/numpy/file formats ([#3106](https://github.com/GenericMappingTools/pygmt/pull/3106))
 * pygmt.blockm*: Add 'output_type' parameter for output in pandas/numpy/file formats ([#3103](https://github.com/GenericMappingTools/pygmt/pull/3103))


### PR DESCRIPTION
Mention a breaking change regarding how text wrapped by extra quotation marks is handled in the changelog v0.12.0. The change was introduced in #3132 (went into v0.12.0). However it was not recognized, but now it is reported in #3457 (after v0.13.0 was released). For details, please see https://github.com/GenericMappingTools/pygmt/issues/3457#issuecomment-2376894897.

So far, it is listed under "Enhancements" as the related PR #3132 is also listed there. The formulation is a first suggestion.

Fixes #3457

**Preview**: https://pygmt-dev--3462.org.readthedocs.build/en/3462/changes.html#id2