### PR TITLE
DOC/tutorial "Plotting lines": General improvements

### DIFF
--- a/examples/tutorials/basics/lines.py
+++ b/examples/tutorials/basics/lines.py
@@ -13,8 +13,9 @@ import pygmt
 # ----------
 #
 # Create a Cartesian figure using the :meth:`pygmt.Figure.basemap` method. Pass lists
-# of two values to the ``x`` and ``y`` parameters. By default, a 0.25-points thick,
-# black, solid line is drawn between these two data points.
+# containing two values to the ``x`` and ``y`` parameters of the
+# :meth:`pygmt.Figure.plot` method. By default, a 0.25-points thick, black, solid
+# line is drawn between these two data points.
 
 fig = pygmt.Figure()
 fig.basemap(region=[0, 10, 0, 10], projection="X15c/10c", frame=True)

--- a/examples/tutorials/basics/lines.py
+++ b/examples/tutorials/basics/lines.py
@@ -52,7 +52,7 @@ fig.show()
 # Change line attributes
 # ----------------------
 #
-# The line attributes can be set by the ``pen`` parameter. ``pen`` takes a string
+# The line attributes can be set by the ``pen`` parameter which takes a string
 # argument with the optional values *width*,\ *color*,\ *style*.
 
 fig = pygmt.Figure()

--- a/examples/tutorials/basics/lines.py
+++ b/examples/tutorials/basics/lines.py
@@ -2,7 +2,7 @@
 Plotting lines
 ==============
 
