### PR TITLE
DOC: Update two gallery examples with Figure.shift_origin as context manager

### DIFF
--- a/examples/gallery/3d_plots/scatter3d.py
+++ b/examples/gallery/3d_plots/scatter3d.py
@@ -92,9 +92,8 @@ fig.plot3d(
     zscale=1.5,
 )
 
-# Shift plot origin in x direction
-fig.shift_origin(xshift="3.1c")
-# Add colorbar legend
-fig.colorbar()
+# Shift plot origin in x direction temporarily and add the color bar
+with fig.shift_origin(xshift=3.1):
+    fig.colorbar()
 
 fig.show()

--- a/examples/gallery/3d_plots/scatter3d.py
+++ b/examples/gallery/3d_plots/scatter3d.py
@@ -92,7 +92,7 @@ fig.plot3d(
     zscale=1.5,
 )
 
-# Shift plot origin in x direction temporarily and add the color bar
+# Shift the plot origin in x direction temporarily and add the colorbar
 with fig.shift_origin(xshift=3.1):
     fig.colorbar()
 

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -42,35 +42,33 @@ fig.basemap(
 # level for all circles to deal with overplotting.
 fig.plot(x=x, y=y, style="c0.15c", fill=fill, transparency=50)
 
-# Shift the plot origin and add top margin histogram.
-fig.shift_origin(yshift=height + 0.25)
+# Shift the plot origin in y direction temporarily and add top margin histogram.
+with fig.shift_origin(yshift=height + 0.25):
+    fig.histogram(
+        projection=f"X{width}/3",
+        frame=["Wsrt", "xf", "yaf+lCounts"],
+        # Give the same value for ymin and ymax to have them calculated automatically.
+        region=[xmin, xmax, 0, 0],
+        data=x,
+        fill=fill,
+        pen="0.1p,white",
+        histtype=0,
+        series=0.2,
+    )
 
-fig.histogram(
-    projection=f"X{width}/3",
-    frame=["Wsrt", "xf", "yaf+lCounts"],
-    # Give the same value for ymin and ymax to have them calculated automatically.
-    region=[xmin, xmax, 0, 0],
-    data=x,
-    fill=fill,
-    pen="0.1p,white",
-    histtype=0,
-    series=0.2,
-)
-
-# Shift the plot origin and add right margin histogram.
-fig.shift_origin(yshift=-height - 0.25, xshift=width + 0.25)
-
-# Plot the horizontal histogram.
-fig.histogram(
-    horizontal=True,
-    projection=f"X3/{height}",
-    # Note that the x- and y-axis are flipped, with the y-axis plotted horizontally.
-    frame=["wSrt", "xf", "yaf+lCounts"],
-    region=[ymin, ymax, 0, 0],
-    data=y,
-    fill=fill,
-    pen="0.1p,white",
-    histtype=0,
-    series=0.2,
-)
+# Shift the plot origin in x direction temporarily and add right margin histogram.
+with fig.shift_origin(xshift=width + 0.25):
+    # Plot the horizontal histogram.
+    fig.histogram(
+        horizontal=True,
+        projection=f"X3/{height}",
+        # Note that the x- and y-axis are flipped, with the y-axis plotted horizontally.
+        frame=["wSrt", "xf", "yaf+lCounts"],
+        region=[ymin, ymax, 0, 0],
+        data=y,
+        fill=fill,
+        pen="0.1p,white",
+        histtype=0,
+        series=0.2,
+    )
 fig.show()

--- a/examples/gallery/histograms/scatter_and_histograms.py
+++ b/examples/gallery/histograms/scatter_and_histograms.py
@@ -62,7 +62,7 @@ with fig.shift_origin(xshift=width + 0.25):
     fig.histogram(
         horizontal=True,
         projection=f"X3/{height}",
-        # Note that the x- and y-axis are flipped, with the y-axis plotted horizontally.
+        # Note that the x- and y-axes are flipped, with the y-axis plotted horizontally.
         frame=["wSrt", "xf", "yaf+lCounts"],
         region=[ymin, ymax, 0, 0],
         data=y,


### PR DESCRIPTION
With PR #2509 merged, now it's possible to simplify a few gallery examples by calling `Figure.shift_origin` as a context manager.

**Preview**:

- https://pygmt-dev--3819.org.readthedocs.build/en/3819/gallery/3d_plots/scatter3d.html
- https://pygmt-dev--3819.org.readthedocs.build/en/3819/gallery/histograms/scatter_and_histograms.html