### PR TITLE
clib.conversion._to_numpy: Add tests for pandas.Series with pandas string dtype

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -2,6 +2,7 @@
 Functions to convert data types into ctypes friendly formats.
 """
 
+import contextlib
 import ctypes as ctp
 import warnings
 from collections.abc import Sequence
@@ -178,6 +179,11 @@ def _to_numpy(data: Any) -> np.ndarray:
     else:
         vec_dtype = str(getattr(data, "dtype", ""))
         array = np.ascontiguousarray(data, dtype=dtypes.get(vec_dtype))
+
+    # Check if a np.object_ array can be converted to np.str_.
+    if array.dtype == np.object_:
+        with contextlib.suppress(TypeError, ValueError):
+            return np.ascontiguousarray(array, dtype=np.str_)
     return array
 
 

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -158,6 +158,9 @@ def _to_numpy(data: Any) -> np.ndarray:
     """
     # Mapping of unsupported dtypes to the expected NumPy dtype.
     dtypes: dict[str, type] = {
+        # For pandas string dtype, "string[python]", "string[pyarrow]" and
+        # "string[pyarrow_numpy]".
+        "string": np.str_,
         "date32[day][pyarrow]": np.datetime64,
         "date64[ms][pyarrow]": np.datetime64,
     }

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1475,7 +1475,7 @@ class Session:
         # 2 columns contains coordinates like longitude, latitude, or datetime string
         # types.
         for col, array in enumerate(arrays[2:]):
-            if pd.api.types.is_string_dtype(array.dtype):
+            if np.issubdtype(array.dtype, np.str_):
                 columns = col + 2
                 break
 
@@ -1506,9 +1506,9 @@ class Session:
                 strings = string_arrays[0]
             elif len(string_arrays) > 1:
                 strings = np.array(
-                    [" ".join(vals) for vals in zip(*string_arrays, strict=True)]
+                    [" ".join(vals) for vals in zip(*string_arrays, strict=True)],
+                    dtype=np.str_,
                 )
-            strings = np.asanyarray(a=strings, dtype=np.str_)
             self.put_strings(
                 dataset, family="GMT_IS_VECTOR|GMT_IS_DUPLICATE", strings=strings
             )

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 from packaging.version import Version
 from pygmt.clib.conversion import _to_numpy
+from pygmt.helpers.testing import skip_if_no
 
 try:
     import pyarrow as pa
@@ -159,6 +160,31 @@ def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
     result = _to_numpy(series)
     _check_result(result, expected_dtype)
     npt.assert_array_equal(result, series)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        None,
+        np.str_,
+        "U10",
+        "string[python]",
+        pytest.param("string[pyarrow]", marks=skip_if_no(package="pyarrow")),
+        pytest.param("string[pyarrow_numpy]", marks=skip_if_no(package="pyarrow")),
+    ],
+)
+def test_to_numpy_pandas_series_pandas_dtypes_string(dtype):
+    """
+    Test the _to_numpy function with pandas.Series of pandas string types.
+
+    In pandas, string arrays can be specified in multiple ways.
+
+    Reference: https://pandas.pydata.org/docs/reference/api/pandas.StringDtype.html
+    """
+    array = pd.Series(["abc", "defg", "12345"], dtype=dtype)
+    result = _to_numpy(array)
+    _check_result(result, np.str_)
+    npt.assert_array_equal(result, array)
 
 
 ########################################################################################


### PR DESCRIPTION
**Description of proposed changes**

Add tests for pandas.Series with string dtype. Six cases are tested:

1. `dtype=None`
2. `dtype=np.str_`
3. `dtype="U10"`
4. `dtype="string[python]"`
5. `dtype="string[pyarrow]"`
6. `dtype="string[pyarrow_numpy]"`

Neither can be converted to `np.str_` directly. Cases 4-6 can be fixed by 01ba31786ddf424027b3c3472339cd43d6fb49d5, and cases 1-3 can be fixed by dac7e8eda7632464f556eaae5f1ac8ac34c9b6bd.


```python
In [1]: import pandas as pd

In [2]: import numpy as np

In [3]: x = pd.Series(["abc", "defg", "12345"], dtype=None)

In [4]: x.dtype
Out[4]: dtype('O')

In [5]: np.ascontiguousarray(x)
Out[5]: array(['abc', 'defg', '12345'], dtype=object)

In [6]: x = pd.Series(["abc", "defg", "12345"], dtype=np.str_)

In [7]: x.dtype
Out[7]: dtype('O')

In [8]: np.ascontiguousarray(x)
Out[8]: array(['abc', 'defg', '12345'], dtype=object)

In [9]: x = pd.Series(["abc", "defg", "12345"], dtype="U10")

In [10]: x.dtype
Out[10]: dtype('O')

In [11]: x = pd.Series(["abc", "defg", "12345"], dtype="string[python]")

In [12]: x.dtype
Out[12]: string[python]

In [13]: str(x.dtype)
Out[13]: 'string'

In [14]: np.ascontiguousarray(x)
Out[14]: array(['abc', 'defg', '12345'], dtype=object)

In [15]: x = pd.Series(["abc", "defg", "12345"], dtype="string[pyarrow]")

In [16]: x.dtype
Out[16]: string[pyarrow]

In [17]: str(x.dtype)
Out[17]: 'string'

In [18]: np.ascontiguousarray(x)
Out[18]: array(['abc', 'defg', '12345'], dtype=object)

In [19]: x = pd.Series(["abc", "defg", "12345"], dtype="string[pyarrow_numpy]")

In [20]: x.dtype
Out[20]: string[pyarrow_numpy]

In [21]: str(x.dtype)
Out[21]: 'string'

In [22]: np.ascontiguousarray(x)
Out[22]: array(['abc', 'defg', '12345'], dtype=object)
```

