### PR TITLE
pygmt.grdfill: Add new parameter 'inquire' to inquire the bounds of holes

### DIFF
--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -59,7 +59,7 @@ def _validate_params(
         param is not None and param is not False
         for param in [constantfill, gridfill, neighborfill, splinefill, inquire, mode]
     )
-    if n_given > 1:  # More than one mutually exclusive parameters are given.
+    if n_given > 1:  # More than one mutually exclusive parameter is given.
         msg = f"Parameters {_fill_params}/'inquire'/'mode' are mutually exclusive."
         raise GMTInvalidInput(msg)
     if n_given == 0:  # No parameters are given.
@@ -176,7 +176,7 @@ def grdfill(
     -------
     ret
         If ``inquire`` is ``True``, return the bounds of each hole as a 2-D numpy array.
-        Otherwise, return type depends on whether the ``outgrid`` parameter is set:
+        Otherwise, the return type depends on whether the ``outgrid`` parameter is set:
 
         - :class:`xarray.DataArray` if ``outgrid`` is not set
         - ``None`` if ``outgrid`` is set (grid output will be stored in the file set by

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -64,7 +64,7 @@ def _validate_params(
         raise GMTInvalidInput(msg)
     if n_given == 0:  # No parameters are given.
         msg = (
-            "Need to specify parameter {_fill_params} for filling holes or "
+            f"Need to specify parameter {_fill_params} for filling holes or "
             "'inquire' for inquiring the bounds of each hole."
         )
         raise GMTInvalidInput(msg)

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -67,8 +67,9 @@ def _parse_fill_mode(
 
 @fmt_docstring
 # TODO(PyGMT>=0.19.0): Remove the deprecated 'no_data' parameter.
+# TODO(PyGMT>=0.19.0): Remove the deprecated 'mode' parameter.
 @deprecate_parameter("no_data", "hole", "v0.15.0", remove_version="v0.19.0")
-@use_alias(A="mode", N="hole", R="region", V="verbose", f="coltypes")
+@use_alias(N="hole", R="region", V="verbose", f="coltypes")
 @kwargs_to_strings(R="sequence")
 def grdfill(
     grid: str | xr.DataArray,
@@ -78,6 +79,7 @@ def grdfill(
     neighborfill: float | bool | None = None,
     splinefill: float | bool | None = None,
     inquire: bool = False,
+    mode: str | None = None,
     **kwargs,
 ) -> xr.DataArray | np.ndarray | None:
     r"""
@@ -117,7 +119,7 @@ def grdfill(
         Output the bounds of each hole. The bounds are returned as a 2-D numpy array in
         the form of (west, east, south, north). No grid fill takes place and ``outgrid``
         is ignored.
-    mode : str
+    mode
         Specify the hole-filling algorithm to use. Choose from **c** for constant fill
         and append the constant value, **n** for nearest neighbor (and optionally append
         a search radius in pixels [default radius is :math:`r^2 = \sqrt{{ X^2 + Y^2 }}`,
@@ -155,8 +157,7 @@ def grdfill(
     array([[1.83333333, 6.16666667, 3.83333333, 8.16666667],
            [6.16666667, 7.83333333, 0.5       , 2.5       ]])
     """
-    # TODO(PyGMT>=0.19.0): Remove the deprecated 'mode' parameter.
-    if kwargs.get("A") is not None:  # The deprecated 'mode' parameter is given.
+    if mode is not None:  # The deprecated 'mode' parameter is given.
         warnings.warn(
             "The 'mode' parameter is deprecated since v0.15.0 and will be removed in "
             "v0.19.0. Use 'constantfill'/'gridfill'/'neighborfill'/'splinefill' "
@@ -164,8 +165,8 @@ def grdfill(
             FutureWarning,
             stacklevel=1,
         )
+        kwargs["A"] = mode
     else:
-        # Determine the -A option from the fill parameters.
         kwargs["A"] = _parse_fill_mode(constantfill, gridfill, neighborfill, splinefill)
 
     if kwargs.get("A") is None and inquire is False:

--- a/pygmt/tests/test_grdfill.py
+++ b/pygmt/tests/test_grdfill.py
@@ -114,12 +114,30 @@ def test_grdfill_gridfill_dataarray(grid):
     npt.assert_array_equal(result[3:6, 3:5], bggrid[3:6, 3:5])
 
 
+def test_grdfill_inquire(grid):
+    """
+    Test grdfill with inquire mode.
+    """
+    bounds = grdfill(grid=grid, inquire=True)
+    assert isinstance(bounds, np.ndarray)
+    assert bounds.shape == (1, 4)
+    npt.assert_allclose(bounds, [[-52.0, -50.0, -21.0, -18.0]])
+
+
 def test_grdfill_required_args(grid):
     """
-    Test that grdfill fails without arguments for `mode` and `L`.
+    Test that grdfill fails without filling parameters or 'inquire'.
     """
     with pytest.raises(GMTInvalidInput):
         grdfill(grid=grid)
+
+
+def test_grdfill_inquire_and_fill(grid):
+    """
+    Test that grdfill fails if both inquire and fill parameters are given.
+    """
+    with pytest.raises(GMTInvalidInput):
+        grdfill(grid=grid, inquire=True, constantfill=20)
 
 
 # TODO(PyGMT>=0.19.0): Remove this test.


### PR DESCRIPTION
Implement the idea in https://github.com/GenericMappingTools/pygmt/issues/3768#issuecomment-2757553426.

## Example
```python
>>> import pygmt
>>> import numpy as np
>>> from pygmt.helpers.testing import load_static_earth_relief

>>> grid = load_static_earth_relief()
>>> # One hole
>>> grid[3:6, 3:5] = np.nan
>>> pygmt.grdfill(grid, inquire=True)
array([[-52., -50., -21., -18.]])

>>> # One more hole
>>> grid[7:9, 2:4] = np.nan
>>> pygmt.grdfill(grid, inquire=True)
array([[-53., -51., -17., -15.],
       [-52., -50., -21., -18.]])
```