### PR TITLE
DOC / Figure.meca: Use table for supported conventions

### DIFF
--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -241,15 +241,15 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
            | *strike2*, *dip2*, *rake2*,
            | *mantissa*, *exponent*
          - | angles in degrees;
-           | *mantissa*, *exponent*are for
-           | seismic moment in dyne-cm
+           | seismic moment is :math:`mantissa * 10 ^ {exponent}`
+           | in dyne-cm
        * - ``"mt"``
          - seismic moment tensor
          - | *mrr*, *mtt*, *mff*,
            | *mrt*, *mrf*, *mtf*,
            | *exponent*
-         - | moment components
-           | in dynes-cm
+         - | moment components 
+           | in :math:`10*{exponent}` dyne-cm
        * - ``"partial"``
          - partial focal mechanism
          - | *strike1*, *dip1*, *strike2*,
@@ -263,7 +263,8 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
            | *n_value*, *n_azimuth*, *n_plunge*,
            | *p_value*, *p_azimuth*, *p_plunge*,
            | *exponent*
-         - values in dyne-cm
+         - | values in :math:`10*{exponent}` dyne-cm;
+           | azimuth and plunge in degrees
 
     Full option list at :gmt-docs:`supplements/seis/meca.html`
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -235,8 +235,8 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
          - *strike*, *dip*, *rake*, *magnitude*
        * - ``"gcmt"``
          - global CMT
-         - | *strike1*, *dip1*, *rake1*, *strike2*, *dip2*, *rake2*,
-           | *mantissa*, *exponent*
+         - *strike1*, *dip1*, *rake1*, *strike2*, *dip2*, *rake2*,
+           *mantissa*, *exponent*
        * - ``"mt"``
          - seismic moment tensor
          - *mrr*, *mtt*, *mff*, *mrt*, *mrf*, *mtf*, *exponent*
@@ -245,8 +245,8 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
          - *strike1*, *dip1*, *strike2*, *fault_type*, *magnitude*
        * - ``"principal_axis"``
          - principal axis
