### PR TITLE
CI: Install DCW and GSHHG datasets on Linux/macOS in the "GMT Dev Tests" workflow

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -86,6 +86,14 @@ jobs:
             pcre
             zlib
 
+      # Install the GSHHG and DCW datasets on Linux/macOS to avoid corrupted files
+      # during GMT auto-downloading. Currently, we can't install them on Windows CI,
+      # because the Windows CI fails to compile "gshhg_version.c" due to unknown reasons
+      # (likely missing DLLs).
+      - name: Install GMT GSHHG and DCW datasets (Linux/macOS)
+        run: micromamba install dcw-gmt gshhg-gmt
+        if: runner.os != 'Windows'
+
       # Checkout current GMT repository
       - name: Checkout the GMT source from ${{ matrix.gmt_git_ref }} branch
         uses: actions/checkout@v4.2.1


### PR DESCRIPTION
**Description of proposed changes**

The "GMT Dev Tests" workflow started to fail frequently on macOS, with errors like:
```
Error:  GMTCLibError("Module 'coast' failed with status code 74:\ncoast [ERROR]: Cannot open file /Users/runner/.gmt/geography/dcw/dcw-gmt.nc!\ncoast [ERROR]: South is outside -90 to +90 degree range\ncoast [ERROR]: General map projection error")
Traceback (most recent call last):
  File "/Users/runner/micromamba/envs/pygmt/lib/python3.12/doctest.py", line 1368, in __run
    exec(compile(example.source, filename, "single",
  File "<doctest pygmt.clib.session.Session.extract_region[6]>", line 1, in <module>
  File "/Users/runner/work/pygmt/pygmt/pygmt/helpers/decorators.py", line 609, in new_module
    return module_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/pygmt/pygmt/pygmt/helpers/decorators.py", line 773, in new_module
    return module_func(*bound.args, **bound.kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/pygmt/pygmt/pygmt/src/coast.py", line 203, in coast
    lib.call_module(module="coast", args=build_arg_list(kwargs))
  File "/Users/runner/work/pygmt/pygmt/pygmt/clib/session.py", line 655, in call_module
    raise GMTCLibError(
pygmt.exceptions.GMTCLibError: Module 'coast' failed with status code 74:
Error: ERROR]: Cannot open file /Users/runner/.gmt/geography/dcw/dcw-gmt.nc!
Error: ERROR]: South is outside -90 to +90 degree range
Error: ERROR]: General map projection error
```
GMT will download the DCW and GSHHG datasets if they are not installed. The download may fail and cause errors like the above.

The solution is to install the dcw-gmt and gshhg-gmt packages, but the Windows CI fails to compile the `gshhg_version.c` file, so we only install them on Linux/macOS.

Supersedes PR #3486.
