### PR TITLE
CI: Add content write permission to the Release Drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,8 +1,7 @@
 # Draft the next release notes
 #
-# This workflow is run to update the next release notes as pull requests are
-# merged into the main branch. The configuration file is located at
-# `.github/release-drafter.yml`.
+# This workflow is run to update the next release notes as pull requests are merged into
+# the main branch. The configuration file is located at `.github/release-drafter.yml`.
 #
 name: Release Drafter
 
@@ -11,10 +10,14 @@ on:
     branches:
       - main
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
     runs-on: ubuntu-latest
     if: github.repository == 'GenericMappingTools/pygmt'
 


### PR DESCRIPTION
Based on the template at https://github.com/release-drafter/release-drafter#usage.

Patches #3861.