### PR TITLE
Use the 'release-branch-semver' version scheme for setuptools_scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ include = ["pygmt*"]
 exclude = ["doc"]
 
 [tool.setuptools_scm]
+version_scheme = "release-branch-semver"
 local_scheme = "node-and-date"
 fallback_version = "999.999.999+unknown"
 


### PR DESCRIPTION
See #3828 for the original issue report.

Upstream explainations at https://setuptools-scm.readthedocs.io/en/latest/extending/#setuptools_scmversion_scheme.

> Semantic versioning for projects with release branches. The same as guess-next-dev (incrementing the pre-release or micro segment) however when on a release branch: a branch whose name (ignoring namespace) parses as a version that matches the most recent tag up to the minor segment. Otherwise if on a non-release branch, increments the minor segment and sets the micro segment to zero, then appends .devN

With the `release-branch-semver` version scheme, the next dev version is `v0.15.0.dev0` rather than `v0.14.1.dev0` after we release `v0.14.0`.

