### PR TITLE
DOC/projections: Make example design consistent

### DIFF
--- a/examples/projections/azim/azim_equidistant.py
+++ b/examples/projections/azim/azim_equidistant.py
@@ -23,6 +23,6 @@ import pygmt
 
 fig = pygmt.Figure()
 fig.coast(
-    region="g", projection="E-100/40/15c", frame="afg", land="gray", water="cornsilk"
+    region="g", projection="E-100/40/15c", frame="afg", land="khaki", water="white"
 )
 fig.show()

--- a/examples/projections/azim/azim_equidistant.py
+++ b/examples/projections/azim/azim_equidistant.py
@@ -22,5 +22,7 @@ world map) in degrees <= 180° (default 180°). The size of the figure is set by
 import pygmt
 
 fig = pygmt.Figure()
-fig.coast(projection="E-100/40/15c", region="g", frame="g", land="gray")
+fig.coast(
+    region="g", projection="E-100/40/15c", frame="afg", land="gray", water="cornsilk"
+)
 fig.show()

--- a/examples/projections/azim/azim_general_perspective.py
+++ b/examples/projections/azim/azim_general_perspective.py
@@ -36,7 +36,7 @@ fig.coast(
     region="g",
     projection="G4/52/12c+a30+t45+v60/60+w0+z250",
     frame="afg",
-    land="gray",
-    water="cornsilk",
+    land="khaki",
+    water="white",
 )
 fig.show()

--- a/examples/projections/azim/azim_general_perspective.py
+++ b/examples/projections/azim/azim_general_perspective.py
@@ -33,9 +33,10 @@ import pygmt
 
 fig = pygmt.Figure()
 fig.coast(
-    projection="G4/52/12c+a30+t45+v60/60+w0+z250",
     region="g",
-    frame=["x10g10", "y5g5"],
+    projection="G4/52/12c+a30+t45+v60/60+w0+z250",
+    frame="afg",
     land="gray",
+    water="cornsilk",
 )
 fig.show()

--- a/examples/projections/azim/azim_general_stereographic.py
+++ b/examples/projections/azim/azim_general_stereographic.py
@@ -26,7 +26,7 @@ fig.coast(
     region=[4, 14, 52, 57],
     projection="S0/90/12c",
     frame="afg",
-    land="gray",
-    water="cornsilk",
+    land="khaki",
+    water="white",
 )
 fig.show()

--- a/examples/projections/azim/azim_general_stereographic.py
+++ b/examples/projections/azim/azim_general_stereographic.py
@@ -22,5 +22,11 @@ distance from projection center (in degrees, < 180, default 90), and the
 import pygmt
 
 fig = pygmt.Figure()
-fig.coast(region=[4, 14, 52, 57], projection="S0/90/12c", frame="ag", land="gray")
+fig.coast(
+    region=[4, 14, 52, 57],
+    projection="S0/90/12c",
+    frame="afg",
+    land="gray",
+    water="cornsilk",
+)
 fig.show()

--- a/examples/projections/azim/azim_gnomonic.py
+++ b/examples/projections/azim/azim_gnomonic.py
@@ -24,6 +24,10 @@ import pygmt
 
 fig = pygmt.Figure()
 fig.coast(
-    region="g", projection="F-90/15/12c", frame="afg", land="gray", water="cornsilk"
+    region="g",
+    projection="F-90/15/12c",
+    frame="afg",
+    land="khaki",
+    water="white",
 )
 fig.show()

--- a/examples/projections/azim/azim_gnomonic.py
+++ b/examples/projections/azim/azim_gnomonic.py
@@ -23,5 +23,7 @@ distance from projection center (in degrees, < 90, default 60), and *scale* or
 import pygmt
 
 fig = pygmt.Figure()
-fig.coast(projection="F-90/15/12c", region="g", frame="20g20", land="gray")
+fig.coast(
+    region="g", projection="F-90/15/12c", frame="afg", land="gray", water="cornsilk"
+)
 fig.show()

--- a/examples/projections/azim/azim_lambert.py
+++ b/examples/projections/azim/azim_lambert.py
@@ -21,6 +21,10 @@ import pygmt
 
 fig = pygmt.Figure()
 fig.coast(
-    region="g", projection="A30/-20/60/12c", frame="afg", land="gray", water="cornsilk"
+    region="g",
+    projection="A30/-20/60/12c",
+    frame="afg",
+    land="khaki",
+    water="white",
 )
 fig.show()

--- a/examples/projections/azim/azim_lambert.py
+++ b/examples/projections/azim/azim_lambert.py
@@ -20,5 +20,7 @@ of the figure.
 import pygmt
 
 fig = pygmt.Figure()
-fig.coast(region="g", frame="afg", land="gray", projection="A30/-20/60/12c")
+fig.coast(
+    region="g", projection="A30/-20/60/12c", frame="afg", land="gray", water="cornsilk"
+)
 fig.show()

--- a/examples/projections/azim/azim_orthographic.py
+++ b/examples/projections/azim/azim_orthographic.py
@@ -22,6 +22,10 @@ import pygmt
 
 fig = pygmt.Figure()
 fig.coast(
-    region="g", projection="G10/52/12c", frame="afg", land="gray", water="cornsilk"
+    region="g",
+    projection="G10/52/12c",
+    frame="afg",
+    land="khaki",
+    water="white",
 )
 fig.show()

--- a/examples/projections/azim/azim_orthographic.py
+++ b/examples/projections/azim/azim_orthographic.py
@@ -21,5 +21,7 @@ and *width* set the figure size.
 import pygmt
 
 fig = pygmt.Figure()
-fig.coast(projection="G10/52/12c", region="g", frame="g", land="gray")
+fig.coast(
+    region="g", projection="G10/52/12c", frame="afg", land="gray", water="cornsilk"
+)
 fig.show()

