### PR TITLE
TYP: Add PathLike and TableLike types for type hints and remove the table-like placeholder

### DIFF
--- a/pygmt/_typing.py
+++ b/pygmt/_typing.py
@@ -4,10 +4,13 @@ Type aliases for type hints.
 
 import contextlib
 import importlib
+import os
 from collections.abc import Sequence
 from typing import Literal
 
 import numpy as np
+import pandas as pd
+import xarray as xr
 
 # Anchor codes
 AnchorCode = Literal["TL", "TC", "TR", "ML", "MC", "MR", "BL", "BC", "BR"]
@@ -16,3 +19,9 @@ AnchorCode = Literal["TL", "TC", "TR", "ML", "MC", "MR", "BL", "BC", "BR"]
 StringArrayTypes = Sequence[str] | np.ndarray
 with contextlib.suppress(ImportError):
     StringArrayTypes |= importlib.import_module(name="pyarrow").StringArray
+
+# PathLike and TableLike types
+PathLike = str | os.PathLike
+TableLike = dict | np.ndarray | pd.DataFrame | xr.Dataset
+with contextlib.suppress(ImportError):
+    TableLike |= importlib.import_module(name="geopandas").GeoDataFrame

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1772,7 +1772,7 @@ class Session:
         check_kind : str or None
             Used to validate the type of data that can be passed in. Choose
             from 'raster', 'vector', or None. Default is None (no validation).
-        data : str or pathlib.Path or xarray.DataArray or {table-like} or dict or None
+        data
             Any raster or vector data format. This could be a file name or
             path, a raster grid, a vector matrix/arrays, or other supported
             data input.

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -4,9 +4,11 @@ Define the Figure class that handles all plotting.
 
 import base64
 import os
-from pathlib import Path, PurePath
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Literal, overload
+
+from pygmt._typing import PathLike
 
 try:
     import IPython
