### PR TITLE
DOC: Update docs to use consistently x direction and y direction

### DIFF
--- a/examples/tutorials/advanced/subplots.py
+++ b/examples/tutorials/advanced/subplots.py
@@ -119,8 +119,8 @@ fig.show()
 #
 # - ``autolabel=True``: Each subplot is automatically labelled 'abcd'.
 # - ``margins=["0.1c", "0.2c"]``: Adjusts the space between adjacent subplots.
-#   In this case, it is set as 0.1 cm in the x-direction and 0.2 cm in the
-#   y-direction.
+#   In this case, it is set as 0.1 cm in the x direction and 0.2 cm in the
+#   y direction.
 # - ``title="My Subplot Heading"``: Adds a title on top of the whole figure.
 #
 # Notice that each subplot was set to use a linear projection ``"X?"``.


### PR DESCRIPTION
Currently in the docs the versions 
- x direction
- y direction 
- x-direction
- y-direction are used. The first two are used most frequently. This PR makes the docs consistent.

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->



<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
