### PR TITLE
Bump to ruff 0.10.0 and fix violations

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
     # Dev dependencies (style checks)
     - codespell
     - pre-commit
-    - ruff>=0.9.6
+    - ruff>=0.10.0
     # Dev dependencies (unit testing)
     - matplotlib-base
     - pytest>=6.0

--- a/pygmt/tests/test_datasets_load_remote_datasets.py
+++ b/pygmt/tests/test_datasets_load_remote_datasets.py
@@ -41,7 +41,7 @@ def test_load_remote_dataset_invalid_resolutions():
     """
     Make sure _load_remote_dataset fails for invalid resolutions.
     """
-    resolutions = "1m 1d bla 60d 001m 03".split()
+    resolutions = ["1m", "1d", "bla", "60d", "001m", "03"]
     resolutions.append(60)
     for resolution in resolutions:
         with pytest.raises(GMTInvalidInput):

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -83,7 +83,20 @@ def test_figure_savefig_exists():
     fig = Figure()
     fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
     prefix = "test_figure_savefig_exists"
-    for fmt in "bmp eps jpg jpeg pdf png ppm tif PNG JPG JPEG Png".split():
+    for fmt in [
+        "bmp",
+        "eps",
+        "jpg",
+        "jpeg",
+        "pdf",
+        "png",
+        "ppm",
+        "tif",
+        "PNG",
+        "JPG",
+        "JPEG",
+        "Png",
+    ]:
         fname = Path(f"{prefix}.{fmt}")
         fig.savefig(fname)
         assert fname.exists()
@@ -192,7 +205,7 @@ def test_figure_savefig_transparent():
     fig = Figure()
     fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
     prefix = "test_figure_savefig_transparent"
-    for fmt in "pdf jpg bmp eps tif".split():
+    for fmt in ["pdf", "jpg", "bmp", "eps", "tif"]:
         fname = f"{prefix}.{fmt}"
         with pytest.raises(GMTInvalidInput):
             fig.savefig(fname, transparent=True)


### PR DESCRIPTION
**Description of proposed changes**

Bumps [ruff](https://github.com/astral-sh/ruff) from 0.9.6 to 0.10.0.
- [Release notes](https://github.com/astral-sh/ruff/releases)
- [Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md)
- [Commits](https://github.com/astral-sh/ruff/compare/0.9.6...0.10.0)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Blog post for release is at https://astral.sh/blog/ruff-v0.10.0. This PR fixes errors with [split-static-string (SIM905)](https://docs.astral.sh/ruff/rules/split-static-string/#split-static-string-sim905)

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes https://github.com/GenericMappingTools/pygmt/pull/3849#issuecomment-2722697332

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
