### PR TITLE
DOC: Fix the author information and the structure in the PDF documention

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -252,3 +252,6 @@ html_context = {
 
 # Options for LaTeX output.
 latex_engine = "xelatex"
+latex_documents = [
+    (root_doc, "pygmt.tex", "The PyGMT Documentation", author, "manual", True)
+]


### PR DESCRIPTION
This PR adds the Sphinx configuration [`latex_documents`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-latex_documents) to `doc/conf.py`.

With this change, the PDF author is set to "The PyGMT developers". Addressing the first point in #3813.

Now the documentation structure is also consistent with the HTML version, by setting the last value in the configuration to `True`. The only side-effect is that, the contents in the README file is not included in the PDF documentation.

**PDF Preview**: https://github.com/GenericMappingTools/pygmt/actions/runs/13710631100/artifacts/2707700541

