### PR TITLE
Session.virtualfile_from_vectors: Remove the deprecated '*args' parameter [deprecated since v0.14.0]

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1390,9 +1390,7 @@ class Session:
                 raise GMTCLibError(msg)
 
     @contextlib.contextmanager
-    def virtualfile_from_vectors(
-        self, vectors: Sequence, *args
-    ) -> Generator[str, None, None]:
+    def virtualfile_from_vectors(self, vectors: Sequence) -> Generator[str, None, None]:
         """
         Store a sequence of 1-D vectors as columns of a dataset inside a virtual file.
 
@@ -1438,21 +1436,6 @@ class Session:
         ...             print(fout.read().strip())
         <vector memory>: N = 3 <1/3> <4/6> <7/9>
         """
-        # TODO(PyGMT>=0.16.0): Remove the "*args" parameter and related codes.
-        # "*args" is added in v0.14.0 for backward-compatibility with the deprecated
-        # syntax of passing multiple vectors as positional arguments.
-        if len(args) > 0:
-            msg = (
-                "Passing multiple arguments to Session.virtualfile_from_vectors is "
-                "deprecated since v0.14.0 and will be unsupported in v0.16.0. "
-                "Put all vectors in a sequence (a tuple or a list) instead and pass "
-                "the sequence as the single argument to this function. "
-                "E.g., use `with lib.virtualfile_from_vectors((x, y, z)) as vfile` "
-                "instead of `with lib.virtualfile_from_vectors(x, y, z) as vfile`."
-            )
-            warnings.warn(message=msg, category=FutureWarning, stacklevel=3)
-            vectors = (vectors, *args)
-
         # Conversion to a C-contiguous array needs to be done here and not in put_vector
         # or put_strings because we need to maintain a reference to the copy while it is
         # being used by the C API. Otherwise, the array would be garbage collected and

--- a/pygmt/tests/test_clib_virtualfile_from_vectors.py
+++ b/pygmt/tests/test_clib_virtualfile_from_vectors.py
@@ -190,28 +190,3 @@ def test_virtualfile_from_vectors_arraylike():
         bounds = "\t".join([f"<{min(i):.0f}/{max(i):.0f}>" for i in (x, y, z)])
         expected = f"<vector memory>: N = {size}\t{bounds}\n"
         assert output == expected
-
-
-# TODO(PyGMT>=0.16.0): Remove this test in PyGMT v0.16.0 in which the "*args" parameter
-# will be removed.
-def test_virtualfile_from_vectors_args():
-    """
-    Test the backward compatibility of the deprecated syntax for passing multiple
-    vectors.
-
-    This test is the same as test_virtualfile_from_vectors_arraylike, but using the
-    old syntax.
-    """
-    size = 13
-    x = list(range(0, size, 1))
-    y = tuple(range(size, size * 2, 1))
-    z = range(size * 2, size * 3, 1)
-    with pytest.warns(FutureWarning, match="virtualfile_from_vectors"):
-        with clib.Session() as lib:
-            with lib.virtualfile_from_vectors(x, y, z) as vfile:
-                with GMTTempFile() as outfile:
-                    lib.call_module("info", [vfile, f"->{outfile.name}"])
-                    output = outfile.read(keep_tabs=True)
-            bounds = "\t".join([f"<{min(i):.0f}/{max(i):.0f}>" for i in (x, y, z)])
-            expected = f"<vector memory>: N = {size}\t{bounds}\n"
-            assert output == expected


### PR DESCRIPTION
Related to https://github.com/GenericMappingTools/pygmt/pull/3522.