### PR TITLE
clib.conversion._to_numpy: Add tests for PyArrow's timestamp type

### DIFF
--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -25,7 +25,7 @@ except ImportError:
         """
 
         @staticmethod
-        def timestamp(*args, **kwargs):
+        def timestamp(unit: str, tz: str | None = None):
             """
             A dummy function to mimic pyarrow.timestamp.
             """
@@ -407,7 +407,7 @@ def test_to_numpy_pyarrow_array_pyarrow_dtypes_date(dtype, expected_dtype):
 )
 def test_to_numpy_pyarrow_timestamp(dtype, expected_dtype):
     """
-    Test the _to_numpy function with PyArrow arrays of PyArrow datetime types.
+    Test the _to_numpy function with PyArrow arrays of PyArrow timestamp types.
 
     pyarrow.timestamp(unit, tz=None) can accept units "s", "ms", "us", and "ns".
 

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -418,4 +418,5 @@ def test_to_numpy_pyarrow_timestamp(dtype, expected_dtype):
     result = _to_numpy(array)
     _check_result(result, np.datetime64)
     assert result.dtype == expected_dtype
-    npt.assert_array_equal(result, array)
+    assert result[0] == np.datetime64("2024-01-02T03:04:05")
+    assert result[1] == np.datetime64("2024-01-02T03:04:06")

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -256,7 +256,7 @@ def test_to_numpy_pandas_series_pyarrow_dtypes_date(dtype, expected_dtype):
 # - Date types:
 #   - date32[day]
 #   - date64[ms]
-# - Datetime types: timestamp
+# - Timestamp types: timestamp[unit], timestamp[unit, tz]
 #
 # In PyArrow, array types can be specified in two ways:
 #

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -17,10 +17,20 @@ try:
     import pyarrow as pa
 
     _HAS_PYARROW = True
-    pa_timestamp = pa.timestamp
 except ImportError:
+
+    class pa:  # noqa: N801
+        """
+        A dummy class to mimic pyarrow.
+        """
+
+        @staticmethod
+        def timestamp(*args, **kwargs):
+            """
+            A dummy function to mimic pyarrow.timestamp.
+            """
+
     _HAS_PYARROW = False
-    pa_timestamp = None
 
 
 def _check_result(result, expected_dtype):
@@ -372,15 +382,15 @@ def test_to_numpy_pyarrow_array_pyarrow_dtypes_date(dtype, expected_dtype):
         pytest.param("timestamp[us]", "datetime64[us]", id="timestamp[us]"),
         pytest.param("timestamp[ns]", "datetime64[ns]", id="timestamp[ns]"),
         pytest.param(
-            pa_timestamp("s", tz="UTC"), "datetime64[s]", id="timestamp[s, tz=UTC]"
+            pa.timestamp("s", tz="UTC"), "datetime64[s]", id="timestamp[s, tz=UTC]"
         ),  # pa.timestamp with tz has no string alias.
         pytest.param(
-            pa_timestamp("s", tz="America/New_York"),
+            pa.timestamp("s", tz="America/New_York"),
             "datetime64[s]",
             id="timestamp[s, tz=America/New_York]",
         ),
         pytest.param(
-            pa_timestamp("s", tz="+07:30"),
+            pa.timestamp("s", tz="+07:30"),
             "datetime64[s]",
             id="timestamp[s, tz=+07:30]",
         ),


### PR DESCRIPTION
[`pyarrow.timestamp`](https://arrow.apache.org/docs/python/generated/pyarrow.timestamp.html) is the datetime dtype in pyarrow. It has two parameters, `unit` and `tz`. 

This PR adds tests to ensure `_to_numpy` support `pyarrow.timestamp`. Please note that, `unit` can only be `s`/`ms`/`us`/`ns`, and ~~`tz` information is discarded when converting to np.datetime64.~~ Actually, when converting to np.datetime64, timezone is corrected to UTC.

```
In [1]: import pyarrow as pa

In [2]: import datetime

In [3]: import numpy as np

In [4]: x = pa.array([datetime.datetime(2024, 1, 1, 12, 34, 56)], type=pa.timestamp("s"))

In [5]: np.ascontiguousarray(x)
Out[5]: array(['2024-01-01T12:34:56'], dtype='datetime64[s]')

In [6]: x = pa.array([datetime.datetime(2024, 1, 1, 12, 34, 56)], type=pa.timestamp("ms"))

In [7]: np.ascontiguousarray(x)
Out[7]: array(['2024-01-01T12:34:56.000'], dtype='datetime64[ms]')

In [8]: x = pa.array([datetime.datetime(2024, 1, 1, 12, 34, 56)], type=pa.timestamp("ms", tz="UTZ"))

In [9]: np.ascontiguousarray(x)
Out[9]: array(['2024-01-01T12:34:56.000'], dtype='datetime64[ms]')
```

Related to #3600.