### PR TITLE
clib.conversion._to_numpy: Add tests for Python sequence of datetime-like objects (#3758)

### DIFF
--- a/pygmt/tests/baseline/test_plot_datetime.png.dvc
+++ b/pygmt/tests/baseline/test_plot_datetime.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 583947facaa873122f0bf18137809cd4
-  size: 12695
+- md5: 0a2eae0da1e3d5b71d7392de1c081346
+  size: 13124
   path: test_plot_datetime.png
   hash: md5

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -2,8 +2,8 @@
 Tests for the _to_numpy function in the clib.conversion module.
 """
 
+import datetime
 import sys
-from datetime import date, datetime
 
 import numpy as np
 import numpy.testing as npt
@@ -78,6 +78,70 @@ def test_to_numpy_python_types(data, expected_dtype):
     result = _to_numpy(data)
     _check_result(result, expected_dtype)
     npt.assert_array_equal(result, data)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(
+            ["2018", "2018-02", "2018-03-01", "2018-04-01T01:02:03"], id="iso8601"
+        ),
+        pytest.param(
+            [
+                datetime.date(2018, 1, 1),
+                datetime.datetime(2018, 2, 1),
+                datetime.date(2018, 3, 1),
+                datetime.datetime(2018, 4, 1, 1, 2, 3),
+            ],
+            id="datetime",
+        ),
+        pytest.param(
+            [
+                np.datetime64("2018"),
+                np.datetime64("2018-02"),
+                np.datetime64("2018-03-01"),
+                np.datetime64("2018-04-01T01:02:03"),
+            ],
+            id="np_datetime64",
+        ),
+        pytest.param(
+            [
+                pd.Timestamp("2018-01-01"),
+                pd.Timestamp("2018-02-01"),
+                pd.Timestamp("2018-03-01"),
+                pd.Timestamp("2018-04-01T01:02:03"),
+            ],
+            id="pd_timestamp",
+        ),
+        pytest.param(
+            [
+                "2018-01-01",
+                np.datetime64("2018-02-01"),
+                datetime.datetime(2018, 3, 1),
+                pd.Timestamp("2018-04-01T01:02:03"),
+            ],
+            id="mixed",
+        ),
+    ],
+)
+def test_to_numpy_python_datetime(data):
+    """
+    Test the _to_numpy function with Python sequence of datetime types.
+    """
+    result = _to_numpy(data)
+    assert result.dtype.type == np.datetime64
+    npt.assert_array_equal(
+        result,
+        np.array(
+            [
+                "2018-01-01T00:00:00",
+                "2018-02-01T00:00:00",
+                "2018-03-01T00:00:00",
+                "2018-04-01T01:02:03",
+            ],
+            dtype="datetime64[s]",
+        ),
+    )
 
 
 ########################################################################################
@@ -466,9 +530,9 @@ def test_to_numpy_pyarrow_date(dtype, expected_dtype):
     Here we explicitly check the dtype and date unit of the result.
     """
     data = [
-        date(2024, 1, 1),
-        datetime(2024, 1, 2),
-        datetime(2024, 1, 3),
+        datetime.date(2024, 1, 1),
+        datetime.datetime(2024, 1, 2),
+        datetime.datetime(2024, 1, 3),
     ]
     array = pa.array(data, type=dtype)
     result = _to_numpy(array)
@@ -512,7 +576,10 @@ def test_to_numpy_pyarrow_timestamp(dtype, expected_dtype):
 
     Reference: https://arrow.apache.org/docs/python/generated/pyarrow.timestamp.html
     """
-    data = [datetime(2024, 1, 2, 3, 4, 5), datetime(2024, 1, 2, 3, 4, 6)]
+    data = [
+        datetime.datetime(2024, 1, 2, 3, 4, 5),
+        datetime.datetime(2024, 1, 2, 3, 4, 6),
+    ]
     array = pa.array(data, type=dtype)
     result = _to_numpy(array)
     _check_result(result, np.datetime64)

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -467,9 +467,14 @@ def test_plot_datetime():
     fig.plot(x=x, y=y, style="a0.2c", pen="1p")
 
     # the Python built-in datetime and date
-    x = [datetime.date(2018, 1, 1), datetime.datetime(2019, 1, 1)]
+    x = [datetime.date(2018, 1, 1), datetime.datetime(2019, 1, 1, 0, 0, 0)]
     y = [8.5, 9.5]
     fig.plot(x=x, y=y, style="i0.2c", pen="1p")
+
+    # Python sequence of pd.Timestamp
+    x = [pd.Timestamp("2018-01-01"), pd.Timestamp("2019-01-01")]
+    y = [5.5, 6.5]
+    fig.plot(x=x, y=y, style="d0.2c", pen="1p")
     return fig
 
 


### PR DESCRIPTION
Backport PR #3758 into v0.14.x branch.

Co-authored-by: Wei Ji <23487320+weiji14@users.noreply.github.com>