### PR TITLE
DOC: Change "Pandas" to "pandas"

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/4-release_checklist.md
@@ -19,7 +19,8 @@ assignees: ''
 
 **Before release**:
 
-- [ ] Check [SPEC 0](https://scientific-python.org/specs/spec-0000/) to see if we need to bump the minimum supported versions of GMT, Python and core package dependencies (NumPy/Pandas/Xarray)
+- [ ] Check [SPEC 0](https://scientific-python.org/specs/spec-0000/) to see if we need to bump the minimum supported versions of GMT, Python and
+      core package dependencies (NumPy, pandas, Xarray)
 - [ ] Review the ["PyGMT Team" page](https://www.pygmt.org/dev/team.html)
 - [ ] Check to ensure that:
   - [ ] Deprecations and related tests are removed for this version by running `grep --include="*.py" -r vX.Y.Z` from the base of the repository

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -17,8 +17,8 @@
 # In draft pull request, only two jobs on Linux are triggered to save on
 # Continuous Integration resources:
 #
-# - Minimum supported Python/NumPy/Pandas/Xarray versions following [SPEC 0](https://scientific-python.org/specs/spec-0000/)
-# - Latest Python/NumPy versions + optional packages (e.g. GeoPandas)
+# - Minimum supported Python, NumPy, pandas, Xarray versions following [SPEC 0](https://scientific-python.org/specs/spec-0000/)
+# - Latest Python, NumPy versions + optional packages (e.g. GeoPandas)
 #
 name: Tests
 
@@ -65,8 +65,8 @@ jobs:
             isDraft: true
           - os: windows-latest
             isDraft: true
-        # Pair Python 3.10 with the minimum supported versions of NumPy/Pandas/Xarray
-        # and Python 3.12 with the latest versions of NumPy/Pandas/Xarray
+        # Pair Python 3.10 with the minimum supported versions of NumPy, pandas, Xarray
+        # and Python 3.12 with the latest versions of NumPy, pandas, Xarray
         # Only install optional packages on Python 3.12
         include:
           - python-version: '3.10'
@@ -79,7 +79,7 @@ jobs:
             pandas-version: ''
             xarray-version: ''
             optional-packages: ' contextily geopandas ipython pyarrow rioxarray sphinx-gallery'
-          # The job below is for testing geopandas v0.x on Ubuntu.
+          # The job below is for testing GeoPandas v0.x on Ubuntu.
           # The python-version here can't be the versions in the matrix.python-version
           # defined above. Otherwise, other jobs will be overridden by this one.
           - os: 'ubuntu-latest'

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -1,7 +1,7 @@
 # Test PyGMT with GMT dev version on Linux/macOS/Windows
 #
 # This workflow runs regular PyGMT tests with the GMT dev version, and also pre-release
-# versions of several dependencies like NumPy, Pandas, Xarray, etc. If any tests fail,
+# versions of several dependencies like NumPy, pandas, Xarray, etc. If any tests fail,
 # it also uploads the diff images as workflow artifacts. The GMT dev version is
 # installed by fetching the latest source codes from the GMT master branch and
 # compiling.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ PyGMT has adopted [SPEC 0](https://scientific-python.org/specs/spec-0000/) along
 rest of the Scientific Python ecosystem, and therefore:
 
 - Support for Python versions be dropped 3 years after their initial release.
-- Support for core package dependencies (NumPy/Pandas/Xarray) be dropped 2 years after
+- Support for core package dependencies (NumPy, pandas, Xarray) be dropped 2 years after
   their initial release.
 
 Similarly, the PyGMT team has decided to discontinue support for GMT versions 3 years

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -127,7 +127,7 @@ PyGMT has adopted [SPEC 0](https://scientific-python.org/specs/spec-0000/) along
 rest of the Scientific Python ecosystem, and therefore:
 
 * Support for Python versions be dropped 3 years after their initial release.
-* Support for core package dependencies (NumPy/pandas/Xarray) be dropped 2 years after
+* Support for core package dependencies (NumPy, pandas, Xarray) be dropped 2 years after
   their initial release.
 
 Similarly, the PyGMT team has decided to discontinue support for GMT versions 3 years

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -127,7 +127,7 @@ PyGMT has adopted [SPEC 0](https://scientific-python.org/specs/spec-0000/) along
 rest of the Scientific Python ecosystem, and therefore:
 
 * Support for Python versions be dropped 3 years after their initial release.
-* Support for core package dependencies (NumPy/Pandas/Xarray) be dropped 2 years after
+* Support for core package dependencies (NumPy/pandas/Xarray) be dropped 2 years after
   their initial release.
 
 Similarly, the PyGMT team has decided to discontinue support for GMT versions 3 years
@@ -229,7 +229,7 @@ publishing the actual release notes at [](changes.md).
    last release (e.g., use `git shortlog HEAD...v0.4.0 -sne`).
 8. Update `doc/minversions.md` with new information on the new release version,
    including a vX.Y.Z documentation link, and minimum required versions of GMT, Python
-   and core package dependencies (NumPy/Pandas/Xarray). Follow
+   and core package dependencies (NumPy, pandas, Xarray). Follow
    [SPEC 0](https://scientific-python.org/specs/spec-0000/) for updates.
 9. Refresh citation information. Specifically, the BibTeX in `README.md` and
    `CITATION.cff` needs to be updated with any metadata changes, including the

--- a/doc/minversions.md
+++ b/doc/minversions.md
@@ -21,13 +21,13 @@ PyGMT has adopted [SPEC 0](https://scientific-python.org/specs/spec-0000/) along
 rest of the Scientific Python ecosystem, and therefore:
 
 - Support for Python versions be dropped 3 years after their initial release.
-- Support for core package dependencies (NumPy/Pandas/Xarray) be dropped 2 years after
+- Support for core package dependencies (NumPy, pandas, Xarray) be dropped 2 years after
   their initial release.
 
 Similarly, the PyGMT team has decided to discontinue support for GMT versions 3 years
 after their initial release.
 
-| PyGMT Version | GMT | Python | NumPy | Pandas | Xarray |
+| PyGMT Version | GMT | Python | NumPy | pandas | Xarray |
 |---|---|---|---|---|---|
 | [Dev][]* [<doc:dev>] | {{ requires.gmt }} | {{ requires.python }} | {{ requires.numpy }} | {{ requires.pandas }} | {{ requires.xarray }} |
 | <tag:v0.13.0> [<doc:v0.13.0>] | >=6.3.0 | >=3.10 | >=1.24 | >=1.5 | >=2022.09 |

--- a/pygmt/_show_versions.py
+++ b/pygmt/_show_versions.py
@@ -103,7 +103,7 @@ def show_versions(file: TextIO | None = sys.stdout):
 
     - PyGMT itself
     - System information (Python version, Operating System)
-    - Core dependency versions (NumPy, Pandas, Xarray, etc)
+    - Core dependency versions (NumPy, pandas, Xarray, etc)
     - GMT library information
 
     It also warns users if the installed Ghostscript version has serious bugs or is


### PR DESCRIPTION
**Description of proposed changes**

Change `Pandas` to `pandas` to be consistent with the pandas documentation.
For context: https://github.com/GenericMappingTools/pygmt/pull/3475#discussion_r1794056563


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
