### PR TITLE
Update min/max values on earth_wdmam tests

### DIFF
--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -144,8 +144,8 @@ def test_earth_mag_01d_wdmam_with_region():
     assert data.shape == (11, 21)
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -56.0, atol=0.2)
-    npt.assert_allclose(data.max(), 55.0, atol=0.2)
+    npt.assert_allclose(data.min(), -56.4, atol=0.2)
+    npt.assert_allclose(data.max(), 53.8, atol=0.2)
 
 
 def test_earth_mag_03m_wdmam_with_region():
@@ -161,8 +161,8 @@ def test_earth_mag_03m_wdmam_with_region():
     assert data.lat.max() == -58
     assert data.lon.min() == 10
     assert data.lon.max() == 13
-    npt.assert_allclose(data.min(), -790.2, atol=0.2)
-    npt.assert_allclose(data.max(), 528.0, atol=0.2)
+    npt.assert_allclose(data.min(), -811.4, atol=0.2)
+    npt.assert_allclose(data.max(), 505.0, atol=0.2)
 
 
 def test_earth_mag_data_source_error():


### PR DESCRIPTION
**Description of proposed changes**

Update some values in World Digital Magnetic Anomaly Map (WDMAM) with_region tests, following update to version 2.2 at https://github.com/GenericMappingTools/remote-datasets/pull/134.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

References:
- Choi, Y., Dyment, J., Lesur, V., Garcia Reyes, Catalan, M., Ishihara, T., Litvinova, T., Hamoudi, M., the WDMAM Task Force*, and the WDMAM Data Providers**, World Digital Magnetic Anomaly Map version 2.2, map available at https://www.wdmam.org/.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes failing tests at https://github.com/GenericMappingTools/pygmt/actions/runs/14022627088/job/39256563007?pr=3639#step:7:1245:

```python-traceback
=================================== FAILURES ===================================
_____________________ test_earth_mag_01d_wdmam_with_region _____________________

    def test_earth_mag_01d_wdmam_with_region():
        """
        Test loading low-resolution WDMAM grid with 'region'.
        """
        data = load_earth_magnetic_anomaly(
            resolution="01d",
            region=[-10, 10, -5, 5],
            registration="gridline",
            data_source="wdmam",
        )
        assert data.shape == (11, 21)
        npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
        npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
>       npt.assert_allclose(data.min(), -56.0, atol=0.2)

../pygmt/tests/test_datasets_earth_magnetic_anomaly.py:147: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

args = (<function assert_allclose.<locals>.compare at 0x7f9d75d219e0>, array(-56.400146, dtype=float32), array(-56.))
kwds = {'equal_nan': True, 'err_msg': '', 'header': 'Not equal to tolerance rtol=1e-07, atol=0.2', 'verbose': True}

    @wraps(func)
    def inner(*args, **kwds):
        with self._recreate_cm():
>           return func(*args, **kwds)
E           AssertionError: 
E           Not equal to tolerance rtol=1e-07, atol=0.2
E           
E           Mismatched elements: 1 / 1 (100%)
E           Max absolute difference: 0.40014648
E           Max relative difference: 0.00714547
E            x: array(-56.400146, dtype=float32)
E            y: array(-56.)

../../../../.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/contextlib.py:81: AssertionError
_____________________ test_earth_mag_03m_wdmam_with_region _____________________

    def test_earth_mag_03m_wdmam_with_region():
        """
        Test loading a subregion of high-resolution WDMAM data.
        """
        data = load_earth_magnetic_anomaly(
            resolution="03m", region=[10, 13, -60, -58], data_source="wdmam"
        )
        assert data.gmt.registration == GridRegistration.GRIDLINE
        assert data.shape == (41, 61)
        assert data.lat.min() == -60
        assert data.lat.max() == -58
        assert data.lon.min() == 10
        assert data.lon.max() == 13
>       npt.assert_allclose(data.min(), -790.2, atol=0.2)

../pygmt/tests/test_datasets_earth_magnetic_anomaly.py:164: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

args = (<function assert_allclose.<locals>.compare at 0x7f9d75d20540>, array(-811.40015, dtype=float32), array(-790.2))
kwds = {'equal_nan': True, 'err_msg': '', 'header': 'Not equal to tolerance rtol=1e-07, atol=0.2', 'verbose': True}

    @wraps(func)
    def inner(*args, **kwds):
        with self._recreate_cm():
>           return func(*args, **kwds)
E           AssertionError: 
E           Not equal to tolerance rtol=1e-07, atol=0.2
E           
E           Mismatched elements: 1 / 1 (100%)
E           Max absolute difference: 21.20014648
E           Max relative difference: 0.02682884
E            x: array(-811.40015, dtype=float32)
E            y: array(-790.2)

../../../../.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/contextlib.py:81: AssertionError
```


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
