### PR TITLE
DOC: Minor improvement of highlighting in docstrings

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -184,7 +184,7 @@ class Figure:
         ----------
         crop : str or bool
             Adjust the BoundingBox and HiResBoundingBox to the minimum
-            required by the image content. Default is True. Append **+u** to
+            required by the image content. Default is ``True``. Append **+u** to
             first remove any GMT-produced time-stamps. Append **+r** to
             *round* the HighResBoundingBox instead of using the ``ceil``
             function. This is going against Adobe Law but can be useful when
@@ -228,7 +228,7 @@ class Figure:
             towards black (100%) [no fading, 0]. Append **+g**\ *paint* to
             paint the BoundingBox behind the illustration and append **+p**\
             [*pen*] to draw the BoundingBox outline (append a pen or accept
-            the default pen of 0.25p,black). **Note**: If both **+g** and
+            the default pen of ``"0.25p, black, solid"``). **Note**: If both **+g** and
             **+f** are used then we use paint as the fade color instead of
             black. Append **+i** to enforce gray-shades by using ICC profiles.
         anti_aliasing : str
@@ -251,8 +251,8 @@ class Figure:
         {verbose}
         """
         kwargs = self._preprocess(**kwargs)
-        # pytest-mpl v0.17.0 added the "metadata" parameter to `Figure.savefig`, which
-        # is not recognized. So remove it before calling `Figure.psconvert`.
+        # pytest-mpl v0.17.0 added the "metadata" parameter to Figure.savefig, which
+        # is not recognized. So remove it before calling Figure.psconvert.
         kwargs.pop("metadata", None)
         # Default cropping the figure to True
         if kwargs.get("A") is None:

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -228,7 +228,7 @@ class Figure:
             towards black (100%) [no fading, 0]. Append **+g**\ *paint* to
             paint the BoundingBox behind the illustration and append **+p**\
             [*pen*] to draw the BoundingBox outline (append a pen or accept
-            the default pen of ``"0.25p, black, solid"``). **Note**: If both **+g** and
+            the default pen of ``"0.25p,black,solid"``). **Note**: If both **+g** and
             **+f** are used then we use *paint* as the fade color instead of
             black. Append **+i** to enforce gray-shades by using ICC profiles.
         anti_aliasing : str

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -229,7 +229,7 @@ class Figure:
             paint the BoundingBox behind the illustration and append **+p**\
             [*pen*] to draw the BoundingBox outline (append a pen or accept
             the default pen of ``"0.25p, black, solid"``). **Note**: If both **+g** and
-            **+f** are used then we use paint as the fade color instead of
+            **+f** are used then we use *paint* as the fade color instead of
             black. Append **+i** to enforce gray-shades by using ICC profiles.
         anti_aliasing : str
             [**g**\|\ **p**\|\ **t**\][**1**\|\ **2**\|\ **4**].

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -47,7 +47,7 @@ def surface(
     oscillations and false local maxima or minima (see Smith and Wessel,
     1990), and you may wish to use :math:`t > 0` to suppress these effects.
     Experience suggests :math:`t \sim 0.25` usually looks good for potential
-    field data and t should be larger (:math:`t \sim 0.35`) for steep
+    field data and :math:`t` should be larger (:math:`t \sim 0.35`) for steep
     topography data. :math:`t = 1` gives a harmonic surface (no maxima or
     minima are possible except at control data points). It is recommended that
     the user preprocess the data with :func:`pygmt.blockmean`,


### PR DESCRIPTION
**Description of proposed changes**

This PR adds just minor improvements of the highlighting in some docstrings of `Figure.psconvert` and `Figure.surface`.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
