### PR TITLE
clib.converison._to_numpy: Add tests for pandas.Series with pandas numeric dtypes

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -169,7 +169,7 @@ def _to_numpy(data: Any) -> np.ndarray:
     }
 
     # The expected numpy dtype for the result numpy array, but can be None.
-    dtype = dtypes.get(str(getattr(data, "dtype", getattr(data, "type", None))))
+    dtype = dtypes.get(str(getattr(data, "dtype", getattr(data, "type", ""))))
 
     # pandas numeric dtypes were converted to np.object_ dtype prior pandas 2.2, and are
     # converted to suitable NumPy dtypes since pandas 2.2. Refer to the following link

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -163,13 +163,13 @@ def _to_numpy(data: Any) -> np.ndarray:
     }
 
     # pandas numeric dtypes were converted to np.object_ dtype prior pandas 2.2, and are
-    # converted to suitable numpy dtypes since pandas 2.2. Refer to the following link
+    # converted to suitable NumPy dtypes since pandas 2.2. Refer to the following link
     # for details: https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#to-numpy-for-numpy-nullable-and-arrow-types-converts-to-suitable-numpy-dtype
     # Here are the workarounds for pandas < 2.2.
     # Following SPEC 0, pandas 2.1 should be dropped in 2025 Q3, so it's likely we can
     # remove the workaround in PyGMT v0.17.0.
     if Version(pd.__version__) < Version("2.2"):
-        # Specify mapping from pandas nullable dtypes to suitable numpy dtypes
+        # Specify mapping from pandas nullable dtypes to suitable NumPy dtypes
         dtypes.update(
             {
                 "Int8": np.int8,
@@ -184,7 +184,7 @@ def _to_numpy(data: Any) -> np.ndarray:
                 "Float64": np.float64,
             }
         )
-        # For pandas.Index/pandas.Series, pandas/pyarrow integer dtypes with missing
+        # For pandas.Index/pandas.Series, pandas/PyArrow integer dtypes with missing
         # values should be cast to NumPy float dtypes and NaN is used as missing value
         # indicator.
         if getattr(data, "hasnans", False):  # pandas.Index/pandas.Series has 'hasnans'

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -188,7 +188,7 @@ def _to_numpy(data: Any) -> np.ndarray:
             # Integer dtypes with missing values are cast to NumPy float dtypes and NaN
             # is used as missing value indicator.
             dtype = np.float64 if data.dtype.kind in "iu" else data.dtype.numpy_dtype
-            data = data.to_numpy(dtype=dtype, na_value=np.nan)
+            data = data.to_numpy(na_value=np.nan).astype(dtype=dtype)
 
     vec_dtype = str(getattr(data, "dtype", ""))
     array = np.ascontiguousarray(data, dtype=dtypes.get(vec_dtype))

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -185,7 +185,7 @@ def _to_numpy(data: Any) -> np.ndarray:
     ):  # pandas Series/Index with pandas nullable numeric dtypes.
         dtype = data.dtype.numpy_dtype  # The expected numpy dtype.
         if getattr(data, "hasnans", False):
-            if dtype.kind in "iu":
+            if data.dtype.kind in "iu":
                 # Integers with missing values are converted to float64.
                 dtype = np.float64
             data = data.to_numpy(na_value=np.nan)

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -162,37 +162,28 @@ def _to_numpy(data: Any) -> np.ndarray:
         "date64[ms][pyarrow]": np.datetime64,
     }
 
+    # The expected numpy dtype for the result numpy array, but can be None.
+    dtype = dtypes.get(str(getattr(data, "dtype", None)))
+
+    # Workarounds for pandas < 2.2. Following SPEC 0, pandas 2.1 should be dropped in
+    # 2025 Q3, so it's likely we can remove the workaround in PyGMT v0.17.0.
+    #
     # pandas numeric dtypes were converted to np.object_ dtype prior pandas 2.2, and are
     # converted to suitable NumPy dtypes since pandas 2.2. Refer to the following link
     # for details: https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#to-numpy-for-numpy-nullable-and-arrow-types-converts-to-suitable-numpy-dtype
-    # Here are the workarounds for pandas < 2.2.
-    # Following SPEC 0, pandas 2.1 should be dropped in 2025 Q3, so it's likely we can
-    # remove the workaround in PyGMT v0.17.0.
-    if Version(pd.__version__) < Version("2.2"):
-        # Specify mapping from pandas nullable dtypes to suitable NumPy dtypes
-        dtypes.update(
-            {
-                "Int8": np.int8,
-                "Int16": np.int16,
-                "Int32": np.int32,
-                "Int64": np.int64,
-                "UInt8": np.uint8,
-                "UInt16": np.uint16,
-                "UInt32": np.uint32,
-                "UInt64": np.uint64,
-                "Float32": np.float32,
-                "Float64": np.float64,
-            }
-        )
-        # For pandas.Index/pandas.Series, pandas/PyArrow integer dtypes with missing
-        # values should be cast to NumPy float dtypes and NaN is used as missing value
-        # indicator.
-        if getattr(data, "hasnans", False):  # pandas.Index/pandas.Series has 'hasnans'
-            dtype = np.float64 if data.dtype.kind in "iu" else data.dtype.numpy_dtype
-            data = data.to_numpy(na_value=np.nan).astype(dtype=dtype)
+    if (
+        Version(pd.__version__) < Version("2.2")
+        and hasattr(data, "dtype")
+        and hasattr(data.dtype, "numpy_dtype")
+    ):  # pandas.Series/pandas.Index with pandas nullable dtypes.
+        dtype = data.dtype.numpy_dtype
+        if data.hasnans:
+            if data.dtype.kind in "iu":
+                # Integers with missing values are converted to float64
+                dtype = np.float64
+            data = data.to_numpy(na_value=np.nan)
 
