### PR TITLE
launch_external_viewer: Use full path when opening the file in a browser

### DIFF
--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -12,6 +12,7 @@ import sys
 import time
 import webbrowser
 from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
 from typing import Any, Literal
 
 import xarray as xr
@@ -580,7 +581,7 @@ def launch_external_viewer(fname: str, waiting: float = 0):
         case "win32":  # Windows
             os.startfile(fname)  # type:ignore[attr-defined] # noqa: S606
         case _:  # Fall back to the browser if can't recognize the operating system.
-            webbrowser.open_new_tab(f"file://{fname}")
+            webbrowser.open_new_tab(f"file://{Path(fname).resolve()}")
     if waiting > 0:
         # Preview images will be deleted when a GMT modern-mode session ends, but the
         # external viewer program may take a few seconds to open the images.

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -202,5 +202,8 @@ def test_launch_external_viewer_unknown_os():
         patch("webbrowser.open_new_tab") as mock_open,
         patch("sys.platform", "unknown"),
     ):
-        launch_external_viewer("preview.png")
-        mock_open.assert_called_once_with("file://preview.png")
+        fname = "preview.png"
+        launch_external_viewer(fname)
+        fullpath = Path(fname).resolve()
+        assert fullpath.is_absolute()
+        mock_open.assert_called_once_with(f"file://{fullpath}")


### PR DESCRIPTION
When opening a file via `webbrowser.open_new_tab`, we use the file URI with the format: `file://{fname}`. Here `fname` must be a full path, as shown below.

```
In [1]: import webbrowser

In [2]: webbrowser.open_new_tab("basemap.pdf")
Out[2]: True

In [3]: webbrowser.open_new_tab("file://basemap.pdf")
Out[3]: True

In [4]: gio: file://basemap.pdf: Operation not supported
```
This PR fixes the bug.