### PR TITLE
Add 'toctree' option to autosummary directive to generate stub pages

### DIFF
--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -17,6 +17,7 @@
 .. rubric:: Methods Summary
 
 .. autosummary::
+    :toctree:
     {% for item in methods %}
     {% if item != '__init__' %}
     {{ objname }}.{{ item }}

--- a/doc/_templates/autosummary/module.rst
+++ b/doc/_templates/autosummary/module.rst
@@ -16,7 +16,7 @@
 .. rubric:: Classes
 
 .. autosummary::
-  :toctree: ./
+  :toctree:
 {% for item in classes %}
   {{ item }}
 {% endfor %}
@@ -29,7 +29,7 @@
 .. rubric:: Functions
 
 .. autosummary::
-  :toctree: ./
+  :toctree:
 {% for item in functions %}
   {{ item }}
 {% endfor %}
@@ -42,7 +42,7 @@
 .. rubric:: Exceptions
 
 .. autosummary::
-  :toctree: ./
+  :toctree:
 {% for item in exceptions %}
   {{ item }}
 {% endfor %}


### PR DESCRIPTION
https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html#directive-option-autosummary-toctree

> The `toctree` option also signals to the sphinx-autogen script that stub pages should be generated for the entries listed in this directive. 

As the documentation says, the `autosummary` directive needs the `toctree` option to trigger the generation of stub pages. Currently, the `class` template misses the `toctree` option. That's why the methods in the summary table are not clickable in https://pygmt-dev--3919.org.readthedocs.build/en/3919/api/generated/pygmt.GMTBackendEntrypoint.html (xref PR #3919).

This PR fixes the issue and also simplifies `:toctree: ./` to `:toctree:` in other templates.

Tested the changes with PR #3919 and it works as expected.