### PR TITLE
clib.conversion._to_numpy: Use pytest.mark.skipif to skip string_view type test for pyarrow < 16

### DIFF
--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -10,6 +10,7 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from packaging.version import Version
+from pygmt._show_versions import _get_module_version
 from pygmt.clib.conversion import _to_numpy
 from pygmt.helpers.testing import skip_if_no
 
@@ -336,7 +337,13 @@ def test_to_numpy_pyarrow_numeric_with_na(dtype, expected_dtype):
         "utf8",  # alias for string
         "large_string",
         "large_utf8",  # alias for large_string
-        "string_view",
+        pytest.param(
+            "string_view",
+            marks=pytest.mark.skipif(
+                Version(_get_module_version("pyarrow")) < Version("16"),
+                reason="string_view type was added since pyarrow 16",
+            ),
+        ),
     ],
 )
 def test_to_numpy_pyarrow_string(dtype):

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -10,7 +10,6 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from packaging.version import Version
-from pygmt._show_versions import _get_module_version
 from pygmt.clib.conversion import _to_numpy
 from pygmt.helpers.testing import skip_if_no
 
@@ -24,6 +23,8 @@ except ImportError:
         """
         A dummy class to mimic pyarrow.
         """
+
+        __version__ = "0.0.0"
 
         @staticmethod
         def timestamp(unit: str, tz: str | None = None):
@@ -340,7 +341,7 @@ def test_to_numpy_pyarrow_numeric_with_na(dtype, expected_dtype):
         pytest.param(
             "string_view",
             marks=pytest.mark.skipif(
-                Version(_get_module_version("pyarrow")) < Version("16"),
+                Version(pa.__version__) < Version("16"),
                 reason="string_view type was added since pyarrow 16",
             ),
         ),


### PR DESCRIPTION
Cherry-picking 4733bda9e710061e79acafc771f8d0b1e32100e8 from PR #3639, but use the dummy `pa` class when pyarrow is not installed.

PyArrow `string_view` was added since pyarrow v16 (https://github.com/apache/arrow/pull/39652).