-    vec_dtype = str(getattr(data, "dtype", ""))
-    array = np.ascontiguousarray(data, dtype=dtypes.get(vec_dtype))
+    array = np.ascontiguousarray(data, dtype=dtype)
     return array
 
 

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -128,7 +128,7 @@ def test_to_numpy_numpy_numeric(dtype, expected_dtype):
 
 
 @pytest.mark.parametrize("dtype", [None, np.str_, "U10"])
-def test_to_numpy_ndarray_numpy_dtypes_string(dtype):
+def test_to_numpy_numpy_string(dtype):
     """
     Test the _to_numpy function with NumPy arrays of string types.
     """
@@ -273,7 +273,7 @@ def test_to_numpy_pandas_numeric_with_na(dtype, expected_dtype):
         pytest.param("string[pyarrow_numpy]", marks=skip_if_no(package="pyarrow")),
     ],
 )
-def test_to_numpy_pandas_series_pandas_dtypes_string(dtype):
+def test_to_numpy_pandas_string(dtype):
     """
     Test the _to_numpy function with pandas.Series of pandas string types.
 
@@ -295,7 +295,7 @@ def test_to_numpy_pandas_series_pandas_dtypes_string(dtype):
         pytest.param("date64[ms][pyarrow]", "datetime64[ms]", id="date64[ms]"),
     ],
 )
-def test_to_numpy_pandas_series_pyarrow_dtypes_date(dtype, expected_dtype):
+def test_to_numpy_pandas_date(dtype, expected_dtype):
     """
     Test the _to_numpy function with pandas.Series of PyArrow date32/date64 types.
     """
@@ -404,7 +404,7 @@ def test_to_numpy_pyarrow_numeric_with_na(dtype, expected_dtype):
         "string_view",
     ],
 )
-def test_to_numpy_pyarrow_array_pyarrow_dtypes_string(dtype):
+def test_to_numpy_pyarrow_string(dtype):
     """
     Test the _to_numpy function with PyArrow arrays of PyArrow string types.
     """
@@ -422,7 +422,7 @@ def test_to_numpy_pyarrow_array_pyarrow_dtypes_string(dtype):
         pytest.param("date64[ms]", "datetime64[ms]", id="date64[ms]"),
     ],
 )
-def test_to_numpy_pyarrow_array_pyarrow_dtypes_date(dtype, expected_dtype):
+def test_to_numpy_pyarrow_date(dtype, expected_dtype):
     """
     Test the _to_numpy function with PyArrow arrays of PyArrow date types.
 

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -104,7 +104,7 @@ np_dtype_params = [
 
 
 @pytest.mark.parametrize(("dtype", "expected_dtype"), np_dtype_params)
-def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, expected_dtype):
+def test_to_numpy_numpy_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with NumPy arrays of NumPy numeric dtypes.
 
@@ -228,7 +228,7 @@ def test_to_numpy_pandas_numeric(dtype, expected_dtype):
         pytest.param("float64[pyarrow]", np.float64, id="float64[pyarrow]", **pa_marks),
     ],
 )
-def test_to_numpy_pandas_series_pandas_dtypes_numeric_with_na(dtype, expected_dtype):
+def test_to_numpy_pandas_numeric_with_na(dtype, expected_dtype):
     """
     Test the _to_numpy function with pandas.Series of pandas/PyArrow numeric dtypes and
     missing values (NA).
@@ -279,7 +279,7 @@ def test_to_numpy_pandas_series_pandas_dtypes_numeric_with_na(dtype, expected_dt
         pytest.param("float64", np.float64, id="float64"),
     ],
 )
-def test_to_numpy_pyarrow_array_pyarrow_dtypes_numeric(dtype, expected_dtype):
+def test_to_numpy_pyarrow_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with PyArrow arrays of PyArrow numeric types.
     """
@@ -310,7 +310,7 @@ def test_to_numpy_pyarrow_array_pyarrow_dtypes_numeric(dtype, expected_dtype):
         pytest.param("float64", np.float64, id="float64"),
     ],
 )
-def test_to_numpy_pyarrow_array_pyarrow_dtypes_numeric_with_na(dtype, expected_dtype):
+def test_to_numpy_pyarrow_numeric_with_na(dtype, expected_dtype):
     """
     Test the _to_numpy function with PyArrow arrays of PyArrow numeric types and NA.
     """

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -4,6 +4,7 @@ Tests for the _to_numpy function in the clib.conversion module.
 
 import numpy as np
 import numpy.testing as npt
+import pandas as pd
 import pytest
 from pygmt.clib.conversion import _to_numpy
 from pygmt.clib.session import DTYPES
@@ -21,7 +22,7 @@ def _check_result(result, supported):
 
 
 ########################################################################################
-# Test the _to_numpy function with NumPy dtypes.
+# Test the _to_numpy function with NumPy arrays.
 #
 # There are 24 fundamental dtypes in NumPy. Not all of them are supported by PyGMT.
 # Reference: https://numpy.org/doc/2.1/reference/arrays.scalars.html
@@ -80,3 +81,47 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
     result = _to_numpy(array)
     _check_result(result, supported)
     npt.assert_array_equal(result, array)
+
+
+########################################################################################
+# Test the _to_numpy function with pandas.Series.
+#
+# In pandas, dtype can be specified by
+#
+# 1. NumPy dtypes (see above)
+# 2. pandas dtypes
+# 3. PyArrow dtypes
+#
+# Reference: https://pandas.pydata.org/docs/reference/arrays.html
+########################################################################################
+@pytest.mark.parametrize(
+    ("dtype", "supported"),
+    [
+        (np.int8, True),
+        (np.int16, True),
+        (np.int32, True),
+        (np.int64, True),
+        (np.longlong, True),
+        (np.uint8, True),
+        (np.uint16, True),
+        (np.uint32, True),
+        (np.uint64, True),
+        (np.ulonglong, True),
+        (np.float16, False),
+        (np.float32, True),
+        (np.float64, True),
+        (np.longdouble, False),
+        (np.complex64, False),
+        (np.complex128, False),
+        (np.clongdouble, False),
+    ],
+)
+def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, supported):
+    """
+    Test the _to_numpy function with pandas.Series of NumPy numeric dtypes.
+    """
+    series = pd.Series([1, 2, 3], dtype=dtype)
+    assert series.dtype == dtype
+    result = _to_numpy(series)
+    _check_result(result, supported)
+    npt.assert_array_equal(result, series)

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -256,7 +256,7 @@ def test_to_numpy_pandas_numeric(dtype, expected_dtype):
         pytest.param("float64[pyarrow]", np.float64, id="float64[pyarrow]", **pa_marks),
     ],
 )
