### PR TITLE
DOC: Set needs_extensions to check sphinx extension versions

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,6 +62,9 @@ extensions = [
     "sphinx_gallery.gen_gallery",
     "sphinxcontrib.cairosvgconverter",
 ]
+needs_extensions = {
+    "sphinx_gallery.gen_gallery": "0.19.0",
+}
 # Options for highlighting.
 pygments_style = "default"
 # Options for object signatures.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,7 +63,7 @@ extensions = [
     "sphinxcontrib.cairosvgconverter",
 ]
 needs_extensions = {
-    "sphinx_gallery.gen_gallery": "0.19.0",
+    "sphinx_gallery.gen_gallery": "0.19",
 }
 # Options for highlighting.
 pygments_style = "default"


### PR DESCRIPTION
**Description of proposed changes**

Set `needs_extensions` to check the installed sphinx-gallery is >=0.19.0 before trying to build the docs. Related to #3805.

xref: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-needs_extensions

> If set, this value must be a dictionary specifying version requirements for extensions in [extensions](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-extensions). The version strings should be in the 'major.minor' form. Requirements do not have to be specified for all extensions, only for those you want to check.

