### PR TITLE
CI: Use the 'ubuntu-latest' runner in the 'Benchmarks' workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   benchmarks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: github.repository == 'GenericMappingTools/pygmt' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run/benchmark'))
     defaults:
       run:


### PR DESCRIPTION
Update `ubuntu-22.04` to `ubuntu-latest` so we don't have to update it manually. 

For reference, currently, we use `ubuntu-latest`/`macos-latest`/`windows-latest` in all workflows except two:

- `ci_legacy_tests`: use the oldest runners supported by GitHub
- `ci_dev_tests`: use the latest (even in preview or beta) runners