### PR TITLE
Update the AUTHORSHIP and Maintainers' Guides to reflect co-author contributions

### DIFF
--- a/AUTHORSHIP.md
+++ b/AUTHORSHIP.md
@@ -42,7 +42,7 @@ The order of authors will be defined by the number of contributions (including c
 and PR reviews) to the repository
 (`git shortlog -sne --group=author --group=trailer:co-authored-by`).
 The order can also be changed on a case-by-case basis. The most common reasons for
-case-by-case changes are contributions to the PyGMT project that due not relate to
+case-by-case changes are contributions to the PyGMT project that do not relate to
 commit numbers, including developing PyGMT lessons such as the
 [ROSES unit](https://www.youtube.com/watch?v=SSIGJEe0BIk), organizing workshops/sprints
 such as the [FOSS4G Workshop](https://github.com/GenericMappingTools/foss4g2019oceania),

--- a/AUTHORSHIP.md
+++ b/AUTHORSHIP.md
@@ -45,8 +45,8 @@ The order can also be changed on a case-by-case basis. The most common reasons f
 case-by-case changes are contributions to the PyGMT project that do not relate to
 commit numbers, including developing PyGMT lessons such as the
 [ROSES unit](https://www.youtube.com/watch?v=SSIGJEe0BIk), organizing workshops/sprints
-such as the [FOSS4G Workshop](https://github.com/GenericMappingTools/foss4g2019oceania),
-the 2020 and 2021 SciPy sprints, writing grants/proposals to support PyGMT, and team
+such as the [AGU24 Workshop](https://github.com/GenericMappingTools/agu24workshop) or
+2020 and 2021 SciPy sprints, writing grants/proposals to support PyGMT, and team
 programming efforts (including reviewing PRs).
 
 If you have contributed and do not wish to be included in Zenodo archives, there are a

--- a/AUTHORSHIP.md
+++ b/AUTHORSHIP.md
@@ -21,10 +21,10 @@ distributions. This is an optional process.
 
 ## Changelog for each release
 
-Every time we make a release, everyone who has made a commit to the repository since the
-previous release will be mentioned in the changelog entry. If their full name is
-available on GitHub, we will use it. Otherwise, we will use the GitHub handle. This is a
-way of saying "Thank you".
+Every time we make a release, everyone who has made a contribution (commits or PR
+reviews) to the repository since the previous release will be mentioned in the changelog.
+If their full name is available on GitHub, we will use it. Otherwise, we will use the
+GitHub handle. This is a way of saying "Thank you".
 
 ## Authorship on Zenodo archives of releases
 
@@ -38,10 +38,12 @@ the repository:
 2. [ORCID](https://orcid.org) (optional)
 3. Affiliation (if omitted, we will use "Unaffiliated")
 
-The order of authors will be defined by the number of commits to the repository
-(`git shortlog -sne`). The order can also be changed on a case-by-case basis. The most
-common reasons for case-by-case changes are contributions to the PyGMT project that due
-not relate to commit numbers, including developing PyGMT lessons such as the
+The order of authors will be defined by the number of contributions (including commits
+and PR reviews) to the repository
+(`git shortlog -sne --group=author --group=trailer:co-authored-by`).
+The order can also be changed on a case-by-case basis. The most common reasons for
+case-by-case changes are contributions to the PyGMT project that due not relate to
+commit numbers, including developing PyGMT lessons such as the
 [ROSES unit](https://www.youtube.com/watch?v=SSIGJEe0BIk), organizing workshops/sprints
 such as the [FOSS4G Workshop](https://github.com/GenericMappingTools/foss4g2019oceania),
 the 2020 and 2021 SciPy sprints, writing grants/proposals to support PyGMT, and team
@@ -78,6 +80,7 @@ To be included as an author on the paper, you *must* satisfy the following crite
    on the paper (even if it's just an "OK", but preferably more).
 
 The order of authors will be defined by the number of commits made since the previous
-major release that has an associated paper (`git shortlog vX.0.0...HEAD -sne`). The order
-of any author who hasn't made any commits will be decided by all authors. The order can
-also be changed on a case-by-case basis.
+major release that has an associated paper
+(`git shortlog vX.Y.Z..HEAD -sne --group=author --group=trailer:co-authored-by`).
+The order of any author who hasn't made any commits will be decided by all authors. The
+order can also be changed on a case-by-case basis.

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -254,9 +254,10 @@ publishing the actual release notes at [](changes.md).
    modules and methods, gallery examples, API docs changes) and entries within each group
    are alphabetical.
 6. Move a few important items from the main sections to the Highlights section.
-7. Edit the list of people who contributed to the release, linking to their
-   GitHub accounts. Sort their names by the number of commits made since the
-   last release (e.g., use `git shortlog HEAD...v0.4.0 -sne`).
+7. Edit the list of people who contributed to the release, linking to their GitHub
+   accounts. Sort their names by the number of contributions (including commits and PR
+   reviews) made since the last release (e.g., use
+   `git shortlog vX.Y.Z..HEAD -sne --group=author --group=trailer:co-authored-by`).
 8. Update `doc/minversions.md` with new information on the new release version,
    including a vX.Y.Z documentation link, and minimum required versions of GMT, Python
    and core package dependencies (NumPy, pandas, Xarray). Follow


### PR DESCRIPTION
See issue #3746 for context. Closes #3746.

This PR updates the AUTHORSHIP file and maintainers' guides to clarify that we consider co-authorship (e.g., PR reviews) when counting contributions. This is in line with what we're saying in AUTHORSHIP:

> Our goal for this document is to establish guidelines for giving credit to       
> contributors for their work. To do so, we will attempt to define:                       
>                                                                                         
> - Fair and diverse ways of providing recognition for contributors' efforts.             
> - Define _contributions_ in a broad way: writing code and/or documentation, providing   
>   ideas, fostering the community, etc.    
> 

To consider co-authorship (PR reviews), we need to use the following command to count the contributions:
```
git shortlog -sne --group=author --group=trailer:co-authored-by
```
For comparison, the first 10 lines of `git shortlog -sne`'s output are:
```
$ git shortlog -sne | head -n 10
  1131	Dongdong Tian <seisman.info@gmail.com>
   291	Yvonne Fröhlich <94163266+yvonnefroehlich@users.noreply.github.com>
   291	dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
   267	Wei Ji <23487320+weiji14@users.noreply.github.com>
   256	Leonardo Uieda <leouieda@gmail.com>
   192	Will Schlitzer <schlitzer90@gmail.com>
   132	Michael Grund <23025878+michaelgrund@users.noreply.github.com>
    68	Meghan Jones <meghanj@alum.mit.edu>
    33	Yao Jiayuan <coreman.seism@gmail.com>
    30	Meghan Jones <meghanj@hawaii.edu>
```
For `git shortlog -sne --group=author --group=trailer:co-authored-by`, the output is:
```
$ git shortlog -sne --group=author --group=trailer:co-authored-by | head -n 10
  1480	Dongdong Tian <seisman.info@gmail.com>
   616	Wei Ji <23487320+weiji14@users.noreply.github.com>
   425	Yvonne Fröhlich <94163266+yvonnefroehlich@users.noreply.github.com>
   291	dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
   267	Michael Grund <23025878+michaelgrund@users.noreply.github.com>
   258	Leonardo Uieda <leouieda@gmail.com>
   237	Will Schlitzer <schlitzer90@gmail.com>
   129	Meghan Jones <meghanj@alum.mit.edu>
    53	Yao Jiayuan <coreman.seism@gmail.com>
    45	Meghan Jones <meghanj@hawaii.edu>
```
These numbers are still different from the numbers on the GitHub contributors page (https://github.com/GenericMappingTools/pygmt/graphs/contributors), but see #3905.