### PR TITLE
Enable ruff's flake8-commas (COM) and refurb (FURB) rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,12 +90,14 @@ select = [
     "B",    # flake8-bugbear
     "BLE",  # flake8-blind-except
     "C4",   # flake8-comprehensions
+    "COM",  # flake8-commas
     "D",    # pydocstyle
     "E",    # pycodestyle
     "EXE",  # flake8-executable
     "F",    # pyflakes
     "FA",   # flake8-future-annotations
     "FLY",  # flynt
+    "FURB", # refurb
     "I",    # isort
     "ICN",  # flake8-import-conventions
     "ISC",  # flake8-implicit-str-concat
@@ -127,6 +129,7 @@ extend-select = [
     "PLW1514",  # {function_name} in text mode without explicit encoding argument
 ]
 ignore = [
+    "COM812",   # Do not always add the trailing commas
     "D200",     # One-line docstring should fit on one line
     "D202",     # No blank lines allowed after function docstring
     "D205",     # 1 blank line required between summary line and description


### PR DESCRIPTION
**Description of proposed changes**

Enable ruff's flake8-commas (COM) and refurb (FURB) rules but disable COM812.

Address https://github.com/GenericMappingTools/pygmt/issues/2741.

- COM: https://docs.astral.sh/ruff/rules/#flake8-commas-com
- FURB: https://docs.astral.sh/ruff/rules/#refurb-furb