### PR TITLE
CI: Install pandas 2.1 + pyarrow in the Python 3.11 job

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -85,7 +85,7 @@ jobs:
           - os: 'ubuntu-latest'
             python-version: '3.11'  # Can't be 3.10 or 3.12.
             numpy-version: '1.24'
-            pandas-version: '=2.0'
+            pandas-version: '=2.1'
             xarray-version: ''
             optional-packages: ' geopandas<1 pyarrow'
 

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -85,9 +85,9 @@ jobs:
           - os: 'ubuntu-latest'
             python-version: '3.11'  # Can't be 3.10 or 3.12.
             numpy-version: '1.24'
-            pandas-version: ''
+            pandas-version: '=2.0'
             xarray-version: ''
-            optional-packages: ' geopandas<1'
+            optional-packages: ' geopandas<1 pyarrow'
 
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
As mentioned in PR #3584, pandas dtype conversion behaviors change in pandas 2.2., so we need to test both pandas<2.2 and pandas>=2.2 in our CI jobs. Our CI jobs already do this since we install pandas=2.0 in the Python 3.10 CI job and pandas latest version (2.2) in the Python 3.12 CI job. 

However, pandas also supports pyarrow as its array backend, and pyarrow is an optional dependency. Currently only the Python 3.12 CI job has pyarrow installed, leaving the pandas<2.2 + pyarrow untested.

I don't think we want to add more CI jobs, so this PR installs pandas 2.1 and pyarrow in the **Python 3.11** job instead.
