### PR TITLE
clib.conversion: Add type hints and improve docstrings for dataarray_to_matrix, vectors_to_arrays, and array_to_datetime

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -5,6 +5,7 @@ Functions to convert data types into ctypes friendly formats.
 import ctypes as ctp
 import warnings
 from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
 import xarray as xr
@@ -284,16 +285,15 @@ def strings_to_ctypes_array(strings: Sequence[str]) -> ctp.Array:
     return (ctp.c_char_p * len(strings))(*[s.encode() for s in strings])
 
 
-def array_to_datetime(array):
+def array_to_datetime(array: Sequence[Any]) -> np.ndarray:
     """
     Convert a 1-D datetime array from various types into numpy.datetime64.
 
-    If the input array is not in legal datetime formats, raise a ValueError
-    exception.
+    If the input array is not in legal datetime formats, raise a ValueError exception.
 
     Parameters
     ----------
-    array : list or 1-D array
+    array
         The input datetime array in various formats.
 
         Supported types:
@@ -305,7 +305,8 @@ def array_to_datetime(array):
 
     Returns
     -------
-    array : 1-D datetime array in numpy.datetime64
+    array
+        1-D datetime array in numpy.datetime64.
 
     Raises
     ------

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -130,26 +130,25 @@ def dataarray_to_matrix(
     return matrix, region, inc
 
 
-def vectors_to_arrays(vectors):
+def vectors_to_arrays(vectors: Sequence[Any]) -> list[np.ndarray]:
     """
-    Convert 1-D vectors (lists, arrays, or pandas.Series) to C contiguous 1-D arrays.
+    Convert 1-D vectors (scalars, lists, or array-like) to C contiguous 1-D arrays.
 
-    Arrays must be in C contiguous order for us to pass their memory pointers
-    to GMT. If any are not, convert them to C order (which requires copying the
-    memory). This usually happens when vectors are columns of a 2-D array or
-    have been sliced.
+    Arrays must be in C contiguous order for us to pass their memory pointers to GMT.
+    If any are not, convert them to C order (which requires copying the memory). This
+    usually happens when vectors are columns of a 2-D array or have been sliced.
 
-    If a vector is a list or pandas.Series, get the underlying numpy array.
+    The returned arrays are guaranteed to be C contiguous and at least 1-D.
 
     Parameters
     ----------
-    vectors : list of lists, 1-D arrays, or pandas.Series
+    vectors
         The vectors that must be converted.
 
     Returns
     -------
-    arrays : list of 1-D arrays
-        The converted numpy arrays
+    arrays
+        List of converted numpy arrays.
 
     Examples
     --------

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -28,7 +28,7 @@ def dataarray_to_matrix(
     grid are negative, the output matrix will be sorted by the DataArray coordinates to
     yield positive increments.
 
-    If the underlying data array is not C contiguous, for example if it's a slice of a
+    If the underlying data array is not C contiguous, for example, if it's a slice of a
     larger grid, a copy will need to be generated.
 
     Parameters


### PR DESCRIPTION
No code changes, just add type hints and improve docstrings.

