### PR TITLE
DOC: Add the missing .md suffix to doc/techref/index.md

### DIFF
--- a/doc/techref/index.md
+++ b/doc/techref/index.md
@@ -12,5 +12,5 @@ projections.md
 fonts.md
 patterns.md
 encodings.md
-environment_variables
+environment_variables.md
 ```


### PR DESCRIPTION
Just a typo.