### PR TITLE
Move Figure.shift_origin tests into a separate test file

### DIFF
--- a/pygmt/tests/baseline/test_figure_shift_origin.png.dvc
+++ b/pygmt/tests/baseline/test_figure_shift_origin.png.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 85e88836e6d32cded37f792de6439fb9
-  size: 9896
-  path: test_figure_shift_origin.png

--- a/pygmt/tests/baseline/test_shift_origin.png.dvc
+++ b/pygmt/tests/baseline/test_shift_origin.png.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 39b241fdd879271cf1e8cf1f73454706
+  size: 9910
+  hash: md5
+  path: test_shift_origin.png

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -292,26 +292,6 @@ def test_figure_show():
     fig.show()
 
 
-@pytest.mark.mpl_image_compare
-def test_figure_shift_origin():
-    """
-    Test if fig.shift_origin works.
-    """
-    kwargs = {"region": [0, 3, 0, 5], "projection": "X3c/5c", "frame": 0}
-    fig = Figure()
-    # First call shift_origin without projection and region.
-    # Test issue https://github.com/GenericMappingTools/pygmt/issues/514
-    fig.shift_origin(xshift="2c", yshift="3c")
-    fig.basemap(**kwargs)
-    fig.shift_origin(xshift="4c")
-    fig.basemap(**kwargs)
-    fig.shift_origin(yshift="6c")
-    fig.basemap(**kwargs)
-    fig.shift_origin(xshift="-4c", yshift="6c")
-    fig.basemap(**kwargs)
-    return fig
-
-
 def test_figure_show_invalid_method():
     """
     Test to check if an error is raised when an invalid method is passed to show.
@@ -405,22 +385,6 @@ class TestSetDisplay:
         """
         with pytest.raises(GMTInvalidInput):
             set_display(method="invalid")
-
-
-def test_figure_unsupported_xshift_yshift():
-    """
-    Raise an exception if X/Y/xshift/yshift is used.
-    """
-    fig = Figure()
-    fig.basemap(region=[0, 1, 0, 1], projection="X1c/1c", frame=True)
-    with pytest.raises(GMTInvalidInput):
-        fig.plot(x=1, y=1, style="c3c", xshift="3c")
-    with pytest.raises(GMTInvalidInput):
-        fig.plot(x=1, y=1, style="c3c", X="3c")
-    with pytest.raises(GMTInvalidInput):
-        fig.plot(x=1, y=1, style="c3c", yshift="3c")
-    with pytest.raises(GMTInvalidInput):
-        fig.plot(x=1, y=1, style="c3c", Y="3c")
 
 
 class TestGetDefaultDisplayMethod:

--- a/pygmt/tests/test_shift_origin.py
+++ b/pygmt/tests/test_shift_origin.py
@@ -8,7 +8,7 @@ from pygmt.figure import Figure
 
 
 @pytest.mark.mpl_image_compare
-def test_figure_shift_origin():
+def test_shift_origin():
     """
     Test if fig.shift_origin works.
     """
@@ -27,7 +27,7 @@ def test_figure_shift_origin():
     return fig
 
 
-def test_figure_unsupported_xshift_yshift():
+def test_shift_origin_unsupported_xshift_yshift():
     """
     Raise an exception if X/Y/xshift/yshift is used.
     """

--- a/pygmt/tests/test_shift_origin.py
+++ b/pygmt/tests/test_shift_origin.py
@@ -1,0 +1,43 @@
+"""
+Test Figure.shift_origin.
+"""
+
+import pytest
+from pygmt.exceptions import GMTInvalidInput
+from pygmt.figure import Figure
+
+
+@pytest.mark.mpl_image_compare
+def test_figure_shift_origin():
+    """
+    Test if fig.shift_origin works.
+    """
+    kwargs = {"region": [0, 3, 0, 5], "projection": "X3c/5c", "frame": 0}
+    fig = Figure()
+    # First call shift_origin without projection and region.
+    # Test issue https://github.com/GenericMappingTools/pygmt/issues/514
+    fig.shift_origin(xshift="2c", yshift="3c")
+    fig.basemap(**kwargs)
+    fig.shift_origin(xshift="4c")
+    fig.basemap(**kwargs)
+    fig.shift_origin(yshift="6c")
+    fig.basemap(**kwargs)
+    fig.shift_origin(xshift="-4c", yshift="6c")
+    fig.basemap(**kwargs)
+    return fig
+
+
+def test_figure_unsupported_xshift_yshift():
+    """
+    Raise an exception if X/Y/xshift/yshift is used.
+    """
+    fig = Figure()
+    fig.basemap(region=[0, 1, 0, 1], projection="X1c/1c", frame=True)
+    with pytest.raises(GMTInvalidInput):
+        fig.plot(x=1, y=1, style="c3c", xshift="3c")
+    with pytest.raises(GMTInvalidInput):
+        fig.plot(x=1, y=1, style="c3c", X="3c")
+    with pytest.raises(GMTInvalidInput):
+        fig.plot(x=1, y=1, style="c3c", yshift="3c")
+    with pytest.raises(GMTInvalidInput):
+        fig.plot(x=1, y=1, style="c3c", Y="3c")


### PR DESCRIPTION
**Description of proposed changes**

`Figure.shift_origin` source code was moved from `pygmt/figure.py` to `pygmt/src/shift_origin.py` in #2485. It make sense to have a separate test file for `Figure.shift_origin`.
