### PR TITLE
GMTDataArrayAccessor: Simplify the codes for the grid registration and gtype during initialization

### DIFF
--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -2,6 +2,7 @@
 GMT accessor for :class:`xarray.DataArray`.
 """
 
+import contextlib
 from pathlib import Path
 
 import xarray as xr
@@ -115,22 +116,17 @@ class GMTDataArrayAccessor:
 
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
+        # Default to Gridline registration and Cartensian grid type
+        self._registration = 0
+        self._gtype = 0
 
-        self._source = self._obj.encoding.get("source")
-        if self._source is not None and Path(self._source).exists():
-            try:
-                # Get grid registration and grid type from the last two columns
-                # of the shortened summary information of `grdinfo`.
+        # If the source file exists, get grid registration and grid type from the last
+        # two columns of the shortened summary information of `grdinfo`.
+        if (_source := self._obj.encoding.get("source")) and Path(_source).exists():
+            with contextlib.suppress(ValueError):
                 self._registration, self._gtype = map(
-                    int, grdinfo(self._source, per_column="n").split()[-2:]
+                    int, grdinfo(_source, per_column="n").split()[-2:]
                 )
-            except ValueError:
-                self._registration = 0  # Default to Gridline registration
-                self._gtype = 0  # Default to Cartesian grid type
-        else:
-            self._registration = 0  # Default to Gridline registration
-            self._gtype = 0  # Default to Cartesian grid type
-        del self._source
 
     @property
     def registration(self):

--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -121,7 +121,7 @@ class GMTDataArrayAccessor:
         self._gtype = 0
 
         # If the source file exists, get grid registration and grid type from the last
-        # two columns of the shortened summary information of `grdinfo`.
+        # two columns of the shortened summary information of grdinfo.
         if (_source := self._obj.encoding.get("source")) and Path(_source).exists():
             with contextlib.suppress(ValueError):
                 self._registration, self._gtype = map(

--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -116,7 +116,7 @@ class GMTDataArrayAccessor:
 
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
-        # Default to Gridline registration and Cartensian grid type
+        # Default to Gridline registration and Cartesian grid type
         self._registration = 0
         self._gtype = 0
 


### PR DESCRIPTION
**Description of proposed changes**

Instead of using the complicated `if-else` and `try-except` statements, this PR refactors the codes by initializing grid registration and gtype to the default values first and then see if we can determine their values using `grdinfo`.

The original codes were added in #500 and #2009.