### PR TITLE
CI: Add issues/contents write permission to the slash commands

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -8,7 +8,8 @@ on:
   repository_dispatch:
     types: [format-command]
 
-permissions: {}
+permissions:
+  contents: write
 
 jobs:
   format:

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -10,7 +10,8 @@ on:
     # Add "edited" type for test purposes. Where possible, avoid using to prevent processing unnecessary events.
     # types: [created, edited]
 
-permissions: {}
+permissions:
+  issues: write
 
 jobs:
   slashCommandDispatch:


### PR DESCRIPTION
The "Slash Command Dispatch" workflow needs the issue write permission to add reactions. 

The "format command" workflow needs the content write permission to push changes to PRs.

Not tested, but they should work based on my understanding.