### PR TITLE
pygmt.set_display: Improve the test by checking if the preview image is opened in the expected way

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -595,11 +595,12 @@ def set_display(method: Literal["external", "notebook", "none", None] = None):
     """
     match method:
         case "external" | "notebook" | "none":
-            SHOW_CONFIG["method"] = method  # type: ignore[assignment]
+            SHOW_CONFIG["method"] = method
         case None:
-            SHOW_CONFIG["method"] = _get_default_display_method()  # type: ignore[assignment]
+            SHOW_CONFIG["method"] = _get_default_display_method()
         case _:
-            raise GMTInvalidInput(
-                f"Invalid display method '{method}'. Valid values are 'external',"
-                "'notebook', 'none' or None."
+            msg = (
+                f"Invalid display method '{method}'. "
+                "Valid values are 'external', 'notebook', 'none' or None."
             )
+            raise GMTInvalidInput(msg)

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -579,19 +579,19 @@ def set_display(method: Literal["external", "notebook", "none", None] = None):
     >>> import pygmt
     >>> fig = pygmt.Figure()
     >>> fig.basemap(region=[0, 10, 0, 10], projection="X10c/5c", frame=True)
-    >>> fig.show()  # will display a PNG image in the current notebook
+    >>> fig.show()  # Will display a PNG image in the current notebook
     >>>
-    >>> # set the display method to "external"
+    >>> # Set the display method to "external"
     >>> pygmt.set_display(method="external")  # doctest: +SKIP
-    >>> fig.show()  # will display a PDF image using the default PDF viewer
+    >>> fig.show()  # Will display a PDF image using the default PDF viewer
     >>>
-    >>> # set the display method to "none"
+    >>> # Set the display method to "none"
     >>> pygmt.set_display(method="none")
-    >>> fig.show()  # will not show any image
+    >>> fig.show()  # Will not show any image
     >>>
-    >>> # reset to the default display method
+    >>> # Reset to the default display method
     >>> pygmt.set_display(method=None)
-    >>> fig.show()  # again, will show a PNG image in the current notebook
+    >>> fig.show()  # Again, will show a PNG image in the current notebook
     """
     match method:
         case "external" | "notebook" | "none":

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -377,13 +377,45 @@ class TestSetDisplay:
 
     def test_set_display(self):
         """
-        Test if pygmt.set_display updates the SHOW_CONFIG variable correctly.
+        Test if pygmt.set_display updates the SHOW_CONFIG variable correctly and
+        Figure.show opens the preview image in the correct way.
         """
-        default_method = SHOW_CONFIG["method"]  # Current default method
+        default_method = SHOW_CONFIG["method"]  # Store the current default method.
 
-        for method in ("notebook", "external", "none"):
-            set_display(method=method)
-            assert SHOW_CONFIG["method"] == method
+        fig = Figure()
+        fig.basemap(region=[0, 3, 6, 9], projection="X1c", frame=True)
+        with (
+            patch("IPython.display.display") as mock_display,
+            patch("pygmt.figure.launch_external_viewer") as mock_viewer,
+        ):
+            # Test the "notebook" display method.
+            set_display(method="notebook")
+            assert SHOW_CONFIG["method"] == "notebook"
+            fig.show()
+            assert mock_display.call_count == 1
+            assert mock_viewer.call_count == 0
+
+        with (
+            patch("IPython.display.display") as mock_display,
+            patch("pygmt.figure.launch_external_viewer") as mock_viewer,
+        ):
+            # Test the "none" display method.
+            set_display(method="none")
+            assert SHOW_CONFIG["method"] == "none"
+            fig.show()
+            assert mock_display.call_count == 0
+            assert mock_viewer.call_count == 0
+
+        with (
+            patch("IPython.display.display") as mock_display,
+            patch("pygmt.figure.launch_external_viewer") as mock_viewer,
+        ):
+            # Test the "external" display method
+            set_display(method="external")
+            assert SHOW_CONFIG["method"] == "external"
+            fig.show()
+            assert mock_display.call_count == 0
+            assert mock_viewer.call_count == 1
 
         # Setting method to None should revert it to the default method.
         set_display(method=None)

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -385,7 +385,7 @@ class TestSetDisplay:
         fig = Figure()
         fig.basemap(region=[0, 3, 6, 9], projection="X1c", frame=True)
         with (
-            patch("IPython.display.display") as mock_display,
+            patch("IPython.display.display", create=True) as mock_display,
             patch("pygmt.figure.launch_external_viewer") as mock_viewer,
         ):
             # Test the "notebook" display method.
@@ -396,7 +396,7 @@ class TestSetDisplay:
             assert mock_viewer.call_count == 0
 
         with (
-            patch("IPython.display.display") as mock_display,
+            patch("IPython.display.display", create=True) as mock_display,
             patch("pygmt.figure.launch_external_viewer") as mock_viewer,
         ):
             # Test the "none" display method.
@@ -407,7 +407,7 @@ class TestSetDisplay:
             assert mock_viewer.call_count == 0
 
         with (
-            patch("IPython.display.display") as mock_display,
+            patch("IPython.display.display", create=True) as mock_display,
             patch("pygmt.figure.launch_external_viewer") as mock_viewer,
         ):
             # Test the "external" display method


### PR DESCRIPTION
**Description of proposed changes**

The `set_display` method can configure the default display method when calling `Figure.show`. Previously, our test only checks if the function changes the global variable `SHOW_CONFIG` correctly and doesn't check if `Figure.show` works in the expected way.

This PR improves the test to make sure that `Figure.show` works as expected after calling `set_display`.