@@ -137,7 +139,7 @@ class Figure:
 
     def savefig(
         self,
-        fname: str | PurePath,
+        fname: PathLike,
         transparent: bool = False,
         crop: bool = True,
         anti_alias: bool = True,

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -408,7 +408,7 @@ def fmt_docstring(module_func):
     ...
     ...     Parameters
     ...     ----------
-    ...     data : str, {table-like}
+    ...     data
     ...         Pass in either a file name to an ASCII data table, a 2-D
     ...         {table-classes}.
     ...     {region}
@@ -423,7 +423,7 @@ def fmt_docstring(module_func):
     <BLANKLINE>
     Parameters
     ----------
-    data : str, numpy.ndarray, pandas.DataFrame, xarray.Dataset, or geo...
+    data
         Pass in either a file name to an ASCII data table, a 2-D
         :class:`numpy.ndarray`, a :class:`pandas.DataFrame`, an
         :class:`xarray.Dataset` made up of 1-D :class:`xarray.DataArray`
@@ -455,9 +455,6 @@ def fmt_docstring(module_func):
             aliases.append(f"   - {arg} = {alias}")
         filler_text["aliases"] = "\n".join(aliases)
 
-    filler_text["table-like"] = (
-        "numpy.ndarray, pandas.DataFrame, xarray.Dataset, or geopandas.GeoDataFrame"
-    )
     filler_text["table-classes"] = (
         ":class:`numpy.ndarray`, a :class:`pandas.DataFrame`, an\n"
         "    :class:`xarray.Dataset` made up of 1-D :class:`xarray.DataArray`\n"

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -141,7 +141,7 @@ COMMON_DOCSTRINGS = {
                 - **+p**: specify that the current value minus the previous
                   value must exceed *gap* for a break to be imposed.""",
     "grid": r"""
-        grid : str or xarray.DataArray
+        grid
             Name of the input grid file or the grid loaded as a
             :class:`xarray.DataArray` object.
 

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -582,18 +582,18 @@ def build_arg_list(  # noqa: PLR0912
 
     if infile:  # infile can be a single file or a list of files
         if isinstance(infile, str | os.PathLike):
-            gmt_args = [str(infile), *gmt_args]
+            gmt_args = [os.fspath(infile), *gmt_args]
         else:
-            gmt_args = [str(_file) for _file in infile] + gmt_args
+            gmt_args = [os.fspath(_file) for _file in infile] + gmt_args
     if outfile is not None:
         if (
             not isinstance(outfile, str | os.PathLike)
-            or str(outfile) in {"", ".", ".."}
-            or str(outfile).endswith(("/", "\\"))
+            or os.fspath(outfile) in {"", ".", ".."}
+            or os.fspath(outfile).endswith(("/", "\\"))
         ):
             msg = f"Invalid output file name '{outfile}'."
             raise GMTInvalidInput(msg)
-        gmt_args.append(f"->{outfile}")
+        gmt_args.append(f"->{os.fspath(outfile)}")
     return gmt_args
 
 

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -4,7 +4,6 @@ Utilities and common tasks for wrapping the GMT modules.
 
 import io
 import os
-import pathlib
 import shutil
 import string
 import subprocess
@@ -17,6 +16,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.encodings import charset
 from pygmt.exceptions import GMTInvalidInput
 
@@ -387,10 +387,10 @@ def data_kind(
     match data:
         case None if required:  # No data provided and required=True.
             kind = "empty"
-        case str() | pathlib.PurePath():  # One file.
+        case str() | os.PathLike():  # One file.
             kind = "file"
         case list() | tuple() if all(
-            isinstance(_file, str | pathlib.PurePath) for _file in data
+            isinstance(_file, str | os.PathLike) for _file in data
         ):  # A list/tuple of files.
             kind = "file"
         case io.StringIO():
@@ -482,8 +482,8 @@ def non_ascii_to_octal(argstr: str, encoding: Encoding = "ISOLatin1+") -> str:
 def build_arg_list(  # noqa: PLR0912
     kwdict: dict[str, Any],
     confdict: Mapping[str, Any] | None = None,
-    infile: str | pathlib.PurePath | Sequence[str | pathlib.PurePath] | None = None,
-    outfile: str | pathlib.PurePath | None = None,
+    infile: PathLike | Sequence[PathLike] | None = None,
+    outfile: PathLike | None = None,
 ) -> list[str]:
     r"""
     Convert keyword dictionaries and input/output files into a list of GMT arguments.
@@ -581,13 +581,13 @@ def build_arg_list(  # noqa: PLR0912
         gmt_args.extend(f"--{key}={value}" for key, value in confdict.items())
 
     if infile:  # infile can be a single file or a list of files
-        if isinstance(infile, str | pathlib.PurePath):
+        if isinstance(infile, str | os.PathLike):
             gmt_args = [str(infile), *gmt_args]
         else:
             gmt_args = [str(_file) for _file in infile] + gmt_args
     if outfile is not None:
         if (
-            not isinstance(outfile, str | pathlib.PurePath)
+            not isinstance(outfile, str | os.PathLike)
             or str(outfile) in {"", ".", ".."}
             or str(outfile).endswith(("/", "\\"))
         ):
@@ -632,7 +632,7 @@ def is_nonstr_iter(value: Any) -> bool:
     return isinstance(value, Iterable) and not isinstance(value, str)
 
 
-def launch_external_viewer(fname: str, waiting: float = 0) -> None:
+def launch_external_viewer(fname: PathLike, waiting: float = 0) -> None:
     """
     Open a file in an external viewer program.
 

--- a/pygmt/helpers/validators.py
+++ b/pygmt/helpers/validators.py
@@ -5,11 +5,12 @@ Functions to check if given arguments are valid.
 import warnings
 from typing import Literal
 
+from pygmt._typing import PathLike
 from pygmt.exceptions import GMTInvalidInput
 
 
 def validate_output_table_type(
-    output_type: Literal["pandas", "numpy", "file"], outfile: str | None = None
+    output_type: Literal["pandas", "numpy", "file"], outfile: PathLike | None = None
 ) -> Literal["pandas", "numpy", "file"]:
     """
     Check if the ``output_type`` and ``outfile`` parameters are valid.

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -3,6 +3,7 @@ binstats - Bin spatial data and determine statistics per bin.
 """
 
 import xarray as xr
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -24,7 +25,9 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     r="registration",
 )
 @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma")
-def binstats(data, outgrid: str | None = None, **kwargs) -> xr.DataArray | None:
+def binstats(
+    data: PathLike | TableLike, outgrid: PathLike | None = None, **kwargs
+) -> xr.DataArray | None:
     r"""
     Bin spatial data and determine statistics per bin.
 
@@ -42,7 +45,7 @@ def binstats(data, outgrid: str | None = None, **kwargs) -> xr.DataArray | None:
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         A file name of an ASCII data table or a 2-D {table-classes}.
     {outgrid}
     statistic : str

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_list,
@@ -87,12 +88,12 @@ def _blockm(
 )
 @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma", o="sequence_comma")
 def blockmean(
-    data=None,
+    data: PathLike | TableLike | None = None,
     x=None,
     y=None,
     z=None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
-    outfile: str | None = None,
+    outfile: PathLike | None = None,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""
@@ -113,7 +114,7 @@ def blockmean(
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.
@@ -191,12 +192,12 @@ def blockmean(
 )
 @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma", o="sequence_comma")
 def blockmedian(
-    data=None,
+    data: PathLike | TableLike | None = None,
     x=None,
     y=None,
     z=None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
-    outfile: str | None = None,
+    outfile: PathLike | None = None,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""
@@ -217,7 +218,7 @@ def blockmedian(
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.
@@ -289,12 +290,12 @@ def blockmedian(
 )
 @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma", o="sequence_comma")
 def blockmode(
-    data=None,
+    data: PathLike | TableLike | None = None,
     x=None,
     y=None,
     z=None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
-    outfile: str | None = None,
+    outfile: PathLike | None = None,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""
@@ -315,7 +316,7 @@ def blockmode(
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -2,6 +2,7 @@
 contour - Contour table data by direct triangulation.
 """
 
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_list,
@@ -37,7 +38,9 @@ from pygmt.helpers import (
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
-def contour(self, data=None, x=None, y=None, z=None, **kwargs):
+def contour(
+    self, data: PathLike | TableLike | None = None, x=None, y=None, z=None, **kwargs
+):
     r"""
     Contour table data by direct triangulation.
 
@@ -52,7 +55,7 @@ def contour(self, data=None, x=None, y=None, z=None, **kwargs):
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -3,6 +3,7 @@ dimfilter - Directional filtering of grids in the space domain.
 """
 
 import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
@@ -20,7 +21,9 @@ __doctest_skip__ = ["dimfilter"]
     V="verbose",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def dimfilter(grid, outgrid: str | None = None, **kwargs) -> xr.DataArray | None:
+def dimfilter(
+    grid: PathLike | xr.DataArray, outgrid: PathLike | None = None, **kwargs
+) -> xr.DataArray | None:
     r"""
     Directional filtering of grids in the space domain.
 

--- a/pygmt/src/filter1d.py
+++ b/pygmt/src/filter1d.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -23,9 +24,9 @@ from pygmt.helpers import (
     N="time_col",
 )
 def filter1d(
-    data,
+    data: PathLike | TableLike,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
-    outfile: str | None = None,
+    outfile: PathLike | None = None,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -2,6 +2,8 @@
 grd2cpt - Make linear or histogram-equalized color palette table from grid.
 """
 
+import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
@@ -31,7 +33,7 @@ __doctest_skip__ = ["grd2cpt"]
     Z="continuous",
 )
 @kwargs_to_strings(G="sequence", L="sequence", R="sequence", T="sequence")
-def grd2cpt(grid, **kwargs):
+def grd2cpt(grid: PathLike | xr.DataArray, **kwargs):
     r"""
     Make linear or histogram-equalized color palette table from grid.
 

--- a/pygmt/src/grd2xyz.py
+++ b/pygmt/src/grd2xyz.py
@@ -7,6 +7,7 @@ from typing import Literal
 import numpy as np
 import pandas as pd
 import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -36,9 +37,9 @@ __doctest_skip__ = ["grd2xyz"]
 )
 @kwargs_to_strings(R="sequence", o="sequence_comma")
 def grd2xyz(
-    grid,
+    grid: PathLike | xr.DataArray,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
-    outfile: str | None = None,
+    outfile: PathLike | None = None,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -3,6 +3,7 @@ grdclip - Clip the range of grid values.
 """
 
 import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_list,
@@ -33,7 +34,11 @@ __doctest_skip__ = ["grdclip"]
     Si="sequence",
     Sr="sequence",
 )
-def grdclip(grid, outgrid: str | None = None, **kwargs) -> xr.DataArray | None:
+def grdclip(
+    grid: PathLike | xr.DataArray,
+    outgrid: PathLike | None = None,
+    **kwargs,
+) -> xr.DataArray | None:
     r"""
     Clip the range of grid values.
 

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -2,6 +2,8 @@
 grdcontour - Make contour map using a grid.
 """
 
+import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_list,
@@ -36,7 +38,7 @@ __doctest_skip__ = ["grdcontour"]
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", L="sequence", c="sequence_comma", p="sequence")
-def grdcontour(self, grid, **kwargs):
+def grdcontour(self, grid: PathLike | xr.DataArray, **kwargs):
     r"""
     Make contour map using a grid.
 

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -5,6 +5,7 @@ grdcut - Extract subregion from a grid or image or a slice from a cube.
 from typing import Literal
 
 import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -30,7 +31,10 @@ __doctest_skip__ = ["grdcut"]
 )
 @kwargs_to_strings(R="sequence")
 def grdcut(
-    grid, kind: Literal["grid", "image"] = "grid", outgrid: str | None = None, **kwargs
+    grid: PathLike | xr.DataArray,
+    kind: Literal["grid", "image"] = "grid",
+    outgrid: PathLike | None = None,
+    **kwargs,
 ) -> xr.DataArray | None:
     r"""
     Extract subregion from a grid or image or a slice from a cube.

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -6,6 +6,7 @@ import warnings
 
 import numpy as np
 import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -111,10 +112,10 @@ def _parse_fill_mode(
 @use_alias(N="hole", R="region", V="verbose", f="coltypes")
 @kwargs_to_strings(R="sequence")
 def grdfill(
-    grid: str | xr.DataArray,
-    outgrid: str | None = None,
+    grid: PathLike | xr.DataArray,
+    outgrid: PathLike | None = None,
     constantfill: float | None = None,
-    gridfill: str | xr.DataArray | None = None,
+    gridfill: PathLike | xr.DataArray | None = None,
     neighborfill: float | bool | None = None,
     splinefill: float | bool | None = None,
     inquire: bool = False,

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -3,6 +3,7 @@ grdfilter - Filter a grid in the space (or time) domain.
 """
 
 import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -21,7 +22,9 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     x="cores",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def grdfilter(grid, outgrid: str | None = None, **kwargs) -> xr.DataArray | None:
+def grdfilter(
+    grid: PathLike | xr.DataArray, outgrid: PathLike | None = None, **kwargs
+) -> xr.DataArray | None:
     r"""
     Filter a grid in the space (or time) domain.
 

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -3,6 +3,7 @@ grdgradient - Compute directional gradients from a grid.
 """
 
 import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -30,7 +31,9 @@ __doctest_skip__ = ["grdgradient"]
     n="interpolation",
 )
 @kwargs_to_strings(A="sequence", E="sequence", R="sequence")
-def grdgradient(grid, outgrid: str | None = None, **kwargs) -> xr.DataArray | None:
+def grdgradient(
+    grid: PathLike | xr.DataArray, outgrid: PathLike | None = None, **kwargs
+) -> xr.DataArray | None:
     r"""
     Compute directional gradients from a grid.
 

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -7,6 +7,7 @@ from typing import Literal
 import numpy as np
 import pandas as pd
 import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -63,7 +64,7 @@ class grdhisteq:  # noqa: N801
     )
     @kwargs_to_strings(R="sequence")
     def equalize_grid(
-        grid, outgrid: str | None = None, **kwargs
+        grid: PathLike | xr.DataArray, outgrid: PathLike | None = None, **kwargs
     ) -> xr.DataArray | None:
         r"""
         Perform histogram equalization for a grid.
@@ -145,9 +146,9 @@ class grdhisteq:  # noqa: N801
     )
     @kwargs_to_strings(R="sequence")
     def compute_bins(
-        grid,
+        grid: PathLike | xr.DataArray,
         output_type: Literal["pandas", "numpy", "file"] = "pandas",
-        outfile: str | None = None,
+        outfile: PathLike | None = None,
         **kwargs,
     ) -> pd.DataFrame | np.ndarray | None:
         r"""

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -2,6 +2,8 @@
 grdimage - Project and plot grids or images.
 """
 
+import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -36,7 +38,7 @@ __doctest_skip__ = ["grdimage"]
     x="cores",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
-def grdimage(self, grid, **kwargs):
+def grdimage(self, grid: PathLike | xr.DataArray, **kwargs):
     r"""
     Project and plot grids or images.
 

--- a/pygmt/src/grdinfo.py
+++ b/pygmt/src/grdinfo.py
@@ -2,6 +2,8 @@
 grdinfo - Extract information from 2-D grids or 3-D cubes.
 """
 
+import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,
@@ -26,7 +28,7 @@ from pygmt.helpers import (
     f="coltypes",
 )
 @kwargs_to_strings(D="sequence", I="sequence", R="sequence")
-def grdinfo(grid, **kwargs):
+def grdinfo(grid: PathLike | xr.DataArray, **kwargs):
     r"""
     Extract information from 2-D grids or 3-D cubes.
 

--- a/pygmt/src/grdinfo.py
+++ b/pygmt/src/grdinfo.py
@@ -28,7 +28,7 @@ from pygmt.helpers import (
     f="coltypes",
 )
 @kwargs_to_strings(D="sequence", I="sequence", R="sequence")
-def grdinfo(grid: PathLike | xr.DataArray, **kwargs):
+def grdinfo(grid: PathLike | xr.DataArray, **kwargs) -> str:
     r"""
     Extract information from 2-D grids or 3-D cubes.
 

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -3,6 +3,7 @@ grdlandmask - Create a "wet-dry" mask grid from shoreline database.
 """
 
 import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
@@ -23,7 +24,7 @@ __doctest_skip__ = ["grdlandmask"]
     x="cores",
 )
 @kwargs_to_strings(I="sequence", R="sequence", N="sequence", E="sequence")
-def grdlandmask(outgrid: str | None = None, **kwargs) -> xr.DataArray | None:
+def grdlandmask(outgrid: PathLike | None = None, **kwargs) -> xr.DataArray | None:
     r"""
     Create a "wet-dry" mask grid from shoreline database.
 

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -3,6 +3,7 @@ grdproject - Forward and inverse map transformation of grids.
 """
 
 import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
@@ -25,7 +26,9 @@ __doctest_skip__ = ["grdproject"]
     r="registration",
 )
 @kwargs_to_strings(C="sequence", D="sequence", R="sequence")
-def grdproject(grid, outgrid: str | None = None, **kwargs) -> xr.DataArray | None:
+def grdproject(
+    grid: PathLike | xr.DataArray, outgrid: PathLike | None = None, **kwargs
+) -> xr.DataArray | None:
     r"""
     Forward and inverse map transformation of grids.
 

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -3,6 +3,7 @@ grdsample - Resample a grid onto a new lattice.
 """
 
 import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -21,7 +22,9 @@ __doctest_skip__ = ["grdsample"]
     x="cores",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def grdsample(grid, outgrid: str | None = None, **kwargs) -> xr.DataArray | None:
+def grdsample(
+    grid: PathLike | xr.DataArray, outgrid: PathLike | None = None, **kwargs
+) -> xr.DataArray | None:
     r"""
     Resample a grid onto a new lattice.
 

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -6,6 +6,8 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
+import xarray as xr
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -48,10 +50,10 @@ __doctest_skip__ = ["grdtrack"]
 )
 @kwargs_to_strings(R="sequence", S="sequence", i="sequence_comma", o="sequence_comma")
 def grdtrack(
-    grid,
-    points=None,
+    grid: PathLike | xr.DataArray,
+    points: PathLike | TableLike | None = None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
-    outfile: str | None = None,
+    outfile: PathLike | None = None,
     newcolname=None,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
@@ -80,7 +82,7 @@ def grdtrack(
     ----------
     {grid}
 
-    points : str, {table-like}
+    points
         Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
     {output_type}

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -2,6 +2,8 @@
 grdview - Create 3-D perspective image or surface mesh from a grid.
 """
 
+import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -31,7 +33,7 @@ __doctest_skip__ = ["grdview"]
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
-def grdview(self, grid, **kwargs):
+def grdview(self, grid: PathLike | xr.DataArray, **kwargs):
     r"""
     Create 3-D perspective image or surface mesh from a grid.
 

--- a/pygmt/src/grdvolume.py
+++ b/pygmt/src/grdvolume.py
@@ -6,6 +6,8 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
+import xarray as xr
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_list,
@@ -27,9 +29,9 @@ __doctest_skip__ = ["grdvolume"]
 )
 @kwargs_to_strings(C="sequence", R="sequence")
 def grdvolume(
-    grid,
+    grid: PathLike | xr.DataArray,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
-    outfile: str | None = None,
+    outfile: PathLike | None = None,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -2,6 +2,7 @@
 Histogram - Calculate and plot histograms.
 """
 
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -39,7 +40,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
 @kwargs_to_strings(
     R="sequence", T="sequence", c="sequence_comma", i="sequence_comma", p="sequence"
 )
-def histogram(self, data, **kwargs):
+def histogram(self, data: PathLike | TableLike, **kwargs):
     r"""
     Calculate and plot histograms.
 
@@ -49,7 +50,7 @@ def histogram(self, data, **kwargs):
 
     Parameters
     ----------
-    data : str, list, {table-like}
+    data
         Pass in either a file name to an ASCII data table, a Python list, a 2-D
         {table-classes}.
     {projection}

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -2,6 +2,7 @@
 image - Plot raster or EPS images.
 """
 
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -20,7 +21,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
-def image(self, imagefile, **kwargs):
+def image(self, imagefile: PathLike, **kwargs):
     r"""
     Plot raster or EPS images.
 

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -3,6 +3,7 @@ info - Get information about data tables.
 """
 
 import numpy as np
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,
@@ -25,7 +26,7 @@ from pygmt.helpers import (
     r="registration",
 )
 @kwargs_to_strings(I="sequence", i="sequence_comma")
-def info(data, **kwargs):
+def info(data: PathLike | TableLike, **kwargs):
     r"""
     Get information about data tables.
 
@@ -48,7 +49,7 @@ def info(data, **kwargs):
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in either a file name to an ASCII data table, a 1-D/2-D
         {table-classes}.
     per_column : bool

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -26,7 +26,7 @@ from pygmt.helpers import (
     r="registration",
 )
 @kwargs_to_strings(I="sequence", i="sequence_comma")
-def info(data: PathLike | TableLike, **kwargs):
+def info(data: PathLike | TableLike, **kwargs) -> np.ndarray | str:
     r"""
     Get information about data tables.
 

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -3,8 +3,8 @@ legend - Plot a legend.
 """
 
 import io
-import pathlib
 
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -31,7 +31,7 @@ from pygmt.helpers import (
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def legend(
     self,
-    spec: str | pathlib.PurePath | io.StringIO | None = None,
+    spec: PathLike | io.StringIO | None = None,
     position="JTR+jTR+o0.2c",
     box="+gwhite+p1p",
     **kwargs,
@@ -56,9 +56,8 @@ def legend(
 
         - ``None`` which means using the automatically generated legend specification
           file
-        - A string or a :class:`pathlib.PurePath` object pointing to the legend
-          specification file
-        - A :class:`io.StringIO` object containing the legend specification.
+        - Path to the legend specification file
+        - A :class:`io.StringIO` object containing the legend specification
 
         See :gmt-docs:`legend.html` for the definition of the legend specification.
     {projection}

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -132,7 +133,7 @@ def _auto_offset(spec) -> bool:
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def meca(  # noqa: PLR0913
     self,
-    spec,
+    spec: PathLike | TableLike,
     scale,
     convention: Literal["aki", "gcmt", "mt", "partial", "principal_axis"] | None = None,
     component: Literal["full", "dc", "deviatoric"] = "full",

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -3,6 +3,7 @@ nearneighbor - Grid table data using a "Nearest neighbor" algorithm.
 """
 
 import xarray as xr
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -30,7 +31,12 @@ __doctest_skip__ = ["nearneighbor"]
 )
 @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma")
 def nearneighbor(
-    data=None, x=None, y=None, z=None, outgrid: str | None = None, **kwargs
+    data: PathLike | TableLike | None = None,
+    x=None,
+    y=None,
+    z=None,
+    outgrid: PathLike | None = None,
+    **kwargs,
 ) -> xr.DataArray | None:
     r"""
     Grid table data using a "Nearest neighbor" algorithm.
@@ -72,7 +78,7 @@ def nearneighbor(
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -4,6 +4,7 @@ plot - Plot lines, polygons, and symbols in 2-D.
 
 from typing import Literal
 
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -52,7 +53,7 @@ from pygmt.src._common import _data_geometry_is_point
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 def plot(  # noqa: PLR0912
     self,
-    data=None,
+    data: PathLike | TableLike | None = None,
     x=None,
     y=None,
     size=None,
@@ -88,7 +89,7 @@ def plot(  # noqa: PLR0912
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
         Use parameter ``incols`` to choose which columns are x, y, fill, and

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -4,6 +4,7 @@ plot3d - Plot lines, polygons, and symbols in 3-D.
 
 from typing import Literal
 
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -53,7 +54,7 @@ from pygmt.src._common import _data_geometry_is_point
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 def plot3d(  # noqa: PLR0912
     self,
-    data=None,
+    data: PathLike | TableLike | None = None,
     x=None,
     y=None,
     z=None,
@@ -90,7 +91,7 @@ def plot3d(  # noqa: PLR0912
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Either a data file name, a 2-D {table-classes}.
         Optionally, use parameter ``incols`` to specify which columns are x, y,
         z, fill, and size, respectively.

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -36,12 +37,12 @@ from pygmt.helpers import (
 )
 @kwargs_to_strings(E="sequence", L="sequence", T="sequence", W="sequence", C="sequence")
 def project(
-    data=None,
+    data: PathLike | TableLike | None = None,
     x=None,
     y=None,
     z=None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
-    outfile: str | None = None,
+    outfile: PathLike | None = None,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""
@@ -112,7 +113,7 @@ def project(
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -2,6 +2,7 @@
 rose - Plot a polar histogram (rose, sector, windrose diagrams).
 """
 
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_list,
@@ -42,7 +43,9 @@ from pygmt.helpers import (
     w="wrap",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
-def rose(self, data=None, length=None, azimuth=None, **kwargs):
+def rose(
+    self, data: PathLike | TableLike | None = None, length=None, azimuth=None, **kwargs
+):
     """
     Plot a polar histogram (rose, sector, windrose diagrams).
 
@@ -62,7 +65,7 @@ def rose(self, data=None, length=None, azimuth=None, **kwargs):
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
         Use parameter ``incols`` to choose which columns are length and

--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_list,
@@ -45,9 +46,9 @@ __doctest_skip__ = ["select"]
 )
 @kwargs_to_strings(M="sequence", R="sequence", i="sequence_comma", o="sequence_comma")
 def select(
-    data=None,
+    data: PathLike | TableLike | None = None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
-    outfile: str | None = None,
+    outfile: PathLike | None = None,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""
@@ -75,7 +76,7 @@ def select(
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
     {output_type}

--- a/pygmt/src/sph2grd.py
+++ b/pygmt/src/sph2grd.py
@@ -3,6 +3,7 @@ sph2grd - Compute grid from spherical harmonic coefficients.
 """
 
 import xarray as xr
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -21,7 +22,9 @@ __doctest_skip__ = ["sph2grd"]
     x="cores",
 )
 @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma")
-def sph2grd(data, outgrid: str | None = None, **kwargs) -> xr.DataArray | None:
+def sph2grd(
+    data: PathLike | TableLike, outgrid: PathLike | None = None, **kwargs
+) -> xr.DataArray | None:
     r"""
     Compute grid from spherical harmonic coefficients.
 
@@ -35,7 +38,7 @@ def sph2grd(data, outgrid: str | None = None, **kwargs) -> xr.DataArray | None:
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in data with L, M, C[L,M], S[L,M] values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -4,6 +4,7 @@ sphere.
 """
 
 import xarray as xr
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
@@ -25,7 +26,11 @@ __doctest_skip__ = ["sphdistance"]
 )
 @kwargs_to_strings(I="sequence", R="sequence")
 def sphdistance(
-    data=None, x=None, y=None, outgrid: str | None = None, **kwargs
+    data: PathLike | TableLike | None = None,
+    x=None,
+    y=None,
+    outgrid: PathLike | None = None,
+    **kwargs,
 ) -> xr.DataArray | None:
     r"""
     Create Voronoi distance, node, or natural nearest-neighbor grid on a sphere.
@@ -41,7 +46,7 @@ def sphdistance(
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in (x, y) or (longitude, latitude) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/sphinterpolate.py
+++ b/pygmt/src/sphinterpolate.py
@@ -3,6 +3,7 @@ sphinterpolate - Spherical gridding in tension of data on a sphere.
 """
 
 import xarray as xr
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -16,7 +17,9 @@ __doctest_skip__ = ["sphinterpolate"]
     V="verbose",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def sphinterpolate(data, outgrid: str | None = None, **kwargs) -> xr.DataArray | None:
