### PR TITLE
DOC: Fix typo "ontop" to "on top"

### DIFF
--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -26,7 +26,7 @@ fig = pygmt.Figure()
 # The region parameter is specified as x_min, x_max, y_min, y_max
 fig.basemap(region=[0, 10, 0, 50], projection="X15c/10c", frame=["afg", "+gbisque"])
 fig.plot(x=[3, 9, 2], y=[4, 9, 37], pen="2p,black")
-# Plot data points ontop of the line
+# Plot data points on top of the line
 # Use squares with a size of 0.3 centimeters, an "orange" fill and a "black" outline
 fig.plot(x=[3, 9, 2], y=[4, 9, 37], style="s0.3c", fill="orange", pen="black")
 fig.show()

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -38,7 +38,7 @@ fig.basemap(
 # Set the line thickness to "2p", the color to "black", and the style to "dashed"
 fig.plot(x=xline, y=yline, pen="2p,black,dashed")
 
-# Plot the square root values ontop of the line
+# Plot the square root values on top of the line
 # Use squares with a size of 0.3 centimeters, an "orange" fill and a "black" outline
 # Symbols are not clipped if they go off the figure
 fig.plot(x=xpoints, y=ypoints, style="s0.3c", fill="orange", pen="black", no_clip=True)

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -35,7 +35,7 @@ fig.basemap(
 # Use as color "black" (default) and as style "solid" (default)
 fig.plot(x=xvalues, y=yvalues, pen="thick,black,solid")
 
-# Plot the data points ontop of the line
+# Plot the data points on top of the line
 # Use circles with 0.3 centimeters diameter, with an "orange" fill and a "black" outline
 # Symbols are not clipped if they go off the figure
 fig.plot(x=xvalues, y=yvalues, style="c0.3c", fill="orange", pen="black", no_clip=True)


### PR DESCRIPTION
**Description of proposed changes**


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
