### PR TITLE
DOC/Gallery example "Scatter plot with histograms": General improvements

### DIFF
--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -25,7 +25,7 @@ xmax = np.ceil(x.max()) + 0.5
 ymin = np.floor(y.min()) - 0.5
 ymax = np.ceil(y.max()) + 0.5
 
-# Set fill color for symbols and bars
+# Set fill color for symbols and bars.
 fill = "seagreen"
 
 # Set the dimensions of the scatter plot.
@@ -38,10 +38,10 @@ fig.basemap(
     frame=["WSrt", "af"],
 )
 
-# Plot data points as circles with a diameter of 0.15 centimeters
+# Plot data points as circles with a diameter of 0.15 centimeters.
 fig.plot(x=x, y=y, style="c0.15c", fill=fill, transparency=50)
 
-# Shift the plot origin and add top margin histogram
+# Shift the plot origin and add top margin histogram.
 fig.shift_origin(yshift=height + 0.25)
 
 fig.histogram(
@@ -56,7 +56,7 @@ fig.histogram(
     series=0.2,
 )
 
-# Shift the plot origin and add right margin histogram
+# Shift the plot origin and add right margin histogram.
 fig.shift_origin(yshift=-height - 0.25, xshift=width + 0.25)
 
 # Plot the horizontal histogram.

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -35,7 +35,7 @@ fig = pygmt.Figure()
 fig.basemap(
     region=[xmin, xmax, ymin, ymax],
     projection=f"X{width}/{height}",
-    frame=["WSrt", "xaf", "yaf"],
+    frame=["WSrt", "af"],
 )
 
 # Plot data points as circles with a diameter of 0.15 centimeters
@@ -46,7 +46,7 @@ fig.shift_origin(yshift=height + 0.25)
 
 fig.histogram(
     projection=f"X{width}/3",
-    frame=["Wsrt", "xaf", "yaf+lCounts"],
+    frame=["Wsrt", "xf", "yaf+lCounts"],
     # Give the same value for ymin and ymax to have them calculated automatically.
     region=[xmin, xmax, 0, 0],
     data=x,
@@ -64,7 +64,7 @@ fig.histogram(
     projection=f"X3/{height}",
     # Note that the y-axis annotations, ticks, and label "Counts" are shown in x-axis
     # direction due to the rotation caused by horizontal=True
-    frame=["wSrt", "xf", "y+lCounts"],
+    frame=["wSrt", "xf", "yaf+lCounts"],
     region=[ymin, ymax, 0, 0],
     data=y,
     fill=fill,

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -38,7 +38,8 @@ fig.basemap(
     frame=["WSrt", "af"],
 )
 
-# Plot data points as circles with a diameter of 0.15 centimeters.
+# Plot data points as circles with a diameter of 0.15 centimeters and set transparency
+# level for all circles to deal with overplotting.
 fig.plot(x=x, y=y, style="c0.15c", fill=fill, transparency=50)
 
 # Shift the plot origin and add top margin histogram.

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -28,14 +28,13 @@ ymax = np.ceil(y.max()) + 0.5
 # Set fill color for symbols and bars
 fill = "seagreen"
 
-# Set plot size.
-# The scatter plot is 10x10, and the histograms are 10x3 and 3x10, respectively.
-width, height = 10, 3
+# Set the dimensions of the scatter plot.
+width, height = 10, 8
 
 fig = pygmt.Figure()
 fig.basemap(
     region=[xmin, xmax, ymin, ymax],
-    projection=f"X{width}/{width}",
+    projection=f"X{width}/{height}",
     frame=["WSrt", "xaf", "yaf"],
 )
 
@@ -43,10 +42,10 @@ fig.basemap(
 fig.plot(x=x, y=y, style="c0.15c", fill=fill, transparency=50)
 
 # Shift the plot origin and add top margin histogram
-fig.shift_origin(yshift=width + 0.25)
+fig.shift_origin(yshift=height + 0.25)
 
 fig.histogram(
-    projection=f"X{width}/{height}",
+    projection=f"X{width}/3",
     frame=["Wsrt", "xaf", "yaf+lCounts"],
     # Give the same value for ymin and ymax to have them calculated automatically.
     region=[xmin, xmax, 0, 0],
@@ -58,11 +57,11 @@ fig.histogram(
 )
 
 # Shift the plot origin and add right margin histogram
-fig.shift_origin(yshift=-width - 0.25, xshift=width + 0.25)
+fig.shift_origin(yshift=-height - 0.25, xshift=width + 0.25)
 
 fig.histogram(
     horizontal=True,
-    projection=f"X{height}/{width}",
+    projection=f"X3/{height}",
     # Note that the y-axis annotations, ticks, and label "Counts" are shown in x-axis
     # direction due to the rotation caused by horizontal=True
     frame=["wSrt", "xf", "y+lCounts"],

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -58,7 +58,7 @@ fig.shift_origin(yshift=f"-{fig_width + 0.25}c", xshift=f"{fig_width + 0.25}c")
 fig.histogram(
     horizontal=True,
     projection=f"X2c/{fig_width}c",
-    # Note that the y-axis annotation "Counts" is shown in x-axis direction due to the
+    # Note that the y-axis label "Counts" is shown in x-axis direction due to the
     # rotation caused by horizontal=True
     frame=["wSrt", "xf1", "y+lCounts"],
     region=[-xymax - 0.5, xymax + 0.5, 0, 0],

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -5,7 +5,7 @@ Scatter plot with histograms
 To create a scatter plot with histograms at the sides of the plot one can use
 :meth:`pygmt.Figure.plot` in combination with :meth:`pygmt.Figure.histogram`.
 The positions of the histograms are plotte by offsetting them from the main
-scatter plot figure using :meth:`pygmt.Figure.shift_origin`.
+scatter plot using :meth:`pygmt.Figure.shift_origin`.
 """
 
 # %%
@@ -21,7 +21,7 @@ y = rng.normal(loc=0, scale=1, size=1000)
 # Get axis limits
 xymax = max(np.max(np.abs(x)), np.max(np.abs(y)))
 
-# Plot width
+# Set plot width
 fig_width = 10
 
 # Set fill color for symbols and bars
@@ -41,7 +41,7 @@ fig.plot(x=x, y=y, style="c0.15c", fill=fillcol, transparency=50)
 fig.shift_origin(yshift=f"{fig_width + 0.25}c")
 
 fig.histogram(
-    projection="X10c/2c",
+    projection=f"X{fig_width}c/2c",
     frame=["Wsrt", "xf1", "y+lCounts"],
     # Give the same value for ymin and ymax to have them calculated automatically
     region=[-xymax - 0.5, xymax + 0.5, 0, 0],
@@ -57,7 +57,7 @@ fig.shift_origin(yshift=f"-{fig_width + 0.25}c", xshift=f"{fig_width + 0.25}c")
 
 fig.histogram(
     horizontal=True,
-    projection="X2c/10c",
+    projection=f"X2c/{fig_width}c",
     # Note that the y-axis annotation "Counts" is shown in x-axis direction due to the
     # rotation caused by horizontal=True
     frame=["wSrt", "xf1", "y+lCounts"],

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -13,8 +13,8 @@ import numpy as np
 import pygmt
 
 # Generate random x, y coordinates from a standard normal distribution.
-# x values are centered on 0 with a standard deviation of 1, and y values are centered on 30 with a
-# standard deviation of 2.
+# x values are centered on 0 with a standard deviation of 1, and y values are centered
+# on 30 with a standard deviation of 2.
 rng = np.random.default_rng()
 x = rng.normal(loc=0, scale=1, size=1000)
 y = rng.normal(loc=30, scale=2, size=1000)

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -4,69 +4,73 @@ Scatter plot with histograms
 
 To create a scatter plot with histograms at the sides of the plot one can use
 :meth:`pygmt.Figure.plot` in combination with :meth:`pygmt.Figure.histogram`.
-The positions of the histograms are plotted by offsetting them from the main
-scatter plot using :meth:`pygmt.Figure.shift_origin`.
+The positions of the histograms are plotted by offsetting them from the main scatter
+plot using :meth:`pygmt.Figure.shift_origin`.
 """
 
 # %%
 import numpy as np
 import pygmt
 
-# Generate random data from a standard normal distribution centered on 0 with a
-# standard deviation of 1
-rng = np.random.default_rng(seed=19680801)
+# Generate random x, y coordinates from a standard normal distribution.
+# x are centered on 0 with a standard deviation of 1, and y are centered on 30 with a
+# standard deviation of 2.
+rng = np.random.default_rng()
 x = rng.normal(loc=0, scale=1, size=1000)
-y = rng.normal(loc=0, scale=1, size=1000)
+y = rng.normal(loc=30, scale=2, size=1000)
 
-# Get axis limits
-xymax = max(np.max(np.abs(x)), np.max(np.abs(y)))
-
-# Set plot width
-fig_width = 10
+# Get axis limits from the data limits. Extend the limits by 0.5 to add some margin.
+xmin = np.floor(x.min()) - 0.5
+xmax = np.ceil(x.max()) + 0.5
+ymin = np.floor(y.min()) - 0.5
+ymax = np.ceil(y.max()) + 0.5
 
 # Set fill color for symbols and bars
-fillcol = "seagreen"
+fill = "seagreen"
+
+# Set plot size.
+# The scatter plot is 10x10, and the histograms are 10x3 and 3x10, respectively.
+width, height = 10, 3
 
 fig = pygmt.Figure()
 fig.basemap(
-    region=[-xymax - 0.5, xymax + 0.5, -xymax - 0.5, xymax + 0.5],
-    projection=f"X{fig_width}c/{fig_width}c",
-    frame=["WSrt", "a1"],
+    region=[xmin, xmax, ymin, ymax],
+    projection=f"X{width}/{width}",
+    frame=["WSrt", "xaf", "yaf"],
 )
 
 # Plot data points as circles with a diameter of 0.15 centimeters
-fig.plot(x=x, y=y, style="c0.15c", fill=fillcol, transparency=50)
+fig.plot(x=x, y=y, style="c0.15c", fill=fill, transparency=50)
 
 # Shift the plot origin and add top margin histogram
-fig.shift_origin(yshift=f"{fig_width + 0.25}c")
+fig.shift_origin(yshift=width + 0.25)
 
 fig.histogram(
-    projection=f"X{fig_width}c/2c",
-    frame=["Wsrt", "xf1", "y+lCounts"],
-    # Give the same value for ymin and ymax to have them calculated automatically
-    region=[-xymax - 0.5, xymax + 0.5, 0, 0],
+    projection=f"X{width}/{height}",
+    frame=["Wsrt", "xaf", "yaf+lCounts"],
+    # Give the same value for ymin and ymax to have them calculated automatically.
+    region=[xmin, xmax, 0, 0],
     data=x,
-    fill=fillcol,
+    fill=fill,
     pen="0.1p,white",
     histtype=0,
-    series=0.1,
+    series=0.2,
 )
 
 # Shift the plot origin and add right margin histogram
-fig.shift_origin(yshift=f"-{fig_width + 0.25}c", xshift=f"{fig_width + 0.25}c")
+fig.shift_origin(yshift=-width - 0.25, xshift=width + 0.25)
 
 fig.histogram(
     horizontal=True,
-    projection=f"X2c/{fig_width}c",
+    projection=f"X{height}/{width}",
     # Note that the y-axis annotations, ticks, and label "Counts" are shown in x-axis
     # direction due to the rotation caused by horizontal=True
-    frame=["wSrt", "xf1", "y+lCounts"],
-    region=[-xymax - 0.5, xymax + 0.5, 0, 0],
+    frame=["wSrt", "xf", "y+lCounts"],
+    region=[ymin, ymax, 0, 0],
     data=y,
-    fill=fillcol,
+    fill=fill,
     pen="0.1p,white",
     histtype=0,
-    series=0.1,
+    series=0.2,
 )
-
 fig.show()

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -2,19 +2,18 @@
 Scatter plot with histograms
 ============================
 
-To create a scatter plot with histograms at the sides of the plot one
-can use :meth:`pygmt.Figure.plot` in combination with
-:meth:`pygmt.Figure.histogram`. The positions of the histograms are plotted
-by offsetting them from the main scatter plot figure using
-:meth:`pygmt.Figure.shift_origin`.
+To create a scatter plot with histograms at the sides of the plot one can use
+:meth:`pygmt.Figure.plot` in combination with :meth:`pygmt.Figure.histogram`.
+The positions of the histograms are plotte by offsetting them from the main
+scatter plot figure using :meth:`pygmt.Figure.shift_origin`.
 """
 
 # %%
 import numpy as np
 import pygmt
 
-# Generate random data from a standard normal distribution centered on 0
-# with a standard deviation of 1
+# Generate random data from a standard normal distribution centered on 0 with a
+# standard deviation of 1
 rng = np.random.default_rng(seed=19680801)
 x = rng.normal(loc=0, scale=1, size=1000)
 y = rng.normal(loc=0, scale=1, size=1000)
@@ -22,27 +21,29 @@ y = rng.normal(loc=0, scale=1, size=1000)
 # Get axis limits
 xymax = max(np.max(np.abs(x)), np.max(np.abs(y)))
 
+# Plot width
+fig_width = 10
+
+# Set fill color for symbols and bars
+fillcol = "seagreen"
 
 fig = pygmt.Figure()
 fig.basemap(
     region=[-xymax - 0.5, xymax + 0.5, -xymax - 0.5, xymax + 0.5],
-    projection="X10c/10c",
+    projection=f"X{fig_width}c/{fig_width}c",
     frame=["WSrt", "a1"],
 )
-
-fillcol = "seagreen"
 
 # Plot data points as circles with a diameter of 0.15 centimeters
 fig.plot(x=x, y=y, style="c0.15c", fill=fillcol, transparency=50)
 
 # Shift the plot origin and add top margin histogram
-fig.shift_origin(yshift="10.25c")
+fig.shift_origin(yshift=f"{fig_width + 0.25}c")
 
 fig.histogram(
     projection="X10c/2c",
     frame=["Wsrt", "xf1", "y+lCounts"],
-    # Give the same value for ymin and ymax to have ymin and ymax
-    # calculated automatically
+    # Give the same value for ymin and ymax to have them calculated automatically
     region=[-xymax - 0.5, xymax + 0.5, 0, 0],
     data=x,
     fill=fillcol,
@@ -52,13 +53,13 @@ fig.histogram(
 )
 
 # Shift the plot origin and add right margin histogram
-fig.shift_origin(yshift="-10.25c", xshift="10.25c")
+fig.shift_origin(yshift=f"-{fig_width + 0.25}c", xshift=f"{fig_width + 0.25}c")
 
 fig.histogram(
     horizontal=True,
     projection="X2c/10c",
-    # Note that the y-axis annotation "Counts" is shown in x-axis direction
-    # due to the rotation caused by horizontal=True
+    # Note that the y-axis annotation "Counts" is shown in x-axis direction due to the
+    # rotation caused by horizontal=True
     frame=["wSrt", "xf1", "y+lCounts"],
     region=[-xymax - 0.5, xymax + 0.5, 0, 0],
     data=y,

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -59,11 +59,11 @@ fig.histogram(
 # Shift the plot origin and add right margin histogram
 fig.shift_origin(yshift=-height - 0.25, xshift=width + 0.25)
 
+# Plot the horizontal histogram.
 fig.histogram(
     horizontal=True,
     projection=f"X3/{height}",
-    # Note that the y-axis annotations, ticks, and label "Counts" are shown in x-axis
-    # direction due to the rotation caused by horizontal=True
+    # Note that the x- and y-axis are flipped, with y-axis plotted horizontally.
     frame=["wSrt", "xf", "yaf+lCounts"],
     region=[ymin, ymax, 0, 0],
     data=y,

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -4,7 +4,7 @@ Scatter plot with histograms
 
 To create a scatter plot with histograms at the sides of the plot one can use
 :meth:`pygmt.Figure.plot` in combination with :meth:`pygmt.Figure.histogram`.
-The positions of the histograms are plotte by offsetting them from the main
+The positions of the histograms are plotted by offsetting them from the main
 scatter plot using :meth:`pygmt.Figure.shift_origin`.
 """
 

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -3,9 +3,9 @@ Scatter plot with histograms
 ============================
 
 To create a scatter plot with histograms at the sides of the plot one can use
-:meth:`pygmt.Figure.plot` in combination with :meth:`pygmt.Figure.histogram`.
-The positions of the histograms are plotted by offsetting them from the main scatter
-plot using :meth:`pygmt.Figure.shift_origin`.
+:meth:`pygmt.Figure.plot` in combination with :meth:`pygmt.Figure.histogram`. The
+positions of the histograms are plotted by offsetting them from the main scatter plot
+using :meth:`pygmt.Figure.shift_origin`.
 """
 
 # %%
@@ -13,7 +13,7 @@ import numpy as np
 import pygmt
 
 # Generate random x, y coordinates from a standard normal distribution.
-# x are centered on 0 with a standard deviation of 1, and y are centered on 30 with a
+# x values are centered on 0 with a standard deviation of 1, and y values are centered on 30 with a
 # standard deviation of 2.
 rng = np.random.default_rng()
 x = rng.normal(loc=0, scale=1, size=1000)
@@ -63,7 +63,7 @@ fig.shift_origin(yshift=-height - 0.25, xshift=width + 0.25)
 fig.histogram(
     horizontal=True,
     projection=f"X3/{height}",
-    # Note that the x- and y-axis are flipped, with y-axis plotted horizontally.
+    # Note that the x- and y-axis are flipped, with the y-axis plotted horizontally.
     frame=["wSrt", "xf", "yaf+lCounts"],
     region=[ymin, ymax, 0, 0],
     data=y,

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -58,8 +58,8 @@ fig.shift_origin(yshift=f"-{fig_width + 0.25}c", xshift=f"{fig_width + 0.25}c")
 fig.histogram(
     horizontal=True,
     projection=f"X2c/{fig_width}c",
-    # Note that the y-axis label "Counts" is shown in x-axis direction due to the
-    # rotation caused by horizontal=True
+    # Note that the y-axis annotations, ticks, and label "Counts" are shown in x-axis
+    # direction due to the rotation caused by horizontal=True
     frame=["wSrt", "xf1", "y+lCounts"],
     region=[-xymax - 0.5, xymax + 0.5, 0, 0],
     data=y,

--- a/examples/tutorials/advanced/cartesian_histograms.py
+++ b/examples/tutorials/advanced/cartesian_histograms.py
@@ -79,8 +79,8 @@ fig.histogram(
     fill="red3",
     pen="1p,darkgray,solid",
     histtype=0,
-    # Use horizontal bars. Note taht the x- and y-axis are flipped, with the x-axis plotted
-    # vertically and the y-axis plotted horizontally.
+    # Use horizontal bars. Note taht the x- and y-axis are flipped, with the x-axis
+    # plotted vertically and the y-axis plotted horizontally.
     horizontal=True,
 )
 

--- a/examples/tutorials/advanced/cartesian_histograms.py
+++ b/examples/tutorials/advanced/cartesian_histograms.py
@@ -79,8 +79,8 @@ fig.histogram(
     fill="red3",
     pen="1p,darkgray,solid",
     histtype=0,
-    # Use horizontal bars. Note taht the x- and y-axis are flipped, with x-axis plotted
-    # vertically and y-axis plotted horizontally.
+    # Use horizontal bars. Note taht the x- and y-axis are flipped, with the x-axis plotted
+    # vertically and the y-axis plotted horizontally.
     horizontal=True,
 )
 

--- a/examples/tutorials/advanced/cartesian_histograms.py
+++ b/examples/tutorials/advanced/cartesian_histograms.py
@@ -79,9 +79,8 @@ fig.histogram(
     fill="red3",
     pen="1p,darkgray,solid",
     histtype=0,
-    # Use horizontal bars
-    # Please note the flip of the x and y axes regarding annotations, ticks, gridlines,
-    # and labels
+    # Use horizontal bars. Note taht the x- and y-axis are flipped, with x-axis plotted
+    # vertically and y-axis plotted horizontally.
     horizontal=True,
 )
 

--- a/examples/tutorials/advanced/cartesian_histograms.py
+++ b/examples/tutorials/advanced/cartesian_histograms.py
@@ -79,7 +79,7 @@ fig.histogram(
     fill="red3",
     pen="1p,darkgray,solid",
     histtype=0,
-    # Use horizontal bars. Note taht the x- and y-axis are flipped, with the x-axis
+    # Use horizontal bars. Note that the x- and y-axis are flipped, with the x-axis
     # plotted vertically and the y-axis plotted horizontally.
     horizontal=True,
 )

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -104,8 +104,9 @@ def histogram(self, data, **kwargs):
         Draw a stairs-step diagram which does not include the internal bars
         of the default histogram.
     horizontal : bool
-        Plot the histogram using horizontal bars instead of the
-        default vertical bars.
+        Plot the histogram horizontally from x = 0 [Default is vertically from y = 0].
+        The plot dimensions remain the same, but the two axes are flipped, i.e., the
+        x-axis is plotted vertically and the y-axis is plotted horizontally.
     series : int, str, or list
         [*min*\ /*max*\ /]\ *inc*\ [**+n**\ ].
         Set the interval for the width of each bar in the histogram.


### PR DESCRIPTION
**Description of proposed changes**

This PR contains general improvements of the Gallery example "Scatter plot with histograms":
- Introduce / use a variable for `xshift` and `yshift` to make them more flexible (but maybe reduced readability?) Feedback is welcome (:
- Rewrap to 88 chars
- Improve / correct a few comments

**Preview**: https://pygmt-dev--3628.org.readthedocs.build/en/3628/gallery/histograms/scatter_and_histograms.html


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
