### PR TITLE
clib.converison._to_numpy: Add tests for numpy arrays of numpy numeric dtypes

### DIFF
--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -4,6 +4,7 @@ Tests for the _to_numpy function in the clib.conversion module.
 
 import numpy as np
 import numpy.testing as npt
+import pandas as pd
 import pytest
 from pygmt.clib.conversion import _to_numpy
 from pygmt.clib.session import DTYPES
@@ -21,7 +22,7 @@ def _check_result(result, supported):
 
 
 ########################################################################################
-# Test the _to_numpy function with NumPy dtypes.
+# Test the _to_numpy function with NumPy arrays.
 #
 # There are 24 fundamental dtypes in NumPy. Not all of them are supported by PyGMT.
 # Reference: https://numpy.org/doc/2.1/reference/arrays.scalars.html
@@ -80,3 +81,47 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
     result = _to_numpy(array)
     _check_result(result, supported)
     npt.assert_array_equal(result, array)
+
+
+########################################################################################
+# Test the _to_numpy function with pandas.Series.
+#
+# In pandas, dtype can be specified by
+#
+# 1. NumPy dtypes (see above)
+# 2. pandas dtypes
+# 3. PyArrow dtypes
+#
+# Reference: https://pandas.pydata.org/docs/reference/arrays.html
+########################################################################################
+@pytest.mark.parametrize(
+    ("dtype", "supported"),
+    [
+        (np.int8, True),
+        (np.int16, True),
+        (np.int32, True),
+        (np.int64, True),
+        (np.longlong, True),
+        (np.uint8, True),
+        (np.uint16, True),
+        (np.uint32, True),
+        (np.uint64, True),
+        (np.ulonglong, True),
+        (np.float16, False),
+        (np.float32, True),
+        (np.float64, True),
+        (np.longdouble, False),
+        (np.complex64, False),
+        (np.complex128, False),
+        (np.clongdouble, False),
+    ],
+)
+def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, supported):
+    """
+    Test the _to_numpy function with pandas.Series of NumPy numeric dtypes.
+    """
+    series = pd.Series([1, 2, 3], dtype=dtype)
+    assert series.dtype == dtype
+    result = _to_numpy(series)
+    _check_result(result, supported)
+    npt.assert_array_equal(result, series)

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -85,14 +85,16 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, expected_dtype):
 
     Test both 1-D and 2-D arrays.
     """
-    # 1-D array
-    array = np.array([1, 2, 3], dtype=dtype)
+    # 1-D array that is not C-contiguous
+    array = np.array([1, 2, 3, 4, 5, 6], dtype=dtype)[::2]
+    assert array.flags.c_contiguous is False
     result = _to_numpy(array)
     _check_result(result, expected_dtype)
     npt.assert_array_equal(result, array, strict=True)
 
-    # 2-D array
-    array = np.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
+    # 2-D array that is not C-contiguous
+    array = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=dtype)[::2, ::2]
+    assert array.flags.c_contiguous is False
     result = _to_numpy(array)
     _check_result(result, expected_dtype)
     npt.assert_array_equal(result, array, strict=True)
@@ -132,7 +134,7 @@ def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with pandas.Series of NumPy numeric dtypes.
     """
