### PR TITLE
clib.session: Add the GMT_SESSION_NOGDALCLOSE flag to keep GDAL open

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -400,7 +400,9 @@ class Session:
         self._print_callback = print_func
 
         padding = self["GMT_PAD_DEFAULT"]
-        session_type = self["GMT_SESSION_EXTERNAL"]
+        # GMT_SESSION_EXTERNAL: GMT is called by an external wrapper.
+        # GMT_SESSION_NOGDALCLOSE: Do not call GDALDestroyDriverManager when using GDAL.
+        session_type = self["GMT_SESSION_EXTERNAL"] + self["GMT_SESSION_NOGDALCLOSE"]
         session = c_create_session(name.encode(), padding, session_type, print_func)
 
         if session is None:


### PR DESCRIPTION
As explained in https://github.com/geopandas/pyogrio/issues/448#issuecomment-2516208038, the errors we see in https://github.com/GenericMappingTools/pygmt/issues/3301, is because GMT destroys the GDAL drivers registered by pyogrio or rasterio.

To avoid GMT destroying the GDAL drivers, we need to add the `GMT_SESSION_NOGDALCLOSE` flag when creating sessions.

The same change is applied in #3305 and it works well. 

xref:

- https://github.com/GenericMappingTools/gmt/blob/3bbf78098641a2cefac918fe0739e7bbcb1e2a69/src/gmt_api.c#L8420
- https://github.com/GenericMappingTools/gmt/blob/804d7674b890fe0e83411b1083ddbb2128b49847/src/gmt_api.c#L4740

Closes https://github.com/geopandas/pyogrio/issues/448.

Closes #3301.