### PR TITLE
Fix earth_day_01d_p to earth_day_01d

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -242,7 +242,7 @@
 * Switch away from Stamen basemaps ([#2717](https://github.com/GenericMappingTools/pygmt/pull/2717))
 * Add the "validate_output_table_type" function to check the "output_type" parameter ([#2772](https://github.com/GenericMappingTools/pygmt/pull/2772))
 * Create "skip_if_no" helper function to skip tests when missing a package ([#2883](https://github.com/GenericMappingTools/pygmt/pull/2883))
-* Fix "fixture_xr_image" to open "earth_day_01d_p" directly with rioxarray ([#2963](https://github.com/GenericMappingTools/pygmt/pull/2963))
+* Fix "fixture_xr_image" to open "earth_day_01d" directly with rioxarray ([#2963](https://github.com/GenericMappingTools/pygmt/pull/2963))
 * Improve the way to import optional modules ([#2809](https://github.com/GenericMappingTools/pygmt/pull/2809))
 * Move variable `__gmt_version__` to pygmt.clib to avoid cyclic-import errors ([#2713](https://github.com/GenericMappingTools/pygmt/pull/2713))
 * Refactor the internal "_load_remote_dataset function" to simplify datasets' definitions ([#2917](https://github.com/GenericMappingTools/pygmt/pull/2917))

--- a/pygmt/datatypes/image.py
+++ b/pygmt/datatypes/image.py
@@ -20,7 +20,7 @@ class _GMT_IMAGE(ctp.Structure):  # noqa: N801
     >>> from pygmt.clib import Session
     >>> with Session() as lib:
     ...     with lib.virtualfile_out(kind="image") as voutimg:
-    ...         lib.call_module("read", ["@earth_day_01d_p", voutimg, "-Ti"])
+    ...         lib.call_module("read", ["@earth_day_01d", voutimg, "-Ti"])
     ...         # Read the image from the virtual file
     ...         image = lib.read_virtualfile(vfname=voutimg, kind="image").contents
     ...         # The image header
@@ -110,7 +110,7 @@ class _GMT_IMAGE(ctp.Structure):  # noqa: N801
         >>> from pygmt.clib import Session
         >>> with Session() as lib:
         ...     with lib.virtualfile_out(kind="image") as voutimg:
-        ...         lib.call_module("read", ["@earth_day_01d_p", voutimg, "-Ti"])
+        ...         lib.call_module("read", ["@earth_day_01d", voutimg, "-Ti"])
         ...         # Read the image from the virtual file
         ...         image = lib.read_virtualfile(voutimg, kind="image")
         ...         # Convert to xarray.DataArray and use it later

--- a/pygmt/helpers/caching.py
+++ b/pygmt/helpers/caching.py
@@ -13,7 +13,7 @@ def cache_data():
     datasets = [
         # List of GMT remote datasets.
         "@earth_age_01d_g",
-        "@earth_day_01d_p",
+        "@earth_day_01d",
         "@earth_faa_01d_g",
         "@earth_gebco_01d_g",
         "@earth_gebcosi_01d_g",

--- a/pygmt/tests/test_clib_read_data.py
+++ b/pygmt/tests/test_clib_read_data.py
@@ -33,10 +33,10 @@ def fixture_expected_xrgrid():
 @pytest.fixture(scope="module", name="expected_xrimage")
 def fixture_expected_xrimage():
     """
-    The expected xr.DataArray object for the @earth_day_01d_p file.
+    The expected xr.DataArray object for the @earth_day_01d file.
     """
     if _HAS_RIOXARRAY:
-        with rioxarray.open_rasterio(which("@earth_day_01d_p")) as da:
+        with rioxarray.open_rasterio(which("@earth_day_01d")) as da:
             dataarray = da.load().drop_vars("spatial_ref")
             return dataarray
     return None
@@ -122,7 +122,7 @@ def test_clib_read_data_grid_actual_image(expected_xrimage):
     Test the Session.read_data method for grid, but actually the file is an image.
     """
     with Session() as lib:
-        image = lib.read_data("@earth_day_01d_p", kind="grid").contents
+        image = lib.read_data("@earth_day_01d", kind="grid").contents
         # Explicitly check n_bands. Only one band is read for 3-band images.
         assert image.header.contents.n_bands == 1
 
@@ -151,7 +151,7 @@ def test_clib_read_data_image(expected_xrimage):
     Test the Session.read_data method for images.
     """
     with Session() as lib:
-        image = lib.read_data("@earth_day_01d_p", kind="image").contents
+        image = lib.read_data("@earth_day_01d", kind="image").contents
 
         xrimage = image.to_dataarray()
         assert xrimage.shape == (3, 180, 360)
@@ -172,7 +172,7 @@ def test_clib_read_data_image_two_steps(expected_xrimage):
     Test the Session.read_data method for images in two steps, first reading the header
     and then the data.
     """
-    infile = "@earth_day_01d_p"
+    infile = "@earth_day_01d"
     with Session() as lib:
         # Read the header first
         data_ptr = lib.read_data(infile, kind="image", mode="GMT_CONTAINER_ONLY")


### PR DESCRIPTION
Unlike other remote datasets, the `earth_day` dataset only provides pixel-registered images. So, its full syntax should be `@earth_day_01d` rather than `@earth_day_01d_p` (ref: https://www.generic-mapping-tools.org/remote-datasets/earth-daynight.html), although the original GeoTIFF files are named like `earth_day_01d_p.tif` (https://oceania.generic-mapping-tools.org/server/earth/earth_day/).

This PR fixes `earth_day_01d_p` to `earth_day_01d`