-    series = pd.Series([1, 2, 3], dtype=dtype)
+    series = pd.Series([1, 2, 3, 4, 5, 6], dtype=dtype)[::2]  # Not C-contiguous
     result = _to_numpy(series)
     _check_result(result, expected_dtype)
     npt.assert_array_equal(result, series)

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -1,0 +1,82 @@
+"""
+Tests for the _to_numpy function in the clib.conversion module.
+"""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+from pygmt.clib.conversion import _to_numpy
+from pygmt.clib.session import DTYPES
+
+
+def _check_result(result, supported):
+    """
+    Check the result of the _to_numpy function.
+    """
+    # Check that the result is a NumPy array and is C-contiguous.
+    assert isinstance(result, np.ndarray)
+    assert result.flags.c_contiguous
+    # Check that the dtype is supported by PyGMT (or the GMT C API).
+    assert (result.dtype.type in DTYPES) == supported
+
+
+########################################################################################
+# Test the _to_numpy function with NumPy dtypes.
+#
+# There are 24 fundamental dtypes in NumPy. Not all of them are supported by PyGMT.
+# Reference: https://numpy.org/doc/2.1/reference/arrays.scalars.html
+#
+# - Numeric dtypes:
+#   - int8, int16, int32, int64, longlong
+#   - uint8, uint16, uint32, uint64, ulonglong
+#   - float16, float32, float64, longdouble
+#   - complex64, complex128, clongdouble
+# - bool
+# - datetime64, timedelta64
+# - str_
+# - bytes_
+# - object_
+# - void
+########################################################################################
+@pytest.mark.parametrize(
+    ("dtype", "supported"),
+    [
+        (np.int8, True),
+        (np.int16, True),
+        (np.int32, True),
+        (np.int64, True),
+        (np.longlong, True),
+        (np.uint8, True),
+        (np.uint16, True),
+        (np.uint32, True),
+        (np.uint64, True),
+        (np.ulonglong, True),
+        (np.float16, False),
+        (np.float32, True),
+        (np.float64, True),
+        (np.longdouble, False),
+        (np.complex64, False),
+        (np.complex128, False),
+        (np.clongdouble, False),
+    ],
+)
+def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
+    """
+    Test the _to_numpy function with NumPy arrays of NumPy numeric dtypes.
+
+    "dtype" is the NumPy dtype to be tested and "supported" is a boolean value
+    indicating whether the dtype is supported by PyGMT (or the GMT C API).
+    """
+    # 1-D array
+    array = np.array([1, 2, 3], dtype=dtype)
+    assert array.dtype == dtype
+    result = _to_numpy(array)
+    _check_result(result, supported)
+    npt.assert_array_equal(result, array)
+
+    # 2-D array
+    array = np.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
+    assert array.dtype == dtype
+    result = _to_numpy(array)
+    _check_result(result, supported)
+    npt.assert_array_equal(result, array)

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -27,6 +27,11 @@ def _check_result(result, expected_dtype):
     [
         pytest.param([1, 2, 3], np.int64, id="int"),
         pytest.param([1.0, 2.0, 3.0], np.float64, id="float"),
+        pytest.param(
+            [complex(+1), complex(-2j), complex("-Infinity+NaNj")],
+            np.complex128,
+            id="complex",
+        ),
     ],
 )
 def test_to_numpy_python_types_numeric(data, expected_dtype):
@@ -83,7 +88,7 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with NumPy arrays of NumPy numeric dtypes.
 
-    Test both 1-D and 2-D arrays.
+    Test both 1-D and 2-D arrays which are not C-contiguous.
     """
     # 1-D array that is not C-contiguous
     array = np.array([1, 2, 3, 4, 5, 6], dtype=dtype)[::2]

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -7,18 +7,16 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from pygmt.clib.conversion import _to_numpy
-from pygmt.clib.session import DTYPES
 
 
-def _check_result(result, supported):
+def _check_result(result, expected_dtype):
     """
-    Check the result of the _to_numpy function.
+    A helper function to check if the result of the _to_numpy function is a C-contiguous
+    NumPy array with the expected dtype.
     """
-    # Check that the result is a NumPy array and is C-contiguous.
     assert isinstance(result, np.ndarray)
     assert result.flags.c_contiguous
-    # Check that the dtype is supported by PyGMT (or the GMT C API).
-    assert (result.dtype.type in DTYPES) == supported
+    assert result.dtype.type == expected_dtype
 
 
 ########################################################################################
@@ -36,8 +34,8 @@ def test_to_numpy_python_types_numeric(data, expected_dtype):
     Test the _to_numpy function with Python built-in numeric types.
     """
     result = _to_numpy(data)
