### PR TITLE
DOC: Use MyST syntax for linking other files

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -94,7 +94,7 @@ PyGMT requires the following libraries to be installed:
 - [packaging](https://packaging.pypa.io)
 
 :::{note}
-For the minimum supported versions of the dependencies, please see {doc}`minversions`.
+For the minimum supported versions of the dependencies, please see [](minversions.md).
 :::
 
 The following are optional dependencies:

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -3,7 +3,7 @@
 This page contains instructions for project maintainers about how our setup works,
 making releases, creating packages, etc.
 
-If you want to make a contribution to the project, see the {doc}`contributing` instead.
+If you want to make a contribution to the project, see the [](contributing.md) instead.
 
 ## Onboarding/Offboarding Access Checklist
 
@@ -22,7 +22,7 @@ communication tools we use.
 ### As a Maintainer
 
 - Add to the [pygmt-maintainers team](https://github.com/orgs/GenericMappingTools/teams/pygmt-maintainers) (gives 'maintain' permission to the repository)
-- Add to "Active Maintainers" on the {doc}`Team Gallery page <team>`
+- Add to "Active Maintainers" on the [Team Gallery page](team.md)
 - Add as a moderator on the [GMT forum](https://forum.generic-mapping-tools.org) (to see mod-only discussions) [optional]
 - Add as a maintainer on [ReadtheDocs](https://readthedocs.org/projects/pygmt-dev) [optional]
 - Add as a curator to the [GMT community](https://zenodo.org/communities/generic-mapping-tools/) on Zenodo (for making releases) [optional]
@@ -38,7 +38,7 @@ the onboarding access checklist:
 
 - Move from the [pygmt-maintainers team](https://github.com/orgs/GenericMappingTools/teams/pygmt-maintainers)
   to the [pygmt-contributors team](https://github.com/orgs/GenericMappingTools/teams/pygmt-contributors)
-- Move from "Active Maintainers" to "Distinguished Contributors" on the {doc}`Team Gallery page <team>`
+- Move from "Active Maintainers" to "Distinguished Contributors" on the [Team Gallery page](team.md)
 - Remove 'maintain' permission from GMT forum, ReadTheDocs, Zenodo
 
 ## Branches
@@ -201,7 +201,7 @@ at `.github/release-drafter.yml`. Configuration settings can be found at
 <https://github.com/release-drafter/release-drafter>.
 
 The drafted release notes are not perfect, so we will need to tidy it prior to
-publishing the actual release notes at {doc}`changes`.
+publishing the actual release notes at [](changes.md).
 
 1. Go to <https://github.com/GenericMappingTools/pygmt/releases> and click on the
    'Edit' button next to the current draft release note. Copy the text of the

--- a/doc/team.md
+++ b/doc/team.md
@@ -4,7 +4,7 @@ We are an international team dedicated to building a Pythonic API for the Generi
 Tools (GMT).
 
 All are welcome to become involved with the PyGMT project! For more information about how
-to get involved, see the {doc}`contributing`. A more complete list of contributors
+to get involved, see the [](contributing.md). A more complete list of contributors
 is available in the [`AUTHORS.md`](https://github.com/GenericMappingTools/pygmt/blob/main/AUTHORS.md)
 file in the source repository.
 
@@ -12,7 +12,7 @@ Distinguished Contributors are recognized for their substantial contributions to
 which may include code, documentation, pull request review, triaging, forum responses,
 community building and engagement, outreach, and inclusion and diversity. Maintainers
 are recognized for their responsibilities in maintaining the project, as detailed in
-the {doc}`maintenance`.
+the [](maintenance.md).
 
 New Distinguished Contributors and Active Maintainers are selected and voted by current
 Active Maintainers before each release. Maintainers that are inactive for more than one

--- a/doc/techref/fonts.md
+++ b/doc/techref/fonts.md
@@ -8,7 +8,7 @@ PyGMT supports the 35 standard PostScript fonts. The table below lists them with
 font numbers and font names. When specifying fonts in PyGMT, you can either give the
 font name or just the font number. For example, to use the font "Helvetica", you can use
 either `"Helvetica"` or `"0"`. For the special fonts "Symbol" (**12**) and
-"ZapfDingbats" (**34**), see the {doc}`/techref/encodings` for the character set.
+"ZapfDingbats" (**34**), see the [](/techref/encodings.md) for the character set.
 The image below the table shows a visual sample for each font.
 
 ```{code-cell}

--- a/doc/techref/projections.md
+++ b/doc/techref/projections.md
@@ -16,34 +16,34 @@ The table below shows the projection codes for the 31 GMT map projections:
 
 | PyGMT Projection Argument | Projection Name |
 | --- | --- |
-| **A**{{ lon0 }}/{{ lat0 }}[/*horizon*]/*width*              | {doc}`/projections/azim/azim_lambert` |
-| **B**{{ lon0 }}/{{ lat0 }}/{{ lat1 }}/{{ lat2 }}/*width*    | {doc}`/projections/conic/conic_albers` |
-| **C**{{ lon0 }}/{{ lat0 }}/*width*                          | {doc}`/projections/cyl/cyl_cassini` |
-| **Cyl_stere**/[{{ lon0 }}/[{{ lat0 }}/]]*width*             | {doc}`/projections/cyl/cyl_stereographic` |
-| **D**{{ lon0 }}/{{ lat0 }}/{{ lat1 }}/{{ lat2 }}/*width*    | {doc}`/projections/conic/conic_equidistant` |
-| **E**{{ lon0 }}/{{ lat0 }}[/*horizon*]/*width*              | {doc}`/projections/azim/azim_equidistant` |
-| **F**{{ lon0 }}/{{ lat0 }}[/*horizon*]/*width*              | {doc}`/projections/azim/azim_gnomonic` |
-| **G**{{ lon0 }}/{{ lat0 }}[/*horizon*]/*width*              | {doc}`/projections/azim/azim_orthographic` |
-| **G**{{ lon0 }}/{{ lat0 }}/*width*[**+a***azimuth*][**+t***tilt*][**+v***vwidth*/*vheight*][**+w***twist*][**+z***altitude*] | {doc}`/projections/azim/azim_general_perspective` |
-| **H**[{{ lon0 }}/]*width*                                   | {doc}`/projections/misc/misc_hammer` |
-| **I**[{{ lon0 }}/]*width*                                   | {doc}`/projections/misc/misc_sinusoidal` |
-| **J**[{{ lon0 }}/]*width*                                   | {doc}`/projections/cyl/cyl_miller` |
-| **Kf**[{{ lon0 }}/]*width*                                  | {doc}`/projections/misc/misc_eckertIV` |
-| **Ks**[{{ lon0 }}/]*width*                                  | {doc}`/projections/misc/misc_eckertVI` |
-| **L**{{ lon0 }}/{{ lat0 }}/{{ lat1 }}/{{ lat2 }}/*width*    | {doc}`/projections/conic/conic_lambert` |
-| **M**[{{ lon0 }}/[{{ lat0 }}/]]*width*                      | {doc}`/projections/cyl/cyl_mercator` |
-| **N**[{{ lon0 }}/]*width*                                   | {doc}`/projections/misc/misc_robinson` |
-| **Oa**{{ lon0 }}/{{ lat0 }}/*azimuth*/*width*[**+v**]             | Oblique Mercator projection: {doc}`1. origin and azimuth </projections/cyl/cyl_oblique_mercator>` |
-| **Ob**{{ lon0 }}/{{ lat0 }}/{{ lon1 }}/{{ lat1 }}/*width*[**+v**] | Oblique Mercator projection: {doc}`2. two points </projections/cyl/cyl_oblique_mercator>` |
-| **Oc**{{ lon0 }}/{{ lat0 }}/{{ lonp }}/{{ latp }}/*width*[**+v**] | Oblique Mercator projection: {doc}`3. origin and projection pole </projections/cyl/cyl_oblique_mercator>` |
-| **P***width*[**+a**][**+f**[**e**\|**p**\|*radius*]][**+r***offset*][**+t***origin*][**+z**[**p**\|*radius*]] | Polar {doc}`azimuthal </projections/nongeo/polar>` ({math}`\theta, r`) or cylindrical |
-| **Poly**/[{{ lon0 }}/[{{ lat0 }}/]]*width*                  | {doc}`/projections/conic/polyconic` |
-| **Q**[{{ lon0 }}/[{{ lat0 }}/]]*width*                      | {doc}`/projections/cyl/cyl_equidistant` |
-| **R**[{{ lon0 }}/]*width*                                   | {doc}`/projections/misc/misc_winkel_tripel` |
-| **S**{{ lon0 }}/{{ lat0 }}[/*horizon*]/*width*              | {doc}`/projections/azim/azim_general_stereographic` |
-| **T**{{ lon0 }}[/{{ lat0 }}]/*width*                        | {doc}`/projections/cyl/cyl_transverse_mercator` |
-| **U***zone*/*width*                                         | {doc}`/projections/cyl/cyl_universal_transverse_mercator` |
-| **V**[{{ lon0 }}/]*width*                                   | {doc}`/projections/misc/misc_van_der_grinten` |
-| **W**[{{ lon0 }}/]*width*                                   | {doc}`/projections/misc/misc_mollweide` |
-| **X***width*[**l**\|**p***exp*\|**T**\|**t**][/*height*[**l**\|**p***exp*\|**T**\|**t**]][**d**] | Cartesian {doc}`linear </projections/nongeo/cartesian_linear>`, {doc}`logarithmic </projections/nongeo/cartesian_logarithmic>`, {doc}`power </projections/nongeo/cartesian_power>`, and time |
-| **Y**{{ lon0 }}/{{ lat0 }}/*width*                          | {doc}`/projections/cyl/cyl_equal_area` |
+| **A**{{ lon0 }}/{{ lat0 }}[/*horizon*]/*width*              | [](/projections/azim/azim_lambert.rst) |
+| **B**{{ lon0 }}/{{ lat0 }}/{{ lat1 }}/{{ lat2 }}/*width*    | [](/projections/conic/conic_albers.rst) |
+| **C**{{ lon0 }}/{{ lat0 }}/*width*                          | [](/projections/cyl/cyl_cassini.rst) |
+| **Cyl_stere**/[{{ lon0 }}/[{{ lat0 }}/]]*width*             | [](/projections/cyl/cyl_stereographic.rst) |
+| **D**{{ lon0 }}/{{ lat0 }}/{{ lat1 }}/{{ lat2 }}/*width*    | [](/projections/conic/conic_equidistant.rst) |
+| **E**{{ lon0 }}/{{ lat0 }}[/*horizon*]/*width*              | [](/projections/azim/azim_equidistant.rst) |
+| **F**{{ lon0 }}/{{ lat0 }}[/*horizon*]/*width*              | [](/projections/azim/azim_gnomonic.rst) |
+| **G**{{ lon0 }}/{{ lat0 }}[/*horizon*]/*width*              | [](/projections/azim/azim_orthographic.rst) |
+| **G**{{ lon0 }}/{{ lat0 }}/*width*[**+a***azimuth*][**+t***tilt*][**+v***vwidth*/*vheight*][**+w***twist*][**+z***altitude*] | [](/projections/azim/azim_general_perspective.rst) |
+| **H**[{{ lon0 }}/]*width*                                   | [](/projections/misc/misc_hammer.rst) |
+| **I**[{{ lon0 }}/]*width*                                   | [](/projections/misc/misc_sinusoidal.rst) |
+| **J**[{{ lon0 }}/]*width*                                   | [](/projections/cyl/cyl_miller.rst) |
+| **Kf**[{{ lon0 }}/]*width*                                  | [](/projections/misc/misc_eckertIV.rst) |
+| **Ks**[{{ lon0 }}/]*width*                                  | [](/projections/misc/misc_eckertVI.rst) |
+| **L**{{ lon0 }}/{{ lat0 }}/{{ lat1 }}/{{ lat2 }}/*width*    | [](/projections/conic/conic_lambert.rst) |
+| **M**[{{ lon0 }}/[{{ lat0 }}/]]*width*                      | [](/projections/cyl/cyl_mercator.rst) |
+| **N**[{{ lon0 }}/]*width*                                   | [](/projections/misc/misc_robinson.rst) |
+| **Oa**{{ lon0 }}/{{ lat0 }}/*azimuth*/*width*[**+v**]             | [Oblique Mercator projection: 1. origin and azimuth](/projections/cyl/cyl_oblique_mercator.rst) |
+| **Ob**{{ lon0 }}/{{ lat0 }}/{{ lon1 }}/{{ lat1 }}/*width*[**+v**] | [Oblique Mercator projection: 2. two points](/projections/cyl/cyl_oblique_mercator.rst) |
+| **Oc**{{ lon0 }}/{{ lat0 }}/{{ lonp }}/{{ latp }}/*width*[**+v**] | [Oblique Mercator projection: 3. origin and projection pole](/projections/cyl/cyl_oblique_mercator.rst) |
+| **P***width*[**+a**][**+f**[**e**\|**p**\|*radius*]][**+r***offset*][**+t***origin*][**+z**[**p**\|*radius*]] | Polar [azimuthal](/projections/nongeo/polar.rst) ({math}`\theta, r`) or cylindrical |
+| **Poly**/[{{ lon0 }}/[{{ lat0 }}/]]*width*                  | [](/projections/conic/polyconic.rst) |
+| **Q**[{{ lon0 }}/[{{ lat0 }}/]]*width*                      | [](/projections/cyl/cyl_equidistant.rst) |
+| **R**[{{ lon0 }}/]*width*                                   | [](/projections/misc/misc_winkel_tripel.rst) |
+| **S**{{ lon0 }}/{{ lat0 }}[/*horizon*]/*width*              | [](/projections/azim/azim_general_stereographic.rst) |
+| **T**{{ lon0 }}[/{{ lat0 }}]/*width*                        | [](/projections/cyl/cyl_transverse_mercator.rst) |
+| **U***zone*/*width*                                         | [](/projections/cyl/cyl_universal_transverse_mercator.rst) |
+| **V**[{{ lon0 }}/]*width*                                   | [](/projections/misc/misc_van_der_grinten.rst) |
+| **W**[{{ lon0 }}/]*width*                                   | [](/projections/misc/misc_mollweide.rst) |
+| **X***width*[**l**\|**p***exp*\|**T**\|**t**][/*height*[**l**\|**p***exp*\|**T**\|**t**]][**d**] | Cartesian [linear](/projections/nongeo/cartesian_linear.rst), [logarithmic](/projections/nongeo/cartesian_logarithmic.rst), [power](/projections/nongeo/cartesian_power.rst), and time |
+| **Y**{{ lon0 }}/{{ lat0 }}/*width*                          | [](/projections/cyl/cyl_equal_area.rst) |

--- a/doc/techref/projections.md
+++ b/doc/techref/projections.md
@@ -33,9 +33,9 @@ The table below shows the projection codes for the 31 GMT map projections:
 | **L**{{ lon0 }}/{{ lat0 }}/{{ lat1 }}/{{ lat2 }}/*width*    | [](/projections/conic/conic_lambert.rst) |
 | **M**[{{ lon0 }}/[{{ lat0 }}/]]*width*                      | [](/projections/cyl/cyl_mercator.rst) |
 | **N**[{{ lon0 }}/]*width*                                   | [](/projections/misc/misc_robinson.rst) |
-| **Oa**{{ lon0 }}/{{ lat0 }}/*azimuth*/*width*[**+v**]             | [Oblique Mercator projection: 1. origin and azimuth](/projections/cyl/cyl_oblique_mercator.rst) |
-| **Ob**{{ lon0 }}/{{ lat0 }}/{{ lon1 }}/{{ lat1 }}/*width*[**+v**] | [Oblique Mercator projection: 2. two points](/projections/cyl/cyl_oblique_mercator.rst) |
-| **Oc**{{ lon0 }}/{{ lat0 }}/{{ lonp }}/{{ latp }}/*width*[**+v**] | [Oblique Mercator projection: 3. origin and projection pole](/projections/cyl/cyl_oblique_mercator.rst) |
+| **Oa**{{ lon0 }}/{{ lat0 }}/*azimuth*/*width*[**+v**]             | Oblique Mercator projection: [1. origin and azimuth](/projections/cyl/cyl_oblique_mercator.rst) |
+| **Ob**{{ lon0 }}/{{ lat0 }}/{{ lon1 }}/{{ lat1 }}/*width*[**+v**] | Oblique Mercator projection: [2. two points](/projections/cyl/cyl_oblique_mercator.rst) |
+| **Oc**{{ lon0 }}/{{ lat0 }}/{{ lonp }}/{{ latp }}/*width*[**+v**] | Oblique Mercator projection: [3. origin and projection pole](/projections/cyl/cyl_oblique_mercator.rst) |
 | **P***width*[**+a**][**+f**[**e**\|**p**\|*radius*]][**+r***offset*][**+t***origin*][**+z**[**p**\|*radius*]] | Polar [azimuthal](/projections/nongeo/polar.rst) ({math}`\theta, r`) or cylindrical |
 | **Poly**/[{{ lon0 }}/[{{ lat0 }}/]]*width*                  | [](/projections/conic/polyconic.rst) |
 | **Q**[{{ lon0 }}/[{{ lat0 }}/]]*width*                      | [](/projections/cyl/cyl_equidistant.rst) |


### PR DESCRIPTION
**Description of proposed changes**

To link to a file, currently we use syntax like:
```
{doc}`/techref/encodings`
```
MyST also allows using Markdown link syntax:
```
[](/techref/encodings)
```
which is IMHO more readable and more familiar to Markdown users.

This PR updates to the MyST syntax.

Reference: https://myst-parser.readthedocs.io/en/latest/syntax/cross-referencing.html#inline-links-with-implicit-text