### PR TITLE
CI: Use windows-2025 in the GMT Dev Tests workflow

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15, windows-2022]
+        os: [ubuntu-24.04, macos-15, windows-2025]
         gmt_git_ref: [master]
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
**Description of proposed changes**

xref: https://github.blog/changelog/2024-12-19-windows-server-2025-is-now-in-public-preview/