-def test_to_numpy_pandas_series_pandas_dtypes_numeric_with_na(dtype, expected_dtype):
+def test_to_numpy_pandas_numeric_with_na(dtype, expected_dtype):
     """
     Test the _to_numpy function with pandas.Series of NumPy/pandas/PyArrow numeric
     dtypes and missing values (NA).

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -85,14 +85,16 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, expected_dtype):
 
     Test both 1-D and 2-D arrays.
     """
-    # 1-D array
-    array = np.array([1, 2, 3], dtype=dtype)
+    # 1-D array that is not C-contiguous
+    array = np.array([1, 2, 3, 4, 5, 6], dtype=dtype)[::2]
+    assert array.flags.c_contiguous is False
     result = _to_numpy(array)
     _check_result(result, expected_dtype)
     npt.assert_array_equal(result, array, strict=True)
 
-    # 2-D array
-    array = np.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
+    # 2-D array that is not C-contiguous
+    array = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=dtype)[::2, ::2]
+    assert array.flags.c_contiguous is False
     result = _to_numpy(array)
     _check_result(result, expected_dtype)
     npt.assert_array_equal(result, array, strict=True)
@@ -132,7 +134,7 @@ def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with pandas.Series of NumPy numeric dtypes.
     """
-    series = pd.Series([1, 2, 3], dtype=dtype)
+    series = pd.Series([1, 2, 3, 4, 5, 6], dtype=dtype)[::2]  # Not C-contiguous
     result = _to_numpy(series)
     _check_result(result, expected_dtype)
     npt.assert_array_equal(result, series)

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -1,0 +1,82 @@
+"""
+Tests for the _to_numpy function in the clib.conversion module.
+"""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+from pygmt.clib.conversion import _to_numpy
+from pygmt.clib.session import DTYPES
+
+
+def _check_result(result, supported):
+    """
+    Check the result of the _to_numpy function.
+    """
+    # Check that the result is a NumPy array and is C-contiguous.
+    assert isinstance(result, np.ndarray)
+    assert result.flags.c_contiguous
+    # Check that the dtype is supported by PyGMT (or the GMT C API).
+    assert (result.dtype.type in DTYPES) == supported
+
+
+########################################################################################
+# Test the _to_numpy function with NumPy dtypes.
+#
+# There are 24 fundamental dtypes in NumPy. Not all of them are supported by PyGMT.
+# Reference: https://numpy.org/doc/2.1/reference/arrays.scalars.html
+#
+# - Numeric dtypes:
+#   - int8, int16, int32, int64, longlong
+#   - uint8, uint16, uint32, uint64, ulonglong
+#   - float16, float32, float64, longdouble
+#   - complex64, complex128, clongdouble
+# - bool
+# - datetime64, timedelta64
+# - str_
+# - bytes_
+# - object_
+# - void
+########################################################################################
+@pytest.mark.parametrize(
+    ("dtype", "supported"),
+    [
+        (np.int8, True),
+        (np.int16, True),
+        (np.int32, True),
+        (np.int64, True),
+        (np.longlong, True),
+        (np.uint8, True),
+        (np.uint16, True),
+        (np.uint32, True),
+        (np.uint64, True),
+        (np.ulonglong, True),
+        (np.float16, False),
+        (np.float32, True),
+        (np.float64, True),
+        (np.longdouble, False),
+        (np.complex64, False),
+        (np.complex128, False),
+        (np.clongdouble, False),
+    ],
+)
+def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
+    """
+    Test the _to_numpy function with NumPy arrays of NumPy numeric dtypes.
+
+    "dtype" is the NumPy dtype to be tested and "supported" is a boolean value
+    indicating whether the dtype is supported by PyGMT (or the GMT C API).
+    """
+    # 1-D array
+    array = np.array([1, 2, 3], dtype=dtype)
+    assert array.dtype == dtype
+    result = _to_numpy(array)
+    _check_result(result, supported)
+    npt.assert_array_equal(result, array)
+
+    # 2-D array
+    array = np.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
+    assert array.dtype == dtype
+    result = _to_numpy(array)
+    _check_result(result, supported)
+    npt.assert_array_equal(result, array)

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -27,6 +27,11 @@ def _check_result(result, expected_dtype):
     [
         pytest.param([1, 2, 3], np.int64, id="int"),
         pytest.param([1.0, 2.0, 3.0], np.float64, id="float"),
+        pytest.param(
+            [complex(+1), complex(-2j), complex("-Infinity+NaNj")],
+            np.complex128,
+            id="complex",
+        ),
     ],
 )
 def test_to_numpy_python_types_numeric(data, expected_dtype):
@@ -83,7 +88,7 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with NumPy arrays of NumPy numeric dtypes.
 
-    Test both 1-D and 2-D arrays.
+    Test both 1-D and 2-D arrays which are not C-contiguous.
     """
     # 1-D array that is not C-contiguous
     array = np.array([1, 2, 3, 4, 5, 6], dtype=dtype)[::2]

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -118,7 +118,7 @@ np_dtype_params = [
 
 
 @pytest.mark.parametrize(("dtype", "expected_dtype"), np_dtype_params)
-def test_to_numpy_numpy_numeric(dtype, expected_dtype):
+def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with NumPy arrays of NumPy numeric dtypes.
 
@@ -257,7 +257,7 @@ def test_to_numpy_pandas_numeric(dtype, expected_dtype):
         pytest.param("float64[pyarrow]", np.float64, id="float64[pyarrow]", **pa_marks),
     ],
 )