-Plotting lines is handled by :meth:`pygmt.Figure.plot`.
+Plotting lines is handled by the method :meth:`pygmt.Figure.plot`.
 """
 
 # %%
@@ -12,51 +12,38 @@ import pygmt
 # Plot lines
 # ----------
 #
-# Create a Cartesian figure using ``projection`` parameter and set the axis
-# scales using ``region`` (in this case, each axis is 0-10). Pass a list of
-# ``x`` and ``y`` values to be plotted as a line.
+# Create a Cartesian figure using the :meth:`pygmt.Figure.basemap` method. Pass lists
+# of two values to the ``x`` and ``y`` parameters. By default, a 0.25-points thick,
+# black, solid line is drawn between these two data points.
 
 fig = pygmt.Figure()
-fig.plot(
-    region=[0, 10, 0, 10],
-    projection="X15c/10c",
-    frame="a",
-    x=[1, 8],
-    y=[5, 9],
-    pen="1p,black",
-)
+fig.basemap(region=[0, 10, 0, 10], projection="X15c/10c", frame=True)
+
+fig.plot(x=[1, 5], y=[5, 9])
+
 fig.show()
 
 # %%
-# Additional line segments can be added by including additional values for
-# ``x`` and ``y``.
+# Additional line segments can be added by including more data points in the lists
+# passed to ``x`` and ``y``.
 
 fig = pygmt.Figure()
-fig.plot(
-    region=[0, 10, 0, 10],
-    projection="X15c/10c",
-    frame="a",
-    x=[1, 6, 9],
-    y=[5, 7, 4],
-    pen="1p,black",
-)
+fig.basemap(region=[0, 10, 0, 10], projection="X15c/10c", frame=True)
+
+fig.plot(x=[1, 5, 8], y=[5, 9, 4])
+
 fig.show()
 
 # %%
-# To plot multiple lines, :meth:`pygmt.Figure.plot` needs to be used for each
-# additional line. Parameters such as ``region``, ``projection``, and ``frame``
-# do not need to be repeated in subsequent uses.
+# To plot multiple lines, :meth:`pygmt.Figure.plot` needs to be used for each line
+# separately.
 
 fig = pygmt.Figure()
-fig.plot(
-    region=[0, 10, 0, 10],
-    projection="X15c/10c",
-    frame="a",
-    x=[1, 6, 9],
-    y=[5, 7, 4],
-    pen="2p,blue",
-)
-fig.plot(x=[2, 4, 10], y=[3, 8, 9], pen="2p,red")
+fig.basemap(region=[0, 10, 0, 10], projection="X15c/10c", frame=True)
+
+fig.plot(x=[1, 5, 8], y=[5, 9, 4])
+fig.plot(x=[2, 4, 9], y=[3, 7, 5])
+
 fig.show()
 
 
@@ -64,71 +51,53 @@ fig.show()
 # Change line attributes
 # ----------------------
 #
-# The line attributes can be set by the ``pen`` parameter. ``pen`` takes a
-# string argument with the optional values *width*,\ *color*,\ *style*.
-#
-# In the example below, the pen width is set to ``5p``, and with ``black`` as
-# the default color and ``solid`` as the default style.
+# The line attributes can be set by the ``pen`` parameter. ``pen`` takes a string
+# argument with the optional values *width*,\ *color*,\ *style*.
 
 fig = pygmt.Figure()
-fig.plot(
-    region=[0, 10, 0, 10],
-    projection="X15c/10c",
-    frame="a",
-    x=[1, 8],
-    y=[3, 9],
-    pen="5p",
-)
+fig.basemap(region=[0, 10, 0, 10], projection="X15c/10c", frame=True)
+
+# Set the pen width to "5p" (5 points), and use the default color "black" and the
+# default style "solid"
+fig.plot(x=[1, 8], y=[3, 9], pen="5p")
+
 fig.show()
 
 # %%
 # The line color can be set and is added after the line width to the ``pen``
-# parameter. In the example below, the line color is set to ``red``.
+# parameter.
 
 fig = pygmt.Figure()
-fig.plot(
-    region=[0, 10, 0, 10],
-    projection="X15c/10c",
-    frame="a",
-    x=[1, 8],
-    y=[3, 9],
-    pen="5p,red",
-)
+fig.basemap(region=[0, 10, 0, 10], projection="X15c/10c", frame=True)
+
+# Set the line color to "red", use the default style "solid"
+fig.plot(x=[1, 8], y=[3, 9], pen="5p,red")
+
 fig.show()
 
 # %%
 # The line style can be set and is added after the line width or color to the
-# ``pen`` parameter.  In the example below, the line style is set to
-# ``..-`` (*dot dot dash*), and the default color ``black`` is used.
+# ``pen`` parameter.
 
 fig = pygmt.Figure()
-fig.plot(
-    region=[0, 10, 0, 10],
-    projection="X15c/10c",
-    frame="a",
-    x=[1, 8],
-    y=[3, 9],
-    pen="5p,..-",
-)
+fig.basemap(region=[0, 10, 0, 10], projection="X15c/10c", frame=True)
+
+# Set the line style to "..-" (dot dot dash), use the default color "black"
+fig.plot(x=[1, 8], y=[3, 9], pen="5p,..-")
+
 fig.show()
 
 # %%
-# The line width, color, and style can all be set in the same ``pen``
-# parameter. In the example below, the line width is set to ``7p``, the color
-# is set to ``green``, and the line style is ``-.-`` (*dash dot dash*).
-#
-# For a gallery showing other ``pen`` settings, see
+# The line width, color, and style can all be set in the same ``pen`` parameter.
+# For a gallery example showing other ``pen`` settings, see
 # :doc:`/gallery/lines/linestyles`.
 
 fig = pygmt.Figure()
-fig.plot(
-    region=[0, 10, 0, 10],
-    projection="X15c/10c",
-    frame="a",
-    x=[1, 8],
-    y=[3, 9],
-    pen="7p,green,-.-",
-)
+fig.basemap(region=[0, 10, 0, 10], projection="X15c/10c", frame=True)
+
+# Draw a 7-points thick, green line with style "-.-" (dash dot dash)
+fig.plot(x=[1, 8], y=[3, 9], pen="7p,green,-.-")
+
 fig.show()
 
-# sphinx_gallery_thumbnail_number = 3
+# sphinx_gallery_thumbnail_number = 6

--- a/examples/tutorials/basics/lines.py
+++ b/examples/tutorials/basics/lines.py
@@ -2,7 +2,7 @@
 Plotting lines
 ==============
 
-Plotting lines is handled by the method :meth:`pygmt.Figure.plot`.
+Plotting lines is handled by the :meth:`pygmt.Figure.plot` method.
 """
 
 # %%


### PR DESCRIPTION
**Description of proposed changes**

This PR improves the tutorial "Plotting lines":

- Add missing words
- Improve formulations, add comments within the code examples
- Rewrap the line length
- Split setting up the Cartesian plot (`Figure.basemap`) and plotting of the line(s) (`Figure.plot`); I personally feel this is clearer to understand, but I am open to other opinions on this change
- Do not use the `pen` parameter (change the `pen` attributes) in the first section, as this parameter will be explained in detail in the second section

**Preview**: https://pygmt-dev--3587.org.readthedocs.build/en/3587/tutorials/basics/lines.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
