### PR TITLE
Fix the 'html-noplot' make target for docs

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -39,7 +39,7 @@ html-noplot: api
 	@echo
 	@echo "Building HTML files without example plots."
 	@echo
-	$(SPHINXBUILD) -D plot_gallery=0 -M html $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+	$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) -D plot_gallery=0
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
`make html-noplot` started to fail after #3761.
```
$ make html-noplot

Generating rst source files of API documentation.

sphinx-autogen -i -t _templates -o api/generated api/*.rst
[autosummary] generating autosummary for: api/index.rst
[autosummary] writing to api/generated

Building HTML files without example plots.

sphinx-build -D plot_gallery=0 -M html -j auto "." "_build" -j auto
usage: sphinx-build [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]
sphinx-build: error: unrecognized arguments: -M
make: *** [Makefile:42: html-noplot] Error 2
```

In `sphinx-build` make-mode, `-M` must be the first option flag, then the source directory and build directory. All other options should be put at the end.

This PR patches https://github.com/GenericMappingTools/pygmt/pull/3761.