### PR TITLE
CI: Use matrix.os instead of runner.os in artifact name

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -177,7 +177,7 @@ jobs:
         uses: actions/upload-artifact@v4.6.0
         if: failure()
         with:
-          name: artifact-${{ runner.os }}-${{ matrix.python-version }}
+          name: artifact-${{ matrix.os }}-${{ matrix.python-version }}
           path: tmp-test-dir-with-unique-name
 
       # Upload coverage to Codecov

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -185,5 +185,5 @@ jobs:
         uses: actions/upload-artifact@v4.6.0
         if: ${{ failure() }}
         with:
-          name: artifact-GMT-${{ matrix.gmt_git_ref }}-${{ runner.os }}
+          name: artifact-GMT-${{ matrix.gmt_git_ref }}-${{ matrix.os }}
           path: tmp-test-dir-with-unique-name

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -185,5 +185,5 @@ jobs:
         uses: actions/upload-artifact@v4.6.0
         if: ${{ failure() }}
         with:
-          name: artifact-GMT-${{ matrix.gmt_git_ref }}-${{ matrix.os }}
+          name: artifact-${{ matrix.os }}-GMT-${{ matrix.gmt_git_ref }}
           path: tmp-test-dir-with-unique-name


### PR DESCRIPTION
**Description of proposed changes**

Fixes error `Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run` on the ubuntu-24.04-arm job. Sample job failure at https://github.com/GenericMappingTools/pygmt/actions/runs/13231430400/job/36929163034#step:16:17


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Patches #3778


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