-def test_to_numpy_pandas_numeric_with_na(dtype, expected_dtype):
+def test_to_numpy_pandas_series_pandas_dtypes_numeric_with_na(dtype, expected_dtype):
     """
     Test the _to_numpy function with pandas.Series of NumPy/pandas/PyArrow numeric
     dtypes and missing values (NA).
@@ -369,7 +369,7 @@ def test_to_numpy_pandas_series_pyarrow_dtypes_date(dtype, expected_dtype):
         pytest.param("float64", np.float64, id="float64"),
     ],
 )
-def test_to_numpy_pyarrow_numeric(dtype, expected_dtype):
+def test_to_numpy_pyarrow_array_pyarrow_dtypes_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with PyArrow arrays of PyArrow numeric types.
     """
@@ -400,7 +400,7 @@ def test_to_numpy_pyarrow_numeric(dtype, expected_dtype):
         pytest.param("float64", np.float64, id="float64"),
     ],
 )
-def test_to_numpy_pyarrow_numeric_with_na(dtype, expected_dtype):
+def test_to_numpy_pyarrow_array_pyarrow_dtypes_numeric_with_na(dtype, expected_dtype):
     """
     Test the _to_numpy function with PyArrow arrays of PyArrow numeric types and NA.
     """

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -159,20 +159,10 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, expected_dtype):
 # 2. https://pandas.pydata.org/docs/user_guide/basics.html#basics-dtypes
 # 3. https://pandas.pydata.org/docs/user_guide/pyarrow.html
 ########################################################################################
-@pytest.mark.parametrize(("dtype", "expected_dtype"), np_dtype_params)
-def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
-    """
-    Test the _to_numpy function with pandas.Series of NumPy numeric dtypes.
-    """
-    series = pd.Series([1, 2, 3, 4, 5, 6], dtype=dtype)[::2]  # Not C-contiguous
-    result = _to_numpy(series)
-    _check_result(result, expected_dtype)
-    npt.assert_array_equal(result, series)
-
-
 @pytest.mark.parametrize(
     ("dtype", "expected_dtype"),
     [
+        *np_dtype_params,
         pytest.param(pd.Int8Dtype(), np.int8, id="Int8"),
         pytest.param(pd.Int16Dtype(), np.int16, id="Int16"),
         pytest.param(pd.Int32Dtype(), np.int32, id="Int32"),
@@ -196,16 +186,16 @@ def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
         pytest.param("float64[pyarrow]", np.float64, id="float64[pyarrow]", **pa_marks),
     ],
 )
-def test_to_numpy_pandas_series_pandas_dtypes_numeric(dtype, expected_dtype):
+def test_to_numpy_pandas_numeric(dtype, expected_dtype):
     """
-    Test the _to_numpy function with pandas.Series of pandas/PyArrow numeric dtypes.
+    Test the _to_numpy function with pandas.Series of NumPy/pandas/PyArrow numeric
+    dtypes.
     """
     data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
     if dtype == "float16[pyarrow]" and Version(pd.__version__) < Version("2.2"):
         # float16 needs special handling for pandas < 2.2.
         # Example from https://arrow.apache.org/docs/python/generated/pyarrow.float16.html
         data = np.array(data, dtype=np.float16)
-
     series = pd.Series(data, dtype=dtype)[::2]  # Not C-contiguous
     result = _to_numpy(series)
     _check_result(result, expected_dtype)

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -143,3 +143,54 @@ def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
     result = _to_numpy(series)
     _check_result(result, expected_dtype)
     npt.assert_array_equal(result, series)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected_dtype"),
+    [
+        pytest.param(pd.Int8Dtype(), np.int8, id="Int8"),
+        pytest.param(pd.Int16Dtype(), np.int16, id="Int16"),
+        pytest.param(pd.Int32Dtype(), np.int32, id="Int32"),
+        pytest.param(pd.Int64Dtype(), np.int64, id="Int64"),
+        pytest.param(pd.UInt8Dtype(), np.uint8, id="UInt8"),
+        pytest.param(pd.UInt16Dtype(), np.uint16, id="UInt16"),
+        pytest.param(pd.UInt32Dtype(), np.uint32, id="UInt32"),
+        pytest.param(pd.UInt64Dtype(), np.uint64, id="UInt64"),
+        pytest.param(pd.Float32Dtype(), np.float32, id="Float32"),
+        pytest.param(pd.Float64Dtype(), np.float64, id="Float64"),
+    ],
+)
+def test_to_numpy_pandas_series_pandas_dtypes_numeric(dtype, expected_dtype):
+    """
+    Test the _to_numpy function with pandas.Series of pandas numeric dtypes.
+    """
+    series = pd.Series([1, 2, 3, 4, 5, 6], dtype=dtype)[::2]  # Not C-contiguous
+    result = _to_numpy(series)
+    _check_result(result, expected_dtype)
+    npt.assert_array_equal(result, series)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected_dtype"),
+    [
+        pytest.param(pd.Int8Dtype(), np.float64, id="Int8"),
+        pytest.param(pd.Int16Dtype(), np.float64, id="Int16"),
+        pytest.param(pd.Int32Dtype(), np.float64, id="Int32"),
+        pytest.param(pd.Int64Dtype(), np.float64, id="Int64"),
+        pytest.param(pd.UInt8Dtype(), np.float64, id="UInt8"),
+        pytest.param(pd.UInt16Dtype(), np.float64, id="UInt16"),
+        pytest.param(pd.UInt32Dtype(), np.float64, id="UInt32"),
+        pytest.param(pd.UInt64Dtype(), np.float64, id="UInt64"),
+        pytest.param(pd.Float32Dtype(), np.float32, id="Float32"),
+        pytest.param(pd.Float64Dtype(), np.float64, id="Float64"),
+    ],
+)
+def test_to_numpy_pandas_series_pandas_dtypes_numeric_with_na(dtype, expected_dtype):
+    """
+    Test the _to_numpy function with pandas.Series of pandas numeric dtypes and NA.
+    """
+    series = pd.Series([1, 2, pd.NA, 4, 5, 6], dtype=dtype)[::2]  # Not C-contiguous
+    assert series.isna().any()
+    result = _to_numpy(series)
+    _check_result(result, expected_dtype)
+    npt.assert_array_equal(result, np.array([1.0, np.nan, 5.0], dtype=expected_dtype))

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -7,18 +7,16 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from pygmt.clib.conversion import _to_numpy
-from pygmt.clib.session import DTYPES
 
 
-def _check_result(result, supported):
+def _check_result(result, expected_dtype):
     """
-    Check the result of the _to_numpy function.
+    A helper function to check if the result of the _to_numpy function is a C-contiguous
+    NumPy array with the expected dtype.
     """
