### PR TITLE
CI: Remove NumPy version from the Tests workflow name

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -49,7 +49,7 @@ concurrency:
 
 jobs:
   test:
-    name: ${{ matrix.os }} - Python ${{ matrix.python-version }} / NumPy ${{ matrix.numpy-version }}
+    name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write  # This is required for requesting OIDC token for codecov


### PR DESCRIPTION
The jobs in the Tests workflow have names like "ubuntu-latest - Python 3.11 / NumPy 1.25".

The NumPy version in the job names is not necessary and can be removed, so that we don't have to update the branch protection rules when we bump the minimum supported or latest NumPy versions.