### PR TITLE
Specify supported platforms with classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ classifiers = [
     "Intended Audience :: Education",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -55,7 +59,6 @@ all = [
 "Issue Tracker" = "https://github.com/GenericMappingTools/pygmt/issues"
 
 [tool.setuptools]
-platforms = ["Any"]
 license-files = ["LICENSE.txt"]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Add "Operating System" classifiers and remove the `platforms` entry in `setuptools` section.

Fixes https://github.com/GenericMappingTools/pygmt/issues/3744.

