### PR TITLE
CI: Upload documentation HTML ZIP archive and PDF file as release assets

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -151,6 +151,12 @@ jobs:
         run: cp -v doc/_build/pygmt-docs.zip doc/_build/pygmt-docs.pdf doc/_build/html/
         if: github.event_name == 'push' && matrix.os == 'ubuntu-latest'
 
+      - name: Upload the HTML ZIP archive and PDF as release assets
+        run: gh release upload ${{ github.ref_name }} doc/_build/pygmt-docs.zip doc/_build/pygmt-docs.pdf
+        if: github.event_name == 'release' && matrix.os == 'ubuntu-latest'
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Checkout the gh-pages branch
         uses: actions/checkout@v4.2.2
         with:


### PR DESCRIPTION
Upload pygmt-docs.zip and pygmt-docs.pdf as release assets when making a release.

I tried to commit the same changes into the main branch of my own fork (https://github.com/seisman/pygmt/commit/bba01b4879fb0ed087f5771e1016d49d0af8bba4) and made a dummy v0.99.9 release at https://github.com/seisman/pygmt/releases/tag/v0.99.9. The two files were uploaded as release assets successfully. 

Addressing https://github.com/GenericMappingTools/pygmt/issues/3731 and #1606.