+def sphinterpolate(
+    data: PathLike | TableLike, outgrid: PathLike | None = None, **kwargs
+) -> xr.DataArray | None:
     r"""
     Spherical gridding in tension of data on a sphere.
 
@@ -32,7 +35,7 @@ def sphinterpolate(data, outgrid: str | None = None, **kwargs) -> xr.DataArray |
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -3,6 +3,7 @@ surface - Grid table data using adjustable tension continuous curvature splines.
 """
 
 import xarray as xr
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -31,7 +32,12 @@ __doctest_skip__ = ["surface"]
 )
 @kwargs_to_strings(I="sequence", R="sequence")
 def surface(
-    data=None, x=None, y=None, z=None, outgrid: str | None = None, **kwargs
+    data: PathLike | TableLike | None = None,
+    x=None,
+    y=None,
+    z=None,
+    outgrid: PathLike | None = None,
+    **kwargs,
 ) -> xr.DataArray | None:
     r"""
     Grid table data using adjustable tension continuous curvature splines.
@@ -69,7 +75,7 @@ def surface(
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         {table-classes}.

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -4,6 +4,7 @@ ternary - Plot data on ternary diagrams.
 
 import pandas as pd
 from packaging.version import Version
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session, __gmt_version__
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -25,7 +26,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def ternary(
     self,
-    data,
+    data: PathLike | TableLike,
     alabel: str | None = None,
     blabel: str | None = None,
     clabel: str | None = None,
@@ -48,7 +49,7 @@ def ternary(
 
     Parameters
     ----------
-    data : str, list, {table-like}
+    data
         Pass in either a file name to an ASCII data table, a Python list, a 2-D
         {table-classes}.
     width : str

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -5,7 +5,7 @@ text - Plot or typeset text.
 from collections.abc import Sequence
 
 import numpy as np
-from pygmt._typing import AnchorCode, StringArrayTypes
+from pygmt._typing import AnchorCode, PathLike, StringArrayTypes, TableLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -44,7 +44,7 @@ from pygmt.helpers import (
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
 def text_(  # noqa: PLR0912
     self,
-    textfiles=None,
+    textfiles: PathLike | TableLike | None = None,
     x=None,
     y=None,
     position: AnchorCode | None = None,

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -8,6 +8,7 @@ from typing import Literal
 import numpy as np
 import pandas as pd
 import xarray as xr
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_list,
@@ -65,7 +66,12 @@ class triangulate:  # noqa: N801
     )
     @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma")
     def regular_grid(
-        data=None, x=None, y=None, z=None, outgrid: str | None = None, **kwargs
+        data: PathLike | TableLike | None = None,
+        x=None,
+        y=None,
+        z=None,
+        outgrid: PathLike | None = None,
+        **kwargs,
     ) -> xr.DataArray | None:
         """
         Delaunay triangle based gridding of Cartesian data.