-    # Check that the result is a NumPy array and is C-contiguous.
     assert isinstance(result, np.ndarray)
     assert result.flags.c_contiguous
-    # Check that the dtype is supported by PyGMT (or the GMT C API).
-    assert (result.dtype.type in DTYPES) == supported
+    assert result.dtype.type == expected_dtype
 
 
 ########################################################################################
@@ -36,8 +34,8 @@ def test_to_numpy_python_types_numeric(data, expected_dtype):
     Test the _to_numpy function with Python built-in numeric types.
     """
     result = _to_numpy(data)
-    _check_result(result, supported=True)
-    npt.assert_array_equal(result, np.array(data, dtype=expected_dtype), strict=True)
+    _check_result(result, expected_dtype)
+    npt.assert_array_equal(result, data)
 
 
 ########################################################################################
@@ -60,28 +58,28 @@ def test_to_numpy_python_types_numeric(data, expected_dtype):
 # Reference: https://numpy.org/doc/2.1/reference/arrays.scalars.html
 ########################################################################################
 @pytest.mark.parametrize(
-    ("dtype", "supported"),
+    ("dtype", "expected_dtype"),
     [
-        (np.int8, True),
-        (np.int16, True),
-        (np.int32, True),
-        (np.int64, True),
-        (np.longlong, True),
-        (np.uint8, True),
-        (np.uint16, True),
-        (np.uint32, True),
-        (np.uint64, True),
-        (np.ulonglong, True),
-        (np.float16, False),
-        (np.float32, True),
-        (np.float64, True),
-        (np.longdouble, False),
-        (np.complex64, False),
-        (np.complex128, False),
-        (np.clongdouble, False),
+        pytest.param(np.int8, np.int8, id="int8"),
+        pytest.param(np.int16, np.int16, id="int16"),
+        pytest.param(np.int32, np.int32, id="int32"),
+        pytest.param(np.int64, np.int64, id="int64"),
+        pytest.param(np.longlong, np.longlong, id="longlong"),
+        pytest.param(np.uint8, np.uint8, id="uint8"),
+        pytest.param(np.uint16, np.uint16, id="uint16"),
+        pytest.param(np.uint32, np.uint32, id="uint32"),
+        pytest.param(np.uint64, np.uint64, id="uint64"),
+        pytest.param(np.ulonglong, np.ulonglong, id="ulonglong"),
+        pytest.param(np.float16, np.float16, id="float16"),
+        pytest.param(np.float32, np.float32, id="float32"),
+        pytest.param(np.float64, np.float64, id="float64"),
+        pytest.param(np.longdouble, np.longdouble, id="longdouble"),
+        pytest.param(np.complex64, np.complex64, id="complex64"),
+        pytest.param(np.complex128, np.complex128, id="complex128"),
+        pytest.param(np.clongdouble, np.clongdouble, id="clongdouble"),
     ],
 )
-def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
+def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with NumPy arrays of NumPy numeric dtypes.
 
@@ -90,13 +88,13 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
     # 1-D array
     array = np.array([1, 2, 3], dtype=dtype)
     result = _to_numpy(array)
-    _check_result(result, supported)
+    _check_result(result, expected_dtype)
     npt.assert_array_equal(result, array, strict=True)
 
     # 2-D array
     array = np.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
     result = _to_numpy(array)
-    _check_result(result, supported)
+    _check_result(result, expected_dtype)
     npt.assert_array_equal(result, array, strict=True)
 
 
@@ -130,33 +128,32 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
 # 3. https://pandas.pydata.org/docs/user_guide/pyarrow.html
 ########################################################################################
 @pytest.mark.parametrize(
-    ("dtype", "supported"),
+    ("dtype", "expected_dtype"),
     [
-        (np.int8, True),
-        (np.int16, True),
-        (np.int32, True),
-        (np.int64, True),
-        (np.longlong, True),
-        (np.uint8, True),
-        (np.uint16, True),
-        (np.uint32, True),
-        (np.uint64, True),
-        (np.ulonglong, True),
-        (np.float16, False),
-        (np.float32, True),
-        (np.float64, True),
-        (np.longdouble, False),
-        (np.complex64, False),
-        (np.complex128, False),
-        (np.clongdouble, False),
+        pytest.param(np.int8, np.int8, id="int8"),
+        pytest.param(np.int16, np.int16, id="int16"),
+        pytest.param(np.int32, np.int32, id="int32"),
+        pytest.param(np.int64, np.int64, id="int64"),
+        pytest.param(np.longlong, np.longlong, id="longlong"),
+        pytest.param(np.uint8, np.uint8, id="uint8"),
+        pytest.param(np.uint16, np.uint16, id="uint16"),
+        pytest.param(np.uint32, np.uint32, id="uint32"),
+        pytest.param(np.uint64, np.uint64, id="uint64"),
+        pytest.param(np.ulonglong, np.ulonglong, id="ulonglong"),
+        pytest.param(np.float16, np.float16, id="float16"),
+        pytest.param(np.float32, np.float32, id="float32"),
+        pytest.param(np.float64, np.float64, id="float64"),
+        pytest.param(np.longdouble, np.longdouble, id="longdouble"),
+        pytest.param(np.complex64, np.complex64, id="complex64"),
+        pytest.param(np.complex128, np.complex128, id="complex128"),
+        pytest.param(np.clongdouble, np.clongdouble, id="clongdouble"),
     ],
 )
-def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, supported):
+def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with pandas.Series of NumPy numeric dtypes.
     """
     series = pd.Series([1, 2, 3], dtype=dtype)
