### PR TITLE
Document Continuous Benchmarking in Maintainers Guides

### DIFF
--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -126,9 +126,12 @@ We use the [CodSpeed](https://codspeed.io) service to continuously track PyGMT's
 performance. The `pytest-codspeed` plugin collects benchmark data and uploads it to the
 CodSpeed server, where results are available at <https://codspeed.io/GenericMappingTools/pygmt>.
 
-Benchmarking is handled through the `benchmarks.yml` GitHub Actions workflow. To include
-a new test in the benchmark suite, apply the `@pytest.mark.benchmark` decorator to the
-test function.
+Benchmarking is handled through the `benchmarks.yml` GitHub Actions workflow. It's
+automatically executed when a pull request is merged into the main branch. To trigger
+benchmarking in a pull request, add the `run/benchmark` label to the pull request.
+
+To include a new test in the benchmark suite, apply the `@pytest.mark.benchmark`
+decorator to a test function.
 
 ## Dependencies Policy
 


### PR DESCRIPTION
**Description of proposed changes**

We have been using the CodSpeed service for about 1 year since #2908. The service seems stable and can help us track the performance.

This PR documents "Continuous Benchmarking" in the "Maintainers Guides", then we should be able to close https://github.com/GenericMappingTools/pygmt/issues/2910.

**Preview**: https://pygmt-dev--3631.org.readthedocs.build/en/3631/maintenance.html