### PR TITLE
Delete the .buildinfo file from gh-pages branch

### DIFF
--- a/.buildinfo
+++ b/.buildinfo
@@ -1,4 +1,0 @@
-# Sphinx build info version 1
-# This file hashes the configuration used when building these files. When it is not found, a full rebuild will be done.
-config: c8dda7ff842071b11bcde3fa87187239
-tags: 645f666f9bcd5a90fca523b33c5a78b7


### PR DESCRIPTION
See https://github.com/GenericMappingTools/pygmt/issues/3731 for context.

The `.buildinfo` file in the `gh-pages` branch is very outdated and is useless.