### PR TITLE
Add notes for issue templates that are only meant for project maintainers

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/4-release_checklist.md
@@ -1,6 +1,6 @@
 ---
 name: PyGMT release checklist
-about: Checklist for a new PyGMT release.
+about: Checklist for a new PyGMT release. [For project maintainers only!]
 title: Release PyGMT vX.Y.Z
 labels: maintenance
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/5-bump_gmt_checklist.md
+++ b/.github/ISSUE_TEMPLATE/5-bump_gmt_checklist.md
@@ -1,6 +1,6 @@
 ---
 name: Bump GMT version checklist
-about: Checklist for bumping the minimum required GMT version.
+about: Checklist for bumping the minimum required GMT version. [For project maintainers only!]
 title: Bump to GMT X.Y.Z
 labels: maintenance
 assignees: ''


### PR DESCRIPTION
**Description of proposed changes**

The "PyGMT release checklist" and "Bump GMT version checklist" are for project maintainers only and should not by used by normal users.

Currently, there is no way to limit who can use these templates (see the accident in https://github.com/GenericMappingTools/pygmt/issues/2558 and a GitHub request in https://github.com/orgs/community/discussions/62395), but at least we can add a note.