### PR TITLE
Improve the description for the 'cores' parameter

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -71,14 +71,11 @@ COMMON_DOCSTRINGS = {
             :gmt-docs:`gmt.html#f-full`.""",
     "cores": r"""
         cores : bool or int
-            [[**-**]\ *n*].
-            Limit the number of cores to be used in any OpenMP-enabled
-            multi-threaded algorithms. By default we try to use all available
-            cores. Set a number *n* to only use n cores (if too large it will
-            be truncated to the maximum cores available). Finally, give a
-            negative number *-n* to select (all - *n*) cores (or at least 1 if
-            *n* equals or exceeds all).
-            """,
+            Specify the number of active cores to be used in any OpenMP-enabled
+            multi-threaded algorithms. By default, all available cores are used. Set a
+            number *n* to use *n* cores (if too large it will be truncated to the
+            maximum cores available); or set a negative number *-n* to select
+            (all - *n*) cores (or at least 1 if *n* equals or exceeds all).""",
     "distcalc": r"""
         distcalc : str
             Determine how spherical distances are calculated

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -73,8 +73,8 @@ COMMON_DOCSTRINGS = {
         cores : bool or int
             Specify the number of active cores to be used in any OpenMP-enabled
             multi-threaded algorithms. By default, all available cores are used. Set a
-            number *n* to use *n* cores (if too large it will be truncated to the
-            maximum cores available); or set a negative number *-n* to select
+            positive number *n* to use *n* cores (if too large it will be truncated to
+            the maximum cores available); or set a negative number *-n* to select
             (all - *n*) cores (or at least 1 if *n* equals or exceeds all).""",
     "distcalc": r"""
         distcalc : str


### PR DESCRIPTION
Upstream documentation at: https://docs.generic-mapping-tools.org/6.5/gmt.html#core-full

Address https://github.com/GenericMappingTools/pygmt/issues/3843. The docstring of this option is not that long so we don't have to move it to https://www.pygmt.org/dev/techref/common_parameters.html

**Preview**: https://pygmt-dev--3923.org.readthedocs.build/en/3923/api/generated/pygmt.grdsample.html#pygmt.grdsample