### PR TITLE
WIP: CI: Enable pytest-xdist in the Benchmarks workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,8 +15,8 @@ on:
   # Run in PRs but only if the PR has the 'run/benchmark' label
   pull_request:
     types: [ opened, reopened, labeled, synchronize ]
-  # 'workflow_dispatch' allows CodSpeed to trigger backtest performance analysis
-  # in order to generate initial data.
+  # 'workflow_dispatch' allows CodSpeed to trigger backtest performance analysis in
+  # order to generate initial data.
   workflow_dispatch:
 
 concurrency:
@@ -69,6 +69,7 @@ jobs:
             pytest
             pytest-codspeed
             pytest-mpl
+            pytest-xdist
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub
@@ -91,4 +92,4 @@ jobs:
         with:
           # 'bash -el -c' is needed to use the custom shell.
           # See https://github.com/CodSpeedHQ/action/issues/65.
-          run: bash -el -c "python -c \"import pygmt; pygmt.show_versions()\"; PYGMT_USE_EXTERNAL_DISPLAY=false python -m pytest -r P --pyargs pygmt --codspeed --override-ini addopts='--verbose'"
+          run: bash -el -c "python -c \"import pygmt; pygmt.show_versions()\"; PYGMT_USE_EXTERNAL_DISPLAY=false python -m pytest -r P --pyargs pygmt --codspeed -n auto --override-ini addopts='--verbose'"


### PR DESCRIPTION
**Description of proposed changes**

With `pytest-xdist`, benchmarking is 2x faster, but there is a crash, so we can't enable the `pytest-xdist` plugin now.