### PR TITLE
Improve the description of rioxarray on the Ecosystem page

### DIFF
--- a/doc/ecosystem.md
+++ b/doc/ecosystem.md
@@ -80,7 +80,7 @@ PyGMT relies on [rioxarray][] in several aspects:
 3. To reproject raster tiles to the target CRS in {func}`pygmt.datasets.load_tile_map`.
 
 ```{note}
-We're working towards to get rid of temporary files when processing/plotting multi-band
+We're working towards avoiding temporary files when processing/plotting multi-band
 rasters in [PR #3468](https://github.com/GenericMappingTools/pygmt/pull/3468).
 ```
 

--- a/doc/ecosystem.md
+++ b/doc/ecosystem.md
@@ -63,8 +63,7 @@ can be directly used in data processing and plotting functions/methods of PyGMT.
 add those tiles as basemap to matplotlib figures or write tile maps to disk into
 geospatial raster files.
 
-In PyGMT, {func}`pygmt.datasets.load_tile_map` and {class}`pygmt.Figure.tilemap` rely
-on it.
+In PyGMT, {func}`pygmt.datasets.load_tile_map` and {meth}`pygmt.Figure.tilemap` rely on it.
 
 ### rioxarray
 
@@ -73,13 +72,16 @@ of rasterio, it enables seamless reading, writing, and manipulation of multi-dim
 arrays with geospatial attributes such as coordinate reference systems (CRS) and spatial
 extent (bounds).
 
-Currently, PyGMT relies on [rioxarray][] to save multi-band rasters to temporary files
-in GeoTIFF format, to support processing and plotting 3-D {class}`xarray.DataArray`
-images.
+PyGMT relies on [rioxarray][] in several aspects:
+
+1. To save multi-band rasters to temporary files in GeoTIFF format, to support processing
+   and plotting 3-D {class}`xarray.DataArray` images.
+2. To write CRS information to the {class}`xarray.DataArray` objects.
+3. To reproject raster tiles to the target CRS in {meth}`pygmt.Figure.tilemap`.
 
 ```{note}
-We're working towards removing the dependency of the [rioxarray][] package in
-[PR #3468](https://github.com/GenericMappingTools/pygmt/pull/3468).
+We're working towards to get rid of temporary files when processing/plotting multi-band
+rasters in [PR #3468](https://github.com/GenericMappingTools/pygmt/pull/3468).
 ```
 
 ### PyArrow

--- a/doc/ecosystem.md
+++ b/doc/ecosystem.md
@@ -77,7 +77,7 @@ PyGMT relies on [rioxarray][] in several aspects:
 1. To save multi-band rasters to temporary files in GeoTIFF format, to support processing
    and plotting 3-D {class}`xarray.DataArray` images.
 2. To write CRS information to the {class}`xarray.DataArray` objects.
-3. To reproject raster tiles to the target CRS in {meth}`pygmt.Figure.tilemap`.
+3. To reproject raster tiles to the target CRS in {func}`pygmt.datasets.load_tile_map`.
 
 ```{note}
 We're working towards to get rid of temporary files when processing/plotting multi-band


### PR DESCRIPTION
PyGMT relies on rioxarray in several aspect. This PR improves the description to clarify it.

**Preview**: https://pygmt-dev--3686.org.readthedocs.build/en/3686/ecosystem.html#rioxarray