### PR TITLE
CI: Pin to sphinx>=6.2 for docs build on Python 3.13

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -110,7 +110,7 @@ jobs:
             python-build
             myst-nb
             panel
-            sphinx
+            sphinx>=6.2
             sphinx-autodoc-typehints
             sphinx-copybutton
             sphinx-design

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -25,7 +25,7 @@ dependencies:
     # Dev dependencies (building documentation)
     - myst-nb
     - panel
-    - sphinx
+    - sphinx>=6.2
     - sphinx-autodoc-typehints
     - sphinx-copybutton
     - sphinx-design

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -171,7 +171,7 @@ exclude_patterns = [
 ]
 
 source_suffix = ".rst"
-needs_sphinx = "1.8"
+needs_sphinx = "6.2"
 # Encoding of source files
 source_encoding = "utf-8-sig"
 root_doc = "index"

--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
     # Dev dependencies (building documentation)
     - myst-nb
     - panel
-    - sphinx
+    - sphinx>=6.2
     - sphinx-autodoc-typehints
     - sphinx-copybutton
     - sphinx-design


### PR DESCRIPTION
**Description of proposed changes**

Fix `ModuleNotFoundError: No module named 'imghdr'` on Python 3.13. Xref https://github.com/sphinx-doc/sphinx/issues/10440#issuecomment-1556180835

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Full traceback from https://readthedocs.org/projects/pygmt-dev/builds/26462203/ in #3490:

```python-traceback
sphinx-autogen -i -t _templates -o api/generated api/*.rst
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/pygmt-dev/conda/3490/bin/sphinx-autogen", line 6, in <module>
    from sphinx.ext.autosummary.generate import main
  File "/home/docs/checkouts/readthedocs.org/user_builds/pygmt-dev/conda/3490/lib/python3.13/site-packages/sphinx/ext/autosummary/__init__.py", line 88, in <module>
    from sphinx.writers.html import HTMLTranslator
  File "/home/docs/checkouts/readthedocs.org/user_builds/pygmt-dev/conda/3490/lib/python3.13/site-packages/sphinx/writers/html.py", line 21, in <module>
    from sphinx.util.images import get_image_size
  File "/home/docs/checkouts/readthedocs.org/user_builds/pygmt-dev/conda/3490/lib/python3.13/site-packages/sphinx/util/images.py", line 4, in <module>
    import imghdr
ModuleNotFoundError: No module named 'imghdr'
make: *** [Makefile:29: api] Error 1
```

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Helps with #3490


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
