### PR TITLE
DOC/Gallery example "Multi-parameter symbols": Show applying a inner diameter ("+i") to a pie wedge ("w")

### DIFF
--- a/examples/gallery/symbols/multi_parameter_symbols.py
+++ b/examples/gallery/symbols/multi_parameter_symbols.py
@@ -2,9 +2,9 @@
 Multi-parameter symbols
 =======================
 
-The :meth:`pygmt.Figure.plot` method can plot individual multi-parameter
-symbols by passing the corresponding shortcuts (**e**, **j**, **r**, **R**,
-**w**) to the ``style`` parameter:
+The :meth:`pygmt.Figure.plot` method can plot individual multi-parameter symbols by
+passing the corresponding shortcuts (**e**, **j**, **r**, **R**, **w**) to the ``style``
+parameter:
 
 - **e**: ellipse
 - **j**: rotated rectangle
@@ -18,10 +18,10 @@ symbols by passing the corresponding shortcuts (**e**, **j**, **r**, **R**,
 import pygmt
 
 # %%
-# We can plot multi-parameter symbols using the same symbol style. We need to
-# define locations (lon, lat) via the ``x`` and ``y`` parameters (scalar for
-# a single symbol or 1-D list for several ones) and two or three symbol
-# parameters after those shortcuts via the ``style`` parameter.
+# We can plot multi-parameter symbols using the same symbol style. We need to define
+# locations (lon, lat) via the ``x`` and ``y`` parameters (scalar for a single symbol
+# or 1-D list for several ones) and two or three symbol parameters after those
+# shortcuts via the ``style`` parameter.
 #
 # The multi-parameter symbols in the ``style`` parameter are defined as:
 #
@@ -30,11 +30,11 @@ import pygmt
 # - **r**: rectangle, ``width/height``
 # - **R**: rounded rectangle, ``width/height/radius``
 # - **w**: pie wedge, ``diameter/startdir/stopdir``, the last two arguments are
-#   directions given in degrees counter-clockwise from horizontal. Append **+i**
-#   and the desired value to apply a inner diameter
+#   directions given in degrees counter-clockwise from horizontal. Append **+i** and
+#   the desired value to apply a inner diameter
 #
-# Upper-case versions **E**, **J**, and **W** are similar to **e**, **j**, and
-# **w** but expect geographic azimuths and distances.
+# Upper-case versions **E**, **J**, and **W** are similar to **e**, **j**, and **w**
+# but expect geographic azimuths and distances.
 
 fig = pygmt.Figure()
 fig.basemap(region=[0, 7, 0, 2], projection="x3c", frame=True)
@@ -55,10 +55,10 @@ fig.plot(x=6.5, y=1, style="w2.5/45/330+i1", fill="lightgray", pen="2p,black")
 fig.show()
 
 # %%
-# We can also plot symbols with varying parameters via defining those values in
-# a 2-D list or numpy array (``[[parameters]]`` for a single symbol or
-# ``[[parameters_1],[parameters_2],[parameters_i]]`` for several ones) or using
-# an appropriately formatted input file and passing it to ``data``.
+# We can also plot symbols with varying parameters via defining those values in a 2-D
+# list or numpy array (``[[parameters]]`` for a single symbol or
+# ``[[parameters_1],[parameters_2],[parameters_i]]`` for several ones) or using an
+# appropriately formatted input file and passing it to ``data``.
 #
 # The symbol parameters in the 2-D list or numpy array are defined as:
 #
@@ -66,9 +66,8 @@ fig.show()
 # - **j**: rotated rectangle, ``[[lon, lat, direction, width, height]]``
 # - **r**: rectangle, ``[[lon, lat, width, height]]``
 # - **R**: rounded rectangle, ``[[lon, lat, width, height, radius]]``
-# - **w**: pie wedge, ``[[lon, lat, diameter, startdir, stopdir]]``, the last
-#   two arguments are directions given in degrees counter-clockwise from
-#   horizontal
+# - **w**: pie wedge, ``[[lon, lat, diameter, startdir, stopdir]]``, the last two
+#   arguments are directions given in degrees counter-clockwise from horizontal
 
 fig = pygmt.Figure()
 fig.basemap(region=[0, 7, 0, 4], projection="x3c", frame=["xa1f0.2", "ya0.5f0.1"])

--- a/examples/gallery/symbols/multi_parameter_symbols.py
+++ b/examples/gallery/symbols/multi_parameter_symbols.py
@@ -31,7 +31,7 @@ import pygmt
 # - **R**: rounded rectangle, ``width/height/radius``
 # - **w**: pie wedge, ``diameter/startdir/stopdir``, the last two arguments are
 #   directions given in degrees counter-clockwise from horizontal. Append **+i** and
-#   the desired value to apply a inner diameter
+#   the desired value to apply a inner diameter.
 #
 # Upper-case versions **E**, **J**, and **W** are similar to **e**, **j**, and **w**
 # but expect geographic azimuths and distances.

--- a/examples/gallery/symbols/multi_parameter_symbols.py
+++ b/examples/gallery/symbols/multi_parameter_symbols.py
@@ -19,9 +19,9 @@ import pygmt
 
 # %%
 # We can plot multi-parameter symbols using the same symbol style. We need to define
-# locations (lon, lat) via the ``x`` and ``y`` parameters (scalar for a single symbol
-# or 1-D list for several ones) and two or three symbol parameters after those
-# shortcuts via the ``style`` parameter.
+# locations (lon, lat) via the ``x`` and ``y`` parameters (scalar for a single symbol or
+# 1-D list for several ones) and two or three symbol parameters after those shortcuts
+# via the ``style`` parameter.
 #
 # The multi-parameter symbols in the ``style`` parameter are defined as:
 #
@@ -30,8 +30,8 @@ import pygmt
 # - **r**: rectangle, ``width/height``
 # - **R**: rounded rectangle, ``width/height/radius``
 # - **w**: pie wedge, ``diameter/startdir/stopdir``, the last two arguments are
-#   directions given in degrees counter-clockwise from horizontal. Append **+i** and
-#   the desired value to apply a inner diameter.
+#   directions given in degrees counter-clockwise from horizontal. Append **+i** and the
+#   desired value to apply a inner diameter.
 #
 # Upper-case versions **E**, **J**, and **W** are similar to **e**, **j**, and **w**
 # but expect geographic azimuths and distances.

--- a/examples/gallery/symbols/multi_parameter_symbols.py
+++ b/examples/gallery/symbols/multi_parameter_symbols.py
@@ -31,7 +31,7 @@ import pygmt
 # - **R**: rounded rectangle, ``width/height/radius``
 # - **w**: pie wedge, ``diameter/startdir/stopdir``, the last two arguments are
 #   directions given in degrees counter-clockwise from horizontal. Append **+i**
-#   and the desired values to adde inner radius
+#   and the desired value to apply a inner diameter
 #
 # Upper-case versions **E**, **J**, and **W** are similar to **e**, **j**, and
 # **w** but expect geographic azimuths and distances.
@@ -49,8 +49,8 @@ fig.plot(x=3, y=1, style="r4/1.5", fill="dodgerblue", pen="2p,black")
 fig.plot(x=4.5, y=1, style="R1.25/4/0.5", fill="seagreen", pen="2p,black")
 # Pie wedge
 fig.plot(x=5.5, y=1, style="w2.5/45/330", fill="lightgray", pen="2p,black")
-# Pie wedge sector
-fig.plot(x=6.5, y=1, style="w2.5/45/330+i1c", fill="lightgray", pen="2p,black")
+# Ring sector
+fig.plot(x=6.5, y=1, style="w2.5/45/330+i1", fill="lightgray", pen="2p,black")
 
 fig.show()
 
@@ -71,7 +71,7 @@ fig.show()
 #   horizontal
 
 fig = pygmt.Figure()
-fig.basemap(region=[0, 6, 0, 4], projection="x3c", frame=["xa1f0.2", "ya0.5f0.1"])
+fig.basemap(region=[0, 7, 0, 4], projection="x3c", frame=["xa1f0.2", "ya0.5f0.1"])
 
 # Ellipse
 data = [[0.5, 1, 45, 3, 1], [0.5, 3, 135, 2, 1]]
@@ -88,6 +88,9 @@ fig.plot(data=data, style="R", fill="seagreen", pen="2p,black")
 # Pie wedge
 data = [[5.5, 1, 2.5, 45, 330], [5.5, 3, 1.5, 60, 300]]
 fig.plot(data=data, style="w", fill="lightgray", pen="2p,black")
+# Ring sector
+data = [[6.5, 1, 2.5, 45, 330], [6.5, 3, 1.5, 60, 300]]
+fig.plot(data=data, style="w+i1", fill="lightgray", pen="2p,black")
 
 fig.show()
 

--- a/examples/gallery/symbols/multi_parameter_symbols.py
+++ b/examples/gallery/symbols/multi_parameter_symbols.py
@@ -30,13 +30,14 @@ import pygmt
 # - **r**: rectangle, ``width/height``
 # - **R**: rounded rectangle, ``width/height/radius``
 # - **w**: pie wedge, ``diameter/startdir/stopdir``, the last two arguments are
-#   directions given in degrees counter-clockwise from horizontal
+#   directions given in degrees counter-clockwise from horizontal. Append **+i**
+#   and the desired values to adde inner radius
 #
 # Upper-case versions **E**, **J**, and **W** are similar to **e**, **j**, and
 # **w** but expect geographic azimuths and distances.
 
 fig = pygmt.Figure()
-fig.basemap(region=[0, 6, 0, 2], projection="x3c", frame=True)
+fig.basemap(region=[0, 7, 0, 2], projection="x3c", frame=True)
 
 # Ellipse
 fig.plot(x=0.5, y=1, style="e45/3/1", fill="orange", pen="2p,black")
@@ -48,6 +49,8 @@ fig.plot(x=3, y=1, style="r4/1.5", fill="dodgerblue", pen="2p,black")
 fig.plot(x=4.5, y=1, style="R1.25/4/0.5", fill="seagreen", pen="2p,black")
 # Pie wedge
 fig.plot(x=5.5, y=1, style="w2.5/45/330", fill="lightgray", pen="2p,black")
+# Pie wedge sector
+fig.plot(x=6.5, y=1, style="w2.5/45/330+i1c", fill="lightgray", pen="2p,black")
 
 fig.show()
 

--- a/examples/gallery/symbols/multi_parameter_symbols.py
+++ b/examples/gallery/symbols/multi_parameter_symbols.py
@@ -31,7 +31,7 @@ import pygmt
 # - **R**: rounded rectangle, ``width/height/radius``
 # - **w**: pie wedge, ``diameter/startdir/stopdir``, the last two arguments are
 #   directions given in degrees counter-clockwise from horizontal. Append **+i** and the
-#   desired value to apply a inner diameter.
+#   desired value to apply an inner diameter.
 #
 # Upper-case versions **E**, **J**, and **W** are similar to **e**, **j**, and **w**
 # but expect geographic azimuths and distances.


### PR DESCRIPTION
**Description of proposed changes**

This PR suggests extending the Gallery example "Multi-parameter symbols" to show applying an  inner diameter (**+i**) to a pie wedge (**w**). If there is a better / clearer term for "ring sector" I am happy to improve this!

<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**: https://pygmt-dev--3624.org.readthedocs.build/en/3624/gallery/symbols/multi_parameter_symbols.html


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
