### PR TITLE
CI: Exclude the pre-commit-ci bots in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -24,6 +24,8 @@ exclude-contributors:
   - 'actions-bot'
   - 'dependabot'
   - 'dependabot[bot]'
+  - 'pre-commit-ci'
+  - 'pre-commit-ci[bot]'
 category-template: '### $TITLE'
 change-template: '* $TITLE ([#$NUMBER]($URL))'
 sort-by: 'title'


### PR DESCRIPTION
**Description of proposed changes**

As shown in https://github.com/GenericMappingTools/pygmt/releases, pre-commit-ci bots are listed as contributors and should be excluded.

<img width="797" alt="image" src="https://github.com/user-attachments/assets/43e2dd35-6f00-4bc3-abcc-540e81dba0bd">