### PR TITLE
WIP: Fix the deprecated 'string[pyarrow_numpy]' syntax in _to_numpy tests

### DIFF
--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -284,7 +284,7 @@ def test_to_numpy_pandas_numeric_with_na(dtype, expected_dtype):
         "string[python]",
         pytest.param("string[pyarrow]", marks=skip_if_no(package="pyarrow")),
         pytest.param(
-            "string[pyarrow_numpy]",
+            pd.StringDtype(storage="pyarrow"),
             marks=[
                 skip_if_no(package="pyarrow"),
                 pytest.mark.skipif(

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -284,7 +284,7 @@ def test_to_numpy_pandas_numeric_with_na(dtype, expected_dtype):
         "string[python]",
         pytest.param("string[pyarrow]", marks=skip_if_no(package="pyarrow")),
         pytest.param(
-            pd.StringDtype(storage="pyarrow"),
+            pd.StringDtype(storage="pyarrow", na_value=np.nan),
             marks=[
                 skip_if_no(package="pyarrow"),
                 pytest.mark.skipif(


### PR DESCRIPTION
Fix the following warning in the "GMT Dev Tests" workflow:
```
pygmt/tests/test_clib_to_numpy.py::test_to_numpy_pandas_string[string[pyarrow_numpy]]
  /home/runner/work/pygmt/pygmt/pygmt/tests/test_clib_to_numpy.py:306: FutureWarning: The 'pyarrow_numpy' storage option name is deprecated and will be removed in pandas 3.0. Use 'pd.StringDtype(storage="pyarrow", na_value-np.nan)' to construct the same dtype.
  Or enable the 'pd.options.future.infer_string = True' option globally and use the "str" alias as a shorthand notation to specify a dtype (instead of "string[pyarrow_numpy]").
    array = pd.Series(["abc", "defg", "12345"], dtype=dtype)
```
https://github.com/GenericMappingTools/pygmt/actions/runs/12423496737/job/34687106831:
