### PR TITLE
Fix the bug of converting Python sequence of datetime-like objects

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -205,6 +205,11 @@ def _to_numpy(data: Any) -> np.ndarray:
 
     array = np.ascontiguousarray(data, dtype=numpy_dtype)
 
+    # Check if a np.object_ or np.str_ array can be converted to np.datetime64.
+    if array.dtype.type in {np.object_, np.str_}:
+        with contextlib.suppress(TypeError, ValueError):
+            return np.ascontiguousarray(array, dtype=np.datetime64)
+
     # Check if a np.object_ array can be converted to np.str_.
     if array.dtype == np.object_:
         with contextlib.suppress(TypeError, ValueError):


### PR DESCRIPTION
Cherry-picked from https://github.com/GenericMappingTools/pygmt/pull/3758. Tests will be added in #3758.

Fixes https://github.com/GenericMappingTools/pygmt/issues/3757.

**Preview for affected tutorial**: https://pygmt-dev--3760.org.readthedocs.build/en/3760/tutorials/advanced/date_time_charts.html#using-python-s-datetime