### PR TITLE
load_tile_map: Add the new parameter 'crs' to set the CRS of the returned dataarray

### DIFF
--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -156,28 +156,25 @@ def load_tile_map(
         )
         raise ImportError(msg)
 
-    contextily_kwargs = {}
-    if zoom_adjust is not None:
-        contextily_kwargs["zoom_adjust"] = zoom_adjust
-        if Version(contextily.__version__) < Version("1.5.0"):
-            msg = (
-                "The `zoom_adjust` parameter requires `contextily>=1.5.0` to work. "
-                "Please upgrade contextily, or manually set the `zoom` level instead."
-            )
-            raise TypeError(msg)
+    if zoom_adjust is not None and Version(contextily.__version__) < Version("1.5.0"):
+        msg = (
+            "The `zoom_adjust` parameter requires `contextily>=1.5.0` to work. "
+            "Please upgrade contextily, or manually set the `zoom` level instead."
+        )
+        raise ValueError(msg)
 
+    # Keyword arguments for contextily.bounds2img
+    contextily_kwargs = {
+        "zoom": zoom,
+        "source": source,
+        "ll": lonlat,
+        "wait": wait,
+        "max_retries": max_retries,
+        "zoom_adjust": zoom_adjust,
+    }
     west, east, south, north = region
     image, extent = contextily.bounds2img(
-        w=west,
-        s=south,
-        e=east,
-        n=north,
-        zoom=zoom,
-        source=source,
-        ll=lonlat,
-        wait=wait,
-        max_retries=max_retries,
-        **contextily_kwargs,
+        w=west, s=south, e=east, n=north, **contextily_kwargs
     )
 
     # Turn RGBA img from channel-last to channel-first and get 3-band RGB only

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -3,7 +3,6 @@ Function to load raster tile maps from XYZ tile providers, and load as
 :class:`xarray.DataArray`.
 """
 
-import contextlib
 from collections.abc import Sequence
 from typing import Literal
 
@@ -11,16 +10,21 @@ from packaging.version import Version
 
 try:
     import contextily
+    from rasterio.crs import CRS
     from xyzservices import TileProvider
 
     _HAS_CONTEXTILY = True
 except ImportError:
+    CRS = None
     TileProvider = None
     _HAS_CONTEXTILY = False
 
-with contextlib.suppress(ImportError):
-    # rioxarray is needed to register the rio accessor
+try:
     import rioxarray  # noqa: F401
+
+    _HAS_RIOXARRAY = True
+except ImportError:
+    _HAS_RIOXARRAY = False
 
 import numpy as np
 import xarray as xr
@@ -33,6 +37,7 @@ def load_tile_map(
     zoom: int | Literal["auto"] = "auto",
     source: TileProvider | str | None = None,
     lonlat: bool = True,
+    crs: str | CRS = "EPSG:3857",
     wait: int = 0,
     max_retries: int = 2,
     zoom_adjust: int | None = None,
@@ -42,7 +47,8 @@ def load_tile_map(
 
     The tiles that compose the map are merged and georeferenced into an
     :class:`xarray.DataArray` image with 3 bands (RGB). Note that the returned image is
-    in a Spherical Mercator (EPSG:3857) coordinate reference system.
+    in a Spherical Mercator (EPSG:3857) coordinate reference system (CRS) by default,
+    but can be customized using the ``crs`` parameter.
 
     Parameters
     ----------
@@ -80,6 +86,10 @@ def load_tile_map(
     lonlat
         If ``False``, coordinates in ``region`` are assumed to be Spherical Mercator as
         opposed to longitude/latitude.
+    crs
+        Coordinate reference system (CRS) of the returned :class:`xarray.DataArray`
+        image. Default is ``"EPSG:3857"`` (i.e., Spherical Mercator). The CRS can be in
+        either string or :class:`rasterio.crs.CRS` format.
     wait
         If the tile API is rate-limited, the number of seconds to wait between a failed
         request and the next try.
@@ -128,11 +138,21 @@ def load_tile_map(
     ...     raster.rio.crs.to_string()
     'EPSG:3857'
     """
