### PR TITLE
Add the missing separators in changelog

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -102,6 +102,8 @@
 * [Will Schlitzer](https://github.com/willschlitzer)
 * [Jiayuan Yao](https://github.com/core-man)
 
+---
+
 ## Release v0.13.0 (2024/09/05)
 
 [![Digital Object Identifier for PyGMT v0.13.0](https://zenodo.org/badge/DOI/10.5281/zenodo.13679420.svg)](https://doi.org/10.5281/zenodo.13679420)
@@ -279,6 +281,8 @@
 * [Yvonne Fröhlich](https://github.com/yvonnefroehlich)
 * [Michael Grund](https://github.com/michaelgrund)
 * [Wei Ji Leong](https://github.com/weiji14)
+
+---
 
 ## Release v0.11.0 (2024/02/01)
 


### PR DESCRIPTION
Following the [maintainers guides](https://www.pygmt.org/dev/maintenance.html#updating-the-changelog), separators `---` should be added between the old and new changelog sections, but apparently, we forgot to do it when releasing v0.12.0 and v0.14.0.

This PR adds the separators back. I also added it to the template in PR https://github.com/GenericMappingTools/pygmt/pull/3730, so that we won't forget it next time.
