### PR TITLE
SPEC 0: Bump minimum supported version to pandas>=2.1

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -73,7 +73,7 @@ jobs:
           # Python 3.11 + core packages (minimum supported versions) + optional packages (minimum supported versions if any)
           - python-version: '3.11'
             numpy-version: '1.25'
-            pandas-version: '=2.0'
+            pandas-version: '=2.1'
             xarray-version: '=2023.04'
             optional-packages: ' contextily geopandas<1 ipython pyarrow-core rioxarray sphinx-gallery'
           # Python 3.13 + core packages (latest versions) + optional packages

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
     - gmt=6.5.0
     - ghostscript=10.04.0
     - numpy>=1.25
-    - pandas>=2.0
+    - pandas>=2.1
     - xarray>=2023.04
     - netCDF4
     - packaging

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -198,10 +198,6 @@ def _to_numpy(data: Any) -> np.ndarray:
     elif isinstance(dtype, pd.ArrowDtype) and hasattr(dtype.pyarrow_dtype, "tz"):
         # pd.ArrowDtype[pa.Timestamp]
         numpy_dtype = getattr(dtype, "numpy_dtype", None)
-        # TODO(pandas>=2.1): Remove the workaround for pandas<2.1.
-        if Version(pd.__version__) < Version("2.1"):
-            # In pandas 2.0, dtype.numpy_type is dtype("O").
-            numpy_dtype = np.dtype(f"M8[{dtype.pyarrow_dtype.unit}]")  # type: ignore[assignment, attr-defined]
 
     array = np.ascontiguousarray(data, dtype=numpy_dtype)
 

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -391,17 +391,7 @@ def test_to_numpy_pandas_numeric_with_na(dtype, expected_dtype):
         "U10",
         "string[python]",
         pytest.param("string[pyarrow]", marks=skip_if_no(package="pyarrow")),
-        pytest.param(
-            "string[pyarrow_numpy]",
-            marks=[
-                skip_if_no(package="pyarrow"),
-                # TODO(pandas>=2.1): Remove the skipif marker for pandas<2.1.
-                pytest.mark.skipif(
-                    Version(pd.__version__) < Version("2.1"),
-                    reason="string[pyarrow_numpy] was added since pandas 2.1",
-                ),
-            ],
-        ),
+        pytest.param("string[pyarrow_numpy]", marks=skip_if_no(package="pyarrow")),
     ],
 )
 def test_to_numpy_pandas_string(dtype):
@@ -536,12 +526,7 @@ def test_to_numpy_pandas_datetime(dtype, expected_dtype):
 
     # Convert to UTC if the dtype is timezone-aware
     if "," in str(dtype):  # A hacky way to decide if the dtype is timezone-aware.
-        # TODO(pandas>=2.1): Simplify the if-else statement.
-        if Version(pd.__version__) < Version("2.1") and dtype.startswith("timestamp"):
-            # pandas 2.0 doesn't have the dt.tz_convert method for pyarrow.Timestamp.
-            series = pd.to_datetime(series, utc=True)
-        else:
-            series = series.dt.tz_convert("UTC")
+        series = series.dt.tz_convert("UTC")
     # Remove time zone information and preserve local time.
     expected_series = series.dt.tz_localize(tz=None)
     npt.assert_array_equal(result, np.array(expected_series, dtype=expected_dtype))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.25",
-    "pandas>=2.0",
+    "pandas>=2.1",
     "xarray>=2023.04",
     "netCDF4",
     "packaging",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Required packages
 numpy>=1.25
-pandas>=2.0
+pandas>=2.1
 xarray>=2023.04
 netCDF4
 packaging


### PR DESCRIPTION
Following [SPEC0](https://scientific-python.org/specs/spec-0000/), we should drop pandas 2.0 support in April 2025.