-    _check_result(result, supported=True)
-    npt.assert_array_equal(result, np.array(data, dtype=expected_dtype), strict=True)
+    _check_result(result, expected_dtype)
+    npt.assert_array_equal(result, data)
 
 
 ########################################################################################
@@ -60,28 +58,28 @@ def test_to_numpy_python_types_numeric(data, expected_dtype):
 # Reference: https://numpy.org/doc/2.1/reference/arrays.scalars.html
 ########################################################################################
 @pytest.mark.parametrize(
-    ("dtype", "supported"),
+    ("dtype", "expected_dtype"),
     [
-        (np.int8, True),
-        (np.int16, True),
-        (np.int32, True),
-        (np.int64, True),
-        (np.longlong, True),
-        (np.uint8, True),
-        (np.uint16, True),
-        (np.uint32, True),
-        (np.uint64, True),
-        (np.ulonglong, True),
-        (np.float16, False),
-        (np.float32, True),
-        (np.float64, True),
-        (np.longdouble, False),
-        (np.complex64, False),
-        (np.complex128, False),
-        (np.clongdouble, False),
+        pytest.param(np.int8, np.int8, id="int8"),
+        pytest.param(np.int16, np.int16, id="int16"),
+        pytest.param(np.int32, np.int32, id="int32"),
+        pytest.param(np.int64, np.int64, id="int64"),
+        pytest.param(np.longlong, np.longlong, id="longlong"),
+        pytest.param(np.uint8, np.uint8, id="uint8"),
+        pytest.param(np.uint16, np.uint16, id="uint16"),
+        pytest.param(np.uint32, np.uint32, id="uint32"),
+        pytest.param(np.uint64, np.uint64, id="uint64"),
+        pytest.param(np.ulonglong, np.ulonglong, id="ulonglong"),
+        pytest.param(np.float16, np.float16, id="float16"),
+        pytest.param(np.float32, np.float32, id="float32"),
+        pytest.param(np.float64, np.float64, id="float64"),
+        pytest.param(np.longdouble, np.longdouble, id="longdouble"),
+        pytest.param(np.complex64, np.complex64, id="complex64"),
+        pytest.param(np.complex128, np.complex128, id="complex128"),
+        pytest.param(np.clongdouble, np.clongdouble, id="clongdouble"),
     ],
 )
-def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
+def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with NumPy arrays of NumPy numeric dtypes.
 
@@ -90,13 +88,13 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
     # 1-D array
     array = np.array([1, 2, 3], dtype=dtype)
     result = _to_numpy(array)
-    _check_result(result, supported)
+    _check_result(result, expected_dtype)
     npt.assert_array_equal(result, array, strict=True)
 
     # 2-D array
     array = np.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
     result = _to_numpy(array)
-    _check_result(result, supported)
+    _check_result(result, expected_dtype)
     npt.assert_array_equal(result, array, strict=True)
 
 
@@ -130,33 +128,32 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
 # 3. https://pandas.pydata.org/docs/user_guide/pyarrow.html
 ########################################################################################
 @pytest.mark.parametrize(
-    ("dtype", "supported"),
+    ("dtype", "expected_dtype"),
     [
-        (np.int8, True),
-        (np.int16, True),
-        (np.int32, True),
-        (np.int64, True),
-        (np.longlong, True),
-        (np.uint8, True),
-        (np.uint16, True),
-        (np.uint32, True),
-        (np.uint64, True),
-        (np.ulonglong, True),
-        (np.float16, False),
-        (np.float32, True),
-        (np.float64, True),
-        (np.longdouble, False),
-        (np.complex64, False),
-        (np.complex128, False),
-        (np.clongdouble, False),
+        pytest.param(np.int8, np.int8, id="int8"),
+        pytest.param(np.int16, np.int16, id="int16"),
+        pytest.param(np.int32, np.int32, id="int32"),
+        pytest.param(np.int64, np.int64, id="int64"),
+        pytest.param(np.longlong, np.longlong, id="longlong"),
+        pytest.param(np.uint8, np.uint8, id="uint8"),
+        pytest.param(np.uint16, np.uint16, id="uint16"),
+        pytest.param(np.uint32, np.uint32, id="uint32"),
+        pytest.param(np.uint64, np.uint64, id="uint64"),
+        pytest.param(np.ulonglong, np.ulonglong, id="ulonglong"),
+        pytest.param(np.float16, np.float16, id="float16"),
+        pytest.param(np.float32, np.float32, id="float32"),
+        pytest.param(np.float64, np.float64, id="float64"),
+        pytest.param(np.longdouble, np.longdouble, id="longdouble"),
+        pytest.param(np.complex64, np.complex64, id="complex64"),
+        pytest.param(np.complex128, np.complex128, id="complex128"),
+        pytest.param(np.clongdouble, np.clongdouble, id="clongdouble"),
     ],
 )
