### PR TITLE
Add enums GridRegistration and GridType for grid registration and type

### DIFF
--- a/doc/_templates/autosummary/enums.rst
+++ b/doc/_templates/autosummary/enums.rst
@@ -1,0 +1,7 @@
+{{ fullname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+    :members:
+    :member-order: bysource

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -205,7 +205,8 @@ Enums
     :nosignatures:
     :template: autosummary/enums.rst
 
-    GridFormat
+    GridReg
+    GridType
 
 .. currentmodule:: pygmt
 

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -205,7 +205,7 @@ Enums
     :nosignatures:
     :template: autosummary/enums.rst
 
-    GridReg
+    GridRegistration
     GridType
 
 .. currentmodule:: pygmt

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -195,6 +195,19 @@ Getting metadata from tabular or grid data:
     info
     grdinfo
 
+Enums
+-----
+
+.. currentmodule:: pygmt.enums
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template: autosummary/enums.rst
+
+    GridFormat
+
+.. currentmodule:: pygmt
 
 Miscellaneous
 -------------
@@ -204,8 +217,6 @@ Miscellaneous
 
     which
     show_versions
-
-.. currentmodule:: pygmt
 
 Datasets
 --------

--- a/pygmt/enums.py
+++ b/pygmt/enums.py
@@ -37,3 +37,21 @@ class GridFormat(IntEnum):
     GD = 22  #: Import through GDAL
     EI = 23  #: ESRI Arc/Info ASCII Grid Interchange format (ASCII integer)
     EF = 24  #: ESRI Arc/Info ASCII Grid Interchange format (ASCII float)
+
+
+class GridReg(IntEnum):
+    """
+    Enum for the grid registration.
+    """
+
+    GRIDLINE = 0  #: Gridline registration
+    PIXEL = 1  #: Pixel registration
+
+
+class GridType(IntEnum):
+    """
+    Enum for the grid type.
+    """
+
+    CARTESIAN = 0  #: Cartesian grid
+    GEOGRAPHIC = 1  #: Geographic grid

--- a/pygmt/enums.py
+++ b/pygmt/enums.py
@@ -39,7 +39,7 @@ class GridFormat(IntEnum):
     EF = 24  #: ESRI Arc/Info ASCII Grid Interchange format (ASCII float)
 
 
-class GridReg(IntEnum):
+class GridRegistration(IntEnum):
     """
     Enum for the grid registration.
     """


### PR DESCRIPTION
This PR adds the enums `GridRegistration` and `GridType` for grid registration and type.


In #3449, we added the enums `GridFormat`, but we didn't add it to the API documentation, because we didn't find a good way to display the enums (see comments in PR #3449). This PR makes the docs work by adding a new `autosummary` template for enums. 

**Preview**: 

- https://pygmt-dev--3693.org.readthedocs.build/en/3693/api/index.html#enums
- https://pygmt-dev--3693.org.readthedocs.build/en/3693/api/generated/pygmt.enums.GridRegistration.html
- https://pygmt-dev--3693.org.readthedocs.build/en/3693/api/generated/pygmt.enums.GridType.html

 
References:

- https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html
- https://rasterio.readthedocs.io/en/latest/_sources/api/rasterio.enums.rst.txt
- https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-autoclass