### PR TITLE
clib.conversion._to_numpy: Add tests for pyarrow.array with pyarrow numeric dtypes

### DIFF
--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -164,9 +164,9 @@ def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
 ########################################################################################
 # Test the _to_numpy function with PyArrow arrays.
 #
-# PyArrow provides the following dtypes:
+# PyArrow provides the following types:
 #
-# - Numeric dtypes:
+# - Numeric types:
 #   - int8, int16, int32, int64
 #   - uint8, uint16, uint32, uint64
 #   - float16, float32, float64
@@ -197,7 +197,7 @@ def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
 )
 def test_to_numpy_pyarrow_array_pyarrow_dtypes_numeric(dtype, expected_dtype):
     """
-    Test the _to_numpy function with PyArrow arrays of PyArrow numeric dtypes.
+    Test the _to_numpy function with PyArrow arrays of PyArrow numeric types.
     """
     data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
     if dtype == "float16":  # float16 needs special handling
@@ -228,7 +228,7 @@ def test_to_numpy_pyarrow_array_pyarrow_dtypes_numeric(dtype, expected_dtype):
 )
 def test_to_numpy_pyarrow_array_pyarrow_dtypes_numeric_with_na(dtype, expected_dtype):
     """
-    Test the _to_numpy function with PyArrow arrays of PyArrow numeric dtypes and NA.
+    Test the _to_numpy function with PyArrow arrays of PyArrow numeric types and NA.
     """
     data = [1.0, 2.0, None, 4.0, 5.0, 6.0]
     if dtype == "float16":  # float16 needs special handling

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -128,7 +128,7 @@ def test_to_numpy_ndarray_numpy_dtypes_numeric(dtype, expected_dtype):
 #
 # 1. NumPy dtypes (see above)
 # 2. pandas dtypes
-# 3. PyArrow dtypes
+# 3. PyArrow types (see below)
 #
 # pandas provides following dtypes:
 #

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -11,6 +11,13 @@ import pytest
 from packaging.version import Version
 from pygmt.clib.conversion import _to_numpy
 
