### PR TITLE
Silence a mypy warning with mypy v1.12.0

### DIFF
--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -441,7 +441,7 @@ def _load_remote_dataset(
             "returned unless only the pixel-registered grid is available."
         )
 
-    fname = f"@{prefix}_{resolution}_{registration[0]}"
+    fname = f"@{prefix}_{resolution}_{registration[0]}"  # type: ignore[index]
     if resinfo.tiled and region is None:
         raise GMTInvalidInput(
             f"'region' is required for {dataset.description} resolution '{resolution}'."


### PR DESCRIPTION
The "Static Type Checks" workflow started to fail due to the newly released mypy v1.12.0 (https://github.com/GenericMappingTools/pygmt/actions/runs/11330529462).

I don't know if it's an indented change or a newly introduced bug, and I don't have a solution for it, so just ignore the mypy error.
```
mypy pygmt
pygmt/datasets/load_remote_dataset.py:444: error: Value of type "Literal['gridline', 'pixel'] | None" is not indexable  [index]
Found 1 error in 1 file (checked 106 source files)
make: *** [Makefile:74: typecheck] Error 1
```
