### PR TITLE
CI: Disable building PDF documentation in ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -36,8 +36,8 @@ sphinx:
    configuration: doc/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
-formats:
-   - pdf
+# formats:
+#   - pdf
 
 # Optionally declare the Python requirements required to build your docs
 conda:


### PR DESCRIPTION
**Description of proposed changes**

Our CI started to build the PDF documentation since PR #3765, and the PDF file for the dev version is deployed to the gh-pages branch and can be accessed via http://pygmt.org/dev/pygmt-docs.pdf.

So we no longer need to build PDF in ReadTheDocs.

This PR disables building PDF in ReadTheDocs. Revert #2876.