### PR TITLE
clib: Fix the return type from ctp.c_uint to ctp.c_int for Session.inquire_virtualfile

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1962,7 +1962,7 @@ class Session:
         c_inquire_virtualfile = self.get_libgmt_func(
             "GMT_Inquire_VirtualFile",
             argtypes=[ctp.c_void_p, ctp.c_char_p],
-            restype=ctp.c_uint,
+            restype=ctp.c_int,
         )
         return c_inquire_virtualfile(self.session_pointer, vfname.encode())
 


### PR DESCRIPTION
**Description of proposed changes**

xref: https://github.com/GenericMappingTools/gmt/blob/5d8e062988c2b1e87c4a13043a684fef7878c585/src/gmt_api.c#L9417

The function returns an `int`, not `uint`.
