### PR TITLE
_check_encoding: Improve efficiency by creating dict outside the for loop

### DIFF
--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -187,7 +187,8 @@ def _check_encoding(argstr: str) -> Encoding:
         charset["ZapfDingbats"].values()
     )
     for encoding in ["ISOLatin1+"] + [f"ISO-8859-{i}" for i in range(1, 17) if i != 12]:
-        if all(c in (set(charset[encoding].values()) | adobe_chars) for c in argstr):
+        chars = set(charset[encoding].values()) | adobe_chars
+        if all(c in chars for c in argstr):
             return encoding  # type: ignore[return-value]
     # Return the "ISOLatin1+" encoding if the string contains characters from multiple
     # charset encodings or contains characters that are not in any charset encoding.


### PR DESCRIPTION
Minor refactor to improve the efficiency of the `_check_encoding` function.

Main branch:
```python
In [1]: from pygmt.helpers.utils import _check_encoding

In [2]: %timeit _check_encoding("123ABC+-?!" * 100)
65.2 μs ± 5.94 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [3]: %timeit _check_encoding("12AB±β①②" * 100)
16.4 ms ± 103 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [4]: %timeit _check_encoding("12ABāáâãäåβ①②" * 100)
24.9 ms ± 77.8 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [5]: %timeit _check_encoding("12ABŒā" * 100)
2.01 ms ± 7.97 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [6]: %timeit _check_encoding("123AB中文" * 100)
2.36 ms ± 179 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

This PR:
```python
In [1]: from pygmt.helpers.utils import _check_encoding

In [2]: %timeit _check_encoding("123ABC+-?!" * 100)
58.3 μs ± 2.03 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [3]: %timeit _check_encoding("12AB±β①②" * 100)
98.9 μs ± 1.64 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [4]: %timeit _check_encoding("12ABāáâãäåβ①②" * 100)
233 μs ± 430 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [5]: %timeit _check_encoding("12ABŒā" * 100)
409 μs ± 2.36 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [6]: %timeit _check_encoding("123AB中文" * 100)
416 μs ± 5.51 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
