### PR TITLE
DOC: Make usage of "lowercase" and "uppercase" consistent across all docs

### DIFF
--- a/doc/techref/patterns.md
+++ b/doc/techref/patterns.md
@@ -11,7 +11,7 @@ image raster file. The former will result in one of the 90 predefined 64x64 bit-
 provided by GMT (see the figure below). The latter allows the user to create customized,
 repeating images using image raster files.
 
-By specifying upper case **P** instead of **p** the image will be bit-reversed, i.e.,
+By specifying uppercase **P** instead of **p** the image will be bit-reversed, i.e.,
 white and black areas will be interchanged (only applies to 1-bit images or predefined
 bit-image patterns). For these patterns and other 1-bit images one may specify
 alternative **b**ackground and **f**oreground colors (by appending **+b**_color_ and/or

--- a/examples/gallery/basemaps/double_y_axes.py
+++ b/examples/gallery/basemaps/double_y_axes.py
@@ -5,7 +5,7 @@ Double Y-axes graph
 The ``frame`` parameter of the plotting methods of the :class:`pygmt.Figure`
 class can control which axes should be plotted and optionally show annotations,
 tick marks, and gridlines. By default, all 4 axes are plotted, along with
-annotations and tick marks (denoted **W**, **S**, **E**, **N**). Lower case
+annotations and tick marks (denoted **W**, **S**, **E**, **N**). Lowercase
 versions (**w**, **s**, **e**, **n**) can be used to denote to only plot the
 axes with tick marks. We can also only plot the axes without annotations and
 tick marks using **l** (left axis), **r** (right axis), **t** (top axis),

--- a/examples/gallery/embellishments/scalebar.py
+++ b/examples/gallery/embellishments/scalebar.py
@@ -12,8 +12,8 @@ This example shows how such a scale bar can be customized:
    - **g**: Give map coordinates as *longitude*\/\ *latitude*.
    - **j**\|\ **J**: Specify a two-character (order independent) code.
      Choose from vertical **T**\(op), **M**\(iddle), or **B**\(ottom) and
-     horizontal **L**\(eft), **C**\(entre), or **R**\(ight). Lower / 
-     uppercase **j** / **J** mean inside / outside of the map bounding 
+     horizontal **L**\(eft), **C**\(entre), or **R**\(ight). Lower /
+     uppercase **j** / **J** mean inside / outside of the map bounding
      box.
    - **n**: Give normalized bounding box coordinates as *nx*\/\ *ny*.
    - **x**: Give plot coordinates as *x*\/\ *y*.

--- a/examples/gallery/embellishments/scalebar.py
+++ b/examples/gallery/embellishments/scalebar.py
@@ -12,8 +12,9 @@ This example shows how such a scale bar can be customized:
    - **g**: Give map coordinates as *longitude*\/\ *latitude*.
    - **j**\|\ **J**: Specify a two-character (order independent) code.
      Choose from vertical **T**\(op), **M**\(iddle), or **B**\(ottom) and
-     horizontal **L**\(eft), **C**\(entre), or **R**\(ight). Lower / upper
-     case **j** / **J** mean inside / outside of the map bounding box.
+     horizontal **L**\(eft), **C**\(entre), or **R**\(ight). Lower / 
+     uppercase **j** / **J** mean inside / outside of the map bounding 
+     box.
    - **n**: Give normalized bounding box coordinates as *nx*\/\ *ny*.
    - **x**: Give plot coordinates as *x*\/\ *y*.
 

--- a/examples/gallery/images/cross_section.py
+++ b/examples/gallery/images/cross_section.py
@@ -37,7 +37,7 @@ fig.grdimage(grid=grid_map, cmap="oleron")
 
 # Add a colorbar for the elevation
 fig.colorbar(
-    # Place the colorbar inside the plot (lower-case "j") in the Bottom Right (BR)
+    # Place the colorbar inside the plot (lowercase "j") in the Bottom Right (BR)
     # corner with an offset ("+o") of 0.7 centimeters and 0.3 centimeters in x or y
     # directions, respectively; move the x label above the horizontal colorbar ("+ml")
     position="jBR+o0.7c/0.8c+h+w5c/0.3c+ml",

--- a/examples/gallery/lines/decorated_lines.py
+++ b/examples/gallery/lines/decorated_lines.py
@@ -51,7 +51,7 @@ for decoline in [
     "~d1c:+sd0.5c+gtan+p1p,black+n-0.2c/0.1c",
     # Give the number of equally spaced symbols by using "n" instead of "d"
     "~n6:+sn0.5c+gtan+p1p,black",
-    # Use upper-case "N" to have symbols at the start and end of the line
+    # Use uppercase "N" to have symbols at the start and end of the line
     "~N6:+sh0.5c+gtan+p1p,black",
     # Suppress the main decorated line by appending "+i"
     "~d1c:+sg0.5c+gtan+p1p,black+i",

--- a/examples/gallery/lines/quoted_lines.py
+++ b/examples/gallery/lines/quoted_lines.py
@@ -33,7 +33,7 @@ for quotedline in [
     "qd1c:+ltext+i",
     # Give the number of equally spaced labels by using "n" instead of "d"
     "qn5:+ltext",
-    # Use upper-case "N" to have labels at the start and end of the line
+    # Use uppercase "N" to have labels at the start and end of the line
     "qN5:+ltext",
     # To only plot a label at the start of the line use "N-1"
     "qN-1:+ltext",

--- a/examples/gallery/symbols/multi_parameter_symbols.py
+++ b/examples/gallery/symbols/multi_parameter_symbols.py
@@ -33,7 +33,7 @@ import pygmt
 #   directions given in degrees counter-clockwise from horizontal. Append **+i** and the
 #   desired value to apply an inner diameter.
 #
-# Upper-case versions **E**, **J**, and **W** are similar to **e**, **j**, and **w**
+# Uppercase versions **E**, **J**, and **W** are similar to **e**, **j**, and **w**
 # but expect geographic azimuths and distances.
 
 fig = pygmt.Figure()

--- a/examples/projections/cyl/cyl_oblique_mercator.py
+++ b/examples/projections/cyl/cyl_oblique_mercator.py
@@ -9,7 +9,7 @@ developed in the early 1900s by several workers.
 
 The projection is set with **o** or **O**. There are three different specification
 ways (**a**\|\ **A**, **b**\|\ **B**, **c**\|\ **C**) available. For all three
-definitions, the upper case letter mean the projection pole is set in the southern
+definitions, the uppercase letter mean the projection pole is set in the southern
 hemisphere [Default is northern hemisphere]. Align the y-axis with the optional
 modifier **+v**. The figure size is set with *scale* or *width*.
 """

--- a/examples/projections/nongeo/cartesian_linear.py
+++ b/examples/projections/nongeo/cartesian_linear.py
@@ -4,7 +4,7 @@ Cartesian linear
 
 **X**\ *width*\ [/*height*] or **x**\ *x-scale*\ [/*y-scale*]
 
-Give the *width* of the figure and the optional *height*. The lower-case version
+Give the *width* of the figure and the optional *height*. The lowercase version
 **x** is similar to **X** but expects an *x-scale* and an optional *y-scale*.
 
 The Cartesian linear projection is primarily designed for regular floating point

--- a/examples/projections/nongeo/cartesian_logarithmic.py
+++ b/examples/projections/nongeo/cartesian_logarithmic.py
@@ -6,7 +6,7 @@ Cartesian logarithmic
 **x**\ *x-scale*\ [**l**][/*y-scale*\ [**l**]]
 
 Give the *width* of the figure and the optional *height*.
-The lower-case version **x** is similar to **X** but expects
+The lowercase version **x** is similar to **X** but expects
 an *x-scale* and an optional *y-scale*.
 Each axis with a logarithmic transformation requires **l** after
 its size argument.

--- a/examples/projections/nongeo/cartesian_power.py
+++ b/examples/projections/nongeo/cartesian_power.py
@@ -6,7 +6,7 @@ Cartesian power
 **x**\ *x-scale*\ [**p**\ *pvalue*][/*y-scale*\ [**p**\ *pvalue*]]
 
 Give the *width* of the figure and the optional argument *height*.
-The lower-case version **x** is similar to **X** but expects
+The lowercase version **x** is similar to **X** but expects
 an *x-scale* and an optional *y-scale*.
 Each axis with a power transformation requires **p** and the exponent
 for that axis after its size argument.

--- a/examples/projections/nongeo/polar.py
+++ b/examples/projections/nongeo/polar.py
@@ -12,7 +12,7 @@ The full syntax for polar projections is:
 
 Limits are set via the ``region`` parameter
 ([*theta_min*, *theta_max*, *radius_min*, *radius_max*]). When using **P**\ *width* you
-have to give the *width* of the figure. The lower-case version **p** is similar to **P**
+have to give the *width* of the figure. The lowercase version **p** is similar to **P**
 but expects a *scale* instead of a width (**p**\ *scale*).
 
 The following customizing modifiers are available:

--- a/examples/tutorials/basics/frames.py
+++ b/examples/tutorials/basics/frames.py
@@ -90,9 +90,9 @@ fig.show()
 # :meth:`pygmt.Figure.basemap`. The map boundaries (or plot axes) are named as
 # West/west/left (**W**, **w**, **l**), South/south/bottom
 # (**S**, **s**, **b**), North/north/top (**N**, **n**, **t**), and
-# East/east/right (**E**, **e**, **r**) sides of a figure. If an upper-case
+# East/east/right (**E**, **e**, **r**) sides of a figure. If an uppercase
 # letter (**W**, **S**, **N**, **E**) is passed, the axis is plotted with
-# tick marks and annotations. The lower-case version
+# tick marks and annotations. The lowercase version
 # (**w**, **s**, **n**, **e**) plots the axis only with tick marks.
 # To only plot the axis pass **l**, **b**, **t**, **r**. By default
 # (``frame=True`` or ``frame="af"``), the West and the South axes are

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -119,13 +119,13 @@ COMMON_DOCSTRINGS = {
             criteria.
 
                 - **x**\|\ **X** - define a gap when there is a large enough
-                  change in the x coordinates (upper case to use projected
+                  change in the x coordinates (uppercase to use projected
                   coordinates).
                 - **y**\|\ **Y** - define a gap when there is a large enough
-                  change in the y coordinates (upper case to use projected
+                  change in the y coordinates (uppercase to use projected
                   coordinates).
                 - **d**\|\ **D** - define a gap when there is a large enough
-                  distance between coordinates (upper case to use projected
+                  distance between coordinates (uppercase to use projected
                   coordinates).
                 - **z** - define a gap when there is a large enough change in
                   the z data. Use **+c**\ *col* to change the z data column

--- a/pygmt/src/filter1d.py
+++ b/pygmt/src/filter1d.py
@@ -75,7 +75,7 @@ def filter1d(
         - **u**: upper (absolute). Return maximum of all values.
         - **U**: upper. Return maximum of all negative values only.
 
-        Upper case type **B**, **C**, **G**, **M**, **P**, **F** will use
+        Uppercase type **B**, **C**, **G**, **M**, **P**, **F** will use
         robust filter versions: i.e., replace outliers (2.5 L1 scale off
         median, using 1.4826 \* median absolute deviation [MAD]) with median
         during filtering.

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -136,7 +136,7 @@ def project(
     convention : str
         Specify the desired output using any combination of **xyzpqrs**, in
         any order [Default is **xypqrsz**]. Do not space between the letters.
-        Use lower case. The output will be columns of values corresponding to
+        Use lowercase. The output will be columns of values corresponding to
         your ``convention``. The **z** flag is special and refers to all
         numerical columns beyond the leading **x** and **y** in your input
         record. The **z** flag also includes any trailing text (which is

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -138,11 +138,11 @@ def text_(  # noqa: PLR0912
         **i** for inches, or **p** for points; if not given we consult
         :gmt-term:`PROJ_LENGTH_UNIT`) or *%* for a percentage of the font
         size. Optionally, use modifier **+t** to set the shape of the text
-        box when using ``fill`` and/or ``pen``. Append lower case **o**
-        to get a straight rectangle [Default is **o**]. Append upper case
+        box when using ``fill`` and/or ``pen``. Append lowercase **o**
+        to get a straight rectangle [Default is **o**]. Append uppercase
         **O** to get a rounded rectangle. In paragraph mode (*paragraph*)
-        you can also append lower case **c** to get a concave rectangle or
-        append upper case **C** to get a convex rectangle.
+        you can also append lowercase **c** to get a concave rectangle or
+        append uppercase **C** to get a convex rectangle.
     fill : str
         Set color for filling text boxes [Default is no fill].
     offset : str


### PR DESCRIPTION
**Description of proposed changes**

In the docs we use lowercase/uppercase, lower-case/upper-case and lower case/upper case. This PR makes all appearances consistent to use lowercase/uppercase.



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
