### PR TITLE
SPEC 0: Bump minimum supported version to Python 3.11

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -54,22 +54,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.12']
+        python-version: ['3.11', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
         # Is it a draft Pull Request (true or false)?
         isDraft:
           - ${{ github.event.pull_request.draft }}
-        # Only run two jobs (Ubuntu + Python 3.10/3.12) for draft PRs
+        # Only run two jobs (Ubuntu + Python 3.11/3.12) for draft PRs
         exclude:
           - os: macos-latest
             isDraft: true
           - os: windows-latest
             isDraft: true
-        # Pair Python 3.10 with the minimum supported versions of NumPy, pandas, Xarray
+        # Pair Python 3.11 with the minimum supported versions of NumPy, pandas, Xarray
         # and Python 3.12 with the latest versions of NumPy, pandas, Xarray
         # Only install optional packages on Python 3.12
         include:
-          - python-version: '3.10'
+          - python-version: '3.11'
             numpy-version: '1.24'
             pandas-version: '=2.0'
             xarray-version: '=2023.04'
@@ -83,7 +83,7 @@ jobs:
           # The python-version here can't be the versions in the matrix.python-version
           # defined above. Otherwise, other jobs will be overridden by this one.
           - os: 'ubuntu-latest'
-            python-version: '3.11'  # Can't be 3.10 or 3.12.
+            python-version: '3.11'  # Can't be 3.11 or 3.12.
             numpy-version: '1.24'
             pandas-version: ''
             xarray-version: ''

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -59,7 +59,7 @@ jobs:
               - conda-forge
               - nodefaults
           create-args: >-
-            python=3.10
+            python=3.11
             gmt=${{ matrix.gmt_version }}
             ghostscript<10
             numpy

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
     - conda-forge
     - nodefaults
 dependencies:
-    - python>=3.10
+    - python>=3.11
     # Required dependencies
     - gmt=6.5.0
     - ghostscript=10.04.0

--- a/pygmt/tests/test_clib_put_vector.py
+++ b/pygmt/tests/test_clib_put_vector.py
@@ -126,7 +126,7 @@ def test_put_vector_string_dtype():
             "2021-02-03T00:00:00",
             "2021-02-03T04:00:00",
             "2021-02-03T04:05:06",
-            f"{datetime.datetime.now(tz=datetime.timezone.utc).strftime('%Y-%m-%d')}T04:50:06",
+            f"{datetime.datetime.now(tz=datetime.UTC).strftime('%Y-%m-%d')}T04:50:06",
         ],
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pygmt"
 description = "A Python interface for the Generic Mapping Tools"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [{name = "The PyGMT Developers", email = "pygmt.team@gmail.com"}]
 keywords = [
     "cartography",
@@ -24,7 +24,6 @@ classifiers = [
     "Intended Audience :: Education",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
**Description of proposed changes**

Following [SPEC 0](https://scientific-python.org/specs/spec-0000/) policy where Python 3.10 should be dropped in 2024 quarter 4.

Changes in this PR:

- [x] Update the minimum Python version in `ci_tests.yaml`
- [x] Update the minimum Python version in `ci_tests_legacy.yaml`
- [x] Update the Python version in the `requires-python` field and remove the related entry from `classifiers` in `pyproject.toml`.
- [ ] Update [branch protection rules](https://github.com/GenericMappingTools/pygmt/settings/branches) 

Supersedes PR #3039.

Need to wait for #3490 to support Python 3.13 first.