### PR TITLE
CI: Bump to Ubuntu 22.04 in the GMT Legacy Tests workflow

### DIFF
--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-13, windows-2019]
+        os: [ubuntu-22.04, macos-13, windows-2019]
         gmt_version: ['6.4']
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
**Description of proposed changes**

Ubuntu 20.04 will be no longer supported soon (https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/).