### PR TITLE
clib.Session: Remove deprecated virtualfile_from_data method, use virtualfile_in instead (Deprecated since v0.13.0)

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -335,7 +335,6 @@ Low level access (these are mostly used by the :mod:`pygmt.clib` package):
     clib.Session.read_virtualfile
     clib.Session.extract_region
     clib.Session.get_libgmt_func
-    clib.Session.virtualfile_from_data
     clib.Session.virtualfile_from_grid
     clib.Session.virtualfile_from_stringio
     clib.Session.virtualfile_from_matrix

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1920,43 +1920,6 @@ class Session:
         file_context = _virtualfile_from(_data)
         return file_context
 
-    # TODO(PyGMT>=0.15.0): Remove the deprecated virtualfile_from_data method.
-    def virtualfile_from_data(
-        self,
-        check_kind=None,
-        data=None,
-        x=None,
-        y=None,
-        z=None,
-        extra_arrays=None,
-        required_z=False,
-        required_data=True,
-    ):
-        """
-        Store any data inside a virtual file.
-
-        .. deprecated: 0.13.0
-
-           Will be removed in v0.15.0. Use :meth:`pygmt.clib.Session.virtualfile_in`
-           instead.
-        """
-        msg = (
-            "API function 'Session.virtualfile_from_data()' has been deprecated since "
-            "v0.13.0 and will be removed in v0.15.0. Use 'Session.virtualfile_in()' "
-            "instead."
-        )
-        warnings.warn(msg, category=FutureWarning, stacklevel=2)
-        return self.virtualfile_in(
-            check_kind=check_kind,
-            data=data,
-            x=x,
-            y=y,
-            z=z,
-            extra_arrays=extra_arrays,
-            required_z=required_z,
-            required_data=required_data,
-        )
-
     @contextlib.contextmanager
     def virtualfile_out(
         self,

--- a/pygmt/tests/test_clib_virtualfile_in.py
+++ b/pygmt/tests/test_clib_virtualfile_in.py
@@ -128,35 +128,3 @@ def test_virtualfile_in_matrix_string_dtype():
                 assert output == "347.5 348.5 -30.5 -30\n"
                 # Should check that lib.virtualfile_from_vectors is called once,
                 # not lib.virtualfile_from_matrix, but it's technically complicated.
-
-
-# TODO(PyGMT>=0.16.0): Remove this test in PyGMT v0.16.0 in which the old usage of
-# virtualfile_from_data is removed.
-def test_virtualfile_from_data():
-    """
-    Test the backwards compatibility of the virtualfile_from_data method.
-
-    This test is the same as test_virtualfile_in_required_z_matrix, but using the
-    deprecated method.
-    """
-    shape = (5, 3)
-    dataframe = pd.DataFrame(
-        data=np.arange(shape[0] * shape[1]).reshape(shape), columns=["x", "y", "z"]
-    )
-    data = np.array(dataframe)
-    with clib.Session() as lib:
-        with pytest.warns(FutureWarning, match="virtualfile_from_data"):
-            with lib.virtualfile_from_data(
-                data=data, required_z=True, check_kind="vector"
-            ) as vfile:
-                with GMTTempFile() as outfile:
-                    lib.call_module("info", [vfile, f"->{outfile.name}"])
-                    output = outfile.read(keep_tabs=True)
-            bounds = "\t".join(
-                [
-                    f"<{i.min():.0f}/{i.max():.0f}>"
-                    for i in (dataframe.x, dataframe.y, dataframe.z)
-                ]
-            )
-            expected = f"<matrix memory>: N = {shape[0]}\t{bounds}\n"
-            assert output == expected


### PR DESCRIPTION
`Session.virtualfile_from_data` was deprecated in #3225.