### PR TITLE
**Breaking**: Figure.text: Fix typesetting of integers when mixed with floating-point values

### DIFF
--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -225,7 +225,7 @@ def text_(  # noqa: PLR0912
                 if name == "angle":
                     extra_arrays.append(np.atleast_1d(arg))
                 else:
-                    extra_arrays.append(np.atleast_1d(arg).astype(str))
+                    extra_arrays.append(np.atleast_1d(np.asarray(arg, dtype=str)))
 
         # If an array of transparency is given, GMT will read it from the last numerical
         # column per data record.
@@ -234,7 +234,7 @@ def text_(  # noqa: PLR0912
             kwargs["t"] = True
 
         # Append text to the last column. Text must be passed in as str type.
-        text = np.atleast_1d(text).astype(str)
+        text = np.atleast_1d(np.asarray(text, dtype=str))
         encoding = _check_encoding("".join(text))
         if encoding != "ascii":
             text = np.vectorize(non_ascii_to_octal, excluded="encoding")(

--- a/pygmt/tests/baseline/test_text_nonstr_text.png.dvc
+++ b/pygmt/tests/baseline/test_text_nonstr_text.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 7c07b7792d61e8094468eab34e8bba50
-  size: 12757
+- md5: 41625972ee97af25965877eb78e0a673
+  size: 12270
   path: test_text_nonstr_text.png
   hash: md5


### PR DESCRIPTION
**Description of proposed changes**

Currently, `Figure.text` allows passing a list of non-string values into the `text` parameter, e.g., `text=[1, 2, 3.0, 4.123, 5.000]`. Internally, these non-string values are converted to an array of strings:

https://github.com/GenericMappingTools/pygmt/blob/5cf7f6a0e5a0c1f4bf610eb0172be596c3918aa0/pygmt/src/text.py#L237

Instead of `np.atleast_1d(text).astype(str)`, we can also use `np.atleast_1d(np.asarray(text, dtype=str))`. The former converts `text` into a numpy array (float64 in this case) first and then converts it to str dtype; the latter converts `text` into str dtype directly. 

Below are their differences:
```python
In [1]: import numpy as np

In [2]: x = [1, 2, 3.0, 4.05, 5.123, 6.0000]

In [3]: np.atleast_1d(x).astype(str)
Out[3]: array(['1.0', '2.0', '3.0', '4.05', '5.123', '6.0'], dtype='<U32')

In [4]: np.atleast_1d(np.asarray(x, dtype=str))
Out[4]: array(['1', '2', '3.0', '4.05', '5.123', '6.0'], dtype='<U5')

In [5]: %timeit np.atleast_1d(x).astype(str)
4.57 μs ± 227 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [6]: %timeit np.atleast_1d(np.asarray(x, dtype=str))
3.8 μs ± 102 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [7]: np.atleast_1d(x).astype(str).itemsize
Out[7]: 128

In [8]: np.atleast_1d(np.asarray(x, dtype=str)).itemsize
Out[8]: 20
```
The latter is faster (3.8 μs vs 4.57 μs) and the resulting array is smaller (20 bytes vs 128 bytes per element).

Also please pay attention to the different string representations. For an integer `1`, the former will typeset `1.0` while the latter will typeset `1`. I think we can declare it as a `Figure.text` for incorrectly typesetting integers when mixed with floating-point numbers.

This PR adopts the latter one to fix the bug. An incorrect baseline image is also updated.

