### PR TITLE
External Resources / AGU24 workshop: Link directly to Jupter book instead of GitHub repo

### DIFF
--- a/doc/external_resources.md
+++ b/doc/external_resources.md
@@ -13,7 +13,7 @@ to submit a pull request with your recommended addition to the
 :::::{grid} 1 2 2 3
 
 ::::{grid-item-card} 2024 AGU PREWS9: Mastering Geospatial Visualizations with GMT/PyGMT
-:link: https://github.com/GenericMappingTools/agu24workshop
+:link: https://www.generic-mapping-tools.org/agu24workshop/
 :text-align: center
 :margin: 0 3 0 0
 


### PR DESCRIPTION
**Description of proposed changes**

Similar to the EGU 2022 workshop, I feel it's better to link to the Jupyter book instead of the GitHub repo.

Patches #3689 

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
- [ ] Use underscores (not hyphens) in names of Python files and directories.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