-    assert series.dtype == dtype
     result = _to_numpy(series)
-    _check_result(result, supported)
+    _check_result(result, expected_dtype)
     npt.assert_array_equal(result, series)

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -205,6 +205,10 @@ def test_to_numpy_pandas_numeric(dtype, expected_dtype):
 @pytest.mark.parametrize(
     ("dtype", "expected_dtype"),
     [
+        pytest.param(np.float16, np.float16, id="float16"),
+        pytest.param(np.float32, np.float32, id="float32"),
+        pytest.param(np.float64, np.float64, id="float64"),
+        pytest.param(np.longdouble, np.longdouble, id="longdouble"),
         pytest.param(pd.Int8Dtype(), np.float64, id="Int8"),
         pytest.param(pd.Int16Dtype(), np.float64, id="Int16"),
         pytest.param(pd.Int32Dtype(), np.float64, id="Int32"),
@@ -230,8 +234,8 @@ def test_to_numpy_pandas_numeric(dtype, expected_dtype):
 )
 def test_to_numpy_pandas_numeric_with_na(dtype, expected_dtype):
     """
-    Test the _to_numpy function with pandas.Series of pandas/PyArrow numeric dtypes and
-    missing values (NA).
+    Test the _to_numpy function with pandas.Series of NumPy/pandas/PyArrow numeric
+    dtypes and missing values (NA).
     """
     data = [1.0, 2.0, None, 4.0, 5.0, 6.0]
     if dtype == "float16[pyarrow]" and Version(pd.__version__) < Version("2.2"):

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -22,6 +22,25 @@ def _check_result(result, supported):
 
 
 ########################################################################################
+# Test the _to_numpy function with Python built-in types.
+########################################################################################
+@pytest.mark.parametrize(
+    ("data", "supported"),
+    [
+        pytest.param([1, 2, 3], True, id="int"),
+        pytest.param([1.0, 2.0, 3.0], True, id="float"),
+    ],
+)
+def test_to_numpy_python_types_numeric(data, supported):
+    """
+    Test the _to_numpy function with Python built-in numeric types.
+    """
+    result = _to_numpy(data)
+    _check_result(result, supported)
+    npt.assert_array_equal(result, data)
+
+
+########################################################################################
 # Test the _to_numpy function with NumPy arrays.
 #
 # There are 24 fundamental dtypes in NumPy. Not all of them are supported by PyGMT.

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -128,7 +128,7 @@ def test_to_numpy_numpy_numeric(dtype, expected_dtype):
 
 
 @pytest.mark.parametrize("dtype", [None, np.str_, "U10"])
-def test_to_numpy_numpy_string(dtype):
+def test_to_numpy_ndarray_numpy_dtypes_string(dtype):
     """
     Test the _to_numpy function with NumPy arrays of string types.
     """
@@ -282,7 +282,7 @@ def test_to_numpy_pandas_numeric_with_na(dtype, expected_dtype):
         ),
     ],
 )
-def test_to_numpy_pandas_string(dtype):
+def test_to_numpy_pandas_series_pandas_dtypes_string(dtype):
     """
     Test the _to_numpy function with pandas.Series of pandas string types.
 
@@ -304,7 +304,7 @@ def test_to_numpy_pandas_string(dtype):
         pytest.param("date64[ms][pyarrow]", "datetime64[ms]", id="date64[ms]"),
     ],
 )
-def test_to_numpy_pandas_date(dtype, expected_dtype):
+def test_to_numpy_pandas_series_pyarrow_dtypes_date(dtype, expected_dtype):
     """
     Test the _to_numpy function with pandas.Series of PyArrow date32/date64 types.
     """
@@ -413,7 +413,7 @@ def test_to_numpy_pyarrow_numeric_with_na(dtype, expected_dtype):
         "string_view",
     ],
 )
-def test_to_numpy_pyarrow_string(dtype):
+def test_to_numpy_pyarrow_array_pyarrow_dtypes_string(dtype):
     """
     Test the _to_numpy function with PyArrow arrays of PyArrow string types.
     """
@@ -431,7 +431,7 @@ def test_to_numpy_pyarrow_string(dtype):
         pytest.param("date64[ms]", "datetime64[ms]", id="date64[ms]"),
     ],
 )
-def test_to_numpy_pyarrow_date(dtype, expected_dtype):
+def test_to_numpy_pyarrow_array_pyarrow_dtypes_date(dtype, expected_dtype):
     """
     Test the _to_numpy function with PyArrow arrays of PyArrow date types.
 

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -57,28 +57,28 @@ def test_to_numpy_python_types_numeric(data, expected_dtype):
 #
 # Reference: https://numpy.org/doc/2.1/reference/arrays.scalars.html
 ########################################################################################
