### PR TITLE
CI: Install dvc via uv in the "GMT Tests" workflow

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -133,7 +133,6 @@ jobs:
             xarray${{ matrix.xarray-version }}
             netCDF4
             packaging
-            dvc
             make
             pip
             python-build

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -153,8 +153,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Setup data version control (DVC)
+      - name: Setup data version control (DVC) [Unix]
         run: python -m pip install dvc
+        if: runner.os != 'Windows'
+
+      - name: Setup data version control (DVC) [Windows]
+        run: choco install dvc
+        if: runner.os == 'Windows'
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -153,13 +153,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Setup data version control (DVC) [Unix]
+      - name: Setup data version control (DVC)
         run: python -m pip install dvc
-        if: runner.os != 'Windows'
-
-      - name: Setup data version control (DVC) [Windows]
-        run: choco install dvc
-        if: runner.os == 'Windows'
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -153,8 +153,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Setup data version control (DVC)
-        run: python -m pip install dvc
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4.2.0
+
+      - name: Install dvc
+        run: uv pip install dvc
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -158,7 +158,7 @@ jobs:
         if: runner.os != 'Windows'
 
       - name: Setup data version control (DVC) [Windows]
-        run: choco install dvc
+        run: winget install --id Iterative.DVC
         if: runner.os == 'Windows'
 
       # Pull baseline image data from dvc remote (DAGsHub)

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -157,11 +157,17 @@ jobs:
         uses: astral-sh/setup-uv@v4.2.0
 
       - name: Install dvc
-        run: uv pip install dvc
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv pip install dvc
+          uv pip list
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote
-        run: dvc pull --no-run-cache --verbose && ls -lhR pygmt/tests/baseline/
+        run: |
+          source .venv/bin/activate
+          uv run dvc pull --no-run-cache --verbose && ls -lhR pygmt/tests/baseline/
 
       # Install the package that we want to test
       - name: Install the package

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.12']
+        python-version: ['3.10', '3.13']
         os: [ubuntu-latest, macos-latest, windows-latest]
         # Is it a draft Pull Request (true or false)?
         isDraft:
@@ -75,7 +75,7 @@ jobs:
             xarray-version: '=2023.04'
             optional-packages: ' contextily geopandas<1 ipython pyarrow rioxarray sphinx-gallery'
           # Python 3.12 + core packages (latest versions) + optional packages
-          - python-version: '3.12'
+          - python-version: '3.13'
             numpy-version: '2.2'
             pandas-version: ''
             xarray-version: ''

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -153,6 +153,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Setup data version control (DVC)
+        uses: iterative/setup-dvc@v1.1.2
+
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote
         run: dvc pull --no-run-cache --verbose && ls -lhR pygmt/tests/baseline/

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.13']
+        python-version: ['3.10', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
         # Is it a draft Pull Request (true or false)?
         isDraft:
@@ -75,7 +75,7 @@ jobs:
             xarray-version: '=2023.04'
             optional-packages: ' contextily geopandas<1 ipython pyarrow rioxarray sphinx-gallery'
           # Python 3.12 + core packages (latest versions) + optional packages
-          - python-version: '3.13'
+          - python-version: '3.12'
             numpy-version: '2.2'
             pandas-version: ''
             xarray-version: ''

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -154,7 +154,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Setup data version control (DVC)
-        uses: iterative/setup-dvc@v1.1.2
+        run: python -m pip install dvc
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -158,7 +158,7 @@ jobs:
         if: runner.os != 'Windows'
 
       - name: Setup data version control (DVC) [Windows]
-        run: winget install --id Iterative.DVC
+        run: choco install dvc
         if: runner.os == 'Windows'
 
       # Pull baseline image data from dvc remote (DAGsHub)


### PR DESCRIPTION
dvc is a complex package that has ~40 direct dependencies (https://github.com/iterative/dvc/blob/007041bfe953db08b832ddea2d3adeaeb74eec95/pyproject.toml#L33). The complicated dvc dependency tree sometimes causes failures or version conflicts  e.g., https://github.com/GenericMappingTools/pygmt/pull/2468, https://github.com/GenericMappingTools/pygmt/pull/2338, https://github.com/GenericMappingTools/pygmt/pull/1544.

In https://github.com/GenericMappingTools/pygmt/pull/3490, we're trying to add the Python 3.13 support to PyGMT. That PR is stale because some dvc dependencies don't have 3.13 support yet (https://github.com/GenericMappingTools/pygmt/pull/3490#discussion_r1889665320), and we may have to wait for a few more days or months.

Since dvc is a dev dependency, we don't have to wait for the conda-forge updates. This PR tries to install dvc in other ways. I've tried the following options:

1. Use https://github.com/iterative/setup-dvc
2. Use `pip`
3. Use `pip` on Linux/macOS and `choco`/`winget` on Windows
4. Use `uv`

It turns out that installing dvc on Linux/macOS only takes ~10 seconds, but on Windows, options 1-3 take 60 seconds, except for option 4, which takes ~10 seconds on all platforms.

The CI job runs (https://github.com/GenericMappingTools/pygmt/actions/runs/12389452771/job/34582514750?pr=3695) for commit 83bb2d73436447b03b92586fd8380a5da663a592 show that, with changes in this PR, we can continue the Python 3.13 support in PR #3490.