### PR TITLE
DOC: Mention datetime tutorial in Cartesian linear projection

### DIFF
--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -4,18 +4,16 @@ Cartesian linear
 
 **X**\ *width*\ [/*height*] or **x**\ *x-scale*\ [/*y-scale*]
 
-Give the *width* of the figure and the optional *height*.
-The lower-case version **x** is similar to **X** but expects
-an *x-scale* and an optional *y-scale*.
+Give the *width* of the figure and the optional *height*. The lower-case version
+**x** is similar to **X** but expects an *x-scale* and an optional *y-scale*.
 
-The Cartesian linear projection is primarily designed for regular
-floating point data. To plot geographical data in a linear
-projection, see the upstream GMT documentation
-:gmt-docs:`Geographic coordinates
+The Cartesian linear projection is primarily designed for regular floating point
+data. To plot geographical data in a linear projection, see the upstream GMT
+documentation :gmt-docs:`Geographic coordinates
 <reference/coordinate-transformations.html#geographic-coordinates>`.
-To make the linear plot using calendar date/time as input
-coordinates, see the GMT documentation
-:gmt-docs:`Calendar time coordinates
+To make the linear plot using calendar date/time as input coordinates, see the
+tutorial :doc:`Plotting datetime charts </tutorials/advanced/date_time_charts>`.
+GMT documentation :gmt-docs:`Calendar time coordinates
 <reference/coordinate-transformations.html#calendar-time-coordinates>`.
 """
 


### PR DESCRIPTION
**Description of proposed changes**

Besides referring to the upstream GMT documentation, it makes sense to mention the PyGMT tutorial regarding how date time input data and format can be visualized in PyGMT.

Also adjust the line length to 81 characters.

**Preview**:

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
