### PR TITLE
Fix the conversion error for pandas.Series with missing values in pandas<=2.1

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -218,7 +218,7 @@ def vectors_to_arrays(vectors):
         ):
             # Workaround for dealing with pd.NA with pandas < 2.2.
             # Bug report at: https://github.com/GenericMappingTools/pygmt/issues/2844
-            # Following SPEC0, pandas 2.1 will be dropped in 2025 Q3, so it's likey
+            # Following SPEC0, pandas 2.1 will be dropped in 2025 Q3, so it's likely
             # we can remove the workaround in PyGMT v0.17.0.
             array = np.ascontiguousarray(vector.astype(float))
         else:

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -204,7 +204,6 @@ def vectors_to_arrays(vectors):
     True
     >>> all(isinstance(a.dtype, np.dtypes.DateTime64DType) for a in arrays)
     True
-
     """
     dtypes = {
         "date32[day][pyarrow]": np.datetime64,


### PR DESCRIPTION
**Description of proposed changes**

See #2844 for the issue report.

It turns out that in pandas <= 2.1, pd.Series with integer values and pd.NA are converted to `object` type, which can't be recognized later, but in pandas >= 2.2, they are converted to float type.

In this PR, we add a workaround for pandas<=2.1 by casting the pd.Series to float type explicitly if it contains pd.NA.

Closes #2844.

As per SPEC 0 policy, support of pandas 2.1 should be dropped in 2025 Q3, so we expect to remove the workaround for PyGMT v0.17.0.