### PR TITLE
Typo fixes before v0.14.0

### DIFF
--- a/pygmt/datasets/earth_free_air_anomaly.py
+++ b/pygmt/datasets/earth_free_air_anomaly.py
@@ -30,8 +30,8 @@ def load_earth_free_air_anomaly(
        :widths: 50 50
        :header-rows: 1
 
-       * - IGPP Earth free-Air anomaly
-         - IGPP Earth free-Air anomaly uncertainty
+       * - IGPP Earth free-air anomaly
+         - IGPP Earth free-air anomaly uncertainty
        * - .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_faa.jpg
          - .. figure:: https://www.generic-mapping-tools.org/remote-datasets/_images/GMT_earth_faaerror.jpg
 

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -248,7 +248,7 @@ class Figure:
         kwargs.pop("metadata", None)
         self.psconvert(prefix=prefix, fmt=fmts[ext], crop=crop, **kwargs)
 
-        # TODO(GMT>=6.5.0): Remve the workaround for upstream bug in GMT<6.5.0.
+        # TODO(GMT>=6.5.0): Remove the workaround for upstream bug in GMT<6.5.0.
         # Remove the .pgw world file if exists. Not necessary after GMT 6.5.0.
         # See upstream fix https://github.com/GenericMappingTools/gmt/pull/7865
         if ext == "tiff":

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -323,7 +323,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
         [**+p**\ *pen*][**+s**\ *size*].
         Offset beachball(s) to the longitude(s) and latitude(s) specified in the last
         two columns of the input file or array, or by ``plot_longitude`` and
-        ``plot_latitude`` if provided. A line from the beachball to the inital location
+        ``plot_latitude`` if provided. A line from the beachball to the initial location
         is drawn. Use **+s**\ *size* to plot a small circle at the initial location and
         to set the diameter of this circle [Default is no circle]. Use **+p**\ *pen* to
         set the pen attributes for this feature [Default is set via ``pen``]. The fill

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ local_scheme = "node-and-date"
 fallback_version = "999.999.999+unknown"
 
 [tool.codespell]
-ignore-words-list = "astroid,oints,reenable,tripel,trough"
+ignore-words-list = "astroid,oints,reenable,tripel,trough,ND"
 
 [tool.coverage.run]
 omit = ["*/tests/*", "*pygmt/__init__.py"]


### PR DESCRIPTION
**Description of proposed changes**

Some typo fixes before making the release v0.14.0.
Feel free to push to this branch in case you find more typos 🚀!

**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
