### PR TITLE
SPEC 0: Bump minimum supported versions to NumPy 1.26

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -72,7 +72,7 @@ jobs:
         include:
           # Python 3.11 + core packages (minimum supported versions) + optional packages (minimum supported versions if any)
           - python-version: '3.11'
-            numpy-version: '1.25'
+            numpy-version: '1.26'
             pandas-version: '=2.1'
             xarray-version: '=2023.04'
             optional-packages: ' contextily geopandas ipython pyarrow-core rioxarray sphinx-gallery'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -61,7 +61,7 @@ jobs:
             python=3.11
             gmt=${{ matrix.gmt_version }}
             ghostscript<10
-            numpy<2
+            numpy=1.26
             pandas
             xarray
             netCDF4

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     # Required dependencies
     - gmt=6.5.0
     - ghostscript=10.04.0
-    - numpy>=1.25
+    - numpy>=1.26
     - pandas>=2.1
     - xarray>=2023.04
     - netCDF4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "numpy>=1.25",
+    "numpy>=1.26",
     "pandas>=2.1",
     "xarray>=2023.04",
     "netCDF4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Required packages
-numpy>=1.25
+numpy>=1.26
 pandas>=2.1
 xarray>=2023.04
 netCDF4


### PR DESCRIPTION
Following [SPEC0](https://scientific-python.org/specs/spec-0000/) policy where NumPy 1.25 should be dropped in 2025 quarter 2. 

Bumps minimum supported NumPy version to 1.26 in the following files:

- [x] `.github/workflows/ci_tests.yaml`
- [x] `.github/workflows/ci_tests_legacy.yaml`
- [x] `environment.yml`
- [x] `pyproject.toml`
- [x] `requirements.txt`

Supersedes #3697. Address #3903.