### PR TITLE
Fix the sphinterpolate failing test in the GMT Dev Tests

### DIFF
--- a/pygmt/tests/test_sphinterpolate.py
+++ b/pygmt/tests/test_sphinterpolate.py
@@ -4,8 +4,10 @@ Test pygmt.sphinterpolate.
 
 from pathlib import Path
 
+import numpy as np
 import numpy.testing as npt
 import pytest
+from packaging.version import Version
 from pygmt import sphinterpolate
 from pygmt.datasets import load_sample_data
 from pygmt.enums import GridRegistration, GridType
@@ -42,4 +44,6 @@ def test_sphinterpolate_no_outgrid(mars):
     npt.assert_allclose(temp_grid.max(), 14628.144)
     npt.assert_allclose(temp_grid.min(), -6908.1987)
     npt.assert_allclose(temp_grid.median(), 118.96849)
-    npt.assert_allclose(temp_grid.mean(), 272.60593)
+    # TODO(NumPy>=2.3.0): Remove the numpy version check.
+    mean = 272.60568 if Version(np.__version__) >= Version("2.3.0dev") else 272.60593
+    npt.assert_allclose(temp_grid.mean(), mean)


### PR DESCRIPTION
There has been one failure in the GMT Dev Tests for a few months:
https://github.com/GenericMappingTools/pygmt/actions/runs/14209237704/job/39813254868#step:15:1058
```
    @pytest.mark.benchmark
    def test_sphinterpolate_no_outgrid(mars):
        """
        Test sphinterpolate with no set outgrid.
        """
        temp_grid = sphinterpolate(data=mars, spacing=1, region="g")
        assert temp_grid.dims == ("lat", "lon")
        assert temp_grid.gmt.gtype == GridType.GEOGRAPHIC
        assert temp_grid.gmt.registration == GridRegistration.GRIDLINE
        npt.assert_allclose(temp_grid.max(), 14628.144)
        npt.assert_allclose(temp_grid.min(), -6908.1987)
        npt.assert_allclose(temp_grid.median(), 118.96849)
>       npt.assert_allclose(temp_grid.mean(), 272.60593)
E       AssertionError: 
E       Not equal to tolerance rtol=1e-07, atol=0
E       
E       Mismatched elements: 1 / 1 (100%)
E       Max absolute difference among violations: 0.00024763
E       Max relative difference among violations: 9.0836965e-07
E        ACTUAL: array(272.60568, dtype=float32)
E        DESIRED: array(272.60593)
```
There are no changes in `sphinterpolate` recently, and it turns out the failure only happens with numpy 2.3.0 dev version. So it's likely there are minor precision changes in numpy.

This PR fixes the issue by checking NumPy version.
