### PR TITLE
Update the Dependencies Policy section in Maintainers Guides

### DIFF
--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -124,14 +124,9 @@ to change the default behaviour at <https://docs.readthedocs.io/en/stable/config
 ## Dependencies Policy
 
 PyGMT has adopted [SPEC 0](https://scientific-python.org/specs/spec-0000/) alongside the
-rest of the scientific Python ecosystem, and therefore:
-
-* Support for Python versions be dropped 3 years after their initial release.
-* Support for core package dependencies (NumPy, pandas, Xarray) be dropped 2 years after
-  their initial release.
-
-Similarly, the PyGMT team has decided to discontinue support for GMT versions 3 years
-after their initial release.
+rest of the scientific Python ecosystem, and made a few extensions based on the needs of
+the project. Please see [Minimum Supported Versions](minversions.md) for the detailed
+policy and the minimum supported versions of GMT, Python and core package dependencies.
 
 In `pyproject.toml`, the `requires-python` key should be set to the minimum supported
 version of Python. Minimum supported versions of GMT, Python and core package


### PR DESCRIPTION
In #3616, we documented our policy for optional dependencies, but forgot to update the similar paragraphs in our Maintainers Guides.

This PR shortens the description in the Maintainers Guides to avoid documenting the policy in multiple places. The new description is copied from the [README.md](https://github.com/GenericMappingTools/pygmt#minimum-supported-versions) file.

**Preview**: https://pygmt-dev--3632.org.readthedocs.build/en/3632/maintenance.html#dependencies-policy