### PR TITLE
List function aliases in a more compact layout

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -456,18 +456,22 @@ def fmt_docstring(module_func):
         Select map :doc:`projection </projections/index>`.
     <BLANKLINE>
     **Aliases:**
+    .. hlist::
+       :columns: 4
     <BLANKLINE>
-    - J = projection
-    - R = region
+       - J = projection
+       - R = region
     <BLANKLINE>
     """  # noqa: D410,D411
     filler_text = {}
 
     if hasattr(module_func, "aliases"):
         aliases = ["**Aliases:**\n"]
+        aliases.append(".. hlist::")
+        aliases.append("   :columns: 4\n")
         for arg in sorted(module_func.aliases):
             alias = module_func.aliases[arg]
-            aliases.append(f"- {arg} = {alias}")
+            aliases.append(f"   - {arg} = {alias}")
         filler_text["aliases"] = "\n".join(aliases)
 
     filler_text["table-like"] = (

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -457,7 +457,7 @@ def fmt_docstring(module_func):
     <BLANKLINE>
     **Aliases:**
     .. hlist::
-       :columns: 4
+       :columns: 3
     <BLANKLINE>
        - J = projection
        - R = region

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -468,7 +468,7 @@ def fmt_docstring(module_func):
     if hasattr(module_func, "aliases"):
         aliases = ["**Aliases:**\n"]
         aliases.append(".. hlist::")
-        aliases.append("   :columns: 4\n")
+        aliases.append("   :columns: 3\n")
         for arg in sorted(module_func.aliases):
             alias = module_func.aliases[arg]
             aliases.append(f"   - {arg} = {alias}")


### PR DESCRIPTION
As shown in the screenshot below (the left one), currently, the function aliases are listed vertically, wasting a lot of vertical spaces. This PR uses the [`hlist`](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-hlist) directive to make the list more compact, by listing 4 items per row (the right one).

| [The main branch](https://www.pygmt.org/dev/api/generated/pygmt.Figure.basemap.html) | [This PR](https://pygmt-dev--3666.org.readthedocs.build/en/3666/api/generated/pygmt.Figure.basemap.html) |
|---|---|
| <img width="885" alt="image" src="https://github.com/user-attachments/assets/6d325a6a-78e3-4d70-9c71-355b7c1321e4"> | <img width="927" alt="image" src="https://github.com/user-attachments/assets/62e1c0f5-b5c2-452d-911e-816a62acd7dd"> |

**Preview**: https://pygmt-dev--3666.org.readthedocs.build/en/3666/api/generated/pygmt.Figure.basemap.html