-         - | *t_value*, *t_azimuth*, *t_plunge*, *n_value*, *n_azimuth*, *n_plunge*,
-           | *p_value*, *p_azimuth*, *p_plunge*, *exponent*
+         - *t_value*, *t_azimuth*, *t_plunge*, *n_value*, *n_azimuth*, *n_plunge*,
+           *p_value*, *p_azimuth*, *p_plunge*, *exponent*
 
     Full option list at :gmt-docs:`supplements/seis/meca.html`
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -221,7 +221,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
     r"""
     Plot focal mechanisms.
 
-    Different conventions are supported:
+    The following conventions are supported:
 
     .. list-table::
        :widths: 15 15 70
@@ -234,7 +234,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
          - Aki and Richard
          - *strike*, *dip*, *rake*, *magnitude*
        * - ``"gcmt"``
-         - global CMT
+         - global centroid moment tensor
          - *strike1*, *dip1*, *rake1*, *strike2*, *dip2*, *rake2*,
            *mantissa*, *exponent*
        * - ``"mt"``
@@ -265,7 +265,8 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
           - Columns 1 and 2: event longitude and latitude
           - Column 3: event depth (in kilometers)
           - Columns 4 to 3+n: focal mechanism parameters. The number of columns *n*
-            depends on the choice of ``convention``, which is described below.
+            depends on the choice of ``convention`` (see the table above for the
+            supported conventions).
           - Columns 4+n and 5+n: longitude and latitude at which to place the
             beachball. ``0 0`` plots the beachball at the longitude and latitude
             given in the columns 1 and 2. [optional; requires ``offset=True``].

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -235,8 +235,8 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
          - *strike*, *dip*, *rake*, *magnitude*
        * - ``"gcmt"``
          - global CMT
-         - *strike1*, *dip1*, *rake1*, *strike2*, *dip2*, *rake2*,
-           *mantissa*, *exponent*
+         - | *strike1*, *dip1*, *rake1*, *strike2*, *dip2*, *rake2*,
+           | *mantissa*, *exponent*
        * - ``"mt"``
          - seismic moment tensor
          - *mrr*, *mtt*, *mff*, *mrt*, *mrf*, *mtf*, *exponent*
@@ -245,8 +245,8 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
          - *strike1*, *dip1*, *strike2*, *fault_type*, *magnitude*
        * - ``"principal_axis"``
          - principal axis
-         - *t_value*, *t_azimuth*, *t_plunge*, *n_value*, *n_azimuth*, *n_plunge*,
-           *p_value*, *p_azimuth*, *p_plunge*, *exponent*
+         - | *t_value*, *t_azimuth*, *t_plunge*, *n_value*, *n_azimuth*, *n_plunge*,
+           | *p_value*, *p_azimuth*, *p_plunge*, *exponent*
 
     Full option list at :gmt-docs:`supplements/seis/meca.html`
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -223,8 +223,8 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
 
     The following focal mechanism conventions are supported:
 
-    .. list-table:: Supported focal mechanism conventions
-       :widths: 15 15 45 25
+    .. list-table:: Supported focal mechanism conventions.
+       :widths: 15 15 40 30
        :header-rows: 1
 
        * - Convention

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -223,7 +223,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
 
     The following conventions are supported:
 
-    .. list-table::
+    .. list-table:: Supported focal mechanism conventions
        :widths: 15 15 70
        :header-rows: 1
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -249,7 +249,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
            | *mrt*, *mrf*, *mtf*,
            | *exponent*
          - | moment components 
-           | in :math:`10*{exponent}` dyn-cm
+           | in :math:`10 ^ {exponent}` dyn-cm
        * - ``"partial"``
          - partial focal mechanism
          - | *strike1*, *dip1*, *strike2*,
@@ -263,7 +263,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
            | *n_value*, *n_azimuth*, *n_plunge*,
            | *p_value*, *p_azimuth*, *p_plunge*,
            | *exponent*
-         - | values in :math:`10*{exponent}` dyn-cm;
+         - | values in :math:`10 ^ {exponent}` dyn-cm;
            | azimuth and plunge in degrees
 
     Full option list at :gmt-docs:`supplements/seis/meca.html`

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -242,14 +242,14 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
            | *mantissa*, *exponent*
          - | angles in degrees;
            | seismic moment is :math:`mantissa * 10 ^ {exponent}`
-           | in dyne-cm
+           | in dyn-cm
        * - ``"mt"``
          - seismic moment tensor
          - | *mrr*, *mtt*, *mff*,
            | *mrt*, *mrf*, *mtf*,
            | *exponent*
          - | moment components 
-           | in :math:`10*{exponent}` dyne-cm
+           | in :math:`10*{exponent}` dyn-cm
        * - ``"partial"``
          - partial focal mechanism
          - | *strike1*, *dip1*, *strike2*,
@@ -263,7 +263,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
            | *n_value*, *n_azimuth*, *n_plunge*,
            | *p_value*, *p_azimuth*, *p_plunge*,
            | *exponent*
-         - | values in :math:`10*{exponent}` dyne-cm;
+         - | values in :math:`10*{exponent}` dyn-cm;
            | azimuth and plunge in degrees
 
     Full option list at :gmt-docs:`supplements/seis/meca.html`
@@ -315,7 +315,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
         [**+l**][**+m**][**+o**\ *dx*\ [/\ *dy*]][**+s**\ *reference*].
         Adjust scaling of the radius of the beachball, which is  proportional to the
         magnitude. By default, *scale* defines the size for magnitude = 5 (i.e., scalar
-        seismic moment M0 = 4.0E23 dynes-cm). If **+l** is used the radius will be
+        seismic moment M0 = 4.0E23 dyn-cm). If **+l** is used the radius will be
         proportional to the seismic moment instead. Use **+s** and give a *reference*
         to change the reference magnitude (or moment), and use **+m** to plot all
         beachballs with the same size. A text string can be specified to appear near

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -249,7 +249,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
            | *mrt*, *mrf*, *mtf*,
            | *exponent*
          - | moment components
-           | in :math:`10 ^ {exponent}` dyn cm
+           | in :math:`10 ^ {{exponent}}` dyn cm
        * - ``"partial"``
          - partial focal mechanism
          - | *strike1*, *dip1*, *strike2*,
@@ -263,7 +263,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
            | *n_value*, *n_azimuth*, *n_plunge*,
            | *p_value*, *p_azimuth*, *p_plunge*,
            | *exponent*
-         - | values in :math:`10 ^ {exponent}` dyn cm;
+         - | values in :math:`10 ^ {{exponent}}` dyn cm;
            | azimuth and plunge in degrees
 
     Full option list at :gmt-docs:`supplements/seis/meca.html`

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -235,7 +235,8 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
          - *strike*, *dip*, *rake*, *magnitude*
        * - ``"gcmt"``
          - global CMT
-         - *strike1*, *dip1*, *rake1*, *strike2*, *dip2*, *rake2*, *mantissa*, *exponent*
+         - *strike1*, *dip1*, *rake1*, *strike2*, *dip2*, *rake2*,
+           *mantissa*, *exponent*
        * - ``"mt"``
          - seismic moment tensor
          - *mrr*, *mtt*, *mff*, *mrt*, *mrf*, *mtf*, *exponent*
@@ -244,8 +245,8 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
          - *strike1*, *dip1*, *strike2*, *fault_type*, *magnitude*
        * - ``"principal_axis"``
          - principal axis
-         - | *t_value*, *t_azimuth*, *t_plunge*, *n_value*, *n_azimuth*, *n_plunge*, 
-         - | *p_value*, *p_azimuth*, *p_plunge*, *exponent*
+         - *t_value*, *t_azimuth*, *t_plunge*, *n_value*, *n_azimuth*, *n_plunge*,
+           *p_value*, *p_azimuth*, *p_plunge*, *exponent*
 
     Full option list at :gmt-docs:`supplements/seis/meca.html`
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -296,7 +296,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
         - *dict* or :class:`pandas.DataFrame`: The dict keys or
           :class:`pandas.DataFrame` column names determine the focal mechanism
           convention. For the different conventions, the combination of keys /
-          column names as given in the tabel above are required.
+          column names as given in the table above are required.
 
           A dict may contain values for a single focal mechanism or lists of
           values for multiple focal mechanisms.

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -223,6 +223,39 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
 
     Full option list at :gmt-docs:`supplements/seis/meca.html`
 
+    Different conventions are supported:
+
+    | Convention | Description | Focal parameters |
+    | --- | --- | --- |
+    | ``"aki"`` | Aki and Richard | *strike*, *dip*, *rake*, *magnitude* |
+    | ``"gcmt"`` | global CMT | *strike1*, *dip1*, *rake1*, *strike2*, *dip2*, *rake2*, *mantissa*, *exponent* |
+    | ``"mt"`` | seismic moment tensor | *mrr*, *mtt*, *mff*, *mrt*, *mrf*, *mtf*, *exponent* |
+    | ``"partial"`` | partial focal mechanism | *strike1*, *dip1*, *strike2*, *fault_type*, *magnitude* |
+    | ``"principal_axis"`` | principal axis | *t_value*, *t_azimuth*, *t_plunge*, *n_value*, *n_azimuth*, *n_plunge*, *p_value*, *p_azimuth*, *p_plunge*, *exponent* |
+
+    .. list-table::
+       :widths: 30  30 30
+       :header-rows: 1
+
+       * - Convention
+         - Description
+         - Focal parameters
+       * - ``"aki"``
+         - Aki and Richard 
+         - *strike*, *dip*, *rake*, *magnitude*
+       * - ``"gcmt"``
+	     - global CMT
+         - *strike1*, *dip1*, *rake1*, *strike2*, *dip2*, *rake2*, *mantissa*, *exponent*
+       * - ``"mt"``
+	     - seismic moment tensor 
+         - *mrr*, *mtt*, *mff*, *mrt*, *mrf*, *mtf*, *exponent*
+       * - ``"partial"`` 
+	     - partial focal mechanism
+         - *strike1*, *dip1*, *strike2*, *fault_type*, *magnitude*
+	   * - ``"principal_axis"`` 
+	     - principal axis
+         - *t_value*, *t_azimuth*, *t_plunge*, *n_value*, *n_azimuth*, *n_plunge*, *p_value*, *p_azimuth*, *p_plunge*, *exponent*
+
     {aliases}
 
     Parameters
@@ -250,16 +283,8 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
           The meanings of columns are the same as above.
         - *dict* or :class:`pandas.DataFrame`: The dict keys or
           :class:`pandas.DataFrame` column names determine the focal mechanism
-          convention. For the different conventions, the following combination of
-          keys / column names are required:
-
-          - ``"aki"``: *strike*, *dip*, *rake*, *magnitude*
-          - ``"gcmt"``: *strike1*, *dip1*, *rake1*, *strike2*, *dip2*, *rake2*,
-            *mantissa*, *exponent*
-          - ``"mt"``: *mrr*, *mtt*, *mff*, *mrt*, *mrf*, *mtf*, *exponent*
-          - ``"partial"``: *strike1*, *dip1*, *strike2*, *fault_type*, *magnitude*
-          - ``"principal_axis"``: *t_value*, *t_azimuth*, *t_plunge*, *n_value*,
-            *n_azimuth*, *n_plunge*, *p_value*, *p_azimuth*, *p_plunge*, *exponent*
+          convention. For the different conventions, the combination of keys /
+          column names as given in the tabel above are required.
 
           A dict may contain values for a single focal mechanism or lists of
           values for multiple focal mechanisms.
@@ -287,14 +312,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
         the text location relative to the beachball [Default is ``"TC"``, i.e., Top
         Center]; append **+o** to offset the text string by *dx*\ /*dy*.
     convention : str
-        Focal mechanism convention. Choose from:
-
-        - ``"aki"`` (Aki and Richards)
-        - ``"gcmt"`` (global CMT)
-        - ``"mt"`` (seismic moment tensor)
-        - ``"partial"`` (partial focal mechanism)
-        - ``"principal_axis"`` (principal axis)
-
+        Focal mechanism convention. See the table above for the supported conventions.
         Ignored if ``spec`` is a dict or :class:`pandas.DataFrame`.
     component : str
         The component of the seismic moment tensor to plot.

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -246,18 +246,21 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
          - | *mrr*, *mtt*, *mff*,
            | *mrt*, *mrf*, *mtf*,
            | *exponent*
-         - moment components in dynes-cm
+         - | moment components
+           | in dynes-cm
        * - ``"partial"``
          - partial focal mechanism
          - | *strike1*, *dip1*, *strike2*,
            | *fault_type*, *magnitude*
-         - | angles in degrees; *fault_type* means
-           | +1/-1 for normal/reverse fault
+         - | angles in degrees;
+           | *fault_type* means +1/-1 for
+           | normal/reverse fault
        * - ``"principal_axis"``
          - principal axis
          - | *t_value*, *t_azimuth*, *t_plunge*,
            | *n_value*, *n_azimuth*, *n_plunge*,
-           | *p_value*, *p_azimuth*, *p_plunge*, *exponent*
+           | *p_value*, *p_azimuth*, *p_plunge*,
+           | *exponent*
          - angles in degrees
 
     Full option list at :gmt-docs:`supplements/seis/meca.html`

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -242,14 +242,14 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
            | *mantissa*, *exponent*
          - | angles in degrees;
            | seismic moment is :math:`mantissa * 10 ^ {exponent}`
-           | in dyn-cm
+           | in dyn cm
        * - ``"mt"``
          - seismic moment tensor
          - | *mrr*, *mtt*, *mff*,
            | *mrt*, *mrf*, *mtf*,
            | *exponent*
          - | moment components
-           | in :math:`10 ^ {exponent}` dyn-cm
+           | in :math:`10 ^ {exponent}` dyn cm
        * - ``"partial"``
          - partial focal mechanism
          - | *strike1*, *dip1*, *strike2*,
@@ -263,7 +263,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
            | *n_value*, *n_azimuth*, *n_plunge*,
            | *p_value*, *p_azimuth*, *p_plunge*,
            | *exponent*
-         - | values in :math:`10 ^ {exponent}` dyn-cm;
+         - | values in :math:`10 ^ {exponent}` dyn cm;
            | azimuth and plunge in degrees
 
     Full option list at :gmt-docs:`supplements/seis/meca.html`
@@ -315,7 +315,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
         [**+l**][**+m**][**+o**\ *dx*\ [/\ *dy*]][**+s**\ *reference*].
         Adjust scaling of the radius of the beachball, which is  proportional to the
         magnitude. By default, *scale* defines the size for magnitude = 5 (i.e., scalar
-        seismic moment M0 = 4.0E23 dyn-cm). If **+l** is used the radius will be
+        seismic moment M0 = 4.0E23 dyn cm). If **+l** is used the radius will be
         proportional to the seismic moment instead. Use **+s** and give a *reference*
         to change the reference magnitude (or moment), and use **+m** to plot all
         beachballs with the same size. A text string can be specified to appear near

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -225,16 +225,8 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
 
     Different conventions are supported:
 
-    | Convention | Description | Focal parameters |
-    | --- | --- | --- |
-    | ``"aki"`` | Aki and Richard | *strike*, *dip*, *rake*, *magnitude* |
-    | ``"gcmt"`` | global CMT | *strike1*, *dip1*, *rake1*, *strike2*, *dip2*, *rake2*, *mantissa*, *exponent* |
-    | ``"mt"`` | seismic moment tensor | *mrr*, *mtt*, *mff*, *mrt*, *mrf*, *mtf*, *exponent* |
-    | ``"partial"`` | partial focal mechanism | *strike1*, *dip1*, *strike2*, *fault_type*, *magnitude* |
-    | ``"principal_axis"`` | principal axis | *t_value*, *t_azimuth*, *t_plunge*, *n_value*, *n_azimuth*, *n_plunge*, *p_value*, *p_azimuth*, *p_plunge*, *exponent* |
-
     .. list-table::
-       :widths: 30  30 30
+       :widths: 30 30 30
        :header-rows: 1
 
        * - Convention

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -221,12 +221,10 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
     r"""
     Plot focal mechanisms.
 