--- a/examples/projections/conic/conic_albers.py
+++ b/examples/projections/conic/conic_albers.py
@@ -29,7 +29,7 @@ fig.coast(
     region="BR+R2",
     projection="B-55/-15/-25/0/12c",
     frame="afg",
-    land="gray80",
-    water="70/130/180",  # steelblue
+    land="seagreen",
+    water="gray90",
 )
 fig.show()

--- a/examples/projections/conic/conic_albers.py
+++ b/examples/projections/conic/conic_albers.py
@@ -26,6 +26,10 @@ import pygmt
 fig = pygmt.Figure()
 # Use the ISO country code for Brazil and add a padding of 2 degrees (+R2)
 fig.coast(
-    projection="B-55/-15/-25/0/12c", region="BR+R2", frame="afg", land="gray", borders=1
+    region="BR+R2",
+    projection="B-55/-15/-25/0/12c",
+    frame="afg",
+    land="gray",
+    water="dodgerblue4",
 )
 fig.show()

--- a/examples/projections/conic/conic_albers.py
+++ b/examples/projections/conic/conic_albers.py
@@ -29,7 +29,7 @@ fig.coast(
     region="BR+R2",
     projection="B-55/-15/-25/0/12c",
     frame="afg",
-    land="gray",
-    water="dodgerblue4",
+    land="gray80",
+    water="70/130/180",  # steelblue
 )
 fig.show()

--- a/examples/projections/conic/conic_equidistant.py
+++ b/examples/projections/conic/conic_equidistant.py
@@ -20,11 +20,10 @@ import pygmt
 
 fig = pygmt.Figure()
 fig.coast(
-    shorelines="1/0.5p",
     region=[-88, -70, 18, 24],
     projection="D-79/21/19/23/12c",
-    land="lightgreen",
-    water="lightblue",
     frame="afg",
+    land="gray",
+    water="dodgerblue4",
 )
 fig.show()

--- a/examples/projections/conic/conic_equidistant.py
+++ b/examples/projections/conic/conic_equidistant.py
@@ -23,7 +23,7 @@ fig.coast(
     region=[-88, -70, 18, 24],
     projection="D-79/21/19/23/12c",
     frame="afg",
-    land="gray80",
-    water="70/130/180",  # steelblue
+    land="seagreen",
+    water="gray90",
 )
 fig.show()

--- a/examples/projections/conic/conic_equidistant.py
+++ b/examples/projections/conic/conic_equidistant.py
@@ -23,7 +23,7 @@ fig.coast(
     region=[-88, -70, 18, 24],
     projection="D-79/21/19/23/12c",
     frame="afg",
-    land="gray",
-    water="dodgerblue4",
+    land="gray80",
+    water="70/130/180",  # steelblue
 )
 fig.show()

--- a/examples/projections/conic/conic_lambert.py
+++ b/examples/projections/conic/conic_lambert.py
@@ -26,8 +26,8 @@ fig.coast(
     region=[-130, -70, 24, 52],
     projection="L-100/35/33/45/12c",
     frame="afg",
-    land="gray",
-    water="dodgerblue4",
+    land="gray80",
+    water="70/130/180",  # steelblue
 )
 
 fig.show()

--- a/examples/projections/conic/conic_lambert.py
+++ b/examples/projections/conic/conic_lambert.py
@@ -23,12 +23,11 @@ import pygmt
 
 fig = pygmt.Figure()
 fig.coast(
-    shorelines="1/0.5p",
     region=[-130, -70, 24, 52],
     projection="L-100/35/33/45/12c",
-    land="gray",
-    borders=["1/thick,black", "2/thin,black"],
     frame="afg",
+    land="gray",
+    water="dodgerblue4",
 )
 
 fig.show()

--- a/examples/projections/conic/conic_lambert.py
+++ b/examples/projections/conic/conic_lambert.py
@@ -26,8 +26,8 @@ fig.coast(
     region=[-130, -70, 24, 52],
     projection="L-100/35/33/45/12c",
     frame="afg",
-    land="gray80",
-    water="70/130/180",  # steelblue
+    land="seagreen",
+    water="gray90",
 )
 
 fig.show()

--- a/examples/projections/conic/polyconic.py
+++ b/examples/projections/conic/polyconic.py
@@ -33,7 +33,7 @@ fig.coast(
     region=[-180, -20, 0, 90],
     projection="Poly/12c",
     frame="afg",
-    land="gray",
-    water="dodgerblue4",
+    land="gray80",
+    water="70/130/180",  # steelblue
 )
 fig.show()

--- a/examples/projections/conic/polyconic.py
+++ b/examples/projections/conic/polyconic.py
@@ -30,12 +30,10 @@ import pygmt
 
 fig = pygmt.Figure()
 fig.coast(
-    shorelines="1/0.5p",
     region=[-180, -20, 0, 90],
     projection="Poly/12c",
+    frame="afg",
     land="gray",
-    borders="1/thick,black",
-    frame="afg10",
+    water="dodgerblue4",
 )
-
 fig.show()

