### PR TITLE
Test timedelta64 dtype arrays with various date/time units

### DIFF
--- a/pygmt/tests/test_clib_put_vector.py
+++ b/pygmt/tests/test_clib_put_vector.py
@@ -171,10 +171,12 @@ def test_put_vector_string_dtype():
 
 def test_put_vector_timedelta64_dtype():
     """
-    Passing timedelta64 type vectors with various time units (year, month,
-    week, day, hour, minute, second, millisecond, microsecond) to a dataset.
+    Passing timedelta64 type vectors with various date/time units to a dataset.
+
+    Valid date/time units can be found at
+    https://numpy.org/devdocs/reference/arrays.datetime.html#datetime-units.
     """
-    for unit in ["Y", "M", "W", "D", "h", "m", "s", "ms", "μs"]:
+    for unit in ["Y", "M", "W", "D", "h", "m", "s", "ms", "us", "ns", "ps", "fs", "as"]:
         with clib.Session() as lib, GMTTempFile() as tmp_file:
             dataset = lib.create_data(
                 family="GMT_IS_DATASET|GMT_VIA_VECTOR",


### PR DESCRIPTION
[`np.timedelta64`](https://numpy.org/devdocs/reference/arrays.scalars.html#numpy.timedelta64) is internally stored as 64-bit integers. So any date/time units listed at https://numpy.org/doc/stable/reference/arrays.datetime.html#datetime-units are supported.

This PR improves the existing test (added in #2884) by testing time units like "ns", "ps", "fs", and "as".

Patches #2884.

