### PR TITLE
Bump to ruff>=0.8.0 and rename rule TCH to TC

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
     # Dev dependencies (style checks)
     - codespell
     - pre-commit
-    - ruff>=0.3.0
+    - ruff>=0.8.0
     # Dev dependencies (unit testing)
     - matplotlib-base
     - pytest>=6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ select = [
     "S",    # flake8-bandit
     "SIM",  # flake8-simplify
     "T20",  # flake8-print
-    "TCH",  # flake8-type-checking
+    "TC",   # flake8-type-checking
     "TID",  # flake8-tidy-imports
     "UP",   # pyupgrade
     "W",    # pycodestyle warnings


### PR DESCRIPTION
**Description of proposed changes**

ruff v0.8.0 was released last week. In this release, rule `TCH` is renamed to `TC`.

Reference: https://astral.sh/blog/ruff-v0.8.0
