### PR TITLE
Use well-known labels in project URLs following PEP753

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,11 @@ all = [
 ]
 
 [project.urls]
-homepage = "https://www.pygmt.org"
-documentation = "https://www.pygmt.org"
-repository = "https://github.com/GenericMappingTools/pygmt"
-changelog = "https://www.pygmt.org/latest/changes.html"
+"Homepage" = "https://www.pygmt.org"
+"Documentation" = "https://www.pygmt.org"
+"Source Code" = "https://github.com/GenericMappingTools/pygmt"
+"Changelog" = "https://www.pygmt.org/latest/changes.html"
+"Issue Tracker" = "https://github.com/GenericMappingTools/pygmt/issues"
 
 [tool.setuptools]
 platforms = ["Any"]


### PR DESCRIPTION
**Description of proposed changes**

Use human-readable labels for project URLs. See the sidebar of https://pypi.org/project/matplotlib/ for how the new URLs will look like:

References:

- https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls
- https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels
- https://docs.pypi.org/project_metadata/#general-url
- https://peps.python.org/pep-0753/ [TL;DR]