--- a/examples/projections/conic/polyconic.py
+++ b/examples/projections/conic/polyconic.py
@@ -33,7 +33,7 @@ fig.coast(
     region=[-180, -20, 0, 90],
     projection="Poly/12c",
     frame="afg",
-    land="gray80",
-    water="70/130/180",  # steelblue
+    land="seagreen",
+    water="gray90",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_cassini.py
+++ b/examples/projections/cyl/cyl_cassini.py
@@ -27,7 +27,7 @@ fig.coast(
     region="MG+R2",
     projection="C47/-19/12c",
     frame="afg",
-    land="seagreen",
-    water="gray90",
+    land="gray80",
+    water="70/130/180",  # steelblue
 )
 fig.show()

--- a/examples/projections/cyl/cyl_cassini.py
+++ b/examples/projections/cyl/cyl_cassini.py
@@ -27,7 +27,7 @@ fig.coast(
     region="MG+R2",
     projection="C47/-19/12c",
     frame="afg",
-    land="darkgreen",
-    water="lightgray",
+    land="seagreen",
+    water="gray90",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_cassini.py
+++ b/examples/projections/cyl/cyl_cassini.py
@@ -28,6 +28,6 @@ fig.coast(
     projection="C47/-19/12c",
     frame="afg",
     land="gray80",
-    water="70/130/180",  # steelblue
+    water="steelblue",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_cassini.py
+++ b/examples/projections/cyl/cyl_cassini.py
@@ -23,5 +23,11 @@ import pygmt
 
 fig = pygmt.Figure()
 # Use the ISO code for Madagascar (MG) and pad it by 2 degrees (+R2)
-fig.coast(projection="C47/-19/12c", region="MG+R2", frame="afg", land="gray", borders=1)
+fig.coast(
+    region="MG+R2",
+    projection="C47/-19/12c",
+    frame="afg",
+    land="darkgreen",
+    water="lightgray",
+)
 fig.show()

--- a/examples/projections/cyl/cyl_equal_area.py
+++ b/examples/projections/cyl/cyl_equal_area.py
@@ -21,7 +21,7 @@ fig.coast(
     region="d",
     projection="Y35/30/12c",
     frame="afg",
-    land="darkgreen",
-    water="lightgray",
+    land="seagreen",
+    water="gray90",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_equal_area.py
+++ b/examples/projections/cyl/cyl_equal_area.py
@@ -22,6 +22,6 @@ fig.coast(
     projection="Y35/30/12c",
     frame="afg",
     land="gray80",
-    water="70/130/180",  # steelblue
+    water="steelblue",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_equal_area.py
+++ b/examples/projections/cyl/cyl_equal_area.py
@@ -21,7 +21,7 @@ fig.coast(
     region="d",
     projection="Y35/30/12c",
     frame="afg",
-    land="seagreen",
-    water="gray90",
+    land="gray80",
+    water="70/130/180",  # steelblue
 )
 fig.show()

--- a/examples/projections/cyl/cyl_equal_area.py
+++ b/examples/projections/cyl/cyl_equal_area.py
@@ -20,8 +20,8 @@ fig = pygmt.Figure()
 fig.coast(
     region="d",
     projection="Y35/30/12c",
-    water="dodgerblue",
-    shorelines="thinnest",
     frame="afg",
+    land="darkgreen",
+    water="lightgray",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_equidistant.py
+++ b/examples/projections/cyl/cyl_equidistant.py
@@ -25,7 +25,7 @@ fig.coast(
     region="d",
     projection="Q12c",
     frame="afg",
-    land="darkgreen",
-    water="lightgray",
+    land="seagreen",
+    water="gray90",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_equidistant.py
+++ b/examples/projections/cyl/cyl_equidistant.py
@@ -25,7 +25,7 @@ fig.coast(
     region="d",
     projection="Q12c",
     frame="afg",
-    land="seagreen",
-    water="gray90",
+    land="gray80",
+    water="70/130/180",  # steelblue
 )
 fig.show()

--- a/examples/projections/cyl/cyl_equidistant.py
+++ b/examples/projections/cyl/cyl_equidistant.py
@@ -24,8 +24,8 @@ fig = pygmt.Figure()
 fig.coast(
     region="d",
     projection="Q12c",
-    land="tan4",
-    water="lightcyan",
     frame="afg",
+    land="darkgreen",
+    water="lightgray",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_equidistant.py
+++ b/examples/projections/cyl/cyl_equidistant.py
@@ -26,6 +26,6 @@ fig.coast(
     projection="Q12c",
     frame="afg",
     land="gray80",
-    water="70/130/180",  # steelblue
+    water="steelblue",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_mercator.py
+++ b/examples/projections/cyl/cyl_mercator.py
@@ -29,6 +29,6 @@ fig.coast(
     projection="M0/0/12c",
     frame="afg",
     land="gray80",
-    water="70/130/180",  # steelblue
+    water="steelblue",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_mercator.py
+++ b/examples/projections/cyl/cyl_mercator.py
@@ -28,7 +28,7 @@ fig.coast(
     region=[0, 360, -80, 80],
     projection="M0/0/12c",
     frame="afg",
-    land="darkgreen",
-    water="lightgray",
+    land="seagreen",
+    water="gray90",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_mercator.py
+++ b/examples/projections/cyl/cyl_mercator.py
@@ -24,5 +24,11 @@ The figure size is set with *scale* or *width*.
 import pygmt
 
 fig = pygmt.Figure()
-fig.coast(region=[0, 360, -80, 80], frame="afg", land="red", projection="M0/0/12c")
+fig.coast(
+    region=[0, 360, -80, 80],
+    projection="M0/0/12c",
+    frame="afg",
+    land="darkgreen",
+    water="lightgray",
+)
 fig.show()

--- a/examples/projections/cyl/cyl_mercator.py
+++ b/examples/projections/cyl/cyl_mercator.py
@@ -28,7 +28,7 @@ fig.coast(
     region=[0, 360, -80, 80],
     projection="M0/0/12c",
     frame="afg",
-    land="seagreen",
-    water="gray90",
+    land="gray80",
+    water="70/130/180",  # steelblue
 )
 fig.show()

--- a/examples/projections/cyl/cyl_miller.py
+++ b/examples/projections/cyl/cyl_miller.py
@@ -24,7 +24,7 @@ fig.coast(
     region=[-180, 180, -80, 80],
     projection="J-65/12c",
     frame="afg",
-    land="darkgreen",
-    water="lightgray",
+    land="seagreen",
+    water="gray90",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_miller.py
+++ b/examples/projections/cyl/cyl_miller.py
@@ -25,6 +25,6 @@ fig.coast(
     projection="J-65/12c",
     frame="afg",
     land="gray80",
-    water="70/130/180",  # steelblue
+    water="steelblue",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_miller.py
+++ b/examples/projections/cyl/cyl_miller.py
@@ -24,7 +24,7 @@ fig.coast(
     region=[-180, 180, -80, 80],
     projection="J-65/12c",
     frame="afg",
-    land="seagreen",
-    water="gray90",
+    land="gray80",
+    water="70/130/180",  # steelblue
 )
 fig.show()

--- a/examples/projections/cyl/cyl_miller.py
+++ b/examples/projections/cyl/cyl_miller.py
@@ -23,9 +23,8 @@ fig = pygmt.Figure()
 fig.coast(
     region=[-180, 180, -80, 80],
     projection="J-65/12c",
-    land="khaki",
-    water="azure",
-    shorelines="thinnest",
     frame="afg",
+    land="darkgreen",
+    water="lightgray",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_oblique_mercator.py
+++ b/examples/projections/cyl/cyl_oblique_mercator.py
@@ -31,8 +31,8 @@ fig.coast(
     # Set bottom left and top right coordinates of the figure with "+r"
     region="-122/35/-107/22+r",
     frame="afg",
-    land="seagreen",
-    water="lightgray",
+    land="gray80",
+    water="steelblue",
 )
 fig.show()
 
@@ -51,8 +51,8 @@ fig.coast(
     projection="Ob130/35/25/35/3c",
     region="130/35/145/40+r",
     frame="afg",
-    land="seagreen",
-    water="lightgray",
+    land="gray80",
+    water="steelblue",
 )
 fig.show()
 
@@ -72,7 +72,7 @@ fig.coast(
     region="270/20/305/25+r",
     frame="afg",
     land="gray80",
-    water="70/130/180",  # steelblue
+    water="steelblue",
 )
 fig.show()
 

--- a/examples/projections/cyl/cyl_oblique_mercator.py
+++ b/examples/projections/cyl/cyl_oblique_mercator.py
@@ -71,8 +71,8 @@ fig.coast(
     projection="Oc280/25.5/22/69/4c",
     region="270/20/305/25+r",
     frame="afg",
-    land="seagreen",
-    water="lightgray",
+    land="gray80",
+    water="70/130/180",  # steelblue
 )
 fig.show()
 

--- a/examples/projections/cyl/cyl_oblique_mercator.py
+++ b/examples/projections/cyl/cyl_oblique_mercator.py
@@ -31,7 +31,7 @@ fig.coast(
     # Set bottom left and top right coordinates of the figure with "+r"
     region="-122/35/-107/22+r",
     frame="afg",
-    land="darkgreen",
+    land="seagreen",
     water="lightgray",
 )
 fig.show()
@@ -51,7 +51,7 @@ fig.coast(
     projection="Ob130/35/25/35/3c",
     region="130/35/145/40+r",
     frame="afg",
-    land="darkgreen",
+    land="seagreen",
     water="lightgray",
 )
 fig.show()
@@ -71,7 +71,7 @@ fig.coast(
     projection="Oc280/25.5/22/69/4c",
     region="270/20/305/25+r",
     frame="afg",
-    land="darkgreen",
+    land="seagreen",
     water="lightgray",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_oblique_mercator.py
+++ b/examples/projections/cyl/cyl_oblique_mercator.py
@@ -31,7 +31,8 @@ fig.coast(
     # Set bottom left and top right coordinates of the figure with "+r"
     region="-122/35/-107/22+r",
     frame="afg",
-    land="gray",
+    land="darkgreen",
+    water="lightgray",
 )
 fig.show()
 
@@ -47,7 +48,11 @@ fig.show()
 
 fig = pygmt.Figure()
 fig.coast(
-    projection="Ob130/35/25/35/3c", region="130/35/145/40+r", frame="afg", land="gray"
+    projection="Ob130/35/25/35/3c",
+    region="130/35/145/40+r",
+    frame="afg",
+    land="darkgreen",
+    water="lightgray",
 )
 fig.show()
 
@@ -63,7 +68,11 @@ fig.show()
 
 fig = pygmt.Figure()
 fig.coast(
-    projection="Oc280/25.5/22/69/4c", region="270/20/305/25+r", frame="afg", land="gray"
+    projection="Oc280/25.5/22/69/4c",
+    region="270/20/305/25+r",
+    frame="afg",
+    land="darkgreen",
+    water="lightgray",
 )
 fig.show()
 

--- a/examples/projections/cyl/cyl_stereographic.py
+++ b/examples/projections/cyl/cyl_stereographic.py
@@ -32,5 +32,11 @@ The standard parallel is typically one of these (but can be any value):
 import pygmt
 
 fig = pygmt.Figure()
-fig.coast(region="g", frame="afg", land="gray", projection="Cyl_stere/30/-20/12c")
+fig.coast(
+    region="g",
+    projection="Cyl_stere/30/-20/12c",
+    frame="afg",
+    land="darkgreen",
+    water="lightgray",
+)
 fig.show()

--- a/examples/projections/cyl/cyl_stereographic.py
+++ b/examples/projections/cyl/cyl_stereographic.py
@@ -37,6 +37,6 @@ fig.coast(
     projection="Cyl_stere/30/-20/12c",
     frame="afg",
     land="gray80",
-    water="70/130/180",  # steelblue
+    water="steelblue",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_stereographic.py
+++ b/examples/projections/cyl/cyl_stereographic.py
@@ -36,7 +36,7 @@ fig.coast(
     region="g",
     projection="Cyl_stere/30/-20/12c",
     frame="afg",
-    land="seagreen",
-    water="gray90",
+    land="gray80",
+    water="70/130/180",  # steelblue
 )
 fig.show()

--- a/examples/projections/cyl/cyl_stereographic.py
+++ b/examples/projections/cyl/cyl_stereographic.py
@@ -36,7 +36,7 @@ fig.coast(
     region="g",
     projection="Cyl_stere/30/-20/12c",
     frame="afg",
-    land="darkgreen",
-    water="lightgray",
+    land="seagreen",
+    water="gray90",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_transverse_mercator.py
@@ -23,9 +23,8 @@ fig = pygmt.Figure()
 fig.coast(
     region=[20, 50, 30, 45],
     projection="T35/12c",
-    land="lightbrown",
-    water="seashell",
-    shorelines="thinnest",
     frame="afg",
+    land="darkgreen",
+    water="lightgray",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_transverse_mercator.py
@@ -24,7 +24,7 @@ fig.coast(
     region=[20, 50, 30, 45],
     projection="T35/12c",
     frame="afg",
-    land="darkgreen",
-    water="lightgray",
+    land="seagreen",
+    water="gray90",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_transverse_mercator.py
@@ -25,6 +25,6 @@ fig.coast(
     projection="T35/12c",
     frame="afg",
     land="gray80",
-    water="70/130/180",  # steelblue
+    water="steelblue",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_transverse_mercator.py
@@ -24,7 +24,7 @@ fig.coast(
     region=[20, 50, 30, 45],
     projection="T35/12c",
     frame="afg",
-    land="seagreen",
-    water="gray90",
+    land="gray80",
+    water="70/130/180",  # steelblue
 )
 fig.show()

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -45,7 +45,7 @@ fig.coast(
     region=[127.5, 128.5, 26, 27],
     projection="U52R/12c",
     frame="afg",
-    land="seagreen",
-    water="gray90",
+    land="gray80",
+    water="70/130/180",  # steelblue
 )
 fig.show()

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -45,7 +45,7 @@ fig.coast(
     region=[127.5, 128.5, 26, 27],
     projection="U52R/12c",
     frame="afg",
-    land="darkgreen",
-    water="lightgray",
+    land="seagreen",
+    water="gray90",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -44,9 +44,8 @@ fig = pygmt.Figure()
 fig.coast(
     region=[127.5, 128.5, 26, 27],
     projection="U52R/12c",
-    land="lightgreen",
-    water="lightblue",
-    shorelines="thinnest",
     frame="afg",
+    land="darkgreen",
+    water="lightgray",
 )
 fig.show()

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -46,6 +46,6 @@ fig.coast(
     projection="U52R/12c",
     frame="afg",
     land="gray80",
-    water="70/130/180",  # steelblue
+    water="steelblue",
 )
 fig.show()

--- a/examples/projections/misc/misc_eckertIV.py
+++ b/examples/projections/misc/misc_eckertIV.py
@@ -18,5 +18,5 @@ import pygmt
 
 fig = pygmt.Figure()
 # Use region "d" to specify global region (-180/180/-90/90)
-fig.coast(region="d", projection="Kf12c", land="ivory", water="bisque4", frame="afg")
+fig.coast(region="d", projection="Kf12c", frame="afg", land="ivory", water="bisque4")
 fig.show()

--- a/examples/projections/misc/misc_eckertVI.py
+++ b/examples/projections/misc/misc_eckertVI.py
@@ -19,5 +19,5 @@ import pygmt
 
 fig = pygmt.Figure()
 # Use region "d" to specify global region (-180/180/-90/90)
-fig.coast(region="d", projection="Ks12c", land="ivory", water="bisque4", frame="afg")
+fig.coast(region="d", projection="Ks12c", frame="afg", land="ivory", water="bisque4")
 fig.show()

--- a/examples/projections/misc/misc_hammer.py
+++ b/examples/projections/misc/misc_hammer.py
@@ -19,5 +19,5 @@ import pygmt
 
 fig = pygmt.Figure()
 # Use region "d" to specify global region (-180/180/-90/90)
-fig.coast(region="d", projection="H12c", land="black", water="cornsilk", frame="afg")
+fig.coast(region="d", projection="H12c", frame="afg", land="ivory", water="bisque4")
 fig.show()

--- a/examples/projections/misc/misc_mollweide.py
+++ b/examples/projections/misc/misc_mollweide.py
@@ -20,5 +20,5 @@ import pygmt
 
 fig = pygmt.Figure()
 # Use region "d" to specify global region (-180/180/-90/90)
-fig.coast(region="d", projection="W12c", land="tomato1", water="skyblue", frame="ag")
+fig.coast(region="d", projection="W12c", frame="afg", land="ivory", water="bisque4")
 fig.show()

--- a/examples/projections/misc/misc_robinson.py
+++ b/examples/projections/misc/misc_robinson.py
@@ -30,5 +30,5 @@ import pygmt
 
 fig = pygmt.Figure()
 # Use region "d" to specify global region (-180/180/-90/90)
-fig.coast(region="d", projection="N12c", land="goldenrod", water="snow2", frame="afg")
+fig.coast(region="d", projection="N12c", frame="afg", land="ivory", water="bisque4")
 fig.show()

--- a/examples/projections/misc/misc_sinusoidal.py
+++ b/examples/projections/misc/misc_sinusoidal.py
@@ -20,5 +20,5 @@ import pygmt
 
 fig = pygmt.Figure()
 # Use region "d" to specify global region (-180/180/-90/90)
-fig.coast(region="d", projection="I12c", land="coral4", water="azure3", frame="afg")
+fig.coast(region="d", projection="I12c", frame="afg", land="ivory", water="bisque4")
 fig.show()

--- a/examples/projections/misc/misc_van_der_grinten.py
+++ b/examples/projections/misc/misc_van_der_grinten.py
@@ -19,5 +19,5 @@ import pygmt
 
 fig = pygmt.Figure()
 # Use region "d" to specify global region (-180/180/-90/90)
-fig.coast(region="d", projection="V12c", land="gray", water="cornsilk", frame="afg")
+fig.coast(region="d", projection="V12c", frame="afg", land="ivory", water="bisque4")
 fig.show()

--- a/examples/projections/misc/misc_winkel_tripel.py
+++ b/examples/projections/misc/misc_winkel_tripel.py
@@ -28,5 +28,5 @@ import pygmt
 
 fig = pygmt.Figure()
 # Use region "d" to specify global region (-180/180/-90/90)
-fig.coast(region="d", projection="R12c", land="burlywood4", water="wheat1", frame="afg")
+fig.coast(region="d", projection="R12c", frame="afg", land="ivory", water="bisque4")
 fig.show()

--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -27,6 +27,6 @@ fig = pygmt.Figure()
 fig.basemap(region=[0, 10, 0, 50], projection="X15c/10c", frame=["afg", "+gbisque"])
 fig.plot(x=[3, 9, 2], y=[4, 9, 37], pen="2p,black")
 # Plot data points ontop of the line
-# Use squares with a size of 0.5 centimeters, a "orange" fill and a "black" outline
+# Use squares with a size of 0.5 centimeters, an "orange" fill and a "black" outline
 fig.plot(x=[3, 9, 2], y=[4, 9, 37], style="s0.5c", fill="orange", pen="black")
 fig.show()

--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -27,6 +27,6 @@ fig = pygmt.Figure()
 fig.basemap(region=[0, 10, 0, 50], projection="X15c/10c", frame=["afg", "+gbisque"])
 fig.plot(x=[3, 9, 2], y=[4, 9, 37], pen="2p,black")
 # Plot data points ontop of the line
-# Use squares with a size of 0.5 centimeters, an "orange" fill and a "black" outline
-fig.plot(x=[3, 9, 2], y=[4, 9, 37], style="s0.5c", fill="orange", pen="black")
+# Use squares with a size of 0.3 centimeters, an "orange" fill and a "black" outline
+fig.plot(x=[3, 9, 2], y=[4, 9, 37], style="s0.3c", fill="orange", pen="black")
 fig.show()

--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -24,7 +24,9 @@ import pygmt
 
 fig = pygmt.Figure()
 # The region parameter is specified as x_min, x_max, y_min, y_max
-fig.basemap(region=[0, 10, 0, 50], projection="X15c/10c", frame="afg")
+fig.basemap(region=[0, 10, 0, 50], projection="X15c/10c", frame=["afg", "+gbisque"])
 fig.plot(x=[3, 9, 2], y=[4, 9, 37], pen="2p,black")
+# Plot data points ontop of the line
+# Use squares with a size of 0.5 centimeters, a "orange" fill and a "black" outline
 fig.plot(x=[3, 9, 2], y=[4, 9, 37], style="s0.5c", fill="orange", pen="black")
 fig.show()

--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -23,17 +23,8 @@ coordinates, see the GMT documentation
 import pygmt
 
 fig = pygmt.Figure()
-fig.plot(
-    # The x and y parameters determine the coordinates of lines
-    x=[3, 9, 2],
-    y=[4, 9, 37],
-    pen="3p,red",
-    # The region parameter sets the x and y ranges of the
-    # Cartesian projection
-    region=[0, 10, 0, 50],
-    projection="X15c/10c",
-    # "WSne" is passed to the frame parameter to put annotations
-    # only on the left and bottom axes
-    frame=["af", "WSne"],
-)
+# The region parameter is specified as x_min, x_max, y_min, y_max
+fig.basemap(region=[0, 10, 0, 50], projection="X15c/10c", frame="afg")
+fig.plot(x=[3, 9, 2], y=[4, 9, 37], pen="2p,black")
+fig.plot(x=[3, 9, 2], y=[4, 9, 37], style="s0.5c", fill="orange", pen="black")
 fig.show()

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -39,7 +39,7 @@ fig.basemap(
 fig.plot(x=xline, y=yline, pen="2p,black,dashed")
 
 # Plot the square root values ontop of the line
-# Use squares with a size of 0.5 centimeters, a "orange" fill and a "black" outline
+# Use squares with a size of 0.5 centimeters, an "orange" fill and a "black" outline
 # Symbols are not clipped if they go off the figure
 fig.plot(x=xpoints, y=ypoints, style="s0.5c", fill="orange", pen="black", no_clip=True)
 fig.show()

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -32,14 +32,14 @@ fig.basemap(
     projection="X15cl/10c",
     # Set the figures frame and color as well as
     # annotations, ticks, and gridlines
-    frame=["WSne", "xa2g3", "ya2f1g2"],
+    frame=["WSne+gbisque", "xa2g3", "ya2f1g2"],
 )
 
 # Set the line thickness to "2p", the color to "black", and the style to "dashed"
 fig.plot(x=xline, y=yline, pen="2p,black,dashed")
 
 # Plot the square root values ontop of the line
-# Use circles with a diameter of 0.5 centimeters, a "orange" fill and a "black" outline
+# Use squares with a size of 0.5 centimeters, a "orange" fill and a "black" outline
 # Symbols are not clipped if they go off the figure
 fig.plot(x=xpoints, y=ypoints, style="s0.5c", fill="orange", pen="black", no_clip=True)
 fig.show()

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -39,7 +39,7 @@ fig.basemap(
 fig.plot(x=xline, y=yline, pen="2p,black,dashed")
 
 # Plot the square root values ontop of the line
-# Use squares with a size of 0.5 centimeters, an "orange" fill and a "black" outline
+# Use squares with a size of 0.3 centimeters, an "orange" fill and a "black" outline
 # Symbols are not clipped if they go off the figure
-fig.plot(x=xpoints, y=ypoints, style="s0.5c", fill="orange", pen="black", no_clip=True)
+fig.plot(x=xpoints, y=ypoints, style="s0.3c", fill="orange", pen="black", no_clip=True)
 fig.show()

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -26,21 +26,20 @@ xpoints = np.arange(0, 101, 10)
 ypoints = xpoints**0.5
 
 fig = pygmt.Figure()
-fig.plot(
+fig.basemap(
     region=[1, 100, 0, 10],
     # Set a logarithmic transformation on the x-axis
     projection="X15cl/10c",
     # Set the figures frame and color as well as
     # annotations, ticks, and gridlines
-    frame=["WSne+gbisque", "xa2g3", "ya2f1g2"],
-    x=xline,
-    y=yline,
-    # Set the line thickness to "1p", the color to "blue",
-    # and the style to "-", i.e. "dashed"
-    pen="1p,blue,-",
+    frame=["WSne", "xa2g3", "ya2f1g2"],
 )
-# Plot square root values as points on the line
-# Style of points is 0.3 cm squares, color fill is "red" with a "black" outline
-# Points are not clipped if they go off the figure
-fig.plot(x=xpoints, y=ypoints, style="s0.3c", fill="red", no_clip=True, pen="black")
+
+# Set the line thickness to "2p", the color to "black", and the style to "dashed"
+fig.plot(x=xline, y=yline, pen="2p,black,dashed")
+
+# Plot the square root values ontop of the line
+# Use circles with a diameter of 0.5 centimeters, a "orange" fill and a "black" outline
+# Symbols are not clipped if they go off the figure
+fig.plot(x=xpoints, y=ypoints, style="s0.5c", fill="orange", pen="black", no_clip=True)
 fig.show()

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -22,23 +22,21 @@ yvalues = np.arange(0, 11)
 xvalues = yvalues**2
 
 fig = pygmt.Figure()
-fig.plot(
+fig.basemap(
     region=[0, 100, 0, 10],
     # Set the power transformation of the x-axis, with a power of 0.5
     projection="X15cp0.5/10c",
-    # Set the figures frame and color as well as
-    # annotations and ticks
-    # The "p" forces to show only square numbers as annotations
-    # of the x-axis
-    frame=["WSne+givory", "xa1p", "ya2f1"],
-    # Set the line thickness to "thick" (equals "1p", i.e. 1 point)
-    # Use as color "black" (default) and as style "solid" (default)
-    pen="thick,black,solid",
-    x=xvalues,
-    y=yvalues,
+    # Set the figures frame as well as annotations and ticks
+    # The "p" forces to show only square numbers as annotations of the x-axis
+    frame=["WSne", "xfga1p", "ya2f1g"],
 )
-# Plot x-, y-values as points on the line
-# Style of points is 0.2 cm circles, color fill is "green" with a "black"
-# outline. Points are not clipped if they go off the figure
-fig.plot(x=xvalues, y=yvalues, style="c0.2c", fill="green", no_clip=True, pen="black")
+
+# Set the line thickness to "thick" (equals "1p", i.e. 1 point)
+# Use as color "black" (default) and as style "solid" (default)
+fig.plot(x=xvalues, y=yvalues, pen="thick,black,solid")
+
+# Plot the data points ontop of the line
+# Use circles with 0.5 centimeters diameter, with a "orange" fill and a "black" outline
+# Symbols are not clipped if they go off the figure
+fig.plot(x=xvalues, y=yvalues, style="c0.5c", fill="orange", pen="black", no_clip=True)
 fig.show()

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -36,7 +36,7 @@ fig.basemap(
 fig.plot(x=xvalues, y=yvalues, pen="thick,black,solid")
 
 # Plot the data points ontop of the line
-# Use circles with 0.5 centimeters diameter, with an "orange" fill and a "black" outline
+# Use circles with 0.3 centimeters diameter, with an "orange" fill and a "black" outline
 # Symbols are not clipped if they go off the figure
-fig.plot(x=xvalues, y=yvalues, style="c0.5c", fill="orange", pen="black", no_clip=True)
+fig.plot(x=xvalues, y=yvalues, style="c0.3c", fill="orange", pen="black", no_clip=True)
 fig.show()

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -36,7 +36,7 @@ fig.basemap(
 fig.plot(x=xvalues, y=yvalues, pen="thick,black,solid")
 
 # Plot the data points ontop of the line
-# Use circles with 0.5 centimeters diameter, with a "orange" fill and a "black" outline
+# Use circles with 0.5 centimeters diameter, with an "orange" fill and a "black" outline
 # Symbols are not clipped if they go off the figure
 fig.plot(x=xvalues, y=yvalues, style="c0.5c", fill="orange", pen="black", no_clip=True)
 fig.show()

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -28,7 +28,7 @@ fig.basemap(
     projection="X15cp0.5/10c",
     # Set the figures frame as well as annotations and ticks
     # The "p" forces to show only square numbers as annotations of the x-axis
-    frame=["WSne", "xfga1p", "ya2f1g"],
+    frame=["WSne+gbisque", "xfga1p", "ya2f1g"],
 )
 
 # Set the line thickness to "thick" (equals "1p", i.e. 1 point)

--- a/examples/projections/nongeo/polar.py
+++ b/examples/projections/nongeo/polar.py
@@ -64,7 +64,7 @@ fig.basemap(
     # set map width to 5 cm
     projection="P5c",
     # set the frame and title; @^ allows for a line break within the title
-    frame=["xa45f", "+tprojection='P5c' @^ region=[0, 360, 0, 1]"],
+    frame=["xa45f", "+gbisque+tprojection='P5c' @^ region=[0, 360, 0, 1]"],
 )
 
 fig.shift_origin(xshift="8c")
@@ -79,7 +79,7 @@ fig.basemap(
     # instead of standard angle
     projection="P5c+a",
     # set the frame and title; @^ allows for a line break within the title
-    frame=["xa45f", "+tprojection='P5c+a' @^ region=[0, 360, 0, 1]"],
+    frame=["xa45f", "+gbisque+tprojection='P5c+a' @^ region=[0, 360, 0, 1]"],
 )
 
 fig.shift_origin(xshift="8c")
@@ -94,7 +94,7 @@ fig.basemap(
     # instead of standard angle
     projection="P5c+a",
     # set the frame and title; @^ allows for a line break within the title
-    frame=["xa45f", "ya0.2", "WNe+tprojection='P5c+a' @^ region=[0, 90, 0, 1]"],
+    frame=["xa45f", "ya0.2", "WNe+gbisque+tprojection='P5c+a' @^ region=[0, 90, 0, 1]"],
 )
 
 fig.shift_origin(xshift="-16c", yshift="-7c")
@@ -113,7 +113,7 @@ fig.basemap(
     frame=[
         "xa30f",
         "ya0.2",
-        "WNe+tprojection='P5c+a+t45' @^ region=[0, 90, 0, 1]",
+        "WNe+gbisque+tprojection='P5c+a+t45' @^ region=[0, 90, 0, 1]",
     ],
 )
 
@@ -133,7 +133,7 @@ fig.basemap(
     frame=[
         "xa30f",
         "ya",
-        "WNse+tprojection='P5c+a+t45' @^ region=[0, 90, 3480, 6371]",
+        "WNse+gbisque+tprojection='P5c+a+t45' @^ region=[0, 90, 3480, 6371]",
     ],
 )
 
@@ -153,7 +153,7 @@ fig.basemap(
     frame=[
         "xa30f",
         "ya",
-        "WNse+tprojection='P5c+a+t45+\\z' @^ region=[0, 90, 3480, 6371]",
+        "WNse+gbisque+tprojection='P5c+a+t45+\\z' @^ region=[0, 90, 3480, 6371]",
     ],
 )
 

--- a/examples/projections/nongeo/polar.py
+++ b/examples/projections/nongeo/polar.py
@@ -63,9 +63,8 @@ fig.basemap(
     region=[0, 360, 0, 1],
     # set map width to 5 cm
     projection="P5c",
-    # set the frame, color, and title
-    # @^ allows for a line break within the title
-    frame=["xa45f", "+gbisque+tprojection='P5c' @^ region=[0, 360, 0, 1]"],
+    # set the frame and title; @^ allows for a line break within the title
+    frame=["xa45f", "+tprojection='P5c' @^ region=[0, 360, 0, 1]"],
 )
 
 fig.shift_origin(xshift="8c")
@@ -79,9 +78,8 @@ fig.basemap(
     # set map width to 5 cm and interpret input data as geographic azimuth
     # instead of standard angle
     projection="P5c+a",
-    # set the frame, color, and title
-    # @^ allows for a line break within the title
-    frame=["xa45f", "+gbisque+tprojection='P5c+a' @^ region=[0, 360, 0, 1]"],
+    # set the frame and title; @^ allows for a line break within the title
+    frame=["xa45f", "+tprojection='P5c+a' @^ region=[0, 360, 0, 1]"],
 )
 
 fig.shift_origin(xshift="8c")
@@ -95,9 +93,8 @@ fig.basemap(
     # set map width to 5 cm and interpret input data as geographic azimuth
     # instead of standard angle
     projection="P5c+a",
-    # set the frame, color, and title
-    # @^ allows for a line break within the title
-    frame=["xa45f", "ya0.2", "WNe+gbisque+tprojection='P5c+a' @^ region=[0, 90, 0, 1]"],
+    # set the frame and title; @^ allows for a line break within the title
+    frame=["xa45f", "ya0.2", "WNe+tprojection='P5c+a' @^ region=[0, 90, 0, 1]"],
 )
 
 fig.shift_origin(xshift="-16c", yshift="-7c")
@@ -112,12 +109,11 @@ fig.basemap(
     # instead of standard angle, rotate coordinate system counterclockwise by
     # 45 degrees
     projection="P5c+a+t45",
-    # set the frame, color, and title
-    # @^ allows for a line break within the title
+    # set the frame and title; @^ allows for a line break within the title
     frame=[
         "xa30f",
         "ya0.2",
-        "WNe+gbisque+tprojection='P5c+a+t45' @^ region=[0, 90, 0, 1]",
+        "WNe+tprojection='P5c+a+t45' @^ region=[0, 90, 0, 1]",
     ],
 )
 
@@ -133,12 +129,11 @@ fig.basemap(
     # instead of standard angle, rotate coordinate system counterclockwise by
     # 45 degrees
     projection="P5c+a+t45",
-    # set the frame, color, and title
-    # @^ allows for a line break within the title
+    # set the frame, and title; @^ allows for a line break within the title
     frame=[
         "xa30f",
         "ya",
-        "WNse+gbisque+tprojection='P5c+a+t45' @^ region=[0, 90, 3480, 6371]",
+        "WNse+tprojection='P5c+a+t45' @^ region=[0, 90, 3480, 6371]",
     ],
 )
 
@@ -154,12 +149,11 @@ fig.basemap(
     # instead of standard angle, rotate coordinate system counterclockwise by
     # 45 degrees, r-axis is marked as depth
     projection="P5c+a+t45+z",
-    # set the frame, color, and title
-    # @^ allows for a line break within the title
+    # set the frame, and title; @^ allows for a line break within the title
     frame=[
         "xa30f",
         "ya",
-        "WNse+gbisque+tprojection='P5c+a+t45+\\z' @^ region=[0, 90, 3480, 6371]",
+        "WNse+tprojection='P5c+a+t45+\\z' @^ region=[0, 90, 3480, 6371]",
     ],
 )
 


### PR DESCRIPTION
**Description of proposed changes**

This PR updates the projection examples to use the same colors for land and water within in one category.
So far I have used this color combinations:
![colors_projections](https://github.com/user-attachments/assets/b2249853-35fc-4a13-ac34-48f81d6336cd)

If we have agreed on the colors, we can use different ways to passe the colors (GMT name, RGB code, HEX codes).
There are also some changes to make the code consistent.


**Preview**:
- **Old**: https://www.pygmt.org/dev/projections/index.html
- **New**: https://pygmt-dev--3464.org.readthedocs.build/en/3464/projections/index.html

Fixes #3458 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
