### PR TITLE
CI: Bump to Windows 2022 in the GMT Legacy Tests workflow

### DIFF
--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-13, windows-2019]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-13, windows-2022]
         gmt_version: ['6.4']
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
> We’re beginning the process of closing down the Windows server 2019 hosted runner image, following our N-1 OS support policy. This image will be fully retired by June 30, 2025. We recommend updating workflows use windows-2022 or windows-2025.

xref: https://github.blog/changelog/2025-04-15-upcoming-breaking-changes-and-releases-for-github-actions/#windows-server-2019-is-closing-down
