### PR TITLE
Autofix: Figure.plot/Figure.plot3d: Fix the check for if "style" contains "v" or "V"

### DIFF
--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -214,7 +214,7 @@ def plot(
         # Parameters for vector styles
         if (
             kwargs.get("S") is not None
-            and kwargs["S"][0] in "vV"
+            and (kwargs["S"] == "" or kwargs["S"] is True or (isinstance(kwargs["S"], str) and kwargs["S"][0] in "vV"))
             and is_nonstr_iter(direction)
         ):
             extra_arrays.extend(direction)

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -198,7 +198,7 @@ def plot3d(
         # Parameters for vector styles
         if (
             kwargs.get("S") is not None
-            and kwargs["S"][0] in "vV"
+            and (kwargs["S"] == "" or kwargs["S"] is True or (isinstance(kwargs["S"], str) and kwargs["S"][0] in "vV"))
             and is_nonstr_iter(direction)
         ):
             extra_arrays.extend(direction)


### PR DESCRIPTION
This change modifies the checking of the `style` parameter in both `plot` and `plot3d` functions to allow for empty strings and boolean values. It ensures that the `-S` option can be specified without arguments when both symbol and size are read from files. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    