### PR TITLE
Fix typos OGC:WGS84 to OGC:CRS84

### DIFF
--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -50,7 +50,7 @@ def tilemap(
 
     **Note**: By default, standard web map tiles served in a Spherical Mercator
     (EPSG:3857) Cartesian format will be reprojected to a geographic coordinate
-    reference system (OGC:WGS84) and plotted with longitude/latitude bounds when
+    reference system (OGC:CRS84) and plotted with longitude/latitude bounds when
     ``lonlat=True``. If reprojection is not desired, please set ``lonlat=False`` and
     provide Spherical Mercator (EPSG:3857) coordinates to the ``region`` parameter.
 

--- a/pygmt/tests/baseline/test_tilemap_ogc_crs84.png.dvc
+++ b/pygmt/tests/baseline/test_tilemap_ogc_crs84.png.dvc
@@ -1,5 +1,5 @@
 outs:
 - md5: 5f225e4dd26f44e07bcbd8e713c67dbe
   size: 37343
-  path: test_tilemap_ogc_wgs84.png
+  path: test_tilemap_ogc_crs84.png
   hash: md5

--- a/pygmt/tests/test_tilemap.py
+++ b/pygmt/tests/test_tilemap.py
@@ -41,9 +41,9 @@ def test_tilemap_web_mercator():
     not (_HAS_CONTEXTILY and _HAS_RIOXARRAY),
     reason="contextily and rioxarray are not installed",
 )
-def test_tilemap_ogc_wgs84():
+def test_tilemap_ogc_crs84():
     """
-    Create a tilemap plot using longitude/latitude coordinates (OGC:WGS84), centred on
+    Create a tilemap plot using longitude/latitude coordinates (OGC:CRS84), centred on
     the international date line.
     """
     fig = Figure()


### PR DESCRIPTION
There is no `OGC:WGS84`, only `OGC:CRS84`. This PR fixes the typos.

@weiji14 Are there any specific reasons that we use "OGC:CRS84", not `EPSG:4326`? 

ChatGPT tells me:

> The difference between **OGC:CRS84** and **EPSG:4326** lies in the order of their coordinate axes, even though both reference the same geographic coordinate system (WGS 84).
> 
> ### Key Differences:
> 
> 1. **Coordinate Order:**
>    - **OGC:CRS84:** The order of coordinates is **longitude, latitude** (X, Y).
>    - **EPSG:4326:** The order of coordinates is **latitude, longitude** (Y, X).
> 
> 2. **Origin and Usage:**
>    - **OGC:CRS84:** Defined by the Open Geospatial Consortium (OGC) and primarily used in GeoJSON and other web mapping standards.
>    - **EPSG:4326:** Defined by the EPSG registry and widely used in GIS software and spatial databases.
> 
> 3. **Use Cases:**
>    - **OGC:CRS84** is commonly used in web applications (e.g., GeoJSON), where the convention follows the Cartesian coordinate system's ordering (X, Y).
>    - **EPSG:4326** is used in traditional GIS applications and standards, aligning with the geographic convention of latitude before longitude (Y, X).
> 
> ### Practical Implications:
> - When working with data, it's crucial to respect the coordinate order expected by the software or standard you’re using.
> - **Interoperability:** If you interchange data between systems expecting different orders (e.g., GeoJSON vs. a GIS application), you might need to swap the coordinate values.
> 
> ### Visual Comparison:
> If a point is located at **40° latitude and -75° longitude**:
> - **OGC:CRS84:** `[-75.0, 40.0]` (longitude, latitude)
> - **EPSG:4326:** `[40.0, -75.0]` (latitude, longitude)
> 
> Despite the axis order difference, the spatial reference system and geodetic model (WGS 84) are identical for both.