### PR TITLE
CI: Ensure no hyphens in Python file and directory names in the "Style Checks" workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,6 @@ Fixes #
 - [ ] Write detailed docstrings for all functions/methods.
 - [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
 - [ ] If adding new functionality, add an example to docstrings or tutorials.
-- [ ] Use underscores (not hyphens) in names of Python files and directories.
 
 **Slash Commands**
 

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -55,8 +55,8 @@ jobs:
 
       - name: Ensure hyphens are not used in names of directories and Python files
         run: |
-          git ls-files '*.py' | grep '-' > output.txt
-          git ls-tree -rd --name-only main | grep '-' >> output.txt
+          git ls-files '*.py' | grep '-' > output.txt || true
+          git ls-tree -rd --name-only main | grep '-' >> output.txt || true
           nfiles=$(wc --lines output.txt | awk '{print $1}')
           if [[ $nfiles > 0 ]]; then
             echo "Following directories/files use hyphens in file names:"

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -52,3 +52,15 @@ jobs:
             rm output.txt
             exit $nfiles
           fi
+
+      - name: Ensure hyphens are not used in names of directories and Python files
+        run: |
+          git ls-files '*.py' | grep '-' > output.txt
+          git ls-tree -rd --name-only main | grep '-' >> output.txt
+          nfiles=$(wc --lines output.txt | awk '{print $1}')
+          if [[ $nfiles > 0 ]]; then
+            echo "Following directories/files use hyphens in file names:"
+            cat output.txt
+            rm output.txt
+            exit $nfiles
+          fi

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Ensure hyphens are not used in names of directories and Python files
         run: |
           git ls-files '*.py' | grep '-' > output.txt || true
-          git ls-tree -rd --name-only main | grep '-' >> output.txt || true
+          git ls-tree -rd --name-only HEAD | grep '-' >> output.txt || true
           nfiles=$(wc --lines output.txt | awk '{print $1}')
           if [[ $nfiles > 0 ]]; then
             echo "Following directories/files use hyphens in file names:"

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -130,9 +130,9 @@ our tests. This way, the *main* branch is always stable.
     integrated separately.
   - Bug fixes should be submitted in separate PRs.
 * How to write and submit a PR
-  - Use underscores for all Python (*.py) files as per
-    [PEP8](https://www.python.org/dev/peps/pep-0008/), not hyphens. Directory
-    names should also use underscores instead of hyphens.
+  - Use underscores for all Python (\*.py) files as per
+    [PEP8](https://www.python.org/dev/peps/pep-0008/), not hyphens. Directory names
+    should also use underscores instead of hyphens.
   - Describe what your PR changes and *why* this is a good thing. Be as
     specific as you can. The PR description is how we keep track of the changes
     made to the project over time.


### PR DESCRIPTION
We've documented that underscores, not hyphens, should be used in Python file and directory names, but we don't have a way to enforce it.

This PR adds a check in the "Style Checks" workflow, so the workflow will fail if there are violations. The following two commands list all Python files and directories.

```
git ls-files '*.py' 
git ls-tree -rd --name-only HEAD 
```
and then we can use `grep "-"` to check hyphens. 

`grep "-"` exits with 0 if hyphens are found and 1 if unfound, which makes GitHub Actions step fail. So we need to add `|| true` so that the commands always exit with 0.

The related entry in the pull request template is removed so keep the template simple.


In 58798339dd82593dae8aa0de3747078e712161d9, one file and directory with hyphens are added to test the workflow. The workflow fails as expected (https://github.com/GenericMappingTools/pygmt/actions/runs/12431105443/job/34707863816?pr=3703).