### PR TITLE
DOC: Use always upper case letters in headings

### DIFF
--- a/doc/techref/patterns.md
+++ b/doc/techref/patterns.md
@@ -1,4 +1,4 @@
-# Bit and hachure patterns
+# Bit and Hachure Patterns
 
 PyGMT supports a variety of bit and hachure patterns that can be used to fill polygons.
 


### PR DESCRIPTION
**Description of proposed changes**

Just minor change to be consistent with the other headings:

![headings_uppercaseletters](https://github.com/user-attachments/assets/5b8a782a-2a43-4f1e-9960-4c7d74ae1dd6)

**Preview**: https://pygmt-dev--3853.org.readthedocs.build/en/3853/techref/index.html

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
