### PR TITLE
CI: Pin rasterio < 1.4.3 temporarily

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -104,6 +104,7 @@ jobs:
             geopandas<1.0
             ipython
             pyarrow
+            rasterio<1.4.3
             rioxarray
             make
             pip

--- a/.github/workflows/ci_doctests.yaml
+++ b/.github/workflows/ci_doctests.yaml
@@ -61,6 +61,7 @@ jobs:
             geopandas
             ipython
             pyarrow
+            rasterio<1.4.3
             rioxarray
             make
             pip

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -73,13 +73,13 @@ jobs:
             numpy-version: '1.24'
             pandas-version: '=2.0'
             xarray-version: '=2023.04'
-            optional-packages: ' contextily geopandas<1 ipython pyarrow rioxarray sphinx-gallery'
+            optional-packages: ' contextily geopandas<1 ipython pyarrow rasterio<1.4.3 rioxarray sphinx-gallery'
           # Python 3.12 + core packages (latest versions) + optional packages
           - python-version: '3.12'
             numpy-version: '2.1'
             pandas-version: ''
             xarray-version: ''
-            optional-packages: ' contextily geopandas>=1.0 ipython pyarrow rioxarray sphinx-gallery'
+            optional-packages: ' contextily geopandas>=1.0 ipython pyarrow rasterio<1.4.3 rioxarray sphinx-gallery'
           # Python 3.11 + core packages (Linux only)
           - os: 'ubuntu-latest'
             python-version: '3.11'

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -152,7 +152,7 @@ jobs:
           python -m pip install --pre --prefer-binary \
                         --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
                         numpy pandas xarray netCDF4 packaging \
-                        build contextily dvc geopandas ipython pyarrow rioxarray \
+                        build contextily dvc geopandas ipython pyarrow rasterio<1.4.3 rioxarray \
                         pytest pytest-cov pytest-doctestplus pytest-mpl pytest-rerunfailures \
                         sphinx-gallery
 

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -152,7 +152,7 @@ jobs:
           python -m pip install --pre --prefer-binary \
                         --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
                         numpy pandas xarray netCDF4 packaging \
-                        build contextily dvc geopandas ipython pyarrow rasterio<1.4.3 rioxarray \
+                        build contextily dvc geopandas ipython pyarrow 'rasterio<1.4.3' rioxarray \
                         pytest pytest-cov pytest-doctestplus pytest-mpl pytest-rerunfailures \
                         sphinx-gallery
 

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -71,6 +71,7 @@ jobs:
             geopandas
             ipython
             pyarrow
+            rasterio<1.4.3
             rioxarray
             sphinx-gallery
             make

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -17,6 +17,7 @@ dependencies:
     - geopandas<1.0
     - ipython
     - pyarrow
+    - rasterio<1.4.3
     - rioxarray
     # Development dependencies (general)
     - make


### PR DESCRIPTION
As reported in https://github.com/GenericMappingTools/pygmt/issues/3301#issuecomment-2513054819, rasterio 1.4.3 causes GDAL driver issues.

This PR pins to rasterio<1.4.3 as a workaround.