### PR TITLE
WIP: Implement virtualfile_from_image

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -84,9 +84,10 @@ def dataarray_to_matrix(grid):
     >>> print(inc)
     [2.0, 2.0]
     """
-    if len(grid.dims) != 2:
+    if len(grid.dims) not in {2, 3}:
         raise GMTInvalidInput(
-            f"Invalid number of grid dimensions '{len(grid.dims)}'. Must be 2."
+            f"Invalid number of grid/image dimensions '{len(grid.dims)}'. "
+            "Must be 2 for grid, or 3 for image."
         )
     # Extract region and inc from the grid
     region = []


### PR DESCRIPTION
**Description of proposed changes**

Enable passing in 3-band images to GMT via a virtualfile mechanism instead of using a temporary GeoTIFF file (thus superseding #2590). This means `rioxarray` won't need to be installed for plotting 3-band images anymore!

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

TODO:
- [x] Initial implementation
- [ ] Deprecate `tempfile_from_image`
- [ ] Add/update unit tests

Notes:
- Implementation based on `virtualfile_from_grid` originally created in #210
- May decide to wrap this into the work at #3099 (have a general `virtualfile_from_xr` method that works with any no. of bands?)

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Supersedes #2590


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
