### PR TITLE
clib.conversion._to_numpy: Add tests for pyarrow.array with pyarrow string types

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -156,8 +156,13 @@ def _to_numpy(data: Any) -> np.ndarray:
     array
         The C contiguous NumPy array.
     """
-    # Mapping of unsupported dtypes to the expected NumPy dtype.
+    # Mapping of unsupported dtypes to expected NumPy dtypes.
     dtypes: dict[str, type] = {
+        # For string dtypes.
+        "large_string": np.str_,  # pa.large_string and pa.large_utf8
+        "string": np.str_,  # pa.string and pa.utf8
+        "string_view": np.str_,  # pa.string_view
+        # For datetime dtypes.
         "date32[day][pyarrow]": np.datetime64,
         "date64[ms][pyarrow]": np.datetime64,
     }
@@ -173,7 +178,7 @@ def _to_numpy(data: Any) -> np.ndarray:
         # we can remove the workaround in PyGMT v0.17.0.
         array = np.ascontiguousarray(data.astype(float))
     else:
-        vec_dtype = str(getattr(data, "dtype", ""))
+        vec_dtype = str(getattr(data, "dtype", getattr(data, "type", "")))
         array = np.ascontiguousarray(data, dtype=dtypes.get(vec_dtype))
     return array
 

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -170,6 +170,7 @@ def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
 #   - int8, int16, int32, int64
 #   - uint8, uint16, uint32, uint64
 #   - float16, float32, float64
+# - String dtypes: string/utf8, large_string/large_utf8, string_view
 #
 # In PyArrow, array types can be specified in two ways:
 #
@@ -237,4 +238,26 @@ def test_to_numpy_pyarrow_array_pyarrow_dtypes_numeric_with_na(dtype, expected_d
     array = pa.array(data, type=dtype)[::2]
     result = _to_numpy(array)
     _check_result(result, expected_dtype)
+    npt.assert_array_equal(result, array)
+
+
+@pytest.mark.skipif(not _HAS_PYARROW, reason="pyarrow is not installed")
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        None,
+        "string",
+        "utf8",  # alias for string
+        "large_string",
+        "large_utf8",  # alias for large_string
+        "string_view",
+    ],
+)
+def test_to_numpy_pyarrow_array_pyarrow_dtypes_string(dtype):
+    """
+    Test the _to_numpy function with PyArrow arrays of PyArrow string types.
+    """
+    array = pa.array(["abc", "defg", "12345"], type=dtype)
+    result = _to_numpy(array)
+    _check_result(result, np.str_)
     npt.assert_array_equal(result, array)

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -205,7 +205,7 @@ def test_to_numpy_pandas_series_pyarrow_dtypes_date(dtype, expected_dtype):
 #   - int8, int16, int32, int64
 #   - uint8, uint16, uint32, uint64
 #   - float16, float32, float64
-# - String dtypes: string/utf8, large_string/large_utf8, string_view
+# - String types: string/utf8, large_string/large_utf8, string_view
 # - Date types:
 #   - date32[day]
 #   - date64[ms]


### PR DESCRIPTION
**Description of proposed changes**

This PR adds tests for PyArrow string types: `string`/`utf8`/`large_string`/`large_utf8`/`string_view` (xref: https://arrow.apache.org/docs/python/api/datatypes.html).

None of them can be converted to np.str_ directly, so we need to mapping them explicitly.

```
In [1]: import pyarrow as pa

In [2]: x = pa.array(["abc", "defg", "12345"], type=pa.string())

In [3]: x.type
Out[3]: DataType(string)

In [4]: str(x.type)
Out[4]: 'string'

In [6]: import numpy as np

In [7]: np.ascontiguousarray(x)
Out[7]: array(['abc', 'defg', '12345'], dtype=object)
```

