### PR TITLE
clib.conversion: Remove the as_c_contiguous function and use np.ascontiguousarray instead

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -123,7 +123,7 @@ def dataarray_to_matrix(grid):
         inc = [abs(i) for i in inc]
         grid = grid.sortby(variables=list(grid.dims), ascending=True)
 
-    matrix = as_c_contiguous(grid[::-1].to_numpy())
+    matrix = np.ascontiguousarray(grid[::-1].to_numpy())
     region = [float(i) for i in region]
     inc = [float(i) for i in inc]
     return matrix, region, inc
@@ -200,51 +200,9 @@ def vectors_to_arrays(vectors):
     for vector in vectors:
         vec_dtype = str(getattr(vector, "dtype", ""))
         array = np.asarray(a=vector, dtype=dtypes.get(vec_dtype))
-        arrays.append(as_c_contiguous(array))
+        arrays.append(np.ascontiguousarray(array))
 
     return arrays
-
-
-def as_c_contiguous(array):
-    """
-    Ensure a numpy array is C contiguous in memory.
-
-    If the array is not C contiguous, a copy will be necessary.
-
-    Parameters
-    ----------
-    array : 1-D array
-        The numpy array
-
-    Returns
-    -------
-    array : 1-D array
-        Array is C contiguous order.
-
-    Examples
-    --------
-
-    >>> import numpy as np
-    >>> data = np.array([[1, 2], [3, 4], [5, 6]])
-    >>> x = data[:, 0]
-    >>> x
-    array([1, 3, 5])
-    >>> x.flags.c_contiguous
-    False
-    >>> new_x = as_c_contiguous(x)
-    >>> new_x
-    array([1, 3, 5])
-    >>> new_x.flags.c_contiguous
-    True
-    >>> x = np.array([8, 9, 10])
-    >>> x.flags.c_contiguous
-    True
-    >>> as_c_contiguous(x).flags.c_contiguous
-    True
-    """
-    if not array.flags.c_contiguous:
-        return array.copy(order="C")
-    return array
 
 
 def sequence_to_ctypes_array(

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -19,7 +19,6 @@ import pandas as pd
 import xarray as xr
 from pygmt.clib.conversion import (
     array_to_datetime,
-    as_c_contiguous,
     dataarray_to_matrix,
     sequence_to_ctypes_array,
     strings_to_ctypes_array,
@@ -1499,7 +1498,7 @@ class Session:
         # collected and the memory freed. Creating it in this context manager
         # guarantees that the copy will be around until the virtual file is
         # closed.
-        matrix = as_c_contiguous(matrix)
+        matrix = np.ascontiguousarray(matrix)
         rows, columns = matrix.shape
 
         family = "GMT_IS_DATASET|GMT_VIA_MATRIX"


### PR DESCRIPTION
**Description of proposed changes**

[np.ascontiguousarray](https://numpy.org/doc/2.0/reference/generated/numpy.ascontiguousarray.html) does the same thing with the `as_c_contiguous` function, and is even slightly faster (see the benchmarks below).

This PR removes the `as_c_contiguous` function (assuming that no one is using this non-public function so the function doesn't go inot a deprecation cycle) and uses `np.ascontiguousarray` instead. 

Benchmarks:
```
In [1]: from pygmt.clib.conversion import as_c_contiguous

In [2]: import numpy as np
```
For a small array:
```python
In [3]: c_array = np.arange(20).reshape((4, 5))

In [4]: c_array.flags
Out[4]:
  C_CONTIGUOUS : True
  F_CONTIGUOUS : False
  OWNDATA : False
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False

In [5]: f_array = c_array.copy(order="F")

In [6]: f_array.flags
Out[6]:
  C_CONTIGUOUS : False
  F_CONTIGUOUS : True
  OWNDATA : True
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False

In [7]: %timeit np.ascontiguousarray(c_array)
55.1 ns ± 0.246 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [8]: %timeit as_c_contiguous(c_array)
82 ns ± 1.28 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [9]: %timeit np.ascontiguousarray(f_array)
331 ns ± 1.46 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [10]: %timeit as_c_contiguous(f_array)
411 ns ± 0.539 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
For a large array:
```python
In [12]: c_array = np.arange(2000000).reshape((4000, 500))

In [13]: f_array = c_array.copy(order="F")

In [14]: %timeit np.ascontiguousarray(c_array)
54.8 ns ± 0.289 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [15]: %timeit as_c_contiguous(c_array)
82.6 ns ± 0.788 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [16]: %timeit np.ascontiguousarray(f_array)
2.76 ms ± 21.2 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [17]: %timeit as_c_contiguous(f_array)
2.75 ms ± 15.7 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```