### PR TITLE
CI: Separate jobs for publishing to TestPyPI and PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -72,7 +72,7 @@ jobs:
         ls -lh dist/
 
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.5.0
       with:
         name: python-package-distributions
         path: dist/
@@ -85,13 +85,13 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/pygmt
+      url: https://test.pypi.org/project/pygmt
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted OIDC publishing
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v4.1.8
       with:
         name: python-package-distributions
         path: dist/
@@ -109,13 +109,13 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/pygmt
+      url: https://pypi.org/project/pygmt/
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted OIDC publishing
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v4.1.8
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -35,13 +35,9 @@ on:
   #    - main
 
 jobs:
-  publish-pypi:
-    name: Publish to PyPI
+  build:
+    name: Build distribution 📦
     runs-on: ubuntu-latest
-    permissions:
-      # This permission is mandatory for OIDC publishing
-      id-token: write
-    if: github.repository == 'GenericMappingTools/pygmt'
 
     steps:
     - name: Checkout
@@ -49,6 +45,7 @@ jobs:
       with:
         # fetch all history so that setuptools-scm works
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v5.3.0
@@ -74,11 +71,54 @@ jobs:
         echo "Generated files:"
         ls -lh dist/
 
-    - name: Publish to Test PyPI
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    if: github.repository == 'GenericMappingTools/pygmt'
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/pygmt
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted OIDC publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Publish distribution 📦 to TestPyPI
       uses: pypa/gh-action-pypi-publish@v1.12.3
       with:
         repository-url: https://test.pypi.org/legacy/
 
-    - name: Publish to PyPI
-      if: startsWith(github.ref, 'refs/tags')
+  publish-pypi:
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    if: github.repository == 'GenericMappingTools/pygmt' && startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pygmt
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted OIDC publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@v1.12.3


### PR DESCRIPTION
**Description of proposed changes**

Have a dedicated build distribution job, and split the publish to TestPyPI and PyPI jobs, to workaround attestation file issue. Xref https://github.com/pypa/gh-action-pypi-publish/issues/283

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

References:
- https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#separate-workflow-for-publishing-to-testpypi

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #3736


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
