### PR TITLE
Bump minimum supported version to pyarrow>=16

### DIFF
--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -69,7 +69,7 @@ jobs:
             contextily=1.5
             geopandas=1.0
             ipython
-            pyarrow-core
+            pyarrow-core=16
             rioxarray
             sphinx-gallery
             make

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
     - contextily>=1.5
     - geopandas>=1.0
     - ipython
-    - pyarrow-core
+    - pyarrow-core>=16
     - rioxarray
     # Development dependencies (general)
     - dvc

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -24,8 +24,6 @@ except ImportError:
         A dummy class to mimic pyarrow.
         """
 
-        __version__ = "0.0.0"
-
         @staticmethod
         def timestamp(unit: str, tz: str | None = None):
             """

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -625,14 +625,7 @@ def test_to_numpy_pyarrow_numeric_with_na(dtype, expected_dtype):
         "utf8",  # alias for string
         "large_string",
         "large_utf8",  # alias for large_string
-        pytest.param(
-            "string_view",
-            # TODO(pyarrow>=16): Remove the skipif marker for pyarrow<16.
-            marks=pytest.mark.skipif(
-                Version(pa.__version__) < Version("16"),
-                reason="string_view type was added since pyarrow 16",
-            ),
-        ),
+        "string_view",
     ],
 )
 def test_to_numpy_pyarrow_string(dtype):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ all = [
     "contextily>=1.5",
     "geopandas>=1.0",
     "IPython",  # 'ipython' is not the correct module name.
-    "pyarrow",
+    "pyarrow>=16",
     "rioxarray",
 ]
 


### PR DESCRIPTION
pyarrow v15 was released in Mar. 2024 and v16 in Apr. 2024.

Address #3903.