-    Full option list at :gmt-docs:`supplements/seis/meca.html`
-
     Different conventions are supported:
 
     .. list-table::
-       :widths: 30 30 30
+       :widths: 15 15 70
        :header-rows: 1
 
        * - Convention
@@ -234,19 +232,22 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
          - Focal parameters
        * - ``"aki"``
          - Aki and Richard
-         - strike, dip, rake, magnitude
+         - *strike*, *dip*, *rake*, *magnitude*
        * - ``"gcmt"``
          - global CMT
-         - strike1, dip1, rake1, strike2, dip2, rake2, mantissa, exponent
+         - *strike1*, *dip1*, *rake1*, *strike2*, *dip2*, *rake2*, *mantissa*, *exponent*
        * - ``"mt"``
          - seismic moment tensor
-         - mrr, mtt, mff, mrt, mrf, mtf, exponent
+         - *mrr*, *mtt*, *mff*, *mrt*, *mrf*, *mtf*, *exponent*
        * - ``"partial"``
          - partial focal mechanism
-         - strike1, dip1, strike2, fault_type, magnitude
+         - *strike1*, *dip1*, *strike2*, *fault_type*, *magnitude*
        * - ``"principal_axis"``
          - principal axis
-         - t_value, t_azimuth, t_plunge, n_value, n_azimuth, n_plunge, p_value, p_azimuth, p_plunge, exponent
+         - | *t_value*, *t_azimuth*, *t_plunge*, *n_value*, *n_azimuth*, *n_plunge*, 
+         - | *p_value*, *p_azimuth*, *p_plunge*, *exponent*
+
+    Full option list at :gmt-docs:`supplements/seis/meca.html`
 
     {aliases}
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -224,29 +224,41 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
     The following focal mechanism conventions are supported:
 
     .. list-table:: Supported focal mechanism conventions
