### PR TITLE
Simplify doc/Makefile with sphinx-build make-mode

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,13 +1,11 @@
 # Makefile for Sphinx documentation
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -j auto
-SPHINXBUILD   = sphinx-build
+SPHINXOPTS    ?= -j auto
+SPHINXBUILD   ?= sphinx-build
 SPHINXAUTOGEN = sphinx-autogen
+SOURCEDIR     = .
 BUILDDIR      = _build
-
-# Internal variables.
-ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees  $(SPHINXOPTS) .
 
 .PHONY: help all api html server clean
 
@@ -28,20 +26,20 @@ api:
 	@echo
 	$(SPHINXAUTOGEN) -i -t _templates -o api/generated api/*.rst
 
-html: api
+html latex: api
 	@echo
-	@echo "Building HTML files."
+	@echo "Building "$@" files."
 	@echo
 	# Set PYGMT_USE_EXTERNAL_DISPLAY to "false" to disable external display
-	PYGMT_USE_EXTERNAL_DISPLAY="false" $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	PYGMT_USE_EXTERNAL_DISPLAY="false" $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+	@echo "Build finished. The files are in $(BUILDDIR)/$@."
 
 html-noplot: api
 	@echo
 	@echo "Building HTML files without example plots."
 	@echo
-	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -D plot_gallery=0 -M html $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
[`sphinx-build`](https://www.sphinx-doc.org/en/master/man/sphinx-build.html) started to provide the so-called [make-mode](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-M) since v1.2.0, which has been [the default mode since v1.5.0](https://www.sphinx-doc.org/en/master/man/sphinx-quickstart.html#cmdoption-sphinx-quickstart-use-make-mode).

Here is a simple comparison for the make-mode and the "normal" mode:

Old normal mode:
```
$(SPHINXBUILD) -b html $(SPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
```
make mode:
```
$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
```

These two modes are very similar, but in make-mode, we use `$(BUILDDIR)` not `$(BUILDDIR)/html`.

A good advantage is that we can use the same command for different Sphinx builders.

This PR updates `doc/Makefile` with the make-mode and also adds the `latex` target to generate LaTeX source files.

Address #1606.