### PR TITLE
Fix an image in README.md (broken on PyPI) and rewrap to 88 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,22 +22,22 @@
 
 ## Why PyGMT?
 
-A beautiful map is worth a thousand words. To truly understand how powerful PyGMT is, play with it online on
-[Binder](https://github.com/GenericMappingTools/try-gmt)! For a quicker introduction, check out our
-[3 minute overview](https://youtu.be/4iPnITXrxVU)!
+A beautiful map is worth a thousand words. To truly understand how powerful PyGMT is,
+play with it online on [Binder](https://github.com/GenericMappingTools/try-gmt)! For a
+quicker introduction, check out our [3 minute overview](https://youtu.be/4iPnITXrxVU)!
 
-Afterwards, feel free to look at our [Tutorials](https://www.pygmt.org/latest/tutorials), visit the
-[Gallery](https://www.pygmt.org/latest/gallery), and check out some
+Afterwards, feel free to look at our [Tutorials](https://www.pygmt.org/latest/tutorials),
+visit the [Gallery](https://www.pygmt.org/latest/gallery), and check out some
 [external PyGMT examples](https://www.pygmt.org/latest/external_resources.html)!
 
-![Quick Introduction to PyGMT YouTube Video](doc/_static/scipy2022-youtube-thumbnail.jpg)
+![Quick Introduction to PyGMT YouTube Video](https://raw.githubusercontent.com/GenericMappingTools/pygmt/refs/heads/main/doc/_static/scipy2022-youtube-thumbnail.jpg)
 
 ## About
 
-PyGMT is a library for processing geospatial and geophysical data and making publication-quality
-maps and figures. It provides a Pythonic interface for the
-[Generic Mapping Tools (GMT)](https://github.com/GenericMappingTools/gmt), a command-line program
-widely used across the Earth, Ocean, and Planetary sciences and beyond.
+PyGMT is a library for processing geospatial and geophysical data and making
+publication-quality maps and figures. It provides a Pythonic interface for the
+[Generic Mapping Tools (GMT)](https://github.com/GenericMappingTools/gmt), a command-line
+program widely used across the Earth, Ocean, and Planetary sciences and beyond.
 
 ## Project goals
 
@@ -45,8 +45,9 @@ widely used across the Earth, Ocean, and Planetary sciences and beyond.
 - Build a Pythonic API for GMT.
 - Interface with the GMT C API directly using ctypes (no system calls).
 - Support for rich display in the Jupyter notebook.
-- Integration with the [scientific Python ecosystem](https://scientific-python.org/): `numpy.ndarray` or
-  `pandas.DataFrame` for data tables, `xarray.DataArray` for grids, and `geopandas.GeoDataFrame` for geographical data.
+- Integration with the [scientific Python ecosystem](https://scientific-python.org/):
+  `numpy.ndarray` or `pandas.DataFrame` for data tables, `xarray.DataArray` for grids,
+  and `geopandas.GeoDataFrame` for geographical data.
 
 ## Quickstart
 
@@ -69,7 +70,8 @@ For other ways to install `pygmt`, see the [full installation instructions](http
 ### Getting started
 
 As a starting point, you can open a [Python interpreter](https://docs.python.org/3/tutorial/interpreter.html)
-or a [Jupyter notebook](https://docs.jupyter.org/en/latest/running.html), and try the following example:
+or a [Jupyter notebook](https://docs.jupyter.org/en/latest/running.html), and try the
+following example:
 
 ``` python
 import pygmt
@@ -79,18 +81,18 @@ fig.text(position="MC", text="PyGMT", font="80p,Helvetica-Bold,red@75")
 fig.show()
 ```
 
-You should see a global map with land and water masses colored in tan and lightblue, respectively. On top,
-there should be the semi-transparent text "PyGMT". For more examples, please have a look at the
-[Gallery](https://www.pygmt.org/latest/gallery/index.html) and
+You should see a global map with land and water masses colored in tan and lightblue,
+respectively. On top, there should be the semi-transparent text "PyGMT". For more examples,
+please have a look at the [Gallery](https://www.pygmt.org/latest/gallery/index.html) and
 [Tutorials](https://www.pygmt.org/latest/tutorials/index.html).
 
 ## Contacting us
 
 - Most discussion happens [on GitHub](https://github.com/GenericMappingTools/pygmt).
-  Feel free to [open an issue](https://github.com/GenericMappingTools/pygmt/issues/new) or comment on any open
-  issue or pull request.
-- We have a [Discourse forum](https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a) where you can ask
-  questions and leave comments.
+  Feel free to [open an issue](https://github.com/GenericMappingTools/pygmt/issues/new)
+  or comment on any open issue or pull request.
+- We have a [Discourse forum](https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a)
+  where you can ask questions and leave comments.
 
 ## Contributing
 
@@ -109,26 +111,29 @@ to see how you can help and give feedback.
 
 **We want your help.** No, really.
 
-There may be a little voice inside your head that is telling you that you're not ready to be an open source
-contributor; that your skills aren't nearly good enough to contribute. What could you possibly offer?
+There may be a little voice inside your head that is telling you that you're not ready
+to be an open source contributor; that your skills aren't nearly good enough to
+contribute. What could you possibly offer?
 
 We assure you that the little voice in your head is wrong.
 
-**Being a contributor doesn't just mean writing code.** Equally important contributions include: writing or
-proof-reading documentation, suggesting or implementing tests, or even giving feedback about the project
-(including giving feedback about the contribution process). If you're coming to the project with fresh eyes,
-you might see the errors and assumptions that seasoned contributors have glossed over. If you can write any
-code at all, you can contribute code to open source. We are constantly trying out new skills, making mistakes,
-and learning from those mistakes. That's how we all improve and we are happy to help others learn.
+**Being a contributor doesn't just mean writing code.** Equally important contributions
+include: writing or proof-reading documentation, suggesting or implementing tests, or
+even giving feedback about the project (including giving feedback about the contribution
+process). If you're coming to the project with fresh eyes, you might see the errors and
+assumptions that seasoned contributors have glossed over. If you can write any code at
+all, you can contribute code to open source. We are constantly trying out new skills,
+making mistakes, and learning from those mistakes. That's how we all improve and we are
+happy to help others learn.
 
 *This disclaimer was adapted from the* [MetPy project](https://github.com/Unidata/MetPy).
 
 ## Citing PyGMT
 
 PyGMT is a community developed project. See the
-[AUTHORS.md](https://github.com/GenericMappingTools/pygmt/blob/main/AUTHORS.md) file on GitHub for a list of
-the people involved and a definition of the term "PyGMT Developers". Feel free to cite our work in your
-research using the following BibTeX:
+[AUTHORS.md](https://github.com/GenericMappingTools/pygmt/blob/main/AUTHORS.md) file
+on GitHub for a list of the people involved and a definition of the term "PyGMT Developers".
+Feel free to cite our work in your research using the following BibTeX:
 
 ```
 @software{
@@ -162,10 +167,10 @@ research using the following BibTeX:
 ```
 
 To cite a specific version of PyGMT, go to our Zenodo page at <https://doi.org/10.5281/zenodo.3781524>
-and use the "Export to BibTeX" function there. It is also strongly recommended to cite the
-[GMT 6 paper](https://doi.org/10.1029/2019GC008515) (which PyGMT wraps around). Note that some modules
-like `dimfilter`, `surface`, and `x2sys` also have their dedicated citations. Further information for
-all these can be found at <https://www.generic-mapping-tools.org/cite>.
+and use the "Export to BibTeX" function there. It is also strongly recommended to cite
+the [GMT 6 paper](https://doi.org/10.1029/2019GC008515) (which PyGMT wraps around). Note
+that some modules like `dimfilter`, `surface`, and `x2sys` also have their dedicated
+citations. Further information for all these can be found at <https://www.generic-mapping-tools.org/cite>.
 
 ## License
 


### PR DESCRIPTION
The image for the "Quick Introduction to PyGMT YouTube Video" doesn't works on PyPI (https://pypi.org/project/pygmt/). It's broken since v0.12.0 (https://pypi.org/project/pygmt/0.12.0/).

This PR fixes the link of image `doc/_static/scipy2022-youtube-thumbnail.jpg` with permanent URLs.