-def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, supported):
+def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with pandas.Series of NumPy numeric dtypes.
     """
     series = pd.Series([1, 2, 3], dtype=dtype)
-    assert series.dtype == dtype
     result = _to_numpy(series)
-    _check_result(result, supported)
+    _check_result(result, expected_dtype)
     npt.assert_array_equal(result, series)

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -22,6 +22,25 @@ def _check_result(result, supported):
 
 
 ########################################################################################
+# Test the _to_numpy function with Python built-in types.
+########################################################################################
+@pytest.mark.parametrize(
+    ("data", "supported"),
+    [
+        pytest.param([1, 2, 3], True, id="int"),
+        pytest.param([1.0, 2.0, 3.0], True, id="float"),
+    ],
+)
+def test_to_numpy_python_types_numeric(data, supported):
+    """
+    Test the _to_numpy function with Python built-in numeric types.
+    """
+    result = _to_numpy(data)
+    _check_result(result, supported)
+    npt.assert_array_equal(result, data)
+
+
+########################################################################################
 # Test the _to_numpy function with NumPy arrays.
 #
 # There are 24 fundamental dtypes in NumPy. Not all of them are supported by PyGMT.

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -57,28 +57,28 @@ def test_to_numpy_python_types_numeric(data, expected_dtype):
 #
 # Reference: https://numpy.org/doc/2.1/reference/arrays.scalars.html
 ########################################################################################
-@pytest.mark.parametrize(
-    ("dtype", "expected_dtype"),
-    [
-        pytest.param(np.int8, np.int8, id="int8"),
-        pytest.param(np.int16, np.int16, id="int16"),
-        pytest.param(np.int32, np.int32, id="int32"),
-        pytest.param(np.int64, np.int64, id="int64"),
-        pytest.param(np.longlong, np.longlong, id="longlong"),
-        pytest.param(np.uint8, np.uint8, id="uint8"),
-        pytest.param(np.uint16, np.uint16, id="uint16"),
-        pytest.param(np.uint32, np.uint32, id="uint32"),
-        pytest.param(np.uint64, np.uint64, id="uint64"),
-        pytest.param(np.ulonglong, np.ulonglong, id="ulonglong"),
-        pytest.param(np.float16, np.float16, id="float16"),
-        pytest.param(np.float32, np.float32, id="float32"),
-        pytest.param(np.float64, np.float64, id="float64"),
-        pytest.param(np.longdouble, np.longdouble, id="longdouble"),
-        pytest.param(np.complex64, np.complex64, id="complex64"),
-        pytest.param(np.complex128, np.complex128, id="complex128"),
-        pytest.param(np.clongdouble, np.clongdouble, id="clongdouble"),
-    ],
-)
+np_dtype_params = [
+    pytest.param(np.int8, np.int8, id="int8"),
+    pytest.param(np.int16, np.int16, id="int16"),
+    pytest.param(np.int32, np.int32, id="int32"),
+    pytest.param(np.int64, np.int64, id="int64"),
+    pytest.param(np.longlong, np.longlong, id="longlong"),
+    pytest.param(np.uint8, np.uint8, id="uint8"),
+    pytest.param(np.uint16, np.uint16, id="uint16"),
+    pytest.param(np.uint32, np.uint32, id="uint32"),
+    pytest.param(np.uint64, np.uint64, id="uint64"),
+    pytest.param(np.ulonglong, np.ulonglong, id="ulonglong"),
+    pytest.param(np.float16, np.float16, id="float16"),
+    pytest.param(np.float32, np.float32, id="float32"),
+    pytest.param(np.float64, np.float64, id="float64"),
+    pytest.param(np.longdouble, np.longdouble, id="longdouble"),
+    pytest.param(np.complex64, np.complex64, id="complex64"),
+    pytest.param(np.complex128, np.complex128, id="complex128"),
+    pytest.param(np.clongdouble, np.clongdouble, id="clongdouble"),
+]
+
+
+@pytest.mark.parametrize(("dtype", "expected_dtype"), np_dtype_params)
 def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with NumPy arrays of NumPy numeric dtypes.
@@ -127,28 +127,7 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, expected_dtype):
 # 2. https://pandas.pydata.org/docs/user_guide/basics.html#basics-dtypes
 # 3. https://pandas.pydata.org/docs/user_guide/pyarrow.html
 ########################################################################################
-@pytest.mark.parametrize(
-    ("dtype", "expected_dtype"),
-    [
-        pytest.param(np.int8, np.int8, id="int8"),
-        pytest.param(np.int16, np.int16, id="int16"),
-        pytest.param(np.int32, np.int32, id="int32"),
-        pytest.param(np.int64, np.int64, id="int64"),
-        pytest.param(np.longlong, np.longlong, id="longlong"),
-        pytest.param(np.uint8, np.uint8, id="uint8"),
-        pytest.param(np.uint16, np.uint16, id="uint16"),
-        pytest.param(np.uint32, np.uint32, id="uint32"),
-        pytest.param(np.uint64, np.uint64, id="uint64"),
-        pytest.param(np.ulonglong, np.ulonglong, id="ulonglong"),
-        pytest.param(np.float16, np.float16, id="float16"),
-        pytest.param(np.float32, np.float32, id="float32"),
-        pytest.param(np.float64, np.float64, id="float64"),
-        pytest.param(np.longdouble, np.longdouble, id="longdouble"),
-        pytest.param(np.complex64, np.complex64, id="complex64"),
-        pytest.param(np.complex128, np.complex128, id="complex128"),
-        pytest.param(np.clongdouble, np.clongdouble, id="clongdouble"),
-    ],
-)
+@pytest.mark.parametrize(("dtype", "expected_dtype"), np_dtype_params)
 def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with pandas.Series of NumPy numeric dtypes.

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -92,7 +92,27 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
 # 2. pandas dtypes
 # 3. PyArrow dtypes
 #
-# Reference: https://pandas.pydata.org/docs/reference/arrays.html
+# pandas provides following dtypes:
+#
+# - Numeric dtypes:
+#   - Int8, Int16, Int32, Int64
+#   - UInt8, UInt16, UInt32, UInt64
+#   - Float32, Float64
+# - DatetimeTZDtype
+# - PeriodDtype
+# - IntervalDtype
+# - StringDtype
+# - CategoricalDtype
+# - SparseDtype
+# - BooleanDtype
+# - ArrowDtype
+#
+# ArrowDtype is a special dtype that is used to store data in the PyArrow format.
+#
+# References:
+# 1. https://pandas.pydata.org/docs/reference/arrays.html
+# 2. https://pandas.pydata.org/docs/user_guide/basics.html#basics-dtypes
+# 3. https://pandas.pydata.org/docs/user_guide/pyarrow.html
 ########################################################################################
 @pytest.mark.parametrize(
     ("dtype", "supported"),

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -2,10 +2,13 @@
 Tests for the _to_numpy function in the clib.conversion module.
 """
 
