### PR TITLE
Add mailmap to consolidate author identities and correctly count contributions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -11,6 +11,7 @@ Max Jones <meghanj@alum.mit.edu> <meghanrjones@users.noreply.github.com>
 Michael Grund <michael_grund@gmx.de> <23025878+michaelgrund@users.noreply.github.com>
 Michael Grund <michael_grund@gmx.de> <michael.grund@kit.edu>
 Michael Grund <michael_grund@gmx.de> <michaelgrund@users.noreply.github.com>
+Wei Ji Leong <23487320+weiji14@users.noreply.github.com>
 Wei Ji Leong <23487320+weiji14@users.noreply.github.com> <weiji.leong@vuw.ac.nz>
 Wei Ji Leong <23487320+weiji14@users.noreply.github.com> <weiji14@users.noreply.github.com>
 Will Schlitzer <schlitzer90@gmail.com> <willschlitzer@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -4,10 +4,10 @@ Jiayuan Yao <coreman.seism@gmail.com>
 Jiayuan Yao <coreman.seism@gmail.com> <core-man@users.noreply.github.com>
 Jing-Hui Tong <86273921+JingHuiTong@users.noreply.github.com>
 Jing-Hui Tong <86273921+JingHuiTong@users.noreply.github.com> <r0922422020@g.ntu.edu.tw>
-Max Jones <meghanj@alum.mit.edu>
-Max Jones <meghanj@alum.mit.edu> <14077947+maxrjones@users.noreply.github.com>
-Max Jones <meghanj@alum.mit.edu> <meghanj@hawaii.edu>
-Max Jones <meghanj@alum.mit.edu> <meghanrjones@users.noreply.github.com>
+Max Jones <14077947+maxrjones@users.noreply.github.com>
+Max Jones <14077947+maxrjones@users.noreply.github.com> <meghanj@alum.mit.edu>
+Max Jones <14077947+maxrjones@users.noreply.github.com> <meghanj@hawaii.edu>
+Max Jones <14077947+maxrjones@users.noreply.github.com> <meghanrjones@users.noreply.github.com>
 Michael Grund <michael_grund@gmx.de> <23025878+michaelgrund@users.noreply.github.com>
 Michael Grund <michael_grund@gmx.de> <michael.grund@kit.edu>
 Michael Grund <michael_grund@gmx.de> <michaelgrund@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -13,6 +13,5 @@ Michael Grund <michael_grund@gmx.de> <michaelgrund@users.noreply.github.com>
 Wei Ji Leong <23487320+weiji14@users.noreply.github.com> <weiji.leong@vuw.ac.nz>
 Wei Ji Leong <23487320+weiji14@users.noreply.github.com> <weiji14@users.noreply.github.com>
 Will Schlitzer <schlitzer90@gmail.com> <willschlitzer@users.noreply.github.com>
-Yvonne Fröhlich <94163266+yvonnefroehlich@users.noreply.github.com> <yvonne.froehlich@kite.edu>
 Yvonne Fröhlich <94163266+yvonnefroehlich@users.noreply.github.com> <yvonne.froehlich@kit.edu>
 Yvonne Fröhlich <94163266+yvonnefroehlich@users.noreply.github.com> <yfroe@gpiseis16.gpi.kit.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -2,6 +2,7 @@ Dongdong Tian <seisman.info@gmail.com>
 Dongdong Tian <seisman.info@gmail.com> <seisman@users.noreply.github.com>
 Jiayuan Yao <coreman.seism@gmail.com>
 Jiayuan Yao <coreman.seism@gmail.com> <core-man@users.noreply.github.com>
+Jing-Hui Tong <86273921+JingHuiTong@users.noreply.github.com>
 Jing-Hui Tong <86273921+JingHuiTong@users.noreply.github.com> <r0922422020@g.ntu.edu.tw>
 Max Jones <meghanj@alum.mit.edu>
 Max Jones <meghanj@alum.mit.edu> <14077947+maxrjones@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,18 @@
+Dongdong Tian <seisman.info@gmail.com>
+Dongdong Tian <seisman.info@gmail.com> <seisman@users.noreply.github.com>
+Jiayuan Yao <coreman.seism@gmail.com>
+Jiayuan Yao <coreman.seism@gmail.com> <core-man@users.noreply.github.com>
+Jing-Hui Tong <86273921+JingHuiTong@users.noreply.github.com> <r0922422020@g.ntu.edu.tw>
+Max Jones <meghanj@alum.mit.edu>
+Max Jones <meghanj@alum.mit.edu> <14077947+maxrjones@users.noreply.github.com>
+Max Jones <meghanj@alum.mit.edu> <meghanj@hawaii.edu>
+Max Jones <meghanj@alum.mit.edu> <meghanrjones@users.noreply.github.com>
+Michael Grund <michael_grund@gmx.de> <23025878+michaelgrund@users.noreply.github.com>
+Michael Grund <michael_grund@gmx.de> <michael.grund@kit.edu>
+Michael Grund <michael_grund@gmx.de> <michaelgrund@users.noreply.github.com>
+Wei Ji Leong <23487320+weiji14@users.noreply.github.com> <weiji.leong@vuw.ac.nz>
+Wei Ji Leong <23487320+weiji14@users.noreply.github.com> <weiji14@users.noreply.github.com>
+Will Schlitzer <schlitzer90@gmail.com> <willschlitzer@users.noreply.github.com>
+Yvonne Fröhlich <94163266+yvonnefroehlich@users.noreply.github.com> <yvonne.froehlich@kite.edu>
+Yvonne Fröhlich <94163266+yvonnefroehlich@users.noreply.github.com> <yvonne.froehlich@kit.edu>
+Yvonne Fröhlich <94163266+yvonnefroehlich@users.noreply.github.com> <yfroe@gpiseis16.gpi.kit.edu>

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ exclude .dvcignore
 exclude .gitignore
 exclude .pre-commit-config.yaml
 exclude .readthedocs.yaml
+exclude .mailmap
 exclude AUTHORSHIP.md
 exclude CONTRIBUTING.md
 exclude Makefile


### PR DESCRIPTION
With the new `git shortlog` command introduced in PR #3904, the number of contributions per author still differs from the counts shown on the GitHub contributors page. This discrepancy is due to variations in the commit author names or email addresses used over time.

This PR adds a `.mailmap` file (xref: https://git-scm.com/docs/gitmailmap) to resolve these inconsistencies automatically, avoiding the need to manually consolidate contributions from the same author.

With this file in place, the contribution counts now match exactly with those shown at https://github.com/GenericMappingTools/pygmt/graphs/contributors (Max is an exception, likely due to a name change from Meghan to Max a few years ago.

```
$ git shortlog -sne --group=author --group=trailer:co-authored-by | head -n 10
  1491	Dongdong Tian <seisman.info@gmail.com>
   626	Wei Ji Leong <23487320+weiji14@users.noreply.github.com>
   427	Yvonne Fröhlich <94163266+yvonnefroehlich@users.noreply.github.com>
   293	Michael Grund <michael_grund@gmx.de>
   291	dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
   258	Leonardo Uieda <leouieda@gmail.com>
   237	Will Schlitzer <schlitzer90@gmail.com>
   203	Max Jones <meghanj@alum.mit.edu>
    55	Jiayuan Yao <coreman.seism@gmail.com>
    17	actions-bot <58130806+actions-bot@users.noreply.github.com>
```

