### PR TITLE
Bump to sphinx-gallery>=0.19 and use list in subsection_order and string in within_subsection_order

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,6 @@ from packaging.requirements import Requirement
 from pygmt import __commit__, __version__
 from pygmt.clib import required_gmt_version
 from pygmt.sphinx_gallery import PyGMTScraper
-from sphinx_gallery.sorting import ExampleTitleSortKey, ExplicitOrder
 
 # Dictionary for dependency name and minimum required versions
 requirements = {
@@ -112,34 +111,32 @@ sphinx_gallery_conf = {
     ],
     # Set paths where to save the generated examples
     "gallery_dirs": ["intro", "tutorials", "gallery", "projections"],
-    "subsection_order": ExplicitOrder(
-        [
-            "../examples/intro",
-            "../examples/tutorials/basics",
-            "../examples/tutorials/advanced",
-            "../examples/gallery/maps",
-            "../examples/gallery/lines",
-            "../examples/gallery/symbols",
-            "../examples/gallery/images",
-            "../examples/gallery/3d_plots",
-            "../examples/gallery/seismology",
-            "../examples/gallery/basemaps",
-            "../examples/gallery/histograms",
-            "../examples/gallery/embellishments",
-            "../examples/projections/azim",
-            "../examples/projections/conic",
-            "../examples/projections/cyl",
-            "../examples/projections/misc",
-            "../examples/projections/nongeo",
-            "../examples/projections/table",
-        ]
-    ),
+    "subsection_order": [
+        "../examples/intro",
+        "../examples/tutorials/basics",
+        "../examples/tutorials/advanced",
+        "../examples/gallery/maps",
+        "../examples/gallery/lines",
+        "../examples/gallery/symbols",
+        "../examples/gallery/images",
+        "../examples/gallery/3d_plots",
+        "../examples/gallery/seismology",
+        "../examples/gallery/basemaps",
+        "../examples/gallery/histograms",
+        "../examples/gallery/embellishments",
+        "../examples/projections/azim",
+        "../examples/projections/conic",
+        "../examples/projections/cyl",
+        "../examples/projections/misc",
+        "../examples/projections/nongeo",
+        "../examples/projections/table",
+    ],
     # Pattern to search for example files
     "filename_pattern": r"\.py",
     # Remove the "Download all examples" button from the top level gallery
     "download_all_examples": False,
     # Sort gallery examples by the file names instead of number of lines [Default]
-    "within_subsection_order": ExampleTitleSortKey,
+    "within_subsection_order": "ExampleTitleSortKey",
     # Directory where function granular galleries are stored
     "backreferences_dir": "api/generated/backreferences",
     # Modules for which function level galleries are created (given as tuple of strings)

--- a/environment.yml
+++ b/environment.yml
@@ -42,7 +42,7 @@ dependencies:
     - sphinx-autodoc-typehints
     - sphinx-copybutton
     - sphinx-design
-    - sphinx-gallery>=0.17.0
+    - sphinx-gallery>=0.19.0
     - sphinx_rtd_theme<3.0
     # Dev dependencies (building PDF documentation)
     - cairosvg


### PR DESCRIPTION
Since sphinx-gallery v0.16, it's possible to use plain list for `subsection_order` and string names for `within_subsection_order`, so we don't have to run `from sphinx_gallery.sorting import ExampleTitleSortKey, ExplicitOrder`.

However, this feature has a bug that wasn't fixed until https://github.com/sphinx-gallery/sphinx-gallery/pull/1391. So, this feature needs sphinx-gallery>=0.19.

xref: 

- https://github.com/sphinx-gallery/sphinx-gallery/issues/1293
- https://sphinx-gallery.github.io/stable/changes.html#v0-16-0
- https://sphinx-gallery.github.io/stable/configuration.html#importing-callables

**Preview**: https://pygmt-dev--3805.org.readthedocs.build/en/3805/index.html