### PR TITLE
CI: Set persist-credentials to true to allow pushing to the gh-pages branch

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -176,7 +176,7 @@ jobs:
           path: deploy
           # Download the entire history
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
         if: (github.event_name == 'release' || github.event_name == 'push') && (matrix.os == 'ubuntu-latest')
 
       - name: Push the built HTML to gh-pages


### PR DESCRIPTION
The "Docs" workflow failed to upload the built HTML files to the gh-pages branch since PR #3861.

The `git push -fq origin gh-pages` command failed with errors like below (https://github.com/GenericMappingTools/pygmt/actions/runs/13937126371/job/39007072378#step:14:4408):
```
fatal: could not read Username for 'https://github.com/': No such device or address
```
but the workflow step doesn't fail. That's why we didn't catch it in PR #3861.

The command fails because we set `persist-credentials` to `false` in that PR. This PR fixes the issue.