+import sys
+
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
+from packaging.version import Version
 from pygmt.clib.conversion import _to_numpy
 
 
@@ -25,7 +28,13 @@ def _check_result(result, expected_dtype):
 @pytest.mark.parametrize(
     ("data", "expected_dtype"),
     [
-        pytest.param([1, 2, 3], np.int64, id="int"),
+        pytest.param(
+            [1, 2, 3],
+            np.int32
+            if sys.platform == "win32" and Version(np.__version__) < Version("2.0")
+            else np.int64,
+            id="int",
+        ),
         pytest.param([1.0, 2.0, 3.0], np.float64, id="float"),
         pytest.param(
             [complex(+1), complex(-2j), complex("-Infinity+NaNj")],

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -25,26 +25,25 @@ def _check_result(result, supported):
 # Test the _to_numpy function with Python built-in types.
 ########################################################################################
 @pytest.mark.parametrize(
-    ("data", "supported"),
+    ("data", "expected_dtype"),
     [
-        pytest.param([1, 2, 3], True, id="int"),
-        pytest.param([1.0, 2.0, 3.0], True, id="float"),
+        pytest.param([1, 2, 3], np.int64, id="int"),
+        pytest.param([1.0, 2.0, 3.0], np.float64, id="float"),
     ],
 )
-def test_to_numpy_python_types_numeric(data, supported):
+def test_to_numpy_python_types_numeric(data, expected_dtype):
     """
     Test the _to_numpy function with Python built-in numeric types.
     """
     result = _to_numpy(data)
-    _check_result(result, supported)
-    npt.assert_array_equal(result, data)
+    _check_result(result, supported=True)
+    npt.assert_array_equal(result, np.array(data, dtype=expected_dtype), strict=True)
 
 
 ########################################################################################
 # Test the _to_numpy function with NumPy arrays.
 #
 # There are 24 fundamental dtypes in NumPy. Not all of them are supported by PyGMT.
-# Reference: https://numpy.org/doc/2.1/reference/arrays.scalars.html
 #
 # - Numeric dtypes:
 #   - int8, int16, int32, int64, longlong
@@ -57,6 +56,8 @@ def test_to_numpy_python_types_numeric(data, supported):
 # - bytes_
 # - object_
 # - void
+#
+# Reference: https://numpy.org/doc/2.1/reference/arrays.scalars.html
 ########################################################################################
 @pytest.mark.parametrize(
     ("dtype", "supported"),
@@ -84,22 +85,19 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
     """
     Test the _to_numpy function with NumPy arrays of NumPy numeric dtypes.
 
-    "dtype" is the NumPy dtype to be tested and "supported" is a boolean value
-    indicating whether the dtype is supported by PyGMT (or the GMT C API).
+    Test both 1-D and 2-D arrays.
     """
     # 1-D array
     array = np.array([1, 2, 3], dtype=dtype)
-    assert array.dtype == dtype
     result = _to_numpy(array)
     _check_result(result, supported)
-    npt.assert_array_equal(result, array)
+    npt.assert_array_equal(result, array, strict=True)
 
     # 2-D array
     array = np.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
-    assert array.dtype == dtype
     result = _to_numpy(array)
     _check_result(result, supported)
-    npt.assert_array_equal(result, array)
+    npt.assert_array_equal(result, array, strict=True)
 
 
 ########################################################################################
@@ -124,9 +122,7 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
 # - CategoricalDtype
 # - SparseDtype
 # - BooleanDtype
-# - ArrowDtype
-#
-# ArrowDtype is a special dtype that is used to store data in the PyArrow format.
+# - ArrowDtype: a special dtype used to store data in the PyArrow format.
 #
 # References:
 # 1. https://pandas.pydata.org/docs/reference/arrays.html


### PR DESCRIPTION
This PR adds tests for `_to_numpy` to ensure it works for the 17 NumPy numeric dtypes, in which 12 are supported by PyGMT.

Related to #3581, #2848, #3513.