### PR TITLE
pyarrow: Map date32[day]/date64[ms] dtypes in pandas objects to np.datetime64 with correct date/time units

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -157,9 +157,9 @@ def _to_numpy(data: Any) -> np.ndarray:
         The C contiguous NumPy array.
     """
     # Mapping of unsupported dtypes to the expected NumPy dtype.
-    dtypes: dict[str, type] = {
-        "date32[day][pyarrow]": np.datetime64,
-        "date64[ms][pyarrow]": np.datetime64,
+    dtypes: dict[str, str | type] = {
+        "date32[day][pyarrow]": "datetime64[D]",
+        "date64[ms][pyarrow]": "datetime64[ms]",
     }
 
     if (


### PR DESCRIPTION
**Description of proposed changes**

Explicitly convert `date32[day][pyarrow]` to `datetime64[D]` and `date64[ms][pyarrow]` to `datetime64[ms]`.

Part of PR #3610. Patches #2845.
