### PR TITLE
Bump minimum supported version to packaging>=24.2

### DIFF
--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -64,7 +64,7 @@ jobs:
             numpy=1.26
             pandas
             xarray
-            packaging
+            packaging=24.2
             contextily=1.5
             geopandas=1.0
             ipython

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
     - numpy>=1.26
     - pandas>=2.1
     - xarray>=2023.07
-    - packaging
+    - packaging>=24.2
     # Optional dependencies
     - contextily>=1.5
     - geopandas>=1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "numpy>=1.26",
     "pandas>=2.1",
     "xarray>=2023.07",
-    "packaging",
+    "packaging>=24.2",
 ]
 dynamic = ["version"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 numpy>=1.26
 pandas>=2.1
 xarray>=2023.07
-packaging
+packaging>=24.2


### PR DESCRIPTION
**Description of proposed changes**

Setuptools>=77.0.0 (pinned in #3699) requires "packaging>=24.2" to work properly. Xref https://github.com/pypa/setuptools/issues/4894

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This fixes a silent error in the "Install the package" step when running `uv run --with pip==23 --resolution lowest-direct --all-extras --dev make install` at #3639. Full traceback copied from https://github.com/GenericMappingTools/pygmt/actions/runs/14729916558/job/41341419988#step:6:103

```python-traceback
python -m pip install --no-deps -e .
Obtaining file:///home/runner/work/pygmt/pygmt
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [45 lines of output]
      Could not find an up-to-date installation of `packaging`. License expressions might not be validated. To enforce validation, please install `packaging>=24.2`.
      Traceback (most recent call last):
        File "/home/runner/work/_temp/setup-uv-cache/archive-v0/ZwA7Six4OPj-bmG_WZxjm/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/runner/work/_temp/setup-uv-cache/archive-v0/ZwA7Six4OPj-bmG_WZxjm/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/runner/work/_temp/setup-uv-cache/archive-v0/ZwA7Six4OPj-bmG_WZxjm/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 132, in get_requires_for_build_editable
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/home/runner/work/pygmt/pygmt/.venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 473, in get_requires_for_build_editable
          return self.get_requires_for_build_wheel(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/runner/work/pygmt/pygmt/.venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/runner/work/pygmt/pygmt/.venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
        File "/home/runner/work/pygmt/pygmt/.venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
        File "<string>", line 1, in <module>
        File "/home/runner/work/pygmt/pygmt/.venv/lib/python3.11/site-packages/setuptools/__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/runner/work/pygmt/pygmt/.venv/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 160, in setup
          dist.parse_config_files()
        File "/home/runner/work/_temp/setup-uv-cache/archive-v0/ZwA7Six4OPj-bmG_WZxjm/lib/python3.11/site-packages/_virtualenv.py", line 20, in parse_config_files
          result = old_parse_config_files(self, *args, **kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/runner/work/pygmt/pygmt/.venv/lib/python3.11/site-packages/setuptools/dist.py", line 756, in parse_config_files
          pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
        File "/home/runner/work/pygmt/pygmt/.venv/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py", line 73, in apply_configuration
          return _apply(dist, config, filepath)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/runner/work/pygmt/pygmt/.venv/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py", line 61, in apply
          dist._finalize_license_expression()
        File "/home/runner/work/pygmt/pygmt/.venv/lib/python3.11/site-packages/setuptools/dist.py", line 427, in _finalize_license_expression
          normalized = str_(_canonicalize_license_expression(license_expr))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/runner/work/pygmt/pygmt/.venv/lib/python3.11/site-packages/setuptools/_normalization.py", line 163, in _missing_canonicalize_license_expression
          raise ImportError(
      ImportError: Cannot import `packaging.licenses`.
              Setuptools>=77.0.0 requires "packaging>=24.2" to work properly.
              Please make sure you have a suitable version installed.
      
      [end of output]
```

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Helps with https://github.com/GenericMappingTools/pygmt/pull/3639


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
