### PR TITLE
CI: Bump to macOS-13 in the 'GMT Legacy Tests' workflow

### DIFF
--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-20.04, macos-13, windows-2019]
         gmt_version: ['6.4']
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
The macOS 12 Actions runner image will begin deprecation on 10/7/24 and will be fully unsupported by 12/3/24

xref: https://github.com/actions/runner-images/issues/10721

Manually triggered run at: https://github.com/GenericMappingTools/pygmt/actions/runs/11303235046