### PR TITLE
CI: Install pyarrow-core instead of pyarrow from conda-forge

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -65,7 +65,7 @@ jobs:
             netCDF4
             packaging
             geopandas
-            pyarrow
+            pyarrow-core
             pytest
             pytest-codspeed
             pytest-mpl

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -103,7 +103,7 @@ jobs:
             contextily
             geopandas
             ipython
-            pyarrow
+            pyarrow-core
             rioxarray
             make
             pip

--- a/.github/workflows/ci_doctests.yaml
+++ b/.github/workflows/ci_doctests.yaml
@@ -60,7 +60,7 @@ jobs:
             contextily
             geopandas
             ipython
-            pyarrow
+            pyarrow-core
             rioxarray
             make
             pip

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -73,7 +73,7 @@ jobs:
             numpy-version: '1.24'
             pandas-version: '=2.0'
             xarray-version: '=2023.04'
-            optional-packages: ' contextily geopandas<1 ipython pyarrow rioxarray sphinx-gallery'
+            optional-packages: ' contextily geopandas<1 ipython pyarrow-core rioxarray sphinx-gallery'
           # Python 3.13 + core packages (latest versions) + optional packages
           - python-version: '3.13'
             numpy-version: '2.2'

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -79,7 +79,7 @@ jobs:
             numpy-version: '2.2'
             pandas-version: ''
             xarray-version: ''
-            optional-packages: ' contextily geopandas>=1.0 ipython pyarrow rioxarray sphinx-gallery'
+            optional-packages: ' contextily geopandas>=1.0 ipython pyarrow-core rioxarray sphinx-gallery'
           # Python 3.12 + core packages (Linux only)
           - os: 'ubuntu-latest'
             python-version: '3.12'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -70,7 +70,7 @@ jobs:
             contextily
             geopandas
             ipython
-            pyarrow
+            pyarrow-core
             rioxarray
             sphinx-gallery
             make

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -16,7 +16,7 @@ dependencies:
     - contextily
     - geopandas
     - ipython
-    - pyarrow
+    - pyarrow-core
     - rioxarray
     # Development dependencies (general)
     - make

--- a/doc/install.md
+++ b/doc/install.md
@@ -162,19 +162,20 @@ From now on, all commands will take place inside the virtual environment called 
 and won't affect your default `base` installation.
 
 ::::: {tip}
-You can also enable more PyGMT functionality by installing PyGMT's optional dependencies in the environment.
+You can also enable more PyGMT functionalities by installing PyGMT's optional
+dependencies in the environment.
 :::: {tab-set}
 ::: {tab-item} mamba
 :sync: mamba
 ```
-mamba install contextily geopandas ipython pyarrow rioxarray
+mamba install contextily geopandas ipython pyarrow-core rioxarray
 ```
 :::
 
 ::: {tab-item} conda
 :sync: conda
 ```
-conda install contextily geopandas ipython pyarrow rioxarray
+conda install contextily geopandas ipython pyarrow-core rioxarray
 ```
 :::
 ::::

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
     - contextily
     - geopandas
     - ipython
-    - pyarrow
+    - pyarrow-core
     - rioxarray
     # Development dependencies (general)
     - dvc


### PR DESCRIPTION
**Description of proposed changes**

Reduce unnecessary optional dependencies when installing `pyarrow` from conda-forge. Xref https://github.com/conda-forge/pyarrow-feedstock/pull/111

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

From https://github.com/conda-forge/pyarrow-feedstock/blob/381a88b6f8957204e34047151c4ca8a3f1e54204/recipe/meta.yaml#L157-L164, this means we won't be installing `libarrow-acero`, `libarrow-dataset`, `libarrow-substrait` and `libparquet`.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