-@pytest.mark.parametrize(
-    ("dtype", "expected_dtype"),
-    [
-        pytest.param(np.int8, np.int8, id="int8"),
-        pytest.param(np.int16, np.int16, id="int16"),
-        pytest.param(np.int32, np.int32, id="int32"),
-        pytest.param(np.int64, np.int64, id="int64"),
-        pytest.param(np.longlong, np.longlong, id="longlong"),
-        pytest.param(np.uint8, np.uint8, id="uint8"),
-        pytest.param(np.uint16, np.uint16, id="uint16"),
-        pytest.param(np.uint32, np.uint32, id="uint32"),
-        pytest.param(np.uint64, np.uint64, id="uint64"),
-        pytest.param(np.ulonglong, np.ulonglong, id="ulonglong"),
-        pytest.param(np.float16, np.float16, id="float16"),
-        pytest.param(np.float32, np.float32, id="float32"),
-        pytest.param(np.float64, np.float64, id="float64"),
-        pytest.param(np.longdouble, np.longdouble, id="longdouble"),
-        pytest.param(np.complex64, np.complex64, id="complex64"),
-        pytest.param(np.complex128, np.complex128, id="complex128"),
-        pytest.param(np.clongdouble, np.clongdouble, id="clongdouble"),
-    ],
-)
+np_dtype_params = [
+    pytest.param(np.int8, np.int8, id="int8"),
+    pytest.param(np.int16, np.int16, id="int16"),
+    pytest.param(np.int32, np.int32, id="int32"),
+    pytest.param(np.int64, np.int64, id="int64"),
+    pytest.param(np.longlong, np.longlong, id="longlong"),
+    pytest.param(np.uint8, np.uint8, id="uint8"),
+    pytest.param(np.uint16, np.uint16, id="uint16"),
+    pytest.param(np.uint32, np.uint32, id="uint32"),
+    pytest.param(np.uint64, np.uint64, id="uint64"),
+    pytest.param(np.ulonglong, np.ulonglong, id="ulonglong"),
+    pytest.param(np.float16, np.float16, id="float16"),
+    pytest.param(np.float32, np.float32, id="float32"),
+    pytest.param(np.float64, np.float64, id="float64"),
+    pytest.param(np.longdouble, np.longdouble, id="longdouble"),
+    pytest.param(np.complex64, np.complex64, id="complex64"),
+    pytest.param(np.complex128, np.complex128, id="complex128"),
+    pytest.param(np.clongdouble, np.clongdouble, id="clongdouble"),
+]
+
+
+@pytest.mark.parametrize(("dtype", "expected_dtype"), np_dtype_params)
 def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with NumPy arrays of NumPy numeric dtypes.
@@ -127,28 +127,7 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, expected_dtype):
 # 2. https://pandas.pydata.org/docs/user_guide/basics.html#basics-dtypes
 # 3. https://pandas.pydata.org/docs/user_guide/pyarrow.html
 ########################################################################################
-@pytest.mark.parametrize(
-    ("dtype", "expected_dtype"),
-    [
-        pytest.param(np.int8, np.int8, id="int8"),
-        pytest.param(np.int16, np.int16, id="int16"),
-        pytest.param(np.int32, np.int32, id="int32"),
-        pytest.param(np.int64, np.int64, id="int64"),
-        pytest.param(np.longlong, np.longlong, id="longlong"),
-        pytest.param(np.uint8, np.uint8, id="uint8"),
-        pytest.param(np.uint16, np.uint16, id="uint16"),
-        pytest.param(np.uint32, np.uint32, id="uint32"),
-        pytest.param(np.uint64, np.uint64, id="uint64"),
-        pytest.param(np.ulonglong, np.ulonglong, id="ulonglong"),
-        pytest.param(np.float16, np.float16, id="float16"),
-        pytest.param(np.float32, np.float32, id="float32"),
-        pytest.param(np.float64, np.float64, id="float64"),
-        pytest.param(np.longdouble, np.longdouble, id="longdouble"),
-        pytest.param(np.complex64, np.complex64, id="complex64"),
-        pytest.param(np.complex128, np.complex128, id="complex128"),
-        pytest.param(np.clongdouble, np.clongdouble, id="clongdouble"),
-    ],
-)
+@pytest.mark.parametrize(("dtype", "expected_dtype"), np_dtype_params)
 def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
     """
     Test the _to_numpy function with pandas.Series of NumPy numeric dtypes.

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -92,7 +92,27 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
 # 2. pandas dtypes
 # 3. PyArrow dtypes
 #
-# Reference: https://pandas.pydata.org/docs/reference/arrays.html
+# pandas provides following dtypes:
+#
+# - Numeric dtypes:
+#   - Int8, Int16, Int32, Int64
+#   - UInt8, UInt16, UInt32, UInt64
+#   - Float32, Float64
+# - DatetimeTZDtype
+# - PeriodDtype
+# - IntervalDtype
+# - StringDtype
+# - CategoricalDtype
+# - SparseDtype
+# - BooleanDtype
+# - ArrowDtype
+#
+# ArrowDtype is a special dtype that is used to store data in the PyArrow format.
+#
+# References:
+# 1. https://pandas.pydata.org/docs/reference/arrays.html
+# 2. https://pandas.pydata.org/docs/user_guide/basics.html#basics-dtypes
+# 3. https://pandas.pydata.org/docs/user_guide/pyarrow.html
 ########################################################################################
 @pytest.mark.parametrize(
     ("dtype", "supported"),

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -25,26 +25,25 @@ def _check_result(result, supported):
 # Test the _to_numpy function with Python built-in types.
 ########################################################################################
 @pytest.mark.parametrize(
-    ("data", "supported"),
+    ("data", "expected_dtype"),
     [
-        pytest.param([1, 2, 3], True, id="int"),
-        pytest.param([1.0, 2.0, 3.0], True, id="float"),
+        pytest.param([1, 2, 3], np.int64, id="int"),
+        pytest.param([1.0, 2.0, 3.0], np.float64, id="float"),
     ],
 )
-def test_to_numpy_python_types_numeric(data, supported):
+def test_to_numpy_python_types_numeric(data, expected_dtype):
     """
     Test the _to_numpy function with Python built-in numeric types.
     """
     result = _to_numpy(data)
-    _check_result(result, supported)
-    npt.assert_array_equal(result, data)
+    _check_result(result, supported=True)
+    npt.assert_array_equal(result, np.array(data, dtype=expected_dtype), strict=True)
 
 
 ########################################################################################
 # Test the _to_numpy function with NumPy arrays.
 #
 # There are 24 fundamental dtypes in NumPy. Not all of them are supported by PyGMT.
-# Reference: https://numpy.org/doc/2.1/reference/arrays.scalars.html
 #
 # - Numeric dtypes:
 #   - int8, int16, int32, int64, longlong
@@ -57,6 +56,8 @@ def test_to_numpy_python_types_numeric(data, supported):
 # - bytes_
 # - object_
 # - void
+#
+# Reference: https://numpy.org/doc/2.1/reference/arrays.scalars.html
 ########################################################################################
 @pytest.mark.parametrize(
     ("dtype", "supported"),
@@ -84,22 +85,19 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
     """
     Test the _to_numpy function with NumPy arrays of NumPy numeric dtypes.
 
