### PR TITLE
Fix a link in .dvcignore

### DIFF
--- a/.dvcignore
+++ b/.dvcignore
@@ -1,3 +1,2 @@
-# Add patterns of files dvc should ignore, which could improve
-# the performance. Learn more at
-# https://dvc.org/doc/user-guide/dvcignore
+# Add patterns of files dvc should ignore, which could improve the performance.
+# Learn more at https://dvc.org/doc/user-guide/project-structure/dvcignore-files


### PR DESCRIPTION
https://dvc.org/doc/user-guide/dvcignore is redirected to https://dvc.org/doc/user-guide/project-structure/dvcignore-files.