### PR TITLE
Update issue templates to avoid line breaks in long paragraph

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yaml
@@ -1,15 +1,15 @@
 name: Bug report
-description: Report a problem/bug to help us improve
+description: Report a problem/bug to help us improve.
 labels: bug
 body:
   - type: markdown
     attributes:
-      value: |
+      value: >
         Thanks for taking the time to fill out this bug report!
   - type: textarea
     attributes:
       label: "Description of the problem"
-      description: |
+      description: >
         Please be as detailed as you can when describing an issue.
         The more information we have, the easier it will be for us to track this down.
     validations:
@@ -17,12 +17,14 @@ body:
   - type: textarea
     attributes:
       label: "Minimal Complete Verifiable Example"
-      description: |
+      description: >
         So that we can understand and fix the issue quickly and efficiently, please provide
         a minimal, self-contained copy-pastable example that demonstrates the issue.
+
         For more details, check out:
 
         - [Minimal Complete Verifiable Examples](https://stackoverflow.com/help/mcve)
+
         - [Craft Minimal Bug Reports](https://matthewrocklin.com/minimal-bug-reports)
 
       placeholder: "PASTE CODE HERE"
@@ -40,9 +42,11 @@ body:
   - type: textarea
     attributes:
       label: "System information"
-      description: |
-        Please paste the output of `python -c "import pygmt; pygmt.show_versions()"`
-        If this command is not successful, please describe your operating system, how you installed PyGMT, how you installed GMT, and paste the full error message.
+      description: >
+        Please paste the output of `python -c "import pygmt; pygmt.show_versions()"`.
+
+        If this command is not successful, please describe your operating system, 
+        how you installed PyGMT, how you installed GMT, and paste the full error message.
       placeholder: "PASTE THE OUTPUT HERE"
       render: bash
     validations:

--- a/.github/ISSUE_TEMPLATE/2-feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.yaml
@@ -5,16 +5,17 @@ body:
   - type: textarea
     attributes:
       label: "Description of the desired feature"
-      description: |
-        Please be as detailed as you can in your description.
-        If possible, include an example of how you would like to use this feature (even better if it's a code example).
+      description: >
+        Please be as detailed as you can in your description. If possible, include 
+        an example of how you would like to use this feature (even better if it's a code example).
   - type: dropdown
     id: help
     attributes:
       label: Are you willing to help implement and maintain this feature?
-      description: |
-        Every feature we add is code that we will have to maintain and keep updated. This takes a lot of effort.
-        If you are willing to be involved in the project and help maintain your feature, it will make it easier for us to accept it.
+      description: >
+        Every feature we add is code that we will have to maintain and keep updated. 
+        This takes a lot of effort. If you are willing to be involved in the project and 
+        help maintain your feature, it will make it easier for us to accept it.
       options:
         - "No"
         - "Yes"

--- a/.github/ISSUE_TEMPLATE/3-module_request.yaml
+++ b/.github/ISSUE_TEMPLATE/3-module_request.yaml
@@ -5,23 +5,29 @@ labels: ["feature request"]
 body:
   - type: markdown
     attributes:
-      value: |
-        Please replace `<module-name>` in the issue title and the description with the name of the requested module and add the description of the module.
+      value: >
+        Please replace `<module-name>` in the issue title and the description with the 
+        name of the requested module and add the description of the module.
   - type: textarea
     id: which-module
     attributes:
       label: Description of the desired module
-      description: Please be as detailed as you can in your description. If possible, include an example of how you would like to use this feature (even better if it's a code example).
-      placeholder: Implement [`<module-name>`](https://docs.generic-mapping-tools.org/latest/<module-name>.html) which `<insert description of the GMT module>`.
+      description: >
+        Please be as detailed as you can in your description. If possible, include 
+        an example of how you would like to use this feature (even better if it's a code example).
+      placeholder: >
+        Implement [`<module-name>`](https://docs.generic-mapping-tools.org/latest/<module-name>.html) 
+        which `<insert description of the GMT module>`.
     validations:
       required: true
   - type: dropdown
     id: help
     attributes:
       label: Are you willing to help implement and maintain this feature?
-      description: |
-        Every feature we add is code that we will have to maintain and keep updated. This takes a lot of effort.
-        If you are willing to be involved in the project and help maintain your feature, it will make it easier for us to accept it.
+      description: >
+        Every feature we add is code that we will have to maintain and keep updated. 
+        This takes a lot of effort. If you are willing to be involved in the project and 
+        help maintain your feature, it will make it easier for us to accept it.
       options:
         - "No"
         - "Yes"
@@ -31,4 +37,5 @@ body:
   - type: markdown
     attributes:
       value: |
-        Progress on wrapping the module will be tracked in the [project board](https://github.com/GenericMappingTools/pygmt/projects/9).
+        Progress on wrapping the module will be tracked in the 
+        [project board](https://github.com/GenericMappingTools/pygmt/projects/9).

--- a/.github/ISSUE_TEMPLATE/3-module_request.yaml
+++ b/.github/ISSUE_TEMPLATE/3-module_request.yaml
@@ -38,4 +38,4 @@ body:
     attributes:
       value: |
         Progress on wrapping the module will be tracked in the 
-        [project board](https://github.com/GenericMappingTools/pygmt/projects/9).
+        [project board](https://github.com/orgs/GenericMappingTools/projects/3).


### PR DESCRIPTION
As shown in the screenshot below, long description are split into multiple lines by line breaks in the issue templates.
![Screenshot from 2024-11-25 15-19-45](https://github.com/user-attachments/assets/6c650c71-cadb-4c72-9813-143570319a4c)

This can be avoided by writting multi-line string using the folded style (using `>` rathen `|`). (xref: https://learnxinyminutes.com/docs/yaml/).

To compare the issue templates in the main branch and this branch:
