### PR TITLE
Fix the bug of converting Python sequence of datetime-like objects (#3760)

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -194,6 +194,11 @@ def _to_numpy(data: Any) -> np.ndarray:
 
     array = np.ascontiguousarray(data, dtype=numpy_dtype)
 
+    # Check if a np.object_ or np.str_ array can be converted to np.datetime64.
+    if array.dtype.type in {np.object_, np.str_}:
+        with contextlib.suppress(TypeError, ValueError):
+            return np.ascontiguousarray(array, dtype=np.datetime64)
+
     # Check if a np.object_ array can be converted to np.str_.
     if array.dtype == np.object_:
         with contextlib.suppress(TypeError, ValueError):


### PR DESCRIPTION
Backport PR #3760 into v0.14.x branch.

Co-authored-by: Wei Ji <23487320+weiji14@users.noreply.github.com>

