### PR TITLE
Remove the lengthy project description on the API reference page

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -1,5 +1,3 @@
-.. _api:
-
 API Reference
 =============
 

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -3,7 +3,7 @@
 API Reference
 =============
 
-.. automodule:: pygmt
+This page gives an overview of all public PyGMT objects, functions and methods.
 
 .. currentmodule:: pygmt
 


### PR DESCRIPTION
Currently, the [API reference page](https://www.pygmt.org/v0.15.0/api/index.html) displays two lengthy paragraphs describing the PyGMT project. 

**Screenshot**
![image](https://github.com/user-attachments/assets/6aa31355-4549-42b4-ae51-c872b1bb6470)

These paragraphs are generated by the `.. automodule:: pygmt` directive, and come from the module docstring in [`pygmt/__init__.py`](https://github.com/GenericMappingTools/pygmt/blob/7d12bae1825cbeddc083333aa854c42a88060c5c/pygmt/__init__.py#L1). 

But users visiting the API reference likely already know what PyGMT is—they’re there to look up functions and methods. So it makes sense to remove the introductory text from this page.

This PR removes the `.. automodule:: pygmt` directive and adds a short description instead. For reference:

- NumPy API: https://numpy.org/doc/stable/reference/index.html
- pandas API: https://pandas.pydata.org/docs/reference/index.html
- xarray API: https://docs.xarray.dev/en/stable/api.html

**Preview:** https://pygmt-dev--3926.org.readthedocs.build/en/3926/api/index.html