+try:
+    import pyarrow as pa
+
+    _HAS_PYARROW = True
+except ImportError:
+    _HAS_PYARROW = False
+
 
 def _check_result(result, expected_dtype):
     """
@@ -152,3 +159,82 @@ def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
     result = _to_numpy(series)
     _check_result(result, expected_dtype)
     npt.assert_array_equal(result, series)
+
+
+########################################################################################
+# Test the _to_numpy function with PyArrow arrays.
+#
+# PyArrow provides the following dtypes:
+#
+# - Numeric dtypes:
+#   - int8, int16, int32, int64
+#   - uint8, uint16, uint32, uint64
+#   - float16, float32, float64
+#
+# In PyArrow, array types can be specified in two ways:
+#
+# - Using string aliases (e.g., "int8")
+# - Using pyarrow.DataType (e.g., ``pa.int8()``)
+#
+# Reference: https://arrow.apache.org/docs/python/api/datatypes.html
+########################################################################################
+@pytest.mark.skipif(not _HAS_PYARROW, reason="pyarrow is not installed")
+@pytest.mark.parametrize(
+    ("dtype", "expected_dtype"),
+    [
+        pytest.param("int8", np.int8, id="int8"),
+        pytest.param("int16", np.int16, id="int16"),
+        pytest.param("int32", np.int32, id="int32"),
+        pytest.param("int64", np.int64, id="int64"),
+        pytest.param("uint8", np.uint8, id="uint8"),
+        pytest.param("uint16", np.uint16, id="uint16"),
+        pytest.param("uint32", np.uint32, id="uint32"),
+        pytest.param("uint64", np.uint64, id="uint64"),
+        pytest.param("float16", np.float16, id="float16"),
+        pytest.param("float32", np.float32, id="float32"),
+        pytest.param("float64", np.float64, id="float64"),
+    ],
+)
+def test_to_numpy_pyarrow_array_pyarrow_dtypes_numeric(dtype, expected_dtype):
+    """
+    Test the _to_numpy function with PyArrow arrays of PyArrow numeric dtypes.
+    """
+    data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    if dtype == "float16":  # float16 needs special handling
+        # Example from https://arrow.apache.org/docs/python/generated/pyarrow.float16.html
+        data = np.array(data, dtype=np.float16)
+    array = pa.array(data, type=dtype)[::2]
+    result = _to_numpy(array)
+    _check_result(result, expected_dtype)
+    npt.assert_array_equal(result, array)
+
+
+@pytest.mark.skipif(not _HAS_PYARROW, reason="pyarrow is not installed")
+@pytest.mark.parametrize(
+    ("dtype", "expected_dtype"),
+    [
+        pytest.param("int8", np.float64, id="int8"),
+        pytest.param("int16", np.float64, id="int16"),
+        pytest.param("int32", np.float64, id="int32"),
+        pytest.param("int64", np.float64, id="int64"),
+        pytest.param("uint8", np.float64, id="uint8"),
+        pytest.param("uint16", np.float64, id="uint16"),
+        pytest.param("uint32", np.float64, id="uint32"),
+        pytest.param("uint64", np.float64, id="uint64"),
+        pytest.param("float16", np.float16, id="float16"),
+        pytest.param("float32", np.float32, id="float32"),
+        pytest.param("float64", np.float64, id="float64"),
+    ],
+)
+def test_to_numpy_pyarrow_array_pyarrow_dtypes_numeric_with_na(dtype, expected_dtype):
+    """
+    Test the _to_numpy function with PyArrow arrays of PyArrow numeric dtypes and NA.
+    """
+    data = [1.0, 2.0, None, 4.0, 5.0, 6.0]
+    if dtype == "float16":  # float16 needs special handling
+        # Example from https://arrow.apache.org/docs/python/generated/pyarrow.float16.html
+        data = np.array(data, dtype=np.float16)
+    array = pa.array(data, type=dtype)[::2]
+    result = _to_numpy(array)
+    _check_result(result, expected_dtype)
+    npt.assert_array_equal(result, array)


### PR DESCRIPTION
**Description of proposed changes**

This PR adds tests for `_to_numpy` to check if it works for PyArrow arrays with pyarrow numeric dtypes.

PyArrow provides 11 numeric dtypes (https://arrow.apache.org/docs/python/api/datatypes.html): int8, int16, int32, int64, uint8, uint16, uint32, uint64, float16, float32, and float64. All can be converted to numpy dtype without issues.

Here is a minimal example to play with pyarrow types.
```python
>>> import numpy as np
>>> import pyarrow as pa
>>> x = pa.array([1, 2, 3], type=pa.int16())
>>> x
<pyarrow.lib.Int16Array object at 0x7fc28a73fb80>
[
  1,
  2,
  3
]
>>> np.ascontiguousarray(x)
array([1, 2, 3], dtype=int16)

>>> x = pa.array([1, 2, None], type=pa.int16())
>>> x
<pyarrow.lib.Int16Array object at 0x7fc28a7ba620>
[
  1,
  2,
  null
]

>>> np.ascontiguousarray(x)
array([ 1.,  2., nan])
```

Please note that `pa.float16` needs special handling:
```python
>>> x = pa.array([1.0, 2.0, 3.0], type=pa.float16())
---------------------------------------------------------------------------
ArrowTypeError                            Traceback (most recent call last)
Cell In[9], line 1
----> 1 x = pa.array([1.0, 2.0, 3.0], type=pa.float16())

File ~/opt/miniforge/envs/pygmt/lib/python3.12/site-packages/pyarrow/array.pxi:370, in pyarrow.lib.array()

File ~/opt/miniforge/envs/pygmt/lib/python3.12/site-packages/pyarrow/array.pxi:42, in pyarrow.lib._sequence_to_array()

File ~/opt/miniforge/envs/pygmt/lib/python3.12/site-packages/pyarrow/error.pxi:155, in pyarrow.lib.pyarrow_internal_check_status()

File ~/opt/miniforge/envs/pygmt/lib/python3.12/site-packages/pyarrow/error.pxi:92, in pyarrow.lib.check_status()

ArrowTypeError: Expected np.float16 instance

>>> # The solution is from https://arrow.apache.org/docs/python/generated/pyarrow.float16.html#pyarrow.float16
>>> x = pa.array(np.array([1.0, 2.0, 3.0], dtype=np.float16), type=pa.float16())
>>> x
<pyarrow.lib.HalfFloatArray object at 0x7fc279308b20>
[
  15360,
  16384,
  16896
]
>>> # The numbers above look weird but when converting to numpy, they're correct
>>> np.ascontiguousarray(x)
array([1., 2., 3.], dtype=float16)
```