-       :widths: 15 15 70
+       :widths: 15 15 45 25
        :header-rows: 1
 
        * - Convention
          - Description
          - Focal parameters
+         - Remark
        * - ``"aki"``
          - Aki and Richard
          - *strike*, *dip*, *rake*, *magnitude*
+         - angles in degrees
        * - ``"gcmt"``
          - global centroid moment tensor
-         - *strike1*, *dip1*, *rake1*, *strike2*, *dip2*, *rake2*,
-           *mantissa*, *exponent*
+         - | *strike1*, *dip1*, *rake1*,
+           | *strike2*, *dip2*, *rake2*,
+           | *mantissa*, *exponent*
+         - angles in degrees
        * - ``"mt"``
          - seismic moment tensor
-         - *mrr*, *mtt*, *mff*, *mrt*, *mrf*, *mtf*, *exponent*
+         - | *mrr*, *mtt*, *mff*,
+           | *mrt*, *mrf*, *mtf*,
+           | *exponent*
+         - moment components in dynes-cm
        * - ``"partial"``
          - partial focal mechanism
-         - *strike1*, *dip1*, *strike2*, *fault_type*, *magnitude*
+         - | *strike1*, *dip1*, *strike2*,
+           | *fault_type*, *magnitude*
+         - | angles in degrees; *fault_type* means
+           | +1/-1 for normal/reverse fault
        * - ``"principal_axis"``
          - principal axis
