### PR TITLE
clib.conversion.strings_to_ctypes_array: Add a doctest for numpy string array

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -307,6 +307,13 @@ def strings_to_ctypes_array(strings: Sequence[str] | np.ndarray) -> ctp.Array:
     <class 'pygmt.clib.conversion.c_char_p_Array_3'>
     >>> [s.decode() for s in ctypes_array]
     ['first', 'second', 'third']
+
+    >>> strings = np.array(["first", "second", "third"])
+    >>> ctypes_array = strings_to_ctypes_array(strings)
+    >>> type(ctypes_array)
+    <class 'pygmt.clib.conversion.c_char_p_Array_3'>
+    >>> [s.decode() for s in ctypes_array]
+    ['first', 'second', 'third']
     """
     return (ctp.c_char_p * len(strings))(*[s.encode() for s in strings])
 


### PR DESCRIPTION
The `strings_to_ctypes_array` function can accept a sequence of strings or a numpy array of strings, but passing numpy string array is not tested. 

This PR adds a test for it.