### PR TITLE
Fix the docstrings of the pygmt.end function

### DIFF
--- a/pygmt/session_management.py
+++ b/pygmt/session_management.py
@@ -17,25 +17,23 @@ def begin():
 
     Only meant to be used once for creating the global session.
     """
-    # On Windows, need to set GMT_SESSION_NAME to a unique value
+    # On Windows, need to set GMT_SESSION_NAME to a unique value.
     if sys.platform == "win32":
         os.environ["GMT_SESSION_NAME"] = unique_name()
 
     prefix = "pygmt-session"
     with Session() as lib:
         lib.call_module(module="begin", args=[prefix])
-        # pygmt relies on GMT modern mode with GMT_COMPATIBILITY at version 6
+        # PyGMT relies on GMT modern mode with GMT_COMPATIBILITY at version 6.
         lib.call_module(module="set", args=["GMT_COMPATIBILITY=6"])
 
 
 def end():
     """
-    Terminate GMT modern mode session and optionally produce the figure files.
+    Terminate the GMT modern mode session created by :func:`pygmt.begin`.
 
-    Called after :func:`pygmt.begin` and all commands that you want included in
-    a session. Will finalize any PostScript plots that were made in the
-    background, convert them to the desired format (specified in
-    ``pygmt.begin``), and bring the figures to the working directory.
+    Called after :func:`pygmt.begin` and all commands that you want included in a
+    session. Will clean up the session directory completely.
     """
     with Session() as lib:
         lib.call_module(module="end", args=[])


### PR DESCRIPTION
The docstrings for the `pygmt.end` function was incorrect.

Calling `gmt end` doesn't do the image conversion at all (done by calling `psconvert`).