-         - *t_value*, *t_azimuth*, *t_plunge*, *n_value*, *n_azimuth*, *n_plunge*,
-           *p_value*, *p_azimuth*, *p_plunge*, *exponent*
+         - | *t_value*, *t_azimuth*, *t_plunge*,
+           | *n_value*, *n_azimuth*, *n_plunge*,
+           | *p_value*, *p_azimuth*, *p_plunge*, *exponent*
+         - angles in degrees
 
     Full option list at :gmt-docs:`supplements/seis/meca.html`
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -221,7 +221,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
     r"""
     Plot focal mechanisms.
 
-    The following conventions are supported:
+    The following focal mechanism conventions are supported:
 
     .. list-table:: Supported focal mechanism conventions
        :widths: 15 15 70

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -241,7 +241,8 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
            | *strike2*, *dip2*, *rake2*,
            | *mantissa*, *exponent*
          - | angles in degrees;
-           | seismic moment is :math:`mantissa * 10 ^ {{exponent}}`
+           | seismic moment is
+           | :math:`mantissa * 10 ^ {{exponent}}`
            | in dyn cm
        * - ``"mt"``
          - seismic moment tensor
@@ -264,7 +265,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
            | *p_value*, *p_azimuth*, *p_plunge*,
            | *exponent*
          - | values in :math:`10 ^ {{exponent}}` dyn cm;
-           | azimuth and plunge in degrees
+           | azimuths and plunges in degrees
 
     Full option list at :gmt-docs:`supplements/seis/meca.html`
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -240,7 +240,9 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
          - | *strike1*, *dip1*, *rake1*,
            | *strike2*, *dip2*, *rake2*,
            | *mantissa*, *exponent*
-         - angles in degrees
+         - | angles in degrees;
+           | *mantissa*, *exponent*are for
+           | seismic moment in dyne-cm
        * - ``"mt"``
          - seismic moment tensor
          - | *mrr*, *mtt*, *mff*,
@@ -261,7 +263,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
            | *n_value*, *n_azimuth*, *n_plunge*,
            | *p_value*, *p_azimuth*, *p_plunge*,
            | *exponent*
-         - angles in degrees
+         - values in dyne-cm
 
     Full option list at :gmt-docs:`supplements/seis/meca.html`
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -234,19 +234,19 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
          - Focal parameters
        * - ``"aki"``
          - Aki and Richard 
-         - *strike*, *dip*, *rake*, *magnitude*
+         - strike, dip, rake, magnitude
        * - ``"gcmt"``
 	     - global CMT
-         - *strike1*, *dip1*, *rake1*, *strike2*, *dip2*, *rake2*, *mantissa*, *exponent*
+         - strike1, dip1, rake1, strike2, dip2, rake2, mantissa, exponent
        * - ``"mt"``
 	     - seismic moment tensor 
-         - *mrr*, *mtt*, *mff*, *mrt*, *mrf*, *mtf*, *exponent*
+         - mrr, mtt, mff, mrt, mrf, mtf, exponent
        * - ``"partial"`` 
 	     - partial focal mechanism
-         - *strike1*, *dip1*, *strike2*, *fault_type*, *magnitude*
+         - strike1, dip1, strike2, fault_type, magnitude
 	   * - ``"principal_axis"`` 
 	     - principal axis
-         - *t_value*, *t_azimuth*, *t_plunge*, *n_value*, *n_azimuth*, *n_plunge*, *p_value*, *p_azimuth*, *p_plunge*, *exponent*
+         - t_value, t_azimuth, t_plunge, n_value, n_azimuth, n_plunge, p_value, p_azimuth, p_plunge, exponent
 
     {aliases}
 

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -241,7 +241,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
            | *strike2*, *dip2*, *rake2*,
            | *mantissa*, *exponent*
          - | angles in degrees;
-           | seismic moment is :math:`mantissa * 10 ^ {exponent}`
+           | seismic moment is :math:`mantissa * 10 ^ {{exponent}}`
            | in dyn cm
        * - ``"mt"``
          - seismic moment tensor

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -233,19 +233,19 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
          - Description
          - Focal parameters
        * - ``"aki"``
-         - Aki and Richard 
+         - Aki and Richard
          - strike, dip, rake, magnitude
        * - ``"gcmt"``
-	     - global CMT
+         - global CMT
          - strike1, dip1, rake1, strike2, dip2, rake2, mantissa, exponent
        * - ``"mt"``
-	     - seismic moment tensor 
+         - seismic moment tensor
          - mrr, mtt, mff, mrt, mrf, mtf, exponent
-       * - ``"partial"`` 
-	     - partial focal mechanism
+       * - ``"partial"``
+         - partial focal mechanism
          - strike1, dip1, strike2, fault_type, magnitude
-	   * - ``"principal_axis"`` 
-	     - principal axis
+       * - ``"principal_axis"``
+         - principal axis
          - t_value, t_azimuth, t_plunge, n_value, n_azimuth, n_plunge, p_value, p_azimuth, p_plunge, exponent
 
     {aliases}

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -248,7 +248,7 @@ def meca(  # noqa: PLR0912, PLR0913, PLR0915
          - | *mrr*, *mtt*, *mff*,
            | *mrt*, *mrf*, *mtf*,
            | *exponent*
-         - | moment components 
+         - | moment components
            | in :math:`10 ^ {exponent}` dyn-cm
        * - ``"partial"``
          - partial focal mechanism


### PR DESCRIPTION
**Description of proposed changes**

Add table for the supported conventions of `Figure.meca` to docs.

Tabels in RST: https://sublime-and-sphinx-guide.readthedocs.io/en/latest/tables.html

See comment https://github.com/GenericMappingTools/pygmt/pull/3517#discussion_r1898603232

**Preview**: https://pygmt-dev--3811.org.readthedocs.build/en/3811/api/generated/pygmt.Figure.meca.html#pygmt.Figure.meca

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