@@ -96,7 +102,7 @@ class triangulate:  # noqa: N801
         ----------
         x/y/z : :class:`numpy.ndarray`
             Arrays of x and y coordinates and values z of the data points.
-        data : str, {table-like}
+        data
             Pass in (x, y[, z]) or (longitude, latitude[, elevation]) values by
             providing a file name to an ASCII data table, a 2-D
             {table-classes}.
@@ -167,13 +173,13 @@ class triangulate:  # noqa: N801
     )
     @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma")
     def delaunay_triples(
-        data=None,
+        data: PathLike | TableLike | None = None,
         x=None,
         y=None,
         z=None,
         *,
         output_type: Literal["pandas", "numpy", "file"] = "pandas",
-        outfile: str | None = None,
+        outfile: PathLike | None = None,
         **kwargs,
     ) -> pd.DataFrame | np.ndarray | None:
         """
@@ -198,7 +204,7 @@ class triangulate:  # noqa: N801
         ----------
         x/y/z : :class:`numpy.ndarray`
             Arrays of x and y coordinates and values z of the data points.
-        data : str, {table-like}
+        data
             Pass in (x, y, z) or (longitude, latitude, elevation) values by
             providing a file name to an ASCII data table, a 2-D
             {table-classes}.

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -4,6 +4,7 @@ velo - Plot velocity vectors, crosses, anisotropy bars, and wedges.
 
 import numpy as np
 import pandas as pd
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -41,7 +42,7 @@ from pygmt.helpers import (
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
-def velo(self, data=None, **kwargs):
+def velo(self, data: PathLike | TableLike | None = None, **kwargs):
     r"""
     Plot velocity vectors, crosses, anisotropy bars, and wedges.
 