+    _default_crs = "EPSG:3857"  # The default CRS returned from contextily
+
     if not _HAS_CONTEXTILY:
         msg = (
             "Package `contextily` is required to be installed to use this function. "
             "Please use `python -m pip install contextily` or "
             "`mamba install -c conda-forge contextily` to install the package."
+        )
+        raise ImportError(msg)
+
+    if crs != _default_crs and not _HAS_RIOXARRAY:
+        msg = (
+            f"Package `rioxarray` is required if CRS is not '{_default_crs}'. "
+            "Please use `python -m pip install rioxarray` or "
+            "`mamba install -c conda-forge rioxarray` to install the package."
         )
         raise ImportError(msg)
 
@@ -176,8 +196,12 @@ def load_tile_map(
         dims=("band", "y", "x"),
     )
 
-    # If rioxarray is installed, set the coordinate reference system
+    # If rioxarray is installed, set the coordinate reference system.
     if hasattr(dataarray, "rio"):
-        dataarray = dataarray.rio.write_crs(input_crs="EPSG:3857")
+        dataarray = dataarray.rio.write_crs(input_crs=_default_crs)
+
+    # Reproject raster image from EPSG:3857 to specified CRS, using rioxarray.
+    if crs != _default_crs:
+        dataarray = dataarray.rio.reproject(dst_crs=crs)
 
     return dataarray

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -138,9 +138,9 @@ def load_tile_map(
     ...     raster.rio.crs.to_string()
     'EPSG:3857'
     """
-    # The CRS of the returned image. Use the tile provider's CRS if available.
-    # Otherwise, default to EPSG:3857.
-    _default_crs = getattr(source, "crs", "EPSG:3857")
+    # The CRS of the source tile provider. If the source is a TileProvider object, use
+    # its crs attribute if available. Otherwise, default to EPSG:3857.
+    _source_crs = getattr(source, "crs", "EPSG:3857")
 
     if not _HAS_CONTEXTILY:
         msg = (
@@ -150,9 +150,9 @@ def load_tile_map(
         )
         raise ImportError(msg)
 
-    if crs != _default_crs and not _HAS_RIOXARRAY:
+    if crs != _source_crs and not _HAS_RIOXARRAY:
         msg = (
-            f"Package `rioxarray` is required if CRS is not '{_default_crs}'. "
+            f"Package `rioxarray` is required if CRS is not '{_source_crs}'. "
             "Please use `python -m pip install rioxarray` or "
             "`mamba install -c conda-forge rioxarray` to install the package."
         )
@@ -198,10 +198,10 @@ def load_tile_map(
 
     # If rioxarray is installed, set the coordinate reference system.
     if hasattr(dataarray, "rio"):
-        dataarray = dataarray.rio.write_crs(input_crs=_default_crs)
+        dataarray = dataarray.rio.write_crs(input_crs=_source_crs)
 
-        # Reproject raster image from EPSG:3857 to specified CRS, using rioxarray.
-        if crs != _default_crs:
+        # Reproject raster image from the source CRS to the specified CRS.
+        if crs != _source_crs:
             dataarray = dataarray.rio.reproject(dst_crs=crs)
 
     return dataarray

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -198,8 +198,8 @@ def load_tile_map(
     if hasattr(dataarray, "rio"):
         dataarray = dataarray.rio.write_crs(input_crs=_default_crs)
 
-    # Reproject raster image from EPSG:3857 to specified CRS, using rioxarray.
-    if crs != _default_crs:
-        dataarray = dataarray.rio.reproject(dst_crs=crs)
+        # Reproject raster image from EPSG:3857 to specified CRS, using rioxarray.
+        if crs != _default_crs:
+            dataarray = dataarray.rio.reproject(dst_crs=crs)
 
     return dataarray

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -156,13 +156,6 @@ def load_tile_map(
         )
         raise ImportError(msg)
 
-    if zoom_adjust is not None and Version(contextily.__version__) < Version("1.5.0"):
-        msg = (
-            "The `zoom_adjust` parameter requires `contextily>=1.5.0` to work. "
-            "Please upgrade contextily, or manually set the `zoom` level instead."
-        )
-        raise ValueError(msg)
-
     # Keyword arguments for contextily.bounds2img
     contextily_kwargs = {
         "zoom": zoom,
@@ -170,8 +163,16 @@ def load_tile_map(
         "ll": lonlat,
         "wait": wait,
         "max_retries": max_retries,
-        "zoom_adjust": zoom_adjust,
     }
+    if zoom_adjust is not None:
+        if Version(contextily.__version__) < Version("1.5.0"):
+            msg = (
+                "The `zoom_adjust` parameter requires `contextily>=1.5.0` to work. "
+                "Please upgrade contextily, or manually set the `zoom` level instead."
+            )
+            raise ValueError(msg)
+        contextily_kwargs["zoom_adjust"] = zoom_adjust
+
     west, east, south, north = region
     image, extent = contextily.bounds2img(
         w=west, s=south, e=east, n=north, **contextily_kwargs

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -138,7 +138,9 @@ def load_tile_map(
     ...     raster.rio.crs.to_string()
     'EPSG:3857'
     """
-    _default_crs = "EPSG:3857"  # The default CRS returned from contextily
+    # The CRS of the returned image. Use the tile provider's CRS if available.
+    # Otherwise, default to EPSG:3857.
+    _default_crs = getattr(source, "crs", "EPSG:3857")
 
     if not _HAS_CONTEXTILY:
         msg = (

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -9,13 +9,9 @@ from pygmt.datasets.tile_map import load_tile_map
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
 try:
-    import rioxarray  # noqa: F401
     from xyzservices import TileProvider
-
-    _HAS_RIOXARRAY = True
 except ImportError:
     TileProvider = None
-    _HAS_RIOXARRAY = False
 
 
 @fmt_docstring
@@ -111,38 +107,21 @@ def tilemap(
 
     kwargs : dict
         Extra keyword arguments to pass to :meth:`pygmt.Figure.grdimage`.
-
-    Raises
-    ------
-    ImportError
-        If ``rioxarray`` is not installed. Follow
-        :doc:`install instructions for rioxarray <rioxarray:installation>`, (e.g. via
-        ``python -m pip install rioxarray``) before using this function.
     """
     kwargs = self._preprocess(**kwargs)
-
-    if not _HAS_RIOXARRAY:
-        raise ImportError(
-            "Package `rioxarray` is required to be installed to use this function. "
-            "Please use `python -m pip install rioxarray` or "
-            "`mamba install -c conda-forge rioxarray` to install the package."
-        )
 
     raster = load_tile_map(
         region=region,
         zoom=zoom,
         source=source,
         lonlat=lonlat,
+        crs="OGC:CRS84" if lonlat is True else "EPSG:3857",
         wait=wait,
         max_retries=max_retries,
         zoom_adjust=zoom_adjust,
     )
-
-    # Reproject raster from Spherical Mercator (EPSG:3857) to lonlat (OGC:CRS84) if
-    # bounding box region was provided in lonlat
-    if lonlat and raster.rio.crs == "EPSG:3857":
-        raster = raster.rio.reproject(dst_crs="OGC:CRS84")
-        raster.gmt.gtype = 1  # set to geographic type
+    if lonlat:
+        raster.gmt.gtype = 1  # Set to geographic type
 
     # Only set region if no_clip is None or False, so that plot is clipped to exact
     # bounding box region

--- a/pygmt/tests/test_tilemap.py
+++ b/pygmt/tests/test_tilemap.py
@@ -2,14 +2,24 @@
 Test Figure.tilemap.
 """
 
+import importlib
+from unittest.mock import patch
+
 import pytest
 from pygmt import Figure
 
-contextily = pytest.importorskip("contextily")
-rioxarray = pytest.importorskip("rioxarray")
+try:
+    import contextily
+
+    _HAS_CONTEXTILY = True
+except ImportError:
+    _HAS_CONTEXTILY = False
+
+_HAS_RIOXARRAY = bool(importlib.util.find_spec("rioxarray"))
 
 
 @pytest.mark.mpl_image_compare
+@pytest.mark.skipif(not _HAS_CONTEXTILY, reason="contextily is not installed")
 def test_tilemap_web_mercator():
     """
     Create a tilemap plot in Spherical Mercator projection (EPSG:3857).
@@ -27,6 +37,10 @@ def test_tilemap_web_mercator():
 
 @pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
+@pytest.mark.skipif(
+    not (_HAS_CONTEXTILY and _HAS_RIOXARRAY),
+    reason="contextily and rioxarray are not installed",
+)
 def test_tilemap_ogc_wgs84():
     """
     Create a tilemap plot using longitude/latitude coordinates (OGC:WGS84), centred on
@@ -45,6 +59,10 @@ def test_tilemap_ogc_wgs84():
 
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("no_clip", [False, True])
+@pytest.mark.skipif(
+    not (_HAS_CONTEXTILY and _HAS_RIOXARRAY),
+    reason="contextily and rioxarray are not installed",
+)
 def test_tilemap_no_clip(no_clip):
     """
     Create a tilemap plot clipped to the Southern Hemisphere when no_clip is False, but
@@ -60,3 +78,34 @@ def test_tilemap_no_clip(no_clip):
         no_clip=no_clip,
     )
     return fig
+
+
+@pytest.mark.skipif(_HAS_CONTEXTILY, reason="contextily is installed.")
+def test_tilemap_no_contextily():
+    """
+    Raise an ImportError when contextily is not installed.
+    """
+    fig = Figure()
+    with pytest.raises(ImportError, match="Package `contextily` is required"):
+        fig.tilemap(
+            region=[-20000000.0, 20000000.0, -20000000.0, 20000000.0],
+            zoom=0,
+            lonlat=False,
+            frame="afg",
+        )
+
+
+@pytest.mark.skipif(_HAS_RIOXARRAY, reason="rioxarray is installed.")
+def test_tilemap_no_rioxarray():
+    """
+    Raise an ImportError when rioxarray is not installed and contextily is installed.
+    """
+    fig = Figure()
+    # In our CI, contextily and rioxarray are installed together, so we will see the
+    # error about contextily, not rioxarray. Here we mock contextily as installed, to
+    # make sure that we see the rioxarray error message when rioxarray is not installed.
+    with patch("pygmt.datasets.tile_map._HAS_CONTEXTILY", True):
+        with pytest.raises(ImportError, match="Package `rioxarray` is required"):
+            fig.tilemap(
+                region=[-180.0, 180.0, -90, 90], zoom=0, lonlat=True, frame="afg"
+            )


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the `crs` parameter to the `load_tile_map` function so that users can change the CRS of the returned raster image without needing to know the details. 

Address https://github.com/GenericMappingTools/pygmt/pull/2125#discussion_r1059868371. 
Closes https://github.com/GenericMappingTools/pygmt/issues/3484.

**Notes for maintainers:**

As far as I know, there are multiple different ways to reproject raster images.

1. [contextily.warp_tiles](https://contextily.readthedocs.io/en/latest/reference.html#contextily.warp_tiles): Internally calls [`rasterio.vrt.WarpedVRT`](https://rasterio.readthedocs.io/en/stable/api/rasterio.vrt.html#rasterio.vrt.WarpedVRT)
2. [rioxarray's rio.reproject](https://corteva.github.io/rioxarray/html/rioxarray.html#rioxarray.raster_array.RasterArray.reproject): Internally calls [`rasterio.warp.reproject`](https://rasterio.readthedocs.io/en/stable/api/rasterio.warp.html#rasterio.warp.reproject)
3. [`rasterio.vrt.WarpedVRT`](https://rasterio.readthedocs.io/en/stable/api/rasterio.vrt.html#rasterio.vrt.WarpedVRT)
4. [`rasterio.warp.reproject`](https://rasterio.readthedocs.io/en/stable/api/rasterio.warp.html#rasterio.warp.reproject)
5. [`gdal.Warp`](https://gdal.org/en/latest/api/python/utilities.html#osgeo.gdal.Warp)
6. ...

Options 3-5 are complicated and I don't think we want to call them directly. Ideally, we should use option 1, so reprojection doesn't rely on an extra dependency `rioxarray`. However, as shown below, the result from `contextily.warp_tiles` doesn't work well with `rio.to_raster`.

Here are codes to compare the results with options 1 and 2:

```python
import xarray as xr
import rioxarray
import contextily as cx
import numpy as np

def image2raster(image, extent, crs="EPSG:3857"):
    """
    Convert an image to a xarray.DataArray raster.

    Copied from pygmt.datasets.tile_map.load_tile_map, except that crs is an input parameter.
    """
    # Turn RGBA img from channel-last to channel-first and get 3-band RGB only
    _image = image.transpose(2, 0, 1)  # Change image from (H, W, C) to (C, H, W)
    rgb_image = _image[0:3, :, :]  # Get just RGB by dropping RGBA's alpha channel
    
    # Georeference RGB image into an xarray.DataArray
    left, right, bottom, top = extent
    dataarray = xr.DataArray(
        data=rgb_image,
        coords={
            "band": np.array(object=[1, 2, 3], dtype=np.uint8),  # Red, Green, Blue
            "y": np.linspace(start=top, stop=bottom, num=rgb_image.shape[1]),
            "x": np.linspace(start=left, stop=right, num=rgb_image.shape[2]),
        },
        dims=("band", "y", "x"),
    )
    dataarray = dataarray.rio.write_crs(input_crs=crs)
    return dataarray

# Image and extent of the global tile
image, extent = cx.bounds2img(w=-180, e=180, s=-90, n=90, ll=True, zoom=0)

# Option 1: Use contextily.warp_tiles
image_warp, extent_warp = cx.warp_tiles(image, extent, "OGC:CRS84")
dataarray_warp = image2raster(image_warp, extent_warp, crs="OGC:CRS84")
print("Using contextily.warp_tiles:", dataarray_warp.rio.bounds())
dataarray_warp.rio.to_raster("result_warp.tiff")

# Option 2: Use rio.reproject
dataarray = image2raster(image, extent, crs="EPSG:3857")
dataarray_reproject = dataarray.rio.reproject("OGC:CRS84")
print("Using rio.reproject:", dataarray_reproject.rio.bounds())
dataarray_reproject.rio.to_raster("result_reproject.tiff")
```
The outputs are:
```
Using contextily.warp_tiles: (-180.55157789333614, -85.9082903958547, 180.18036434850873, 85.66487761291295)
Using rio.reproject: (-180.0, -84.8307625666717, 180.00000000000006, 85.11165075221737)
```
As you can see, the longitude range is (-180.55157789333614, 180.18036434850873) with `contextily.warp_tiles`, which will lead to GMT errors like:
```
grdimage [ERROR]: Map region exceeds 360 degrees
grdimage [ERROR]: General map projection error
```
Two more notes:

- There is an open request to use `rasterio.warp.reproject` instead of `rasterio.vrt.WarpedVRT` in `warp_tiles` (https://github.com/geopandas/contextily/issues/88). If it's done, then the result from `warp_tiles` will be likely the same as the one from `rio.reproject`
- Currently, we need to save raster into temporary files by calling `rio.to_raster` (https://github.com/GenericMappingTools/pygmt/blob/988746bba290d16826ab4040d973af7137c5d3be/pygmt/helpers/tempfile.py#L204). We don't have to do it after https://github.com/GenericMappingTools/pygmt/pull/3468. 

**Preview**: https://pygmt-dev--3554.org.readthedocs.build/en/3554/api/generated/pygmt.datasets.load_tile_map.html


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
