### PR TITLE
clib.Session: Remove deprecated open_virtual_file method, use open_virtualfile instead  (Deprecated since v0.11.0)

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1389,24 +1389,6 @@ class Session:
                 msg = f"Failed to close virtual file '{vfname}'."
                 raise GMTCLibError(msg)
 
-    # TODO(PyGMT>=0.15.0): Remove the deprecated open_virtual_file method.
-    def open_virtual_file(self, family, geometry, direction, data):
-        """
-        Open a GMT virtual file associated with a data object for reading or writing.
-
-        .. deprecated: 0.11.0
-
-           Will be removed in v0.15.0. Use :meth:`pygmt.clib.Session.open_virtualfile`
-           instead.
-        """
-        msg = (
-            "API function `Session.open_virtual_file()' has been deprecated "
-            "since v0.11.0 and will be removed in v0.15.0. "
-            "Use `Session.open_virtualfile()' instead."
-        )
-        warnings.warn(msg, category=FutureWarning, stacklevel=2)
-        return self.open_virtualfile(family, geometry, direction, data)
-
     @contextlib.contextmanager
     def virtualfile_from_vectors(
         self, vectors: Sequence, *args

--- a/pygmt/tests/test_clib_virtualfiles.py
+++ b/pygmt/tests/test_clib_virtualfiles.py
@@ -107,35 +107,3 @@ def test_open_virtualfile_bad_direction():
         with pytest.raises(GMTInvalidInput):
             with lib.open_virtualfile(*vfargs):
                 pass
-
-
-# TODO(PyGMT>=0.15.0): Remove the test after removing the deprecated open_virtual_file
-# method.
-def test_open_virtual_file():
-    """
-    Test the deprecated Session.open_virtual_file method.
-
-    This test is the same as test_open_virtualfile, but using the deprecated method.
-    """
-    shape = (5, 3)
-    with clib.Session() as lib:
-        family = "GMT_IS_DATASET|GMT_VIA_MATRIX"
-        geometry = "GMT_IS_POINT"
-        dataset = lib.create_data(
-            family=family,
-            geometry=geometry,
-            mode="GMT_CONTAINER_ONLY",
-            dim=[shape[1], shape[0], 1, 0],  # columns, rows, layers, dtype
-        )
-        data = np.arange(shape[0] * shape[1]).reshape(shape)
-        lib.put_matrix(dataset, matrix=data)
-        # Add the dataset to a virtual file and pass it along to gmt info
-        with pytest.warns(FutureWarning, match="open_virtual_file"):
-            vfargs = (family, geometry, "GMT_IN|GMT_IS_REFERENCE", dataset)
-            with lib.open_virtual_file(*vfargs) as vfile:
-                with GMTTempFile() as outfile:
-                    lib.call_module("info", [vfile, f"->{outfile.name}"])
-                    output = outfile.read(keep_tabs=True)
-        bounds = "\t".join([f"<{col.min():.0f}/{col.max():.0f}>" for col in data.T])
-        expected = f"<matrix memory>: N = {shape[0]}\t{bounds}\n"
-        assert output == expected


### PR DESCRIPTION
`Session.open_virtual_file` was deprecated in #2996.