-    "dtype" is the NumPy dtype to be tested and "supported" is a boolean value
-    indicating whether the dtype is supported by PyGMT (or the GMT C API).
+    Test both 1-D and 2-D arrays.
     """
     # 1-D array
     array = np.array([1, 2, 3], dtype=dtype)
-    assert array.dtype == dtype
     result = _to_numpy(array)
     _check_result(result, supported)
-    npt.assert_array_equal(result, array)
+    npt.assert_array_equal(result, array, strict=True)
 
     # 2-D array
     array = np.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
-    assert array.dtype == dtype
     result = _to_numpy(array)
     _check_result(result, supported)
-    npt.assert_array_equal(result, array)
+    npt.assert_array_equal(result, array, strict=True)
 
 
 ########################################################################################
@@ -124,9 +122,7 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, supported):
 # - CategoricalDtype
 # - SparseDtype
 # - BooleanDtype
-# - ArrowDtype
-#
-# ArrowDtype is a special dtype that is used to store data in the PyArrow format.
+# - ArrowDtype: a special dtype used to store data in the PyArrow format.
 #
 # References:
 # 1. https://pandas.pydata.org/docs/reference/arrays.html

--- a/pygmt/tests/test_clib_vectors_to_arrays.py
+++ b/pygmt/tests/test_clib_vectors_to_arrays.py
@@ -69,17 +69,6 @@ def test_vectors_to_arrays_not_c_contiguous():
     _check_arrays(arrays)
 
 
-def test_vectors_to_arrays_pandas_nan():
-    """
-    Test the vectors_to_arrays function with pandas Series containing NaNs.
-    """
-    vectors = [pd.Series(data=[0, 4, pd.NA, 8, 6], dtype=pd.Int32Dtype())]
-    arrays = vectors_to_arrays(vectors)
-    npt.assert_equal(arrays[0], np.array([0, 4, np.nan, 8, 6], dtype=np.float64))
-    assert arrays[0].dtype == np.float64
-    _check_arrays(arrays)
-
-
 @pytest.mark.skipif(not _HAS_PYARROW, reason="pyarrow is not installed.")
 def test_vectors_to_arrays_pyarrow_datetime():
     """


### PR DESCRIPTION
This PR adds tests for pandas.Series with pandas/pyarrow numeric dtypes (in 7222db23bbdfbb298b211c02ab981e71ab433be6).

Tests pass with pandas 2.2 but fail with pandas 2.1. Check https://github.com/GenericMappingTools/pygmt/actions/runs/11714111582/job/32628172796?pr=3584 for details.

The failures are due to upstream pandas v2.2 changes. Previously, all pandas nullable dtypes are converted to np.object_ dtype. Since pandas v2.2, the new rules are (source: https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#to-numpy-for-numpy-nullable-and-arrow-types-converts-to-suitable-numpy-dtype):

> - float dtypes are cast to NumPy floats
> - integer dtypes without missing values are cast to NumPy integer dtypes
> - integer dtypes with missing values are cast to NumPy float dtypes and NaN is used as missing value indicator
> - boolean dtypes without missing values are cast to NumPy bool dtype
> - boolean dtypes with missing values keep object dtype
> - datetime and timedelta types are cast to Numpy datetime64 and timedelta64 types respectively and NaT is used as missing value indicator

Following the first three points, we add the workaround for pandas<2.2 to explicitly specify how to map pandas dtypes into numpy dtypes (a4f15cd778b146cc787450ba81b36da81a3a2efd). It is an improved version of PR #3505.

Here is the minimal example to understand the behavior change:

**With pandas 2.1**
```python
In [1]: import numpy as np

In [2]: import pandas as pd

In [3]: x = pd.Series([1, 2, 3], dtype=pd.Int32Dtype())

In [4]: x.dtype
Out[4]: Int32Dtype()

In [5]: np.ascontiguousarray(x)
Out[5]: array([1, 2, 3], dtype=object)

In [6]: x = pd.Series([1, pd.NA, 3], dtype=pd.Int32Dtype())

In [7]: np.ascontiguousarray(x)
Out[7]: array([1, <NA>, 3], dtype=object)
```
**With pandas 2.2**
```python
In [1]: import numpy as np

In [2]: import pandas as pd

In [3]: x = pd.Series([1, 2, 3], dtype=pd.Int32Dtype())

In [4]: np.ascontiguousarray(x)
Out[4]: array([1, 2, 3], dtype=int32)

In [5]: x = pd.Series([1, pd.NA, 3], dtype=pd.Int32Dtype())

In [6]: np.ascontiguousarray(x)
Out[6]: array([ 1., nan,  3.])
```

Related to #3581, #2848, #3513, #3583.

~~Wait for #3583.~~