### PR TITLE
SPEC 0: Bump minimum supported version to xarray>=2023.07

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -74,7 +74,7 @@ jobs:
           - python-version: '3.11'
             numpy-version: '1.25'
             pandas-version: '=2.1'
-            xarray-version: '=2023.04'
+            xarray-version: '=2023.07'
             optional-packages: ' contextily geopandas ipython pyarrow-core rioxarray sphinx-gallery'
           # Python 3.13 + core packages (latest versions) + optional packages
           - python-version: '3.13'

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
     - ghostscript=10.04.0
     - numpy>=1.25
     - pandas>=2.1
-    - xarray>=2023.04
+    - xarray>=2023.07
     - netCDF4
     - packaging
     # Optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.25",
     "pandas>=2.1",
-    "xarray>=2023.04",
+    "xarray>=2023.07",
     "netCDF4",
     "packaging",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Required packages
 numpy>=1.25
 pandas>=2.1
-xarray>=2023.04
+xarray>=2023.07
 netCDF4
 packaging


### PR DESCRIPTION
Following [SPEC0](https://scientific-python.org/specs/spec-0000/) policy, we should bump to xarray>=2023.07 in 2025 quarter 2. 

- [x] `.github/workflows/ci_tests.yaml`
- [x] `environment.yml`
- [x] `pyproject.toml`
- [x] `requirements.txt`

Supersedes #3460. Address #3903.