### PR TITLE
CI: Use pytest '--override-ini' to override 'addopts' setting in the "Benchmarks" workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -91,4 +91,4 @@ jobs:
         with:
           # 'bash -el -c' is needed to use the custom shell.
           # See https://github.com/CodSpeedHQ/action/issues/65.
-          run: bash -el -c "python -c \"import pygmt; pygmt.show_versions()\"; PYGMT_USE_EXTERNAL_DISPLAY=false python -m pytest -r P --pyargs pygmt --codspeed"
+          run: bash -el -c "python -c \"import pygmt; pygmt.show_versions()\"; PYGMT_USE_EXTERNAL_DISPLAY=false python -m pytest -r P --pyargs pygmt --codspeed --override-ini addopts='--verbose'"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -68,6 +68,7 @@ jobs:
             pyarrow
             pytest
             pytest-codspeed
+            pytest-mpl
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -68,7 +68,6 @@ jobs:
             pyarrow
             pytest
             pytest-codspeed
-            pytest-mpl
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,5 +173,4 @@ minversion = "6.0"
 addopts = "--verbose --color=yes --durations=0 --durations-min=0.2 --doctest-modules --mpl --mpl-results-path=results"
 markers = [
     "benchmark: mark a test with custom benchmark settings.",
-    "mpl_image_compare: Compares matplotlib figures against a baseline image",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,4 +173,5 @@ minversion = "6.0"
 addopts = "--verbose --color=yes --durations=0 --durations-min=0.2 --doctest-modules --mpl --mpl-results-path=results"
 markers = [
     "benchmark: mark a test with custom benchmark settings.",
+    "mpl_image_compare: Compares matplotlib figures against a baseline image",
 ]


### PR DESCRIPTION
**Description of proposed changes**

In the benchmarks workflow, we don't care if the generated images are correct or not, so we don't do the image comparisons. Then we see many warnings (first noticed in #2923 but are ignored) like :
```
  pygmt/tests/test_basemap.py::test_basemap
    /home/runner/micromamba/envs/pygmt/lib/python3.12/site-packages/_pytest/python.py:163: PytestReturnNotNoneWarning: Expected None, but pygmt/tests/test_basemap.py::test_basemap returned <pygmt.figure.Figure object at 0x42dd3630>, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
      warnings.warn(
```
I think the warnings mean that the "pytest-mpl" plugin is not activated.

However, with the latest `pytest-codspeed` v3.0.0, the Benchmarks workflow suddenly broke (initially reported in https://github.com/GenericMappingTools/pygmt/pull/2933#issuecomment-2477854615). Now the workflow fails with errors like:
```
  =================================== FAILURES ===================================
  _________________________________ test_basemap _________________________________
  Image file not found for comparison test in: 
  	/home/runner/work/pygmt/pygmt/pygmt/tests/baseline
  (This is expected for new tests.)
  Generated Image: 
  	/home/runner/work/pygmt/pygmt/results/pygmt.tests.test_basemap.test_basemap/result.png
```
The errors mean that the `pytest-mpl` plugin is activated now.

This PR fixes the issue by using the `--override-ini` option to override the `addopts` option, so that the `--mpl` option is not added automatically.

With this PR, the remaining warnings are:
```
  =============================== warnings summary ===============================
  ../../../micromamba/envs/pygmt/lib/python3.12/site-packages/numpy/_core/getlimits.py:548
    /home/runner/micromamba/envs/pygmt/lib/python3.12/site-packages/numpy/_core/getlimits.py:548: UserWarning: Signature b'\x00\xd0\xcc\xcc\xcc\xcc\xcc\xcc\xfb\xbf\x00\x00\x00\x00\x00\x00' for <class 'numpy.longdouble'> does not match any known type: falling back to type probe function.
    This warnings indicates broken support for the dtype!
      machar = _get_machar(dtype)
  pygmt/tests/test_clib_put_matrix.py::test_put_matrix_grid
    <frozen importlib._bootstrap>:488: RuntimeWarning: numpy.ndarray size changed, may indicate binary incompatibility. Expected 16 from C header, got 96 from PyObject
  pygmt/tests/test_geopandas.py::test_geopandas_info_geodataframe
  pygmt/tests/test_geopandas.py::test_geopandas_info_geodataframe
    /home/runner/micromamba/envs/pygmt/lib/python3.12/site-packages/pyogrio/geopandas.py:662: UserWarning: 'crs' was not provided.  The output dataset will not have projection information defined and may not be usable in other systems.
      write(
```