### PR TITLE
SPEC 0: Bump minimum supported version to NumPy 1.25

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -70,7 +70,7 @@ jobs:
         include:
           # Python 3.11 + core packages (minimum supported versions) + optional packages (minimum supported versions if any)
           - python-version: '3.11'
-            numpy-version: '1.24'
+            numpy-version: '1.25'
             pandas-version: '=2.0'
             xarray-version: '=2023.04'
             optional-packages: ' contextily geopandas<1 ipython pyarrow rioxarray sphinx-gallery'

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     # Required dependencies
     - gmt=6.5.0
     - ghostscript=10.04.0
-    - numpy>=1.24
+    - numpy>=1.25
     - pandas>=2.0
     - xarray>=2023.04
     - netCDF4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
 ]
 dependencies = [
-    "numpy>=1.24",
+    "numpy>=1.25",
     "pandas>=2.0",
     "xarray>=2023.04",
     "netCDF4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Required packages
-numpy>=1.24
+numpy>=1.25
 pandas>=2.0
 xarray>=2023.04
 netCDF4


### PR DESCRIPTION
**Description of proposed changes**

Following [SPEC0](https://scientific-python.org/specs/spec-0000/) policy where NumPy 1.24 should be dropped in 2024 quarter 4. 

Bumps minimum supported NumPy version to 1.25 in the following files:

- [x] `.github/workflows/ci_tests.yaml`
- [x] `environment.yml`
- [x] `pyproject.toml`
- [x] `requirements.txt`

Previous PR at https://github.com/GenericMappingTools/pygmt/pull/3286.