### PR TITLE
DOC/Gallery example "Configuring PyGMT defaults": General improvements

### DIFF
--- a/examples/tutorials/advanced/configuration.py
+++ b/examples/tutorials/advanced/configuration.py
@@ -2,8 +2,7 @@
 Configuring PyGMT defaults
 ==========================
 
-Default GMT parameters can be set globally or locally using
-:class:`pygmt.config`.
+Default GMT parameters can be set globally or locally using :class:`pygmt.config`.
 """
 
 # %%
@@ -13,9 +12,9 @@ import pygmt
 # Configuring default GMT parameters
 # ----------------------------------
 #
-# Users can override default parameters either temporarily (locally) or
-# permanently (globally) using :class:`pygmt.config`. The full list of default
-# parameters that can be changed can be found at :gmt-docs:`gmt.conf.html`.
+# Users can override default parameters either temporarily (locally) or permanently
+# (globally) using :class:`pygmt.config`. The full list of default parameters that can
+# be changed can be found at :gmt-docs:`gmt.conf.html`.
 #
 # We demonstrate the usage of :class:`pygmt.config` by configuring a map plot.
 
@@ -31,18 +30,17 @@ fig.show()
 # Globally overriding defaults
 # ----------------------------
 #
-# The ``MAP_FRAME_TYPE`` parameter specifies the style of map frame to use, of
-# which there are 5 options: ``fancy`` (default, see above), ``fancy+``,
-# ``plain``, ``graph`` (which does not apply to geographical maps) and
-# ``inside``.
+# The ``MAP_FRAME_TYPE`` parameter specifies the style of map frame to use, of which
+# there are 5 options: ``fancy`` (default, see above), ``fancy+``, ``plain``, ``graph``
+# (which does not apply to geographical maps) and ``inside``.
 #
-# The ``FORMAT_GEO_MAP`` parameter controls the format of geographical tick
-# annotations. The default uses degrees and minutes. Here we specify the ticks
-# to be a decimal number of degrees.
+# The ``FORMAT_GEO_MAP`` parameter controls the format of geographical tick annotations.
+# The default uses degrees and minutes. Here we specify the ticks to be a decimal number
+# of degrees.
 
 fig = pygmt.Figure()
 
-# Configuration for the 'current figure'.
+# Configuration for the 'current figure'
 pygmt.config(MAP_FRAME_TYPE="plain")
 pygmt.config(FORMAT_GEO_MAP="ddd.xx")
 
@@ -56,14 +54,13 @@ fig.show()
 # Locally overriding defaults
 # ---------------------------
 #
-# It is also possible to temporarily override the default parameters, which is
-# very useful for limiting the scope of changes to a particular plot.
-# :class:`pygmt.config` is implemented as a context manager, which handles the
-# setup and teardown of a GMT session. Python users are likely familiar with
-# the ``with open(...) as file:`` snippet, which returns a ``file`` context
-# manager. In this way, it can be used to override a parameter for a single
-# command, or a sequence of commands. An application of :class:`pygmt.config`
-# as a context manager is shown below:
+# It is also possible to temporarily override the default parameters, which is very
+# useful for limiting the scope of changes to a particular plot. :class:`pygmt.config`
+# is implemented as a context manager, which handles the setup and teardown of a GMT
+# session. Python users are likely familiar with the ``with open(...) as file:``
+# snippet, which returns a ``file`` context manager. In this way, it can be used to
+# override a parameter for a single command, or a sequence of commands. An application
+# of :class:`pygmt.config` as a context manager is shown below:
 
 fig = pygmt.Figure()
 
@@ -72,8 +69,8 @@ with pygmt.config(MAP_FRAME_TYPE="fancy+"):
     fig.basemap(region=[115, 119.5, 4, 7.5], projection="M10c", frame=True)
 fig.coast(land="black", water="skyblue")
 
-# Shift plot origin down by 10cm to plot another map
-fig.shift_origin(yshift="-10c")
+# Shift plot origin down by the hight of the figure to plot another map
+fig.shift_origin(yshift="-h")
 
 # This figure retains the default "fancy" frame
 fig.basemap(region=[115, 119.5, 4, 7.5], projection="M10c", frame=True)

--- a/examples/tutorials/advanced/configuration.py
+++ b/examples/tutorials/advanced/configuration.py
@@ -69,7 +69,7 @@ with pygmt.config(MAP_FRAME_TYPE="fancy+"):
     fig.basemap(region=[115, 119.5, 4, 7.5], projection="M10c", frame=True)
 fig.coast(land="black", water="skyblue")
 
-# Shift plot origin down by the hight of the figure to plot another map
+# Shift plot origin down by the height of the figure to plot another map
 fig.shift_origin(yshift="-h")
 
 # This figure retains the default "fancy" frame


### PR DESCRIPTION
**Description of proposed changes**

This PR contains general improvements of the advanced Tutorial "Configuring PyGMT defaults":
- Make argument passed to `yshift` flexible
- Re-wrapp to 88 chars

**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
