### PR TITLE
DOC: Fix formatting in grdfill docstrings

### DIFF
--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -185,6 +185,7 @@ def grdfill(
     Example
     -------
     Fill holes in a bathymetric grid with a constant value of 20.
+
     >>> import pygmt
     >>> # Load a bathymetric grid with missing data
     >>> earth_relief_holes = pygmt.datasets.load_sample_data(name="earth_relief_holes")
@@ -192,6 +193,7 @@ def grdfill(
     >>> filled_grid = pygmt.grdfill(grid=earth_relief_holes, constantfill=20)
 
     Inquire the bounds of each hole.
+
     >>> pygmt.grdfill(grid=earth_relief_holes, inquire=True)
     array([[1.83333333, 6.16666667, 3.83333333, 8.16666667],
            [6.16666667, 7.83333333, 0.5       , 2.5       ]])


### PR DESCRIPTION
The grdfill documentation doesn't look correct (https://www.pygmt.org/dev/api/generated/pygmt.grdfill.html#pygmt.grdfill):

![image](https://github.com/user-attachments/assets/70207093-1a09-44b2-a4ad-01e25d727eb9)

This PR fixes the issue.

**Preview**: https://pygmt-dev--3891.org.readthedocs.build/en/3891/api/generated/pygmt.grdfill.html#pygmt.grdfill

~~Still need to wait for feedback in #3881.~~