### PR TITLE
DOC: Rename Gallery example for GMT logo

### DIFF
--- a/examples/gallery/embellishments/gmt_logo.py
+++ b/examples/gallery/embellishments/gmt_logo.py
@@ -11,7 +11,7 @@ import pygmt
 fig = pygmt.Figure()
 fig.basemap(region=[0, 10, 0, 2], projection="X6c", frame=True)
 
-# Add the GMT logo in the Top Right (TR) corner of the current figure, scaled up to be 3
+# Add the GMT logo in the Top Right (TR) corner of the current plot, scaled up to be 3
 # centimeters wide and offset by 0.3 cm in x direction and 0.6 cm in y direction.
 fig.logo(position="jTR+o0.3c/0.6c+w3c")
 

--- a/examples/gallery/embellishments/gmt_logo.py
+++ b/examples/gallery/embellishments/gmt_logo.py
@@ -1,6 +1,6 @@
 """
-Logo
-====
+GMT logo
+========
 
 The :meth:`pygmt.Figure.logo` method allows to place the GMT logo on a map.
 """

--- a/examples/gallery/embellishments/gmt_logo.py
+++ b/examples/gallery/embellishments/gmt_logo.py
@@ -2,7 +2,7 @@
 GMT logo
 ========
 
-The :meth:`pygmt.Figure.logo` method allows to place the GMT logo on a map.
+The :meth:`pygmt.Figure.logo` method allows to place the GMT logo on a figure.
 """
 
 # %%

--- a/examples/gallery/embellishments/gmt_logo.py
+++ b/examples/gallery/embellishments/gmt_logo.py
@@ -11,8 +11,8 @@ import pygmt
 fig = pygmt.Figure()
 fig.basemap(region=[0, 10, 0, 2], projection="X6c", frame=True)
 
-# Add the GMT logo in the Top Right (TR) corner of the current map, scaled up to be 3 cm
-# wide and offset by 0.3 cm in x direction and 0.6 cm in y direction.
+# Add the GMT logo in the Top Right (TR) corner of the current figure, scaled up to be 3
+# centimeters wide and offset by 0.3 cm in x direction and 0.6 cm in y direction.
 fig.logo(position="jTR+o0.3c/0.6c+w3c")
 
 fig.show()

--- a/examples/gallery/embellishments/gmt_logo.py
+++ b/examples/gallery/embellishments/gmt_logo.py
@@ -11,9 +11,8 @@ import pygmt
 fig = pygmt.Figure()
 fig.basemap(region=[0, 10, 0, 2], projection="X6c", frame=True)
 
-# Add the GMT logo in the Top Right (TR) corner of the current map,
-# scaled up to be 3 cm wide and offset by 0.3 cm in x direction
-# and 0.6 cm in y direction.
+# Add the GMT logo in the Top Right (TR) corner of the current map, scaled up to be 3 cm
+# wide and offset by 0.3 cm in x direction and 0.6 cm in y direction.
 fig.logo(position="jTR+o0.3c/0.6c+w3c")
 
 fig.show()


### PR DESCRIPTION
**Description of proposed changes**

In case we have a separate gallery example for the PyGMT logo in the future, I feel it makes sense to rename the already existing gallery example for the GMT logo and adjust the title to be more specific.

Also rewrap to the maximum allowed line length, which seems to be extended in the last ruff release, and is now 88 characters.

**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
