### PR TITLE
CI: Run the 'GMT Tests' workflow on Python 3.10/3.12 with optional packages and Python 3.11 without optional packages

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -1,24 +1,26 @@
 # Test PyGMT on Linux/macOS/Windows
 #
-# This workflow runs regular PyGMT tests and uploads test coverage reports stored
-# in `.coverage.xml` to https://app.codecov.io/gh/GenericMappingTools/pygmt
-# via the [Codecov GitHub Action](https://github.com/codecov/codecov-action).
-# More codecov related configurations are stored in `.github/codecov.yml`.
-# If any tests fail, it also uploads the diff images as workflow artifacts.
+# This workflow runs regular PyGMT tests and uploads test coverage reports stored in
+# `.coverage.xml` to https://app.codecov.io/gh/GenericMappingTools/pygmt via the
+# [Codecov GitHub Action](https://github.com/codecov/codecov-action). More codecov
+# related configurations are stored in `.github/codecov.yml`. If any tests fail, it also
+# uploads the diff images as workflow artifacts.
 #
 # It is run:
 # 1. on every commit to the main branch
-# 2. on every commit to the pull request branches, unless the pull requests only
-#    contain non-code changes.
+# 2. on every commit to the pull request branches, unless the pull requests only contain
+#    non-code changes.
 # 3. when a new release is published
 #
 # It is also scheduled to run daily on the main branch.
 #
-# In draft pull request, only two jobs on Linux are triggered to save on
-# Continuous Integration resources:
+# In draft pull request, only jobs on Linux are triggered to save on Continuous
+# Integration resources:
 #
-# - Minimum supported Python, NumPy, pandas, Xarray versions following [SPEC 0](https://scientific-python.org/specs/spec-0000/)
-# - Latest Python, NumPy versions + optional packages (e.g. GeoPandas)
+# - Minimum supported Python + core packages (minimum supported versions)
+#   + optional packages (minimum supported versions if any)
+# - Latest Python + core packages (latest versions) + optional packages
+# - Last release before the latest Python + core packages
 #
 name: Tests
 
@@ -54,40 +56,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
         # Is it a draft Pull Request (true or false)?
         isDraft:
           - ${{ github.event.pull_request.draft }}
-        # Only run two jobs (Ubuntu + Python 3.10/3.12) for draft PRs
+        # Only run three jobs on Ubuntu for draft PRs
         exclude:
           - os: macos-latest
             isDraft: true
           - os: windows-latest
             isDraft: true
-        # Pair Python 3.10 with the minimum supported versions of NumPy, pandas, Xarray
-        # and Python 3.12 with the latest versions of NumPy, pandas, Xarray
-        # Only install optional packages on Python 3.12
         include:
+          # Python 3.10 + core packages (minimum supported versions) + optional packages (minimum supported versions if any)
           - python-version: '3.10'
             numpy-version: '1.24'
             pandas-version: '=2.0'
             xarray-version: '=2023.04'
-            optional-packages: ''
+            optional-packages: ' contextily geopandas<1 ipython pyarrow rioxarray sphinx-gallery'
+          # Python 3.12 + core packages (latest versions) + optional packages
           - python-version: '3.12'
             numpy-version: '2.1'
             pandas-version: ''
             xarray-version: ''
-            optional-packages: ' contextily geopandas ipython pyarrow rioxarray sphinx-gallery'
-          # The job below is for testing GeoPandas v0.x on Ubuntu.
-          # The python-version here can't be the versions in the matrix.python-version
-          # defined above. Otherwise, other jobs will be overridden by this one.
-          - os: 'ubuntu-latest'
-            python-version: '3.11'  # Can't be 3.10 or 3.12.
-            numpy-version: '1.24'
-            pandas-version: '=2.1'
+            optional-packages: ' contextily geopandas>=1.0 ipython pyarrow rioxarray sphinx-gallery'
+          # Python 3.11 + core packages
+          - python-version: '3.11'
+            numpy-version: ''
+            pandas-version: ''
             xarray-version: ''
-            optional-packages: ' geopandas<1 pyarrow'
+            optional-packages: ''
 
     timeout-minutes: 30
     defaults:

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
         # Is it a draft Pull Request (true or false)?
         isDraft:
@@ -80,8 +80,9 @@ jobs:
             pandas-version: ''
             xarray-version: ''
             optional-packages: ' contextily geopandas>=1.0 ipython pyarrow rioxarray sphinx-gallery'
-          # Python 3.11 + core packages
-          - python-version: '3.11'
+          # Python 3.11 + core packages (Linux only)
+          - os: 'ubuntu-latest'
+            python-version: '3.11'
             numpy-version: ''
             pandas-version: ''
             xarray-version: ''

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -119,9 +119,9 @@ def load_tile_map(
     Frozen({'band': 3, 'y': 256, 'x': 512})
     >>> raster.coords  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     Coordinates:
-      * band         (band) uint8 ... 1 2 3
-      * y            (y) float64 ... -7.081e-10 -7.858e+04 ... -1.996e+07 -2.004e+07
-      * x            (x) float64 ... -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
+      * band         (band) uint8... 1 2 3
+      * y            (y) float64... -7.081e-10 -7.858e+04 ... -1.996e+07 -2.004e+07
+      * x            (x) float64... -2.004e+07 -1.996e+07 ... 1.996e+07 2.004e+07
         spatial_ref  int... 0
     >>> # CRS is set only if rioxarray is available
     >>> if hasattr(raster, "rio"):

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -183,7 +183,16 @@ def test_to_numpy_pandas_series_numpy_dtypes_numeric(dtype, expected_dtype):
         "U10",
         "string[python]",
         pytest.param("string[pyarrow]", marks=skip_if_no(package="pyarrow")),
-        pytest.param("string[pyarrow_numpy]", marks=skip_if_no(package="pyarrow")),
+        pytest.param(
+            "string[pyarrow_numpy]",
+            marks=[
+                skip_if_no(package="pyarrow"),
+                pytest.mark.skipif(
+                    Version(pd.__version__) < Version("2.1"),
+                    reason="string[pyarrow_numpy] was added since pandas 2.1",
+                ),
+            ],
+        ),
     ],
 )
 def test_to_numpy_pandas_series_pandas_dtypes_string(dtype):


### PR DESCRIPTION
**Description of proposed changes**

Implement the idea in https://github.com/GenericMappingTools/pygmt/issues/3615#issue-2654377417.

Now the workflow has 7 jobs:

- Python 3.10 + core packages (minimum supported versions) + optional packages (minimum supported versions if any)
- Python 3.12 + core packages (latest versions) + optional packages
- Python 3.11 + core packages [Linux only to ensure optional packages are truly **optional**]