### PR TITLE
clib.conversion._to_numpy: Add tests for pyarrow.array with date32/date64 dtype

### DIFF
--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -3,6 +3,7 @@ Tests for the _to_numpy function in the clib.conversion module.
 """
 
 import sys
+from datetime import date, datetime
 
 import numpy as np
 import numpy.testing as npt
@@ -170,6 +171,9 @@ def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
 #   - int8, int16, int32, int64
 #   - uint8, uint16, uint32, uint64
 #   - float16, float32, float64
+# - Date types:
+#   - date32[day]
+#   - date64[ms]
 #
 # In PyArrow, array types can be specified in two ways:
 #
@@ -238,3 +242,35 @@ def test_to_numpy_pyarrow_array_pyarrow_dtypes_numeric_with_na(dtype, expected_d
     result = _to_numpy(array)
     _check_result(result, expected_dtype)
     npt.assert_array_equal(result, array)
+
+
+@pytest.mark.skipif(not _HAS_PYARROW, reason="pyarrow is not installed")
+@pytest.mark.parametrize(
+    ("dtype", "expected_dtype"),
+    [
+        pytest.param("date32[day]", "datetime64[D]", id="date32[day]"),
+        pytest.param("date64[ms]", "datetime64[ms]", id="date64[ms]"),
+    ],
+)
+def test_to_numpy_pyarrow_array_pyarrow_dtypes_date(dtype, expected_dtype):
+    """
+    Test the _to_numpy function with PyArrow arrays of PyArrow date types.
+
+    date32[day] and date64[ms] are stored as 32-bit and 64-bit integers, respectively,
+    representing the number of days and milliseconds since the UNIX epoch (1970-01-01).
+
+    Here we explicitly check the dtype and date unit of the result.
+    """
+    data = [
+        date(2024, 1, 1),
+        datetime(2024, 1, 2),
+        datetime(2024, 1, 3),
+    ]
+    array = pa.array(data, type=dtype)
+    result = _to_numpy(array)
+    _check_result(result, np.datetime64)
+    assert result.dtype == expected_dtype  # Explicitly check the date unit.
+    npt.assert_array_equal(
+        result,
+        np.array(["2024-01-01", "2024-01-02", "2024-01-03"], dtype=expected_dtype),
+    )


### PR DESCRIPTION
**Description of proposed changes**

Add tests for pyarrow.array with [date64](https://arrow.apache.org/docs/python/generated/pyarrow.date64.html#pyarrow.date64)/[date32](https://arrow.apache.org/docs/python/generated/pyarrow.date32.html#pyarrow.date32) dtype. 

These two types can be converted directly to numpy datetime64 with correct date units, as shown below.
```python
In [1]: from datetime import datetime, date

In [2]: import numpy as np

In [3]: import pyarrow as pa

In [4]: x = pa.array([datetime(2012, 1, 1), date(2013, 1, 1)], type=pa.date32())

In [5]: x
Out[5]:
<pyarrow.lib.Date32Array object at 0x7f7142b70c40>
[
  2012-01-01,
  2013-01-01
]

In [6]: np.ascontiguousarray(x)
Out[6]: array(['2012-01-01', '2013-01-01'], dtype='datetime64[D]')

In [7]: x = pa.array([datetime(2012, 1, 1), date(2013, 1, 1)], type=pa.date64())

In [8]: x
Out[8]:
<pyarrow.lib.Date64Array object at 0x7f726ffb8ca0>
[
  2012-01-01,
  2013-01-01
]

In [9]: np.ascontiguousarray(x)
Out[9]:
array(['2012-01-01T00:00:00.000', '2013-01-01T00:00:00.000'],
      dtype='datetime64[ms]')
```