### PR TITLE
Add a doctest for checking ndims when the input is a sequence of scalars

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -171,6 +171,13 @@ def vectors_to_arrays(vectors):
     >>> all(isinstance(i, np.ndarray) for i in vectors_to_arrays(data))
     True
 
+    >>> # Sequence of scalars are converted to 1-D arrays
+    >>> data = vectors_to_arrays([1, 2, 3.0])
+    >>> data
+    [array([1]), array([2]), array([3.])]
+    >>> [i.ndim for i in data]  # Check that they are 1-D arrays
+    [1, 1, 1]
+
     >>> import datetime
     >>> import pytest
     >>> pa = pytest.importorskip("pyarrow")

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -206,9 +206,7 @@ def vectors_to_arrays(vectors):
     arrays = []
     for vector in vectors:
         vec_dtype = str(getattr(vector, "dtype", ""))
-        array = np.asarray(a=vector, dtype=dtypes.get(vec_dtype))
-        arrays.append(np.ascontiguousarray(array))
-
+        arrays.append(np.ascontiguousarray(vector, dtype=dtypes.get(vec_dtype)))
     return arrays
 
 


### PR DESCRIPTION
**Description of proposed changes**

The `vectors_to_arrays` function is only used in the `virtualfile_from_vectors` function, which expects a sequence of 1-D numpy arrays:

https://github.com/GenericMappingTools/pygmt/blob/130d0cb32ab601a345033997aa8d9603e35abe77/pygmt/clib/session.py#L1392

Before PR #3492, we used our own `as_c_contiguous` function, and it's not guaranteed that the returned arrays are 1-D. For example, if we check out the codes before #3492 (i.e., `git checkout 331998daf76844827cd2e296af3879844d8f92f1`) and pass a list of scalars to the function, we'll get a list of numpy scalar (0-D) arrays:
```python
In [1]: from pygmt.clib.conversion import vectors_to_arrays

In [2]: vectors_to_arrays([1, 2, 3.0])
Out[2]: [array(1), array(2), array(3.)]
```
The returned 0-D arrays will cause errors when we try to check the lengths of arrays:
https://github.com/GenericMappingTools/pygmt/blob/130d0cb32ab601a345033997aa8d9603e35abe77/pygmt/clib/session.py#L1403

So, we should make sure that the returned arrays are 1-D. This can be done by applying the `np.atleast_1d` function to arrays.

It turns out that the [`np.ascontiguousarray`](https://numpy.org/doc/2.0/reference/generated/numpy.ascontiguousarray.html) function always returns ndim>=1 arrays:

> Return a contiguous array (ndim >= 1) in memory (C order).

This can be verified below (using the main branch):
```
In [1]: from pygmt.clib.conversion import vectors_to_arrays

In [2]: vectors_to_arrays([1, 2, 3.0])
Out[2]: [array([1]), array([2]), array([3.])]
```

So we don't have to call `np.atleast_1d` explicitly here and in wrappers like `Figure.text` and in `virtualfile_in`:
https://github.com/GenericMappingTools/pygmt/blob/130d0cb32ab601a345033997aa8d9603e35abe77/pygmt/clib/session.py#L1811-L1814

This PR adds a doctest to ensure that a sequence of scalars is converted to a list of 1-D arrays. I'll open a separate PR (see #3498) to remove the unnecessary `np.atleast_1d` calls in other functions.
