### PR TITLE
Remove unnecessary np.atleast_1d calls from Figure.text and Session.virtualfile_in

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1809,9 +1809,9 @@ class Session:
                 warnings.warn(message=msg, category=RuntimeWarning, stacklevel=2)
             _data = (data,) if not isinstance(data, pathlib.PurePath) else (str(data),)
         elif kind == "vectors":
-            _data = [np.atleast_1d(x), np.atleast_1d(y)]
+            _data = [x, y]
             if z is not None:
-                _data.append(np.atleast_1d(z))
+                _data.append(z)
             if extra_arrays:
                 _data.extend(extra_arrays)
         elif kind == "matrix":  # turn 2-D arrays into list of vectors

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -223,19 +223,19 @@ def text_(  # noqa: PLR0912
                 kwargs["F"] += flag
                 # angle is numeric type and font/justify are str type.
                 if name == "angle":
-                    extra_arrays.append(np.atleast_1d(arg))
+                    extra_arrays.append(arg)
                 else:
-                    extra_arrays.append(np.atleast_1d(np.asarray(arg, dtype=str)))
+                    extra_arrays.append(np.asarray(arg, dtype=str))
 
         # If an array of transparency is given, GMT will read it from the last numerical
         # column per data record.
         if is_nonstr_iter(kwargs.get("t")):
-            extra_arrays.append(np.atleast_1d(kwargs["t"]))
+            extra_arrays.append(kwargs["t"])
             kwargs["t"] = True
 
         # Append text to the last column. Text must be passed in as str type.
-        text = np.atleast_1d(np.asarray(text, dtype=str))
-        encoding = _check_encoding("".join(text))
+        text = np.asarray(text, dtype=str)
+        encoding = _check_encoding("".join(text.flatten()))
         if encoding != "ascii":
             text = np.vectorize(non_ascii_to_octal, excluded="encoding")(
                 text, encoding=encoding


### PR DESCRIPTION
**Description of proposed changes**

As explained in #3497, calling `np.atleast_1d` explicitly is no longer necessary after we adopted the `numpy.ascontiguousarray` function in PR #3492.

This PR removes the `np.atleast_1d` calls from `Figure.text` and `Session.virtualfile_in`.

After this PR, `np.atleast_1d` is only used in `Figure.meca` because pandas needs 1-D arrays, e.g., 

https://github.com/GenericMappingTools/pygmt/blob/130d0cb32ab601a345033997aa8d9603e35abe77/pygmt/src/meca.py#L422