### PR TITLE
Bump to ruff 0.8.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
     # Dev dependencies (style checks)
     - codespell
     - pre-commit
-    - ruff>=0.8.0
+    - ruff>=0.8.2
     # Dev dependencies (unit testing)
     - matplotlib-base
     - pytest>=6.0

--- a/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
+++ b/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
@@ -23,7 +23,7 @@ def test_earth_vertical_gravity_gradient_01d():
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -40.1875, atol=1 / 32)
     npt.assert_allclose(data.max(), 45.96875, atol=1 / 32)
-    assert data[1, 1].isnull()  # noqa: PD003  # ruff's bug
+    assert data[1, 1].isnull()
 
 
 def test_earth_vertical_gravity_gradient_01d_with_region():

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -191,7 +191,7 @@ def test_earth_relief_holes():
     npt.assert_allclose(grid.max(), 1601)
     npt.assert_allclose(grid.min(), -4929.5)
     # Test for the NaN values in the remote file
-    assert grid[2, 21].isnull()
+    assert grid[2, 21].isnull()  # noqa: PD003  # ruff's bug
 
 
 def test_maunaloa_co2():

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -191,7 +191,7 @@ def test_earth_relief_holes():
     npt.assert_allclose(grid.max(), 1601)
     npt.assert_allclose(grid.min(), -4929.5)
     # Test for the NaN values in the remote file
-    assert grid[2, 21].isnull()  # noqa: PD003  # ruff's bug
+    assert grid[2, 21].isnull()
 
 
 def test_maunaloa_co2():


### PR DESCRIPTION
[ruff 0.8.2](https://github.com/astral-sh/ruff/releases/tag/0.8.2) is released and we can remove the `# noqa: PD003` flags.

This PR bumps to ruff 0.8.2.