### PR TITLE
Earth day/night remote dataset: Fix typo - use plural

### DIFF
--- a/pygmt/datasets/earth_day.py
+++ b/pygmt/datasets/earth_day.py
@@ -60,9 +60,8 @@ def load_blue_marble(
     Parameters
     ----------
     resolution
-        The image resolution. The suffix ``d``, ``m``, and ``s`` stand for arc-degree,
-        arc-minute, and arc-second.
-
+        The image resolution. The suffix ``d``, ``m``, and ``s`` stand for arc-degrees,
+        arc-minutes, and arc-seconds.
     region
         The subregion of the image to load, in the form of a sequence [*xmin*, *xmax*,
         *ymin*, *ymax*].

--- a/pygmt/datasets/earth_night.py
+++ b/pygmt/datasets/earth_night.py
@@ -60,9 +60,8 @@ def load_black_marble(
     Parameters
     ----------
     resolution
-        The image resolution. The suffix ``d``, ``m``, and ``s`` stand for arc-degree,
-        arc-minute, and arc-second.
-
+        The image resolution. The suffix ``d``, ``m``, and ``s`` stand for arc-degrees,
+        arc-minutes, and arc-seconds.
     region
         The subregion of the image to load, in the form of a sequence [*xmin*, *xmax*,
         *ymin*, *ymax*].


### PR DESCRIPTION
**Description of proposed changes**

A tiny typo fix to be consistent with the documentation of the other remote dataset.

Thanks for adding the access to these images - looks interesting (:

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
