### PR TITLE
POC: Add common docstrings for meca/coupe

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -358,12 +358,12 @@ COMMON_DOCSTRINGS = {
     "spec": r"""
         spec : str, 1-D numpy array, 2-D numpy array, dict, or pandas.DataFrame
             Data that contain focal mechanism parameters.
-    
+
             ``spec`` can be specified in either of the following types:
-    
+
             - *str*: a file name containing focal mechanism parameters as columns. The
               meaning of each column is:
-    
+
               - Columns 1 and 2: event longitude and latitude
               - Column 3: event depth (in kilometers)
               - Columns 4 to 3+n: focal mechanism parameters. The number of columns *n*
@@ -373,7 +373,7 @@ COMMON_DOCSTRINGS = {
                 beachball. ``0 0`` plots the beachball at the longitude and latitude
                 given in the columns 1 and 2. [optional; requires ``offset=True``].
               - Last Column: text string to appear near the beachball [optional].
-    
+
             - *1-D np.array*: focal mechanism parameters of a single event.
               The meanings of columns are the same as above.
             - *2-D np.array*: focal mechanism parameters of multiple events.
@@ -382,14 +382,14 @@ COMMON_DOCSTRINGS = {
               :class:`pandas.DataFrame` column names determine the focal mechanism
               convention. For the different conventions, the combination of keys /
               column names as given in the table above are required.
-    
+
               A dict may contain values for a single focal mechanism or lists of
               values for multiple focal mechanisms.
-    
+
               Both dict and :class:`pandas.DataFrame` may optionally contain the keys /
               column names: ``latitude``, ``longitude``, ``depth``, ``plot_longitude``,
               ``plot_latitude``, and/or ``event_name``.
-    
+
             If ``spec`` is either a str or a 1-D or 2-D numpy array, the ``convention``
             parameter is required to interpret the columns. If ``spec`` is a dict or
             a :class:`pandas.DataFrame`, ``convention`` is not needed and ignored if

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -393,7 +393,7 @@ COMMON_DOCSTRINGS = {
             If ``spec`` is either a str or a 1-D or 2-D numpy array, the ``convention``
             parameter is required to interpret the columns. If ``spec`` is a dict or
             a :class:`pandas.DataFrame`, ``convention`` is not needed and ignored if
-            specified.
+            specified. """,
     "transparency": r"""
         transparency : float
             Set transparency level, in [0-100] percent range

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -355,6 +355,45 @@ COMMON_DOCSTRINGS = {
             **Note**: If ``region=grdfile`` is used then the grid spacing and
             the registration have already been initialized; use ``spacing`` and
             ``registration`` to override these values.""",
+    "spec": r"""
+        spec : str, 1-D numpy array, 2-D numpy array, dict, or pandas.DataFrame
+            Data that contain focal mechanism parameters.
+    
+            ``spec`` can be specified in either of the following types:
+    
+            - *str*: a file name containing focal mechanism parameters as columns. The
+              meaning of each column is:
+    
+              - Columns 1 and 2: event longitude and latitude
+              - Column 3: event depth (in kilometers)
+              - Columns 4 to 3+n: focal mechanism parameters. The number of columns *n*
+                depends on the choice of ``convention`` (see the table above for the
+                supported conventions).
+              - Columns 4+n and 5+n: longitude and latitude at which to place the
+                beachball. ``0 0`` plots the beachball at the longitude and latitude
+                given in the columns 1 and 2. [optional; requires ``offset=True``].
+              - Last Column: text string to appear near the beachball [optional].
+    
+            - *1-D np.array*: focal mechanism parameters of a single event.
+              The meanings of columns are the same as above.
+            - *2-D np.array*: focal mechanism parameters of multiple events.
+              The meanings of columns are the same as above.
+            - *dict* or :class:`pandas.DataFrame`: The dict keys or
+              :class:`pandas.DataFrame` column names determine the focal mechanism
+              convention. For the different conventions, the combination of keys /
+              column names as given in the table above are required.
+    
+              A dict may contain values for a single focal mechanism or lists of
+              values for multiple focal mechanisms.
+    
+              Both dict and :class:`pandas.DataFrame` may optionally contain the keys /
+              column names: ``latitude``, ``longitude``, ``depth``, ``plot_longitude``,
+              ``plot_latitude``, and/or ``event_name``.
+    
+            If ``spec`` is either a str or a 1-D or 2-D numpy array, the ``convention``
+            parameter is required to interpret the columns. If ``spec`` is a dict or
+            a :class:`pandas.DataFrame`, ``convention`` is not needed and ignored if
+            specified.
     "transparency": r"""
         transparency : float
             Set transparency level, in [0-100] percent range

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -99,6 +99,7 @@ def meca(  # noqa: PLR0912, PLR0913
 
     Parameters
     ----------
+    {spec}
     scale : float or str
         *scale*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*]\
         [**+l**][**+m**][**+o**\ *dx*\ [/\ *dy*]][**+s**\ *reference*].
@@ -192,7 +193,6 @@ def meca(  # noqa: PLR0912, PLR0913
     {verbose}
     {panel}
     {perspective}
-    {spec}
     {transparency}
     """
     kwargs = self._preprocess(**kwargs)

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -99,44 +99,6 @@ def meca(  # noqa: PLR0912, PLR0913
 
     Parameters
     ----------
-    spec : str, 1-D numpy array, 2-D numpy array, dict, or pandas.DataFrame
-        Data that contain focal mechanism parameters.
-
-        ``spec`` can be specified in either of the following types:
-
-        - *str*: a file name containing focal mechanism parameters as columns. The
-          meaning of each column is:
-
-          - Columns 1 and 2: event longitude and latitude
-          - Column 3: event depth (in kilometers)
-          - Columns 4 to 3+n: focal mechanism parameters. The number of columns *n*
-            depends on the choice of ``convention`` (see the table above for the
-            supported conventions).
-          - Columns 4+n and 5+n: longitude and latitude at which to place the
-            beachball. ``0 0`` plots the beachball at the longitude and latitude
-            given in the columns 1 and 2. [optional; requires ``offset=True``].
-          - Last Column: text string to appear near the beachball [optional].
-
-        - *1-D np.array*: focal mechanism parameters of a single event.
-          The meanings of columns are the same as above.
-        - *2-D np.array*: focal mechanism parameters of multiple events.
-          The meanings of columns are the same as above.
-        - *dict* or :class:`pandas.DataFrame`: The dict keys or
-          :class:`pandas.DataFrame` column names determine the focal mechanism
-          convention. For the different conventions, the combination of keys /
-          column names as given in the table above are required.
-
-          A dict may contain values for a single focal mechanism or lists of
-          values for multiple focal mechanisms.
-
-          Both dict and :class:`pandas.DataFrame` may optionally contain the keys /
-          column names: ``latitude``, ``longitude``, ``depth``, ``plot_longitude``,
-          ``plot_latitude``, and/or ``event_name``.
-
-        If ``spec`` is either a str or a 1-D or 2-D numpy array, the ``convention``
-        parameter is required to interpret the columns. If ``spec`` is a dict or
-        a :class:`pandas.DataFrame`, ``convention`` is not needed and ignored if
-        specified.
     scale : float or str
         *scale*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*]\
         [**+l**][**+m**][**+o**\ *dx*\ [/\ *dy*]][**+s**\ *reference*].
@@ -230,6 +192,7 @@ def meca(  # noqa: PLR0912, PLR0913
     {verbose}
     {panel}
     {perspective}
+    {spec}
     {transparency}
     """
     kwargs = self._preprocess(**kwargs)


### PR DESCRIPTION
**Description of proposed changes**

Related to #3817. 


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->



<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:

https://pygmt-dev--3825.org.readthedocs.build/en/3825/api/generated/pygmt.Figure.meca.html


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