@@ -60,7 +61,7 @@ def velo(self, data=None, **kwargs):
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
         Note that text columns are only supported with file or

--- a/pygmt/src/which.py
+++ b/pygmt/src/which.py
@@ -4,7 +4,7 @@ which - Find full path to specified files.
 
 from collections.abc import Sequence
 
-from pygmt._type import PathLike
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, is_nonstr_iter, use_alias
 

--- a/pygmt/src/which.py
+++ b/pygmt/src/which.py
@@ -2,13 +2,16 @@
 which - Find full path to specified files.
 """
 
+from collections.abc import Sequence
+
+from pygmt._type import PathLike
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, is_nonstr_iter, use_alias
 
 
 @fmt_docstring
 @use_alias(G="download", V="verbose")
-def which(fname, **kwargs) -> str | list[str]:
+def which(fname: PathLike | Sequence[PathLike], **kwargs) -> str | list[str]:
     r"""
     Find full path to specified files.
 

--- a/pygmt/src/which.py
+++ b/pygmt/src/which.py
@@ -70,7 +70,7 @@ def which(fname: PathLike | Sequence[PathLike], **kwargs) -> str | list[str]:
 
     match paths.size:
         case 0:
-            _fname = "', '".join(fname) if is_nonstr_iter(fname) else fname
+            _fname = "', '".join(fname) if is_nonstr_iter(fname) else fname  # type: ignore[arg-type]
             msg = f"File(s) '{_fname}' not found."
             raise FileNotFoundError(msg)
         case 1:

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -2,6 +2,7 @@
 wiggle - Plot z=f(x,y) anomalies along tracks.
 """
 
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -31,7 +32,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 def wiggle(
     self,
-    data=None,
+    data: PathLike | TableLike | None = None,
     x=None,
     y=None,
     z=None,
@@ -55,7 +56,7 @@ def wiggle(
     ----------
     x/y/z : 1-D arrays
         The arrays of x and y coordinates and z data points.
-    data : str, {table-like}
+    data
         Pass in either a file name to an ASCII data table, a 2-D
         {table-classes}.
         Use parameter ``incols`` to choose which columns are x, y, z,

--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
+from pygmt._typing import PathLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -71,7 +72,9 @@ def tempfile_from_dftrack(track, suffix):
 )
 @kwargs_to_strings(R="sequence")
 def x2sys_cross(
-    tracks=None, outfile: str | None = None, **kwargs
+    tracks=None,
+    outfile: PathLike | None = None,
+    **kwargs,
 ) -> pd.DataFrame | None:
     r"""
     Calculate crossovers between track data files.

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -3,6 +3,7 @@ xyz2grd - Convert data table to a grid.
 """
 
 import xarray as xr
+from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
@@ -29,7 +30,12 @@ __doctest_skip__ = ["xyz2grd"]
 )
 @kwargs_to_strings(I="sequence", R="sequence")
 def xyz2grd(
-    data=None, x=None, y=None, z=None, outgrid: str | None = None, **kwargs
+    data: PathLike | TableLike | None = None,
+    x=None,
+    y=None,
+    z=None,
+    outgrid: PathLike | None = None,
+    **kwargs,
 ) -> xr.DataArray | None:
     r"""
     Convert data table to a grid.
