### PR TITLE
Add PyArrow as an optional dependency

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -103,6 +103,7 @@ jobs:
             contextily
             geopandas<1.0
             ipython
+            pyarrow
             rioxarray
             make
             pip

--- a/.github/workflows/type_checks.yml
+++ b/.github/workflows/type_checks.yml
@@ -50,7 +50,7 @@ jobs:
           # 4. other packages that are used somewhere in PyGMT
           python -m pip install \
             numpy pandas xarray netcdf4 packaging \
-            contextily geopandas ipython rioxarray \
+            contextily geopandas ipython pyarrow rioxarray \
             mypy pandas-stubs \
             matplotlib pytest
           python -m pip list

--- a/.github/workflows/type_checks.yml
+++ b/.github/workflows/type_checks.yml
@@ -51,7 +51,7 @@ jobs:
           python -m pip install \
             numpy pandas xarray netcdf4 packaging \
             contextily geopandas ipython pyarrow rioxarray \
-            mypy pandas-stubs \
+            mypy pandas-stubs pyarrow-stubs \
             matplotlib pytest
           python -m pip list
 

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -16,6 +16,7 @@ dependencies:
     - contextily
     - geopandas<1.0
     - ipython
+    - pyarrow
     - rioxarray
     # Development dependencies (general)
     - make

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
     - contextily
     - geopandas
     - ipython
+    - pyarrow
     - rioxarray
     # Development dependencies (general)
     - dvc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ all = [
     "contextily",
     "geopandas",
     "IPython",  # 'ipython' is not the correct module name.
+    "pyarrow",
     "rioxarray",
 ]
 


### PR DESCRIPTION
We're working towards supporting more PyArrow data types in #2800. I think it makes sense to explicitly add it as an optional dependency, just like what we're doing to contexily, geopandas, ipython and rioxarray. 

FYI, we already mentioned `pyarrow` as an optional dependency on [the PyGMT Ecosystem page](https://www.pygmt.org/dev/ecosystem.html) and recommended to install it in #3506.

This PR supersedes some changes in PR #2933.