### PR TITLE
Figure.plot/Figure.plot3d: Improve the check of the "style" parameter for "v" or "V"

### DIFF
--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -213,7 +213,8 @@ def plot(
     if kind == "empty":  # Add more columns for vectors input
         # Parameters for vector styles
         if (
-            kwargs.get("S") is not None
+            isinstance(kwargs.get("S"), str)
+            and len(kwargs["S"]) >= 1
             and kwargs["S"][0] in "vV"
             and is_nonstr_iter(direction)
         ):

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -197,7 +197,8 @@ def plot3d(
     if kind == "empty":  # Add more columns for vectors input
         # Parameters for vector styles
         if (
-            kwargs.get("S") is not None
+            isinstance(kwargs.get("S"), str)
+            and len(kwargs["S"]) >= 1
             and kwargs["S"][0] in "vV"
             and is_nonstr_iter(direction)
         ):


### PR DESCRIPTION
In GMT, when both symbol and size are read from files, the `-S` option can be specified without arguments. Thus, `style=""` or `style=True` should be valid.

However, currently we check `kwargs.get("S") is not None and kwargs["S"][0] in "vV"` which doesn't make sense if `style` is not a string or is an empty string. 

This PR fixes the checking of the `style` parameter.

Strictly speaking, it's a bug, but I don't want to add one more test for such a minor change. So mark it as "maintenance" and "skip-changelog".