### PR TITLE
Pin numpy<2 in ci_tests_legacy.yaml

### DIFF
--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -62,7 +62,7 @@ jobs:
             python=3.10
             gmt=${{ matrix.gmt_version }}
             ghostscript<10
-            numpy
+            numpy<2
             pandas
             xarray
             netCDF4

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -12,7 +12,7 @@ on:
   # push:
   #   branches: [ main ]
   # Uncomment the 'pull_request' line below to trigger the workflow in PR
-  # pull_request:
+  pull_request:
     # types: [ready_for_review]
     # paths:
     #  - 'pygmt/**'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -12,7 +12,7 @@ on:
   # push:
   #   branches: [ main ]
   # Uncomment the 'pull_request' line below to trigger the workflow in PR
-  pull_request:
+  # pull_request:
     # types: [ready_for_review]
     # paths:
     #  - 'pygmt/**'

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ doctest: _runtest
 # run tests without image comparisons
 # run pytest without the --mpl option to disable image comparisons
 # use '-o addopts' to override 'addopts' settings in pyproject.toml file
-test_no_images: PYTEST_ARGS=-o addopts="--verbose --durations=0 --durations-min=0.2 --doctest-modules"
+test_no_images: PYTEST_ARGS=-o addopts="--verbose --color=yes --durations=0 --durations-min=0.2 --doctest-modules"
 test_no_images: _runtest
 
 format:


### PR DESCRIPTION
**Description of proposed changes**

The `ci_test_legacy.yaml` GitHub workflow has been failing since last month with a TypeError, e.g. at https://github.com/GenericMappingTools/pygmt/actions/runs/11450983970/job/31859442362#step:6:1474:

```python-traceback
___________________ test_geopandas_plot3d_non_default_circle ___________________

args = (), kwargs = {}

    def wrapper(*args, **kwargs):
>       store.return_value[test_name] = obj(*args, **kwargs)

../../../../micromamba/envs/pygmt/lib/python3.10/site-packages/pytest_mpl/plugin.py:125: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../pygmt/tests/test_geopandas.py:145: in test_geopandas_plot3d_non_default_circle
    multipoint = shapely.geometry.MultiPoint([(0.5, 0.5, 0.5), (1.5, 1.5, 1.5)])
../../../../micromamba/envs/pygmt/lib/python3.10/site-packages/shapely/geometry/multipoint.py:62: in __new__
    return shapely.multipoints(subs)
../../../../micromamba/envs/pygmt/lib/python3.10/site-packages/shapely/decorators.py:77: in wrapped
    return func(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

geometries = array([<POINT Z (0.5 0.5 0.5)>, <POINT Z (1.5 1.5 1.5)>], dtype=object)
indices = None, out = None, kwargs = {}, typ = <GeometryType.MULTIPOINT: 4>

    @multithreading_enabled
    def multipoints(geometries, indices=None, out=None, **kwargs):
        """Create multipoints from arrays of points
    
        Parameters
        ----------
        geometries : array_like
            An array of points or coordinates (see points).
        indices : array_like, optional
            Indices into the target array where input geometries belong. If
            provided, both geometries and indices should be 1D and have matching
            sizes. Indices should be in increasing order. Missing indices result
            in a ValueError unless ``out`` is  provided, in which case the original
            value in ``out`` is kept.
        out : ndarray, optional
            An array (with dtype object) to output the geometries into.
        **kwargs
            See :ref:`NumPy ufunc docs <ufuncs.kwargs>` for other keyword arguments.
            Ignored if ``indices`` is provided.
    
        Examples
        --------
        Multipoints are constructed from points:
    
        >>> point_1 = points([1, 1])
        >>> point_2 = points([2, 2])
        >>> multipoints([point_1, point_2])
        <MULTIPOINT (1 1, 2 2)>
        >>> multipoints([[point_1, point_2], [point_2, None]]).tolist()
        [<MULTIPOINT (1 1, 2 2)>, <MULTIPOINT (2 2)>]
    
        Or from coordinates directly:
    
        >>> multipoints([[0, 0], [2, 2], [3, 3]])
        <MULTIPOINT (0 0, 2 2, 3 3)>
    
        Multiple multipoints of different sizes can be constructed efficiently using the
        ``indices`` keyword argument:
    
        >>> multipoints([point_1, point_2, point_2], indices=[0, 0, 1]).tolist()
        [<MULTIPOINT (1 1, 2 2)>, <MULTIPOINT (2 2)>]
    
        Missing input values (``None``) are ignored and may result in an
        empty multipoint:
    
        >>> multipoints([None])
        <MULTIPOINT EMPTY>
        >>> multipoints([point_1, None], indices=[0, 0]).tolist()
        [<MULTIPOINT (1 1)>]
        >>> multipoints([point_1, None], indices=[0, 1]).tolist()
        [<MULTIPOINT (1 1)>, <MULTIPOINT EMPTY>]
        """
        typ = GeometryType.MULTIPOINT
        geometries = np.asarray(geometries)
        if not isinstance(geometries, Geometry) and np.issubdtype(
            geometries.dtype, np.number
        ):
            geometries = points(geometries)
        if indices is None:
>           return lib.create_collection(geometries, typ, out=out, **kwargs)
E           TypeError: ufunc 'create_collection' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''

```

The solution upstream at shapely https://github.com/shapely/shapely/issues/2098 is to upgrade to shapely 2.0.6 to deal with the incompatibilty with numpy 2.1. But I think we should just test on `numpy<2` since the legacy tests are meant to test old versions.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Also, I've cherry-picked commit 12630755aba4b1274a5e088df08ce2ef198d2d02 from #3639 here so that the terminal outputs for the legacy tests are colored (as per #3330).

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
