### PR TITLE
Remove the sg_execution_times.rst file auto-generated by sphinx-gallery

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -55,7 +55,5 @@ server:
 clean:
 	rm -rf $(BUILDDIR)
 	rm -rf api/generated
-	rm -rf intro
-	rm -rf tutorials
-	rm -rf gallery
-	rm -rf projections
+	rm -rf intro tutorials gallery projections
+	rm -rf sg_execution_times.rst


### PR DESCRIPTION
`sg_execution_times.rst` is auto-generated by sphinx-gallery, and `make clean` should delete it.