### PR TITLE
CI: Test NumPy 2.2 in the GMT Tests workflow

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -76,7 +76,7 @@ jobs:
             optional-packages: ' contextily geopandas<1 ipython pyarrow rioxarray sphinx-gallery'
           # Python 3.12 + core packages (latest versions) + optional packages
           - python-version: '3.12'
-            numpy-version: '2.1'
+            numpy-version: '2.2'
             pandas-version: ''
             xarray-version: ''
             optional-packages: ' contextily geopandas>=1.0 ipython pyarrow rioxarray sphinx-gallery'


### PR DESCRIPTION
**Description of proposed changes**

Bumps [numpy](https://github.com/numpy/numpy) from 2.1 to 2.2. [NumPy 2.2.0](https://github.com/numpy/numpy/releases/tag/v2.2.0) was released on 8 Dec 2024.

This is in line with PyGMT's policy on [SPEC0](https://scientific-python.org/specs/spec-0000/#support-window) at https://www.pygmt.org/v0.12.0/maintenance.html#dependencies-policy.

Note that the branch protection rules at [GenericMappingTools/pygmt/settings/branches](https://github.com/GenericMappingTools/pygmt/settings/branches) will need to be changed to use Python 3.12/Numpy 2.2 before this Pull Request is merged.

Supersedes #3401