### PR TITLE
POC: Extend GMTDataArrayAccessor to support grid operations

### DIFF
--- a/pygmt/accessors.py
+++ b/pygmt/accessors.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import xarray as xr
 from pygmt.enums import GridRegistration, GridType
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.src.grdinfo import grdinfo
+from pygmt.src import grdfill, grdinfo
 
 
 @xr.register_dataarray_accessor("gmt")
@@ -176,3 +176,11 @@ class GMTDataArrayAccessor:
             )
             raise GMTInvalidInput(msg)
         self._gtype = GridType(value)
+
+    def fill(self, **kwargs):
+        """
+        Interpolate across holes in the grid.
+
+        See the :meth:`pygmt.grdfill` for available parameters.
+        """
+        return grdfill(grid=self._obj, **kwargs)


### PR DESCRIPTION
Address https://github.com/GenericMappingTools/pygmt/issues/499#issuecomment-2726421306.

This is a POC PR to show how GMTDataArrayAccessor can access GMT's grid-operation modules, i.e., `grid.gmt.fill(**kwargs)` instead of `pygmt.grdfill(grid, **kwargs)`:

```python
In [1]: import pygmt

In [2]: from pygmt.helpers.testing import load_static_earth_relief

In [3]: import numpy as np

In [4]: grid = load_static_earth_relief()

In [5]: grid[3:6, 3:5] = np.nan

In [6]: grid
Out[6]: 
<xarray.DataArray 'z' (lat: 14, lon: 8)> Size: 448B
array([[347.5, 344.5, 386. , 640.5, 617. , 579. , 646.5, 671. ],
       [383. , 284.5, 344.5, 394. , 491. , 556.5, 578.5, 618.5],
       [373. , 367.5, 349. , 352.5, 419.5, 428. , 570. , 667.5],
       [557. , 435. , 385.5,   nan,   nan, 496. , 519.5, 833.5],
       [561.5, 539. , 446.5,   nan,   nan, 553. , 726.5, 981. ],
       [310. , 521.5, 757. ,   nan,   nan, 524. , 686.5, 794. ],
       [521.5, 682.5, 796. , 886. , 571.5, 638.5, 739.5, 881.5],
       [308. , 595.5, 555.5, 556. , 580. , 770. , 927. , 920. ],
       [601. , 526.5, 535. , 299. , 398.5, 645. , 797.5, 964. ],
       [494.5, 488.5, 357. , 254.5, 286. , 484.5, 653.5, 930. ],
       [450.5, 395.5, 366. , 248. , 250. , 354.5, 550. , 797.5],
       [345.5, 320. , 335. , 292. , 207.5, 247. , 325. , 346.5],
       [349. , 313. , 325.5, 247. , 191. , 225. , 260. , 452.5],
       [347.5, 331.5, 309. , 282. , 190. , 208. , 299.5, 348. ]],
      dtype=float32)
Coordinates:
  * lon      (lon) float64 64B -54.5 -53.5 -52.5 -51.5 -50.5 -49.5 -48.5 -47.5
  * lat      (lat) float64 112B -23.5 -22.5 -21.5 -20.5 ... -12.5 -11.5 -10.5
Attributes:
    long_name:     elevation (m)
    actual_range:  [190. 981.]

In [7]: grid.gmt.fill(mode="c20")
Out[7]: 
<xarray.DataArray 'z' (lat: 14, lon: 8)> Size: 448B
array([[347.5, 344.5, 386. , 640.5, 617. , 579. , 646.5, 671. ],
       [383. , 284.5, 344.5, 394. , 491. , 556.5, 578.5, 618.5],
       [373. , 367.5, 349. , 352.5, 419.5, 428. , 570. , 667.5],
       [557. , 435. , 385.5,  20. ,  20. , 496. , 519.5, 833.5],
       [561.5, 539. , 446.5,  20. ,  20. , 553. , 726.5, 981. ],
       [310. , 521.5, 757. ,  20. ,  20. , 524. , 686.5, 794. ],
       [521.5, 682.5, 796. , 886. , 571.5, 638.5, 739.5, 881.5],
       [308. , 595.5, 555.5, 556. , 580. , 770. , 927. , 920. ],
       [601. , 526.5, 535. , 299. , 398.5, 645. , 797.5, 964. ],
       [494.5, 488.5, 357. , 254.5, 286. , 484.5, 653.5, 930. ],
       [450.5, 395.5, 366. , 248. , 250. , 354.5, 550. , 797.5],
       [345.5, 320. , 335. , 292. , 207.5, 247. , 325. , 346.5],
       [349. , 313. , 325.5, 247. , 191. , 225. , 260. , 452.5],
       [347.5, 331.5, 309. , 282. , 190. , 208. , 299.5, 348. ]],
      dtype=float32)
Coordinates:
  * lat      (lat) float64 112B -23.5 -22.5 -21.5 -20.5 ... -12.5 -11.5 -10.5
  * lon      (lon) float64 64B -54.5 -53.5 -52.5 -51.5 -50.5 -49.5 -48.5 -47.5
Attributes:
    Conventions:   CF-1.7
    title:         
    history:       gmt grdfill @GMTAPI@-S-I-G-M-G-N-000000 -Ac20 -G@GMTAPI@-S...
    description:   
    actual_range:  [190. 981.]
    long_name:     z
```