### PR TITLE
Ensure non-ASCII characters are typeset correctly even if PS_CHAR_ENCODING is not 'ISOLatin1+'

### DIFF
--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -506,17 +506,14 @@ def build_arg_list(  # noqa: PLR0912
         else:
             gmt_args.append(f"-{key}{value}")
 
-    # Convert non-ASCII characters (if any) in the arguments to octal codes
-    encoding = _check_encoding("".join(gmt_args))
-    if encoding != "ascii":
-        gmt_args = [non_ascii_to_octal(arg, encoding=encoding) for arg in gmt_args]
     gmt_args = sorted(gmt_args)
 
-    # Set --PS_CHAR_ENCODING=encoding if necessary
-    if encoding not in {"ascii", "ISOLatin1+"} and not (
-        confdict and "PS_CHAR_ENCODING" in confdict
-    ):
-        gmt_args.append(f"--PS_CHAR_ENCODING={encoding}")
+    # Convert non-ASCII characters (if any) in the arguments to octal codes and set
+    # --PS_CHAR_ENCODING=encoding if necessary
+    if (encoding := _check_encoding("".join(gmt_args))) != "ascii":
+        gmt_args = [non_ascii_to_octal(arg, encoding=encoding) for arg in gmt_args]
+        if not (confdict and "PS_CHAR_ENCODING" in confdict):
+            gmt_args.append(f"--PS_CHAR_ENCODING={encoding}")
 
     if confdict:
         gmt_args.extend(f"--{key}={value}" for key, value in confdict.items())

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -238,15 +238,12 @@ def text_(  # noqa: PLR0912
 
         # Append text to the last column. Text must be passed in as str type.
         text = np.asarray(text, dtype=np.str_)
-        encoding = _check_encoding("".join(text.flatten()))
-        if encoding != "ascii":
+        if (encoding := _check_encoding("".join(text.flatten()))) != "ascii":
             text = np.vectorize(non_ascii_to_octal, excluded="encoding")(
                 text, encoding=encoding
             )
+            confdict["PS_CHAR_ENCODING"] = encoding
         extra_arrays.append(text)
-
-        if encoding not in {"ascii", "ISOLatin1+"}:
-            confdict = {"PS_CHAR_ENCODING": encoding}
     else:
         if isinstance(position, str):
             kwargs["F"] += f"+c{position}+t{text}"

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from pygmt import Figure
+from pygmt import Figure, config
 from pygmt.exceptions import GMTCLibError, GMTInvalidInput
 from pygmt.helpers import GMTTempFile
 
@@ -410,12 +410,17 @@ def test_text_nonstr_text():
     return fig
 
 
-@pytest.mark.mpl_image_compare
-def test_text_nonascii():
+@pytest.mark.mpl_image_compare(filename="test_text_nonascii.png")
+@pytest.mark.parametrize("encoding", ["ISOLatin1+", "Standard+"])
+def test_text_nonascii(encoding):
     """
     Test passing text strings with non-ascii characters.
+
+    Default PS_CHAR_ENCODING setting should not affect the result.
     """
     fig = Figure()
+    if encoding == "Standard+":  # Temporarily set the PS_CHAR_ENCODING to "Standard+".
+        config(PS_CHAR_ENCODING="Standard+")
     fig.basemap(region=[0, 10, 0, 10], projection="X10c", frame=True)
     fig.text(position="TL", text="position-text:°α")  # noqa: RUF001
     fig.text(x=1, y=1, text="xytext:°α")  # noqa: RUF001


### PR DESCRIPTION
**Description of proposed changes**

Non-ASCII characters may not be typeset correctly if the default PS_CHAR_ENCODING setting is not `ISOLatin1+`. This can happen when (1) GMT is compiled with US units as default; (2) users have a global `gmt.conf` file with `PS_CHAR_ENCODING` set to `Standard+`; (3) users set `PS_CHAR_ENCODING` to `Standard+` in the middle of a script. 

Taking the gallery example at https://www.pygmt.org/dev/tutorials/advanced/non_ascii_text.html as an example.

If you have a `gmt.conf` file with `PS_CHAR_ENCODING` set to `Standard+` (e.g., you can create a `gmt.conf` file by running GMT command `gmt set PS_CHAR_ENCODING=Standard+` in terminal), running the gallery example will result in the incorrect figure shown in the left column below:

| PS_CHAR_ENCODING=Standard+ | PS_CHAR_ENCODING=ISOLatin1+ |
|---|---|
| ![Standard+](https://github.com/user-attachments/assets/08fe90a4-39b5-4b54-8fc8-49a9e26caa18) | ![image](https://github.com/user-attachments/assets/2be53218-6124-4d50-a4f0-2291199c8def) | 

Previously, we assumed the default PS_CHAR_ENCODING is `ISOLatin1+` and didn't add `--PS_CHAR_ENCODING=ISOLatin1+` if the text string contains non-ASCII characters in the ISOLatin1+ charset. This PR fixes the issue by always adding `--PS_CHAR_ENCODING=<encoding>` even if *encoding* is `ISOLatin1+`.

In 8c346835314514c9aad21e9c78851f6a48f54590, the existing test `test_text_nonascii` is modified to show that setting `PS_CHAR_ENCODING` to `Standard+` breaks the test (https://github.com/GenericMappingTools/pygmt/actions/runs/11800822308/job/32872646796?pr=3611). The fix is added in d9e5203fb.

Closes #2204.