@@ -46,7 +52,7 @@ def xyz2grd(
 
     Parameters
     ----------
-    data : str, {table-like}
+    data
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D {table-classes}.
     x/y/z : 1-D arrays


### PR DESCRIPTION
This PR adds two types for type hints:

- `PathLike`: `str | os.PathLike`, representing a path to an ASCII file
- `TableLike`: ` dict | np.ndarray | pd.DataFrame | xr.Dataset | gpd.GeoDataFrame` . 2-D table-like object that contains tabular data. Similar to the `table-like` placeholder https://github.com/GenericMappingTools/pygmt/blob/99a63402ccdbca4b35619f004b833406916f562c/pygmt/helpers/decorators.py#L458-L460

and does the following replacements:

- `data` => `data: PathLike | TableLike`
- `data=None` => `data: PathLike | TableLike | None = None`
- `outgrid: str | None = None` => `outgrid: PathLike | None = None`
- `grid` => `grid: PathLike | xr.DataArray`
- `outgrid: str | None = None` => `outgrid: PathLike | None = None`

**Preview**:

- https://pygmt-dev--3920.org.readthedocs.build/en/3920/api/generated/pygmt.grdclip.html#pygmt.grdclip
- https://pygmt-dev--3920.org.readthedocs.build/en/3920/api/generated/pygmt.xyz2grd.html#pygmt.xyz2grd