### PR TITLE
Figure.meca: Add aliases for "-Fa", "-Fe", "-Fg", "-Ft", "-Fp"

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -385,8 +385,8 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
         double couple transparently.
     pt_axes : bool or str
         [*size*[/*p_symbol*[*t_symbol*]]].
-        Compute and plot P and T axes with symbols. Optionally specify size and
-        (separate) P and T axes symbols from the following: circle (**c**),
+        Compute and plot the P and T axes with symbols. Optionally specify size
+        and (separate) P and T axes symbols from the following: circle (**c**),
         diamond (**d**), hexagon (**h**), inverse triangle (**i**), point (**p**),
         square (**s**), triangle (**t**), cross (**x**) [Default is ``"6p/cc"``].
     p_axisfill : str

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -190,6 +190,11 @@ def convention_params(convention):
     B="frame",
     C="cmap",
     E="extensionfill",
+    Fa="pt_axes",
+    Fe="t_axisfill",
+    Fg="p_axisfill",
+    Ft="t_axispen",
+    Fp="p_axispen",
     Fr="labelbox",
     G="compressionfill",
     J="projection",
@@ -378,6 +383,26 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
         transparent by drawing only the nodal planes and the circumference.
         For non-double couple mechanisms, ``nodal=0`` overlays best
         double couple transparently.
+    pt_axes : bool or str
+        [*size*[/*p_symbol*[*t_symbol*]]].
+        Compute and plot P and T axes with symbols. Optionally specify size and
+        (separate) P and T axes symbols from the following: circle (**c**),
+        diamond (**d**), hexagon (**h**), inverse triangle (**i**), point (**p**),
+        square (**s**), triangle (**t**), cross (**x**) [Default is ``"6p/cc"``].
+    p_axisfill : str
+        Set color or pattern for filling the P axis symbol [Default is set via
+        ``compressionfill``].
+    t_axisfill : str
+        Set color or pattern for filling the T axis symbol [Default is set via
+        ``extensionfill``].
+    p_axispen : bool or str
+        [*pen*].
+        Draw the P axis outline. Use *pen* to set the pen attributes for this
+        feature [Default is set via ``pen``].
+    t_axispen : bool or str
+        [*pen*].
+        Draw the T axis outline. Use *pen* to set the pen attributes for this
+        feature [Default is set via ``pen``].
     cmap : str
         File name of a CPT file or a series of comma-separated colors (e.g.,
         *color1,color2,color3*) to build a linear continuous CPT from those


### PR DESCRIPTION
**Description of proposed changes**

This PR adds aliases for the GMT flags used for plotting the P and T axes for `Figure.meca`:

| GMT flag | PyGMT alias |
| --- | --- |
| **Fa** | ``pt_axes`` |
| **Fe** | ``t_axisfill`` |
| **Fg** | ``p_axisfill`` |
| **Ft** | ``t_axispen`` |
| **Fp** | ``p_axispen`` |

The docstrings are orientated on the upstream GMT documentation at https://docs.generic-mapping-tools.org/dev/supplements/seis/meca.html#f.

**Preview**:

Fixes #

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
