### PR TITLE
Fix the dataset link in the RGB image gallery example

### DIFF
--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -22,7 +22,7 @@ import rioxarray
 # %%
 # Read 3-band data from GeoTIFF into an xarray.DataArray object:
 with rioxarray.open_rasterio(
-    filename="https://oin-hotosm.s3.us-east-1.amazonaws.com/64d6a49a19cb3a000147a65b/0/64d6a49a19cb3a000147a65c.tif",
+    filename="https://oin-hotosm-temp.s3.us-east-1.amazonaws.com/64d6a49a19cb3a000147a65b/0/64d6a49a19cb3a000147a65c.tif",
     overview_level=5,
 ) as img:
     # Subset to area of Lāhainā in EPSG:32604 coordinates


### PR DESCRIPTION
The "RGB images" gallery example was originally added in #2641. The example tiff file was from https://map.openaerialmap.org/#/-156.64478302001953,20.89666397351934,11/square/022300003203/64d6ae6619cb3a000147a65f?resolution=high&_k=nh7cia.

It turns out the source URL of the tiff has changed a little.


This PR fixes https://github.com/GenericMappingTools/pygmt/issues/3771.

**Preview**: https://pygmt-dev--3781.org.readthedocs.build/en/3781/gallery/images/rgb_image.html
