### PR TITLE
Set registration and gtype properly as enums on gmt accessor init

### DIFF
--- a/pygmt/tests/test_binstats.py
+++ b/pygmt/tests/test_binstats.py
@@ -43,7 +43,7 @@ def test_binstats_no_outgrid():
         region="g",
     )
     assert temp_grid.dims == ("y", "x")
-    assert temp_grid.gmt.gtype == GridType.CARTESIAN
+    assert temp_grid.gmt.gtype is GridType.CARTESIAN
     assert temp_grid.gmt.registration == GridRegistration.GRIDLINE
     npt.assert_allclose(temp_grid.max(), 35971536)
     npt.assert_allclose(temp_grid.min(), 53)

--- a/pygmt/tests/test_binstats.py
+++ b/pygmt/tests/test_binstats.py
@@ -44,7 +44,7 @@ def test_binstats_no_outgrid():
     )
     assert temp_grid.dims == ("y", "x")
     assert temp_grid.gmt.gtype is GridType.CARTESIAN
-    assert temp_grid.gmt.registration == GridRegistration.GRIDLINE
+    assert temp_grid.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(temp_grid.max(), 35971536)
     npt.assert_allclose(temp_grid.min(), 53)
     npt.assert_allclose(temp_grid.median(), 1232714.5)

--- a/pygmt/tests/test_datasets_earth_age.py
+++ b/pygmt/tests/test_datasets_earth_age.py
@@ -19,7 +19,7 @@ def test_earth_age_01d():
     assert data.attrs["units"] == "Myr"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), 0.37, atol=0.01)
@@ -32,7 +32,7 @@ def test_earth_age_01d_with_region():
     """
     data = load_earth_age(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), 11.13, atol=0.01)
@@ -46,7 +46,7 @@ def test_earth_age_01m_default_registration():
     """
     data = load_earth_age(resolution="01m", region=[-10, -9, 3, 5])
     assert data.shape == (121, 61)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     assert data.coords["lat"].data.min() == 3.0
     assert data.coords["lat"].data.max() == 5.0
     assert data.coords["lon"].data.min() == -10.0

--- a/pygmt/tests/test_datasets_earth_day.py
+++ b/pygmt/tests/test_datasets_earth_day.py
@@ -19,7 +19,7 @@ def test_blue_marble_01d():
     assert data.attrs["description"] == "NASA Day Images"
     assert data.shape == (3, 180, 360)
     assert data.dtype == "uint8"
-    assert data.gmt.registration == GridRegistration.PIXEL
+    assert data.gmt.registration is GridRegistration.PIXEL
     assert data.gmt.gtype is GridType.GEOGRAPHIC
     npt.assert_allclose(data.y, np.arange(89.5, -90.5, -1))
     npt.assert_allclose(data.x, np.arange(-179.5, 180.5, 1))
@@ -34,7 +34,7 @@ def test_blue_marble_01d_with_region():
     data = load_blue_marble(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (3, 10, 20)
     assert data.dtype == "uint8"
-    assert data.gmt.registration == GridRegistration.PIXEL
+    assert data.gmt.registration is GridRegistration.PIXEL
     assert data.gmt.gtype is GridType.GEOGRAPHIC
     npt.assert_allclose(data.y, np.arange(4.5, -5.5, -1))
     npt.assert_allclose(data.x, np.arange(-9.5, 10.5, 1))

--- a/pygmt/tests/test_datasets_earth_day.py
+++ b/pygmt/tests/test_datasets_earth_day.py
@@ -20,7 +20,7 @@ def test_blue_marble_01d():
     assert data.shape == (3, 180, 360)
     assert data.dtype == "uint8"
     assert data.gmt.registration == GridRegistration.PIXEL
-    assert data.gmt.gtype == GridType.GEOGRAPHIC
+    assert data.gmt.gtype is GridType.GEOGRAPHIC
     npt.assert_allclose(data.y, np.arange(89.5, -90.5, -1))
     npt.assert_allclose(data.x, np.arange(-179.5, 180.5, 1))
     npt.assert_allclose(data.min(), 10, atol=1)
@@ -35,7 +35,7 @@ def test_blue_marble_01d_with_region():
     assert data.shape == (3, 10, 20)
     assert data.dtype == "uint8"
     assert data.gmt.registration == GridRegistration.PIXEL
-    assert data.gmt.gtype == GridType.GEOGRAPHIC
+    assert data.gmt.gtype is GridType.GEOGRAPHIC
     npt.assert_allclose(data.y, np.arange(4.5, -5.5, -1))
     npt.assert_allclose(data.x, np.arange(-9.5, 10.5, 1))
     npt.assert_allclose(data.min(), 10, atol=1)

--- a/pygmt/tests/test_datasets_earth_deflection.py
+++ b/pygmt/tests/test_datasets_earth_deflection.py
@@ -20,7 +20,7 @@ def test_earth_edefl_01d():
     assert data.attrs["units"] == "micro-radians"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -142.64, atol=0.04)
@@ -33,7 +33,7 @@ def test_earth_edefl_01d_with_region():
     """
     data = load_earth_deflection(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -28.92, atol=0.04)
@@ -47,7 +47,7 @@ def test_earth_edefl_01m_default_registration():
     """
     data = load_earth_deflection(resolution="01m", region=[-10, -9, 3, 5])
     assert data.shape == (120, 60)
-    assert data.gmt.registration == GridRegistration.PIXEL
+    assert data.gmt.registration is GridRegistration.PIXEL
     npt.assert_allclose(data.coords["lat"].data.min(), 3.008333333)
     npt.assert_allclose(data.coords["lat"].data.max(), 4.991666666)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.99166666)
@@ -67,7 +67,7 @@ def test_earth_ndefl_01d():
     assert data.attrs["units"] == "micro-radians"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -214.8, atol=0.04)
@@ -82,7 +82,7 @@ def test_earth_ndefl_01d_with_region():
         resolution="01d", region=[-10, 10, -5, 5], component="north"
     )
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -48.08, atol=0.04)
@@ -98,7 +98,7 @@ def test_earth_ndefl_01m_default_registration():
         resolution="01m", region=[-10, -9, 3, 5], component="north"
     )
     assert data.shape == (120, 60)
-    assert data.gmt.registration == GridRegistration.PIXEL
+    assert data.gmt.registration is GridRegistration.PIXEL
     npt.assert_allclose(data.coords["lat"].data.min(), 3.008333333)
     npt.assert_allclose(data.coords["lat"].data.max(), 4.991666666)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.99166666)

--- a/pygmt/tests/test_datasets_earth_dist.py
+++ b/pygmt/tests/test_datasets_earth_dist.py
@@ -18,7 +18,7 @@ def test_earth_dist_01d():
     assert data.attrs["units"] == "kilometers"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -2655.7, atol=0.01)
@@ -31,7 +31,7 @@ def test_earth_dist_01d_with_region():
     """
     data = load_earth_dist(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -1081.94, atol=0.01)
@@ -45,7 +45,7 @@ def test_earth_dist_01m_default_registration():
     """
     data = load_earth_dist(resolution="01m", region=[-10, -9, 3, 5])
     assert data.shape == (121, 61)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     assert data.coords["lat"].data.min() == 3.0
     assert data.coords["lat"].data.max() == 5.0
     assert data.coords["lon"].data.min() == -10.0

--- a/pygmt/tests/test_datasets_earth_free_air_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_free_air_anomaly.py
@@ -19,7 +19,7 @@ def test_earth_faa_01d():
     assert data.attrs["units"] == "mGal"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -188.85, atol=0.025)
@@ -32,7 +32,7 @@ def test_earth_faa_01d_with_region():
     """
     data = load_earth_free_air_anomaly(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -36.125, atol=0.025)
@@ -46,7 +46,7 @@ def test_earth_faa_01m_default_registration():
     """
     data = load_earth_free_air_anomaly(resolution="01m", region=[-10, -9, 3, 5])
     assert data.shape == (120, 60)
-    assert data.gmt.registration == GridRegistration.PIXEL
+    assert data.gmt.registration is GridRegistration.PIXEL
     npt.assert_allclose(data.coords["lat"].data.min(), 3.008333333)
     npt.assert_allclose(data.coords["lat"].data.max(), 4.991666666)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.99166666)
@@ -66,7 +66,7 @@ def test_earth_faaerror_01d():
     assert data.attrs["units"] == "mGal"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), 0.0, atol=0.04)
@@ -81,7 +81,7 @@ def test_earth_faaerror_01d_with_region():
         resolution="01d", region=[-10, 10, -5, 5], uncertainty=True
     )
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), 0.72, atol=0.04)
@@ -97,7 +97,7 @@ def test_earth_faaerror_01m_default_registration():
         resolution="01m", region=[-10, -9, 3, 5], uncertainty=True
     )
     assert data.shape == (120, 60)
-    assert data.gmt.registration == GridRegistration.PIXEL
+    assert data.gmt.registration is GridRegistration.PIXEL
     npt.assert_allclose(data.coords["lat"].data.min(), 3.008333333)
     npt.assert_allclose(data.coords["lat"].data.max(), 4.991666666)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.99166666)

--- a/pygmt/tests/test_datasets_earth_geoid.py
+++ b/pygmt/tests/test_datasets_earth_geoid.py
@@ -19,7 +19,7 @@ def test_earth_geoid_01d():
     assert data.attrs["units"] == "meters"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -106.06, atol=0.01)
@@ -32,7 +32,7 @@ def test_earth_geoid_01d_with_region():
     """
     data = load_earth_geoid(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), 5.57, atol=0.01)
@@ -46,7 +46,7 @@ def test_earth_geoid_01m_default_registration():
     """
     data = load_earth_geoid(resolution="01m", region=[-10, -9, 3, 5])
     assert data.shape == (121, 61)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     assert data.coords["lat"].data.min() == 3.0
     assert data.coords["lat"].data.max() == 5.0
     assert data.coords["lon"].data.min() == -10.0

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -21,7 +21,7 @@ def test_earth_mag_01d():
     assert data.attrs["units"] == "nT"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -336.2, atol=0.2)
@@ -34,7 +34,7 @@ def test_earth_mag_01d_with_region():
     """
     data = load_earth_magnetic_anomaly(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -54.4, atol=0.2)
@@ -48,7 +48,7 @@ def test_earth_mag_02m_default_registration():
     """
     data = load_earth_magnetic_anomaly(resolution="02m", region=[-10, -9, 3, 5])
     assert data.shape == (60, 30)
-    assert data.gmt.registration == GridRegistration.PIXEL
+    assert data.gmt.registration is GridRegistration.PIXEL
     npt.assert_allclose(data.coords["lat"].data.min(), 3.016666667)
     npt.assert_allclose(data.coords["lat"].data.max(), 4.983333333)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.98333333)
@@ -68,7 +68,7 @@ def test_earth_mag4km_01d():
     assert data.attrs["units"] == "nT"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -436.8, atol=0.2)
@@ -103,7 +103,7 @@ def test_earth_mag4km_02m_default_registration():
         data_source="emag2_4km",
     )
     assert data.shape == (60, 90)
-    assert data.gmt.registration == GridRegistration.PIXEL
+    assert data.gmt.registration is GridRegistration.PIXEL
     npt.assert_allclose(data.coords["lat"].data.min(), 4.01666667)
     npt.assert_allclose(data.coords["lat"].data.max(), 5.98333333)
     npt.assert_allclose(data.coords["lon"].data.min(), -114.98333333)
@@ -155,7 +155,7 @@ def test_earth_mag_03m_wdmam_with_region():
     data = load_earth_magnetic_anomaly(
         resolution="03m", region=[10, 13, -60, -58], data_source="wdmam"
     )
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     assert data.shape == (41, 61)
     assert data.lat.min() == -60
     assert data.lat.max() == -58

--- a/pygmt/tests/test_datasets_earth_mask.py
+++ b/pygmt/tests/test_datasets_earth_mask.py
@@ -17,7 +17,7 @@ def test_earth_mask_01d():
     assert data.attrs["description"] == "GSHHG Earth mask"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     assert data.gmt.gtype is GridType.GEOGRAPHIC
     assert data.dtype == "int8"
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
@@ -33,7 +33,7 @@ def test_earth_mask_01d_with_region():
     """
     data = load_earth_mask(resolution="01d", region=[-7, 4, 13, 19])
     assert data.shape == (7, 12)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     assert data.gmt.gtype is GridType.GEOGRAPHIC
     assert data.dtype == "int8"
     npt.assert_allclose(data.lat, np.arange(13, 20, 1))

--- a/pygmt/tests/test_datasets_earth_mask.py
+++ b/pygmt/tests/test_datasets_earth_mask.py
@@ -18,7 +18,7 @@ def test_earth_mask_01d():
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
     assert data.gmt.registration == GridRegistration.GRIDLINE
-    assert data.gmt.gtype == GridType.GEOGRAPHIC
+    assert data.gmt.gtype is GridType.GEOGRAPHIC
     assert data.dtype == "int8"
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
@@ -34,7 +34,7 @@ def test_earth_mask_01d_with_region():
     data = load_earth_mask(resolution="01d", region=[-7, 4, 13, 19])
     assert data.shape == (7, 12)
     assert data.gmt.registration == GridRegistration.GRIDLINE
-    assert data.gmt.gtype == GridType.GEOGRAPHIC
+    assert data.gmt.gtype is GridType.GEOGRAPHIC
     assert data.dtype == "int8"
     npt.assert_allclose(data.lat, np.arange(13, 20, 1))
     npt.assert_allclose(data.lon, np.arange(-7, 5, 1))

--- a/pygmt/tests/test_datasets_earth_mean_sea_surface.py
+++ b/pygmt/tests/test_datasets_earth_mean_sea_surface.py
@@ -18,7 +18,7 @@ def test_earth_mss_01d():
     assert data.attrs["units"] == "meters"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -104.71, atol=0.01)
@@ -31,7 +31,7 @@ def test_earth_mss_01d_with_region():
     """
     data = load_earth_mean_sea_surface(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), 6.53, atol=0.01)
@@ -45,7 +45,7 @@ def test_earth_mss_01m_default_registration():
     """
     data = load_earth_mean_sea_surface(resolution="01m", region=[-10, -9, 3, 5])
     assert data.shape == (121, 61)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     assert data.coords["lat"].data.min() == 3.0
     assert data.coords["lat"].data.max() == 5.0
     assert data.coords["lon"].data.min() == -10.0

--- a/pygmt/tests/test_datasets_earth_night.py
+++ b/pygmt/tests/test_datasets_earth_night.py
@@ -20,7 +20,7 @@ def test_black_marble_01d():
     assert data.shape == (3, 180, 360)
     assert data.dtype == "uint8"
     assert data.gmt.registration == GridRegistration.PIXEL
-    assert data.gmt.gtype == GridType.GEOGRAPHIC
+    assert data.gmt.gtype is GridType.GEOGRAPHIC
     npt.assert_allclose(data.y, np.arange(89.5, -90.5, -1))
     npt.assert_allclose(data.x, np.arange(-179.5, 180.5, 1))
     npt.assert_allclose(data.min(), 3, atol=1)
@@ -35,7 +35,7 @@ def test_black_marble_01d_with_region():
     assert data.shape == (3, 10, 20)
     assert data.dtype == "uint8"
     assert data.gmt.registration == GridRegistration.PIXEL
-    assert data.gmt.gtype == GridType.GEOGRAPHIC
+    assert data.gmt.gtype is GridType.GEOGRAPHIC
     npt.assert_allclose(data.y, np.arange(4.5, -5.5, -1))
     npt.assert_allclose(data.x, np.arange(-9.5, 10.5, 1))
     npt.assert_allclose(data.min(), 3, atol=1)

--- a/pygmt/tests/test_datasets_earth_night.py
+++ b/pygmt/tests/test_datasets_earth_night.py
@@ -19,7 +19,7 @@ def test_black_marble_01d():
     assert data.attrs["description"] == "NASA Night Images"
     assert data.shape == (3, 180, 360)
     assert data.dtype == "uint8"
-    assert data.gmt.registration == GridRegistration.PIXEL
+    assert data.gmt.registration is GridRegistration.PIXEL
     assert data.gmt.gtype is GridType.GEOGRAPHIC
     npt.assert_allclose(data.y, np.arange(89.5, -90.5, -1))
     npt.assert_allclose(data.x, np.arange(-179.5, 180.5, 1))
@@ -34,7 +34,7 @@ def test_black_marble_01d_with_region():
     data = load_black_marble(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (3, 10, 20)
     assert data.dtype == "uint8"
-    assert data.gmt.registration == GridRegistration.PIXEL
+    assert data.gmt.registration is GridRegistration.PIXEL
     assert data.gmt.gtype is GridType.GEOGRAPHIC
     npt.assert_allclose(data.y, np.arange(4.5, -5.5, -1))
     npt.assert_allclose(data.x, np.arange(-9.5, 10.5, 1))

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -26,7 +26,7 @@ def test_earth_relief_01d_igpp_synbath(data_source):
     assert data.attrs["vertical_datum"] == "EGM96"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -7174.0, atol=0.5)
@@ -46,7 +46,7 @@ def test_earth_relief_01d_gebco(data_source):
     assert data.attrs["vertical_datum"] == "EGM96"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -7169.0, atol=1.0)
@@ -63,7 +63,7 @@ def test_earth_relief_01d_with_region_srtm():
         data_source="igpp",
     )
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -5137.0, atol=0.5)
@@ -80,7 +80,7 @@ def test_earth_relief_01d_with_region_gebco():
         data_source="gebco",
     )
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -5118.0, atol=1.0)
@@ -93,7 +93,7 @@ def test_earth_relief_30m():
     """
     data = load_earth_relief(resolution="30m")
     assert data.shape == (361, 721)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 90.5, 0.5))
     npt.assert_allclose(data.lon, np.arange(-180, 180.5, 0.5))
     npt.assert_allclose(data.min(), -8279.5, atol=0.5)
@@ -111,7 +111,7 @@ def test_earth_gebcosi_15m_with_region():
         data_source="gebcosi",
     )
     assert data.shape == (16, 8)
-    assert data.gmt.registration == GridRegistration.PIXEL
+    assert data.gmt.registration is GridRegistration.PIXEL
     npt.assert_allclose(data.lat, np.arange(-87.875, -84, 0.25))
     npt.assert_allclose(data.lon, np.arange(85.125, 87, 0.25))
     npt.assert_allclose(data.min(), -492, atol=1.0)
@@ -184,7 +184,7 @@ def test_earth_relief_15s_default_registration():
     """
     data = load_earth_relief(resolution="15s", region=[-10, -9.5, 4, 5])
     assert data.shape == (240, 120)
-    assert data.gmt.registration == GridRegistration.PIXEL
+    assert data.gmt.registration is GridRegistration.PIXEL
     npt.assert_allclose(data.coords["lat"].data.min(), 4.002083)
     npt.assert_allclose(data.coords["lat"].data.max(), 4.997917)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.997917)
@@ -205,7 +205,7 @@ def test_earth_relief_03s_default_registration():
     """
     data = load_earth_relief(resolution="03s", region=[-10, -9.8, 4.9, 5])
     assert data.shape == (121, 241)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.coords["lat"].data.min(), 4.9)
     npt.assert_allclose(data.coords["lat"].data.max(), 5)
     npt.assert_allclose(data.coords["lon"].data.min(), -10)

--- a/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
+++ b/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
@@ -19,7 +19,7 @@ def test_earth_vertical_gravity_gradient_01d():
     assert data.attrs["units"] == "Eotvos"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -40.1875, atol=1 / 32)
@@ -35,7 +35,7 @@ def test_earth_vertical_gravity_gradient_01d_with_region():
         resolution="01d", region=[-10, 10, -5, 5]
     )
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -5.34375, atol=1 / 32)
@@ -51,7 +51,7 @@ def test_earth_vertical_gravity_gradient_01m_default_registration():
         resolution="01m", region=[-10, -9, 3, 5]
     )
     assert data.shape == (120, 60)
-    assert data.gmt.registration == GridRegistration.PIXEL
+    assert data.gmt.registration is GridRegistration.PIXEL
     npt.assert_allclose(data.coords["lat"].data.min(), 3.008333333)
     npt.assert_allclose(data.coords["lat"].data.max(), 4.991666666)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.99166666)

--- a/pygmt/tests/test_datasets_load_remote_datasets.py
+++ b/pygmt/tests/test_datasets_load_remote_datasets.py
@@ -31,7 +31,7 @@ def test_load_remote_dataset_benchmark_with_region():
     assert data.attrs["long_name"] == "ages (Myr)"
     assert data.attrs["units"] == "Myr"
     assert data.attrs["horizontal_datum"] == "WGS84"
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     assert data.shape == (11, 21)
     # Can't access the cpt attribute using virtual files
     # assert data.attrs["cpt"] == "@earth_age.cpt"

--- a/pygmt/tests/test_datasets_mars_relief.py
+++ b/pygmt/tests/test_datasets_mars_relief.py
@@ -18,7 +18,7 @@ def test_mars_relief_01d():
     assert data.attrs["description"] == "NASA Mars (MOLA) relief"
     assert data.attrs["units"] == "meters"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -7421.0, atol=0.5)
@@ -31,7 +31,7 @@ def test_mars_relief_01d_with_region():
     """
     data = load_mars_relief(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -2502.0, atol=0.5)
@@ -45,7 +45,7 @@ def test_mars_relief_01m_default_registration():
     """
     data = load_mars_relief(resolution="01m", region=[-10, -9, 3, 5])
     assert data.shape == (121, 61)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     assert data.coords["lat"].data.min() == 3.0
     assert data.coords["lat"].data.max() == 5.0
     assert data.coords["lon"].data.min() == -10.0

--- a/pygmt/tests/test_datasets_mean_dynamic_topography.py
+++ b/pygmt/tests/test_datasets_mean_dynamic_topography.py
@@ -18,7 +18,7 @@ def test_earth_mdt_01d():
     assert data.attrs["units"] == "meters"
     assert data.attrs["horizontal_datum"] == "WGS84"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -1.4668, atol=0.0001)
@@ -31,7 +31,7 @@ def test_earth_mdt_01d_with_region():
     """
     data = load_earth_mean_dynamic_topography(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), 0.346, atol=0.0001)
@@ -45,7 +45,7 @@ def test_earth_mdt_07m_default_registration():
     """
     data = load_earth_mean_dynamic_topography(resolution="07m", region=[-10, -9, 3, 5])
     assert data.shape == (17, 9)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     assert data.coords["lat"].data.min() == 3.0
     assert data.coords["lat"].data.max() == 5.0
     assert data.coords["lon"].data.min() == -10.0

--- a/pygmt/tests/test_datasets_mercury_relief.py
+++ b/pygmt/tests/test_datasets_mercury_relief.py
@@ -18,7 +18,7 @@ def test_mercury_relief_01d():
     assert data.attrs["description"] == "USGS Mercury relief"
     assert data.attrs["units"] == "meters"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -5103.5, atol=0.5)
@@ -31,7 +31,7 @@ def test_mercury_relief_01d_with_region():
     """
     data = load_mercury_relief(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -327.0, atol=0.5)
@@ -45,7 +45,7 @@ def test_mercury_relief_01m_default_registration():
     """
     data = load_mercury_relief(resolution="01m", region=[-10, -9, 3, 5])
     assert data.shape == (121, 61)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     assert data.coords["lat"].data.min() == 3.0
     assert data.coords["lat"].data.max() == 5.0
     assert data.coords["lon"].data.min() == -10.0

--- a/pygmt/tests/test_datasets_moon_relief.py
+++ b/pygmt/tests/test_datasets_moon_relief.py
@@ -18,7 +18,7 @@ def test_moon_relief_01d():
     assert data.attrs["description"] == "USGS Moon (LOLA) relief"
     assert data.attrs["units"] == "meters"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -7669.0, atol=0.5)
@@ -31,7 +31,7 @@ def test_moon_relief_01d_with_region():
     """
     data = load_moon_relief(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -1122.0, atol=0.5)
@@ -45,7 +45,7 @@ def test_moon_relief_01m_default_registration():
     """
     data = load_moon_relief(resolution="01m", region=[-10, -9, 3, 5])
     assert data.shape == (121, 61)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     assert data.coords["lat"].data.min() == 3.0
     assert data.coords["lat"].data.max() == 5.0
     assert data.coords["lon"].data.min() == -10.0

--- a/pygmt/tests/test_datasets_pluto_relief.py
+++ b/pygmt/tests/test_datasets_pluto_relief.py
@@ -18,7 +18,7 @@ def test_pluto_relief_01d():
     assert data.attrs["description"] == "USGS Pluto relief"
     assert data.attrs["units"] == "meters"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -3021.0, atol=0.25)
@@ -31,7 +31,7 @@ def test_pluto_relief_01d_with_region():
     """
     data = load_pluto_relief(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -1319.25, atol=0.25)
@@ -45,7 +45,7 @@ def test_pluto_relief_01m_default_registration():
     """
     data = load_pluto_relief(resolution="01m", region=[-10, -9, 3, 5])
     assert data.shape == (121, 61)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     assert data.coords["lat"].data.min() == 3.0
     assert data.coords["lat"].data.max() == 5.0
     assert data.coords["lon"].data.min() == -10.0

--- a/pygmt/tests/test_datasets_venus_relief.py
+++ b/pygmt/tests/test_datasets_venus_relief.py
@@ -18,7 +18,7 @@ def test_venus_relief_01d():
     assert data.attrs["description"] == "NASA Magellan Venus relief"
     assert data.attrs["units"] == "meters"
     assert data.shape == (181, 361)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), -2069.0, atol=0.5)
@@ -31,7 +31,7 @@ def test_venus_relief_01d_with_region():
     """
     data = load_venus_relief(resolution="01d", region=[-10, 10, -5, 5])
     assert data.shape == (11, 21)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -1244.0, atol=0.5)
@@ -45,7 +45,7 @@ def test_venus_relief_01m_default_registration():
     """
     data = load_venus_relief(resolution="01m", region=[-10, -9, 3, 5])
     assert data.shape == (121, 61)
-    assert data.gmt.registration == GridRegistration.GRIDLINE
+    assert data.gmt.registration is GridRegistration.GRIDLINE
     assert data.coords["lat"].data.min() == 3.0
     assert data.coords["lat"].data.max() == 5.0
     assert data.coords["lon"].data.min() == -10.0

--- a/pygmt/tests/test_dimfilter.py
+++ b/pygmt/tests/test_dimfilter.py
@@ -71,7 +71,7 @@ def test_dimfilter_no_outgrid(grid, expected_grid):
     )
     assert result.dims == ("lat", "lon")
     assert result.gmt.gtype is GridType.GEOGRAPHIC
-    assert result.gmt.registration == GridRegistration.PIXEL
+    assert result.gmt.registration is GridRegistration.PIXEL
     xr.testing.assert_allclose(a=result, b=expected_grid)
 
 

--- a/pygmt/tests/test_dimfilter.py
+++ b/pygmt/tests/test_dimfilter.py
@@ -70,7 +70,7 @@ def test_dimfilter_no_outgrid(grid, expected_grid):
         grid=grid, filter="m600", distance=4, sectors="l6", region=[-55, -51, -24, -19]
     )
     assert result.dims == ("lat", "lon")
-    assert result.gmt.gtype == GridType.GEOGRAPHIC
+    assert result.gmt.gtype is GridType.GEOGRAPHIC
     assert result.gmt.registration == GridRegistration.PIXEL
     xr.testing.assert_allclose(a=result, b=expected_grid)
 

--- a/pygmt/tests/test_grdclip.py
+++ b/pygmt/tests/test_grdclip.py
@@ -56,7 +56,7 @@ def test_grdclip_outgrid(grid, expected_grid):
         assert Path(tmpfile.name).stat().st_size > 0  # check that outgrid exists
         temp_grid = xr.load_dataarray(tmpfile.name, engine="gmt", raster_kind="grid")
         assert temp_grid.dims == ("lat", "lon")
-        assert temp_grid.gmt.gtype == GridType.GEOGRAPHIC
+        assert temp_grid.gmt.gtype is GridType.GEOGRAPHIC
         assert temp_grid.gmt.registration == GridRegistration.PIXEL
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
@@ -70,7 +70,7 @@ def test_grdclip_no_outgrid(grid, expected_grid):
         grid=grid, below=[550, -1000], above=[700, 1000], region=[-53, -49, -19, -16]
     )
     assert temp_grid.dims == ("lat", "lon")
-    assert temp_grid.gmt.gtype == GridType.GEOGRAPHIC
+    assert temp_grid.gmt.gtype is GridType.GEOGRAPHIC
     assert temp_grid.gmt.registration == GridRegistration.PIXEL
     xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 

--- a/pygmt/tests/test_grdclip.py
+++ b/pygmt/tests/test_grdclip.py
@@ -57,7 +57,7 @@ def test_grdclip_outgrid(grid, expected_grid):
         temp_grid = xr.load_dataarray(tmpfile.name, engine="gmt", raster_kind="grid")
         assert temp_grid.dims == ("lat", "lon")
         assert temp_grid.gmt.gtype is GridType.GEOGRAPHIC
-        assert temp_grid.gmt.registration == GridRegistration.PIXEL
+        assert temp_grid.gmt.registration is GridRegistration.PIXEL
         xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 
@@ -71,7 +71,7 @@ def test_grdclip_no_outgrid(grid, expected_grid):
     )
     assert temp_grid.dims == ("lat", "lon")
     assert temp_grid.gmt.gtype is GridType.GEOGRAPHIC
-    assert temp_grid.gmt.registration == GridRegistration.PIXEL
+    assert temp_grid.gmt.registration is GridRegistration.PIXEL
     xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 

--- a/pygmt/tests/test_grdfill.py
+++ b/pygmt/tests/test_grdfill.py
@@ -65,7 +65,7 @@ def test_grdfill_dataarray_out(grid, expected_grid):
     result = grdfill(grid=grid, constantfill=20)
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
-    assert result.gmt.gtype == GridType.GEOGRAPHIC
+    assert result.gmt.gtype is GridType.GEOGRAPHIC
     assert result.gmt.registration == GridRegistration.PIXEL
     # check information of the output grid
     xr.testing.assert_allclose(a=result, b=expected_grid)
@@ -80,7 +80,7 @@ def test_grdfill_asymmetric_pad(grid, expected_grid):
     result = grdfill(grid=grid, constantfill=20, region=[-55, -50, -24, -16])
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
-    assert result.gmt.gtype == GridType.GEOGRAPHIC
+    assert result.gmt.gtype is GridType.GEOGRAPHIC
     assert result.gmt.registration == GridRegistration.PIXEL
     # check information of the output grid
     xr.testing.assert_allclose(

--- a/pygmt/tests/test_grdfill.py
+++ b/pygmt/tests/test_grdfill.py
@@ -66,7 +66,7 @@ def test_grdfill_dataarray_out(grid, expected_grid):
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
     assert result.gmt.gtype is GridType.GEOGRAPHIC
-    assert result.gmt.registration == GridRegistration.PIXEL
+    assert result.gmt.registration is GridRegistration.PIXEL
     # check information of the output grid
     xr.testing.assert_allclose(a=result, b=expected_grid)
 
@@ -81,7 +81,7 @@ def test_grdfill_asymmetric_pad(grid, expected_grid):
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
     assert result.gmt.gtype is GridType.GEOGRAPHIC
-    assert result.gmt.registration == GridRegistration.PIXEL
+    assert result.gmt.registration is GridRegistration.PIXEL
     # check information of the output grid
     xr.testing.assert_allclose(
         a=result, b=expected_grid.sel(lon=slice(-55, -50), lat=slice(-24, -16))

--- a/pygmt/tests/test_grdfilter.py
+++ b/pygmt/tests/test_grdfilter.py
@@ -52,7 +52,7 @@ def test_grdfilter_dataarray_in_dataarray_out(grid, expected_grid):
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
     assert result.gmt.gtype is GridType.GEOGRAPHIC
-    assert result.gmt.registration == GridRegistration.PIXEL
+    assert result.gmt.registration is GridRegistration.PIXEL
     # check information of the output grid
     xr.testing.assert_allclose(a=result, b=expected_grid)
 

--- a/pygmt/tests/test_grdfilter.py
+++ b/pygmt/tests/test_grdfilter.py
@@ -51,7 +51,7 @@ def test_grdfilter_dataarray_in_dataarray_out(grid, expected_grid):
     )
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
-    assert result.gmt.gtype == GridType.GEOGRAPHIC
+    assert result.gmt.gtype is GridType.GEOGRAPHIC
     assert result.gmt.registration == GridRegistration.PIXEL
     # check information of the output grid
     xr.testing.assert_allclose(a=result, b=expected_grid)

--- a/pygmt/tests/test_grdgradient.py
+++ b/pygmt/tests/test_grdgradient.py
@@ -68,7 +68,7 @@ def test_grdgradient_no_outgrid(grid, expected_grid):
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
     assert result.gmt.gtype is GridType.GEOGRAPHIC
-    assert result.gmt.registration == GridRegistration.PIXEL
+    assert result.gmt.registration is GridRegistration.PIXEL
     # check information of the output grid
     xr.testing.assert_allclose(a=result, b=expected_grid)
 

--- a/pygmt/tests/test_grdgradient.py
+++ b/pygmt/tests/test_grdgradient.py
@@ -67,7 +67,7 @@ def test_grdgradient_no_outgrid(grid, expected_grid):
     )
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
-    assert result.gmt.gtype == GridType.GEOGRAPHIC
+    assert result.gmt.gtype is GridType.GEOGRAPHIC
     assert result.gmt.registration == GridRegistration.PIXEL
     # check information of the output grid
     xr.testing.assert_allclose(a=result, b=expected_grid)

--- a/pygmt/tests/test_grdhisteq.py
+++ b/pygmt/tests/test_grdhisteq.py
@@ -80,7 +80,7 @@ def test_equalize_grid_no_outgrid(grid, expected_grid, region):
         grid=grid, divisions=2, region=region, outgrid=None
     )
     assert temp_grid.gmt.gtype is GridType.GEOGRAPHIC
-    assert temp_grid.gmt.registration == GridRegistration.PIXEL
+    assert temp_grid.gmt.registration is GridRegistration.PIXEL
     xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 
 

--- a/pygmt/tests/test_grdhisteq.py
+++ b/pygmt/tests/test_grdhisteq.py
@@ -79,7 +79,7 @@ def test_equalize_grid_no_outgrid(grid, expected_grid, region):
     temp_grid = grdhisteq.equalize_grid(
         grid=grid, divisions=2, region=region, outgrid=None
     )
-    assert temp_grid.gmt.gtype == GridType.GEOGRAPHIC
+    assert temp_grid.gmt.gtype is GridType.GEOGRAPHIC
     assert temp_grid.gmt.registration == GridRegistration.PIXEL
     xr.testing.assert_allclose(a=temp_grid, b=expected_grid)
 

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -172,7 +172,7 @@ def test_grdimage_over_dateline(xrgrid):
     See also https://github.com/GenericMappingTools/pygmt/issues/375.
     """
     fig = Figure()
-    assert xrgrid.gmt.registration == GridRegistration.GRIDLINE
+    assert xrgrid.gmt.registration is GridRegistration.GRIDLINE
     xrgrid.gmt.gtype = GridType.GEOGRAPHIC
     fig.grdimage(grid=xrgrid, region="g", projection="A0/0/1c")
     return fig
@@ -190,7 +190,7 @@ def test_grdimage_global_subset(grid_360):
     """
     # Get a slice of South America and Africa only (lat=-90:31, lon=-180:41)
     sliced_grid = grid_360[0:121, 0:221]
-    assert sliced_grid.gmt.registration == GridRegistration.GRIDLINE
+    assert sliced_grid.gmt.registration is GridRegistration.GRIDLINE
     assert sliced_grid.gmt.gtype is GridType.CARTESIAN
 
     fig = Figure()

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -191,7 +191,7 @@ def test_grdimage_global_subset(grid_360):
     # Get a slice of South America and Africa only (lat=-90:31, lon=-180:41)
     sliced_grid = grid_360[0:121, 0:221]
     assert sliced_grid.gmt.registration == GridRegistration.GRIDLINE
-    assert sliced_grid.gmt.gtype == GridType.CARTESIAN
+    assert sliced_grid.gmt.gtype is GridType.CARTESIAN
 
     fig = Figure()
     fig.grdimage(

--- a/pygmt/tests/test_grdlandmask.py
+++ b/pygmt/tests/test_grdlandmask.py
@@ -55,7 +55,7 @@ def test_grdlandmask_no_outgrid(expected_grid):
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
     assert result.gmt.gtype is GridType.GEOGRAPHIC
-    assert result.gmt.registration == GridRegistration.GRIDLINE
+    assert result.gmt.registration is GridRegistration.GRIDLINE
     # check information of the output grid
     xr.testing.assert_allclose(a=result, b=expected_grid)
 

--- a/pygmt/tests/test_grdlandmask.py
+++ b/pygmt/tests/test_grdlandmask.py
@@ -54,7 +54,7 @@ def test_grdlandmask_no_outgrid(expected_grid):
     result = grdlandmask(spacing=1, region=[125, 130, 30, 35], cores=2)
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
-    assert result.gmt.gtype == GridType.GEOGRAPHIC
+    assert result.gmt.gtype is GridType.GEOGRAPHIC
     assert result.gmt.registration == GridRegistration.GRIDLINE
     # check information of the output grid
     xr.testing.assert_allclose(a=result, b=expected_grid)

--- a/pygmt/tests/test_grdproject.py
+++ b/pygmt/tests/test_grdproject.py
@@ -76,7 +76,7 @@ def test_grdproject_no_outgrid(grid, projection, expected_grid):
         grid=grid, projection=projection, spacing=3, region=[-53, -51, -20, -17]
     )
     assert result.gmt.gtype is GridType.CARTESIAN
-    assert result.gmt.registration == GridRegistration.PIXEL
+    assert result.gmt.registration is GridRegistration.PIXEL
     # check information of the output grid
     xr.testing.assert_allclose(a=result, b=expected_grid)
 

--- a/pygmt/tests/test_grdproject.py
+++ b/pygmt/tests/test_grdproject.py
@@ -71,11 +71,11 @@ def test_grdproject_no_outgrid(grid, projection, expected_grid):
 
     Also check that providing the projection as an EPSG code or PROJ4 string works.
     """
-    assert grid.gmt.gtype == GridType.GEOGRAPHIC
+    assert grid.gmt.gtype is GridType.GEOGRAPHIC
     result = grdproject(
         grid=grid, projection=projection, spacing=3, region=[-53, -51, -20, -17]
     )
-    assert result.gmt.gtype == GridType.CARTESIAN
+    assert result.gmt.gtype is GridType.CARTESIAN
     assert result.gmt.registration == GridRegistration.PIXEL
     # check information of the output grid
     xr.testing.assert_allclose(a=result, b=expected_grid)

--- a/pygmt/tests/test_grdsample.py
+++ b/pygmt/tests/test_grdsample.py
@@ -79,7 +79,7 @@ def test_grdsample_dataarray_out(grid, expected_grid, region, spacing):
     result = grdsample(grid=grid, spacing=spacing, region=region, cores=2)
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
-    assert result.gmt.gtype == GridType.GEOGRAPHIC
+    assert result.gmt.gtype is GridType.GEOGRAPHIC
     assert result.gmt.registration == GridRegistration.PIXEL
     # check information of the output grid
     xr.testing.assert_allclose(a=result, b=expected_grid)

--- a/pygmt/tests/test_grdsample.py
+++ b/pygmt/tests/test_grdsample.py
@@ -80,7 +80,7 @@ def test_grdsample_dataarray_out(grid, expected_grid, region, spacing):
     # check information of the output grid
     assert isinstance(result, xr.DataArray)
     assert result.gmt.gtype is GridType.GEOGRAPHIC
-    assert result.gmt.registration == GridRegistration.PIXEL
+    assert result.gmt.registration is GridRegistration.PIXEL
     # check information of the output grid
     xr.testing.assert_allclose(a=result, b=expected_grid)
 
@@ -89,8 +89,8 @@ def test_grdsample_registration_changes(grid):
     """
     Test grdsample with no set outgrid and applying registration changes.
     """
-    assert grid.gmt.registration == GridRegistration.PIXEL
+    assert grid.gmt.registration is GridRegistration.PIXEL
     translated_grid = grdsample(grid=grid, translate=True)
-    assert translated_grid.gmt.registration == GridRegistration.GRIDLINE
+    assert translated_grid.gmt.registration is GridRegistration.GRIDLINE
     registration_grid = grdsample(grid=translated_grid, registration="p")
-    assert registration_grid.gmt.registration == GridRegistration.PIXEL
+    assert registration_grid.gmt.registration is GridRegistration.PIXEL

--- a/pygmt/tests/test_io.py
+++ b/pygmt/tests/test_io.py
@@ -29,7 +29,7 @@ def test_io_load_dataarray():
             dataarray = load_dataarray(tmpfile.name)
 
         assert dataarray.gmt.gtype is GridType.CARTESIAN
-        assert dataarray.gmt.registration == GridRegistration.PIXEL
+        assert dataarray.gmt.registration is GridRegistration.PIXEL
         # this would fail if we used xr.open_dataarray instead of load_dataarray
         dataarray.to_netcdf(tmpfile.name)
 

--- a/pygmt/tests/test_io.py
+++ b/pygmt/tests/test_io.py
@@ -28,7 +28,7 @@ def test_io_load_dataarray():
         with pytest.warns(FutureWarning):
             dataarray = load_dataarray(tmpfile.name)
 
-        assert dataarray.gmt.gtype == GridType.CARTESIAN
+        assert dataarray.gmt.gtype is GridType.CARTESIAN
         assert dataarray.gmt.registration == GridRegistration.PIXEL
         # this would fail if we used xr.open_dataarray instead of load_dataarray
         dataarray.to_netcdf(tmpfile.name)

--- a/pygmt/tests/test_nearneighbor.py
+++ b/pygmt/tests/test_nearneighbor.py
@@ -34,7 +34,7 @@ def test_nearneighbor_input_data(array_func, ship_data):
     )
     assert isinstance(output, xr.DataArray)
     assert output.gmt.registration == GridRegistration.GRIDLINE
-    assert output.gmt.gtype == GridType.GEOGRAPHIC
+    assert output.gmt.gtype is GridType.GEOGRAPHIC
     assert output.shape == (121, 121)
     npt.assert_allclose(output.mean(), -2378.2385)
 

--- a/pygmt/tests/test_nearneighbor.py
+++ b/pygmt/tests/test_nearneighbor.py
@@ -33,7 +33,7 @@ def test_nearneighbor_input_data(array_func, ship_data):
         data=data, spacing="5m", region=[245, 255, 20, 30], search_radius="10m"
     )
     assert isinstance(output, xr.DataArray)
-    assert output.gmt.registration == GridRegistration.GRIDLINE
+    assert output.gmt.registration is GridRegistration.GRIDLINE
     assert output.gmt.gtype is GridType.GEOGRAPHIC
     assert output.shape == (121, 121)
     npt.assert_allclose(output.mean(), -2378.2385)

--- a/pygmt/tests/test_sph2grd.py
+++ b/pygmt/tests/test_sph2grd.py
@@ -30,7 +30,7 @@ def test_sph2grd_no_outgrid():
     """
     temp_grid = sph2grd(data="@EGM96_to_36.txt", spacing=1, region="g", cores=2)
     assert temp_grid.dims == ("y", "x")
-    assert temp_grid.gmt.gtype == GridType.CARTESIAN
+    assert temp_grid.gmt.gtype is GridType.CARTESIAN
     assert temp_grid.gmt.registration == GridRegistration.GRIDLINE
     npt.assert_allclose(temp_grid.max(), 0.00021961, rtol=1e-4)
     npt.assert_allclose(temp_grid.min(), -0.0004326, rtol=1e-4)

--- a/pygmt/tests/test_sph2grd.py
+++ b/pygmt/tests/test_sph2grd.py
@@ -31,7 +31,7 @@ def test_sph2grd_no_outgrid():
     temp_grid = sph2grd(data="@EGM96_to_36.txt", spacing=1, region="g", cores=2)
     assert temp_grid.dims == ("y", "x")
     assert temp_grid.gmt.gtype is GridType.CARTESIAN
-    assert temp_grid.gmt.registration == GridRegistration.GRIDLINE
+    assert temp_grid.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(temp_grid.max(), 0.00021961, rtol=1e-4)
     npt.assert_allclose(temp_grid.min(), -0.0004326, rtol=1e-4)
     npt.assert_allclose(temp_grid.median(), -0.00010894, rtol=1e-4)

--- a/pygmt/tests/test_sphdistance.py
+++ b/pygmt/tests/test_sphdistance.py
@@ -31,7 +31,7 @@ def test_sphdistance_xy_inputs():
     temp_grid = sphdistance(x=x, y=y, spacing=[1, 2], region=[82, 87, 22, 24])
     assert temp_grid.dims == ("lat", "lon")
     assert temp_grid.gmt.gtype is GridType.GEOGRAPHIC
-    assert temp_grid.gmt.registration == GridRegistration.GRIDLINE
+    assert temp_grid.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(temp_grid.max(), 232977.546875)
     npt.assert_allclose(temp_grid.min(), 0)
     npt.assert_allclose(temp_grid.median(), 0)
@@ -58,7 +58,7 @@ def test_sphdistance_no_outgrid(array):
     temp_grid = sphdistance(data=array, spacing=[1, 2], region=[82, 87, 22, 24])
     assert temp_grid.dims == ("lat", "lon")
     assert temp_grid.gmt.gtype is GridType.GEOGRAPHIC
-    assert temp_grid.gmt.registration == GridRegistration.GRIDLINE
+    assert temp_grid.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(temp_grid.max(), 232977.546875)
     npt.assert_allclose(temp_grid.min(), 0)
     npt.assert_allclose(temp_grid.median(), 0)

--- a/pygmt/tests/test_sphdistance.py
+++ b/pygmt/tests/test_sphdistance.py
@@ -30,7 +30,7 @@ def test_sphdistance_xy_inputs():
     x = [85.5, 82.3, 85.8, 86.5]
     temp_grid = sphdistance(x=x, y=y, spacing=[1, 2], region=[82, 87, 22, 24])
     assert temp_grid.dims == ("lat", "lon")
-    assert temp_grid.gmt.gtype == GridType.GEOGRAPHIC
+    assert temp_grid.gmt.gtype is GridType.GEOGRAPHIC
     assert temp_grid.gmt.registration == GridRegistration.GRIDLINE
     npt.assert_allclose(temp_grid.max(), 232977.546875)
     npt.assert_allclose(temp_grid.min(), 0)
@@ -57,7 +57,7 @@ def test_sphdistance_no_outgrid(array):
     """
     temp_grid = sphdistance(data=array, spacing=[1, 2], region=[82, 87, 22, 24])
     assert temp_grid.dims == ("lat", "lon")
-    assert temp_grid.gmt.gtype == GridType.GEOGRAPHIC
+    assert temp_grid.gmt.gtype is GridType.GEOGRAPHIC
     assert temp_grid.gmt.registration == GridRegistration.GRIDLINE
     npt.assert_allclose(temp_grid.max(), 232977.546875)
     npt.assert_allclose(temp_grid.min(), 0)

--- a/pygmt/tests/test_sphinterpolate.py
+++ b/pygmt/tests/test_sphinterpolate.py
@@ -39,7 +39,7 @@ def test_sphinterpolate_no_outgrid(mars):
     """
     temp_grid = sphinterpolate(data=mars, spacing=1, region="g")
     assert temp_grid.dims == ("lat", "lon")
-    assert temp_grid.gmt.gtype == GridType.GEOGRAPHIC
+    assert temp_grid.gmt.gtype is GridType.GEOGRAPHIC
     assert temp_grid.gmt.registration == GridRegistration.GRIDLINE
     npt.assert_allclose(temp_grid.max(), 14628.144)
     npt.assert_allclose(temp_grid.min(), -6908.1987)

--- a/pygmt/tests/test_sphinterpolate.py
+++ b/pygmt/tests/test_sphinterpolate.py
@@ -40,7 +40,7 @@ def test_sphinterpolate_no_outgrid(mars):
     temp_grid = sphinterpolate(data=mars, spacing=1, region="g")
     assert temp_grid.dims == ("lat", "lon")
     assert temp_grid.gmt.gtype is GridType.GEOGRAPHIC
-    assert temp_grid.gmt.registration == GridRegistration.GRIDLINE
+    assert temp_grid.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(temp_grid.max(), 14628.144)
     npt.assert_allclose(temp_grid.min(), -6908.1987)
     npt.assert_allclose(temp_grid.median(), 118.96849)

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -73,7 +73,7 @@ def check_values(grid, expected_grid):
     Check the attributes and values of the DataArray returned by surface.
     """
     assert isinstance(grid, xr.DataArray)
-    assert grid.gmt.registration == GridRegistration.GRIDLINE
+    assert grid.gmt.registration is GridRegistration.GRIDLINE
     assert grid.gmt.gtype is GridType.CARTESIAN
     xr.testing.assert_allclose(a=grid, b=expected_grid)
 

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -74,7 +74,7 @@ def check_values(grid, expected_grid):
     """
     assert isinstance(grid, xr.DataArray)
     assert grid.gmt.registration == GridRegistration.GRIDLINE
-    assert grid.gmt.gtype == GridType.CARTESIAN
+    assert grid.gmt.gtype is GridType.CARTESIAN
     xr.testing.assert_allclose(a=grid, b=expected_grid)
 
 

--- a/pygmt/tests/test_triangulate.py
+++ b/pygmt/tests/test_triangulate.py
@@ -140,7 +140,7 @@ def test_regular_grid_no_outgrid(dataframe, expected_grid):
     data = dataframe.to_numpy()
     output = triangulate.regular_grid(data=data, spacing=1, region=[2, 4, 5, 6])
     assert isinstance(output, xr.DataArray)
-    assert output.gmt.registration == GridRegistration.GRIDLINE
+    assert output.gmt.registration is GridRegistration.GRIDLINE
     assert output.gmt.gtype is GridType.CARTESIAN
     xr.testing.assert_allclose(a=output, b=expected_grid)
 
@@ -158,6 +158,6 @@ def test_regular_grid_with_outgrid_param(dataframe, expected_grid):
         assert Path(tmpfile.name).stat().st_size > 0  # check that outgrid exists
         grid = xr.load_dataarray(tmpfile.name, engine="gmt", raster_kind="grid")
         assert isinstance(grid, xr.DataArray)
-        assert grid.gmt.registration == GridRegistration.GRIDLINE
+        assert grid.gmt.registration is GridRegistration.GRIDLINE
         assert grid.gmt.gtype is GridType.CARTESIAN
         xr.testing.assert_allclose(a=grid, b=expected_grid)

--- a/pygmt/tests/test_triangulate.py
+++ b/pygmt/tests/test_triangulate.py
@@ -141,7 +141,7 @@ def test_regular_grid_no_outgrid(dataframe, expected_grid):
     output = triangulate.regular_grid(data=data, spacing=1, region=[2, 4, 5, 6])
     assert isinstance(output, xr.DataArray)
     assert output.gmt.registration == GridRegistration.GRIDLINE
-    assert output.gmt.gtype == GridType.CARTESIAN
+    assert output.gmt.gtype is GridType.CARTESIAN
     xr.testing.assert_allclose(a=output, b=expected_grid)
 
 
@@ -159,5 +159,5 @@ def test_regular_grid_with_outgrid_param(dataframe, expected_grid):
         grid = xr.load_dataarray(tmpfile.name, engine="gmt", raster_kind="grid")
         assert isinstance(grid, xr.DataArray)
         assert grid.gmt.registration == GridRegistration.GRIDLINE
-        assert grid.gmt.gtype == GridType.CARTESIAN
+        assert grid.gmt.gtype is GridType.CARTESIAN
         xr.testing.assert_allclose(a=grid, b=expected_grid)

--- a/pygmt/tests/test_xarray_accessor.py
+++ b/pygmt/tests/test_xarray_accessor.py
@@ -25,7 +25,7 @@ def test_xarray_accessor_gridline_cartesian():
     """
     grid = xr.load_dataarray("@test.dat.nc", engine="gmt", raster_kind="grid")
     assert grid.gmt.registration == GridRegistration.GRIDLINE
-    assert grid.gmt.gtype == GridType.CARTESIAN
+    assert grid.gmt.gtype is GridType.CARTESIAN
 
 
 def test_xarray_accessor_pixel_geographic():
@@ -35,7 +35,7 @@ def test_xarray_accessor_pixel_geographic():
     """
     grid = xr.load_dataarray("@earth_relief_01d_p", engine="gmt", raster_kind="grid")
     assert grid.gmt.registration == GridRegistration.PIXEL
-    assert grid.gmt.gtype == GridType.GEOGRAPHIC
+    assert grid.gmt.gtype is GridType.GEOGRAPHIC
 
 
 def test_xarray_accessor_set_registration():
@@ -69,23 +69,23 @@ def test_xarray_accessor_set_gtype():
     Check that we can set the gtype of a grid.
     """
     grid = xr.DataArray(data=[[0.1, 0.2], [0.3, 0.4]])
-    assert grid.gmt.gtype == GridType.CARTESIAN == 0  # Default gtype
+    assert grid.gmt.gtype is GridType.CARTESIAN == 0  # Default gtype
 
     # Set the gtype to geographic
     grid.gmt.gtype = GridType.GEOGRAPHIC
-    assert grid.gmt.gtype == GridType.GEOGRAPHIC == 1
+    assert grid.gmt.gtype is GridType.GEOGRAPHIC == 1
 
     # Set the gtype to Cartesian
     grid.gmt.gtype = GridType.CARTESIAN
-    assert grid.gmt.gtype == GridType.CARTESIAN == 0
+    assert grid.gmt.gtype is GridType.CARTESIAN == 0
 
     # Set the gtype to geographic but using a numerical value
     grid.gmt.gtype = 1
-    assert grid.gmt.gtype == GridType.GEOGRAPHIC == 1
+    assert grid.gmt.gtype is GridType.GEOGRAPHIC == 1
 
     # Set the gtype to Cartesian but using a numerical value
     grid.gmt.gtype = 0
-    assert grid.gmt.gtype == GridType.CARTESIAN == 0
+    assert grid.gmt.gtype is GridType.CARTESIAN == 0
 
 
 def test_xarray_accessor_set_invalid_registration_and_gtype():
@@ -127,7 +127,7 @@ def test_xarray_accessor_sliced_datacube():
             grid = dataset.sel(level=500, month=1, drop=True).z
 
         assert grid.gmt.registration == GridRegistration.GRIDLINE
-        assert grid.gmt.gtype == GridType.GEOGRAPHIC
+        assert grid.gmt.gtype is GridType.GEOGRAPHIC
     finally:
         Path(fname).unlink()
 
@@ -143,7 +143,7 @@ def test_xarray_accessor_grid_source_file_not_exist():
     )
     # Registration and gtype are correct.
     assert grid.gmt.registration == GridRegistration.PIXEL
-    assert grid.gmt.gtype == GridType.GEOGRAPHIC
+    assert grid.gmt.gtype is GridType.GEOGRAPHIC
     # The source grid file is undefined.
     assert grid.encoding.get("source") is None
 
@@ -151,10 +151,10 @@ def test_xarray_accessor_grid_source_file_not_exist():
     # grid file doesn't exist.
     sliced_grid = grid[1:3, 1:3]
     assert sliced_grid.gmt.registration == GridRegistration.GRIDLINE
-    assert sliced_grid.gmt.gtype == GridType.CARTESIAN
+    assert sliced_grid.gmt.gtype is GridType.CARTESIAN
 
     # Still possible to manually set registration and gtype.
     sliced_grid.gmt.registration = GridRegistration.PIXEL
     sliced_grid.gmt.gtype = GridType.GEOGRAPHIC
     assert sliced_grid.gmt.registration == GridRegistration.PIXEL
-    assert sliced_grid.gmt.gtype == GridType.GEOGRAPHIC
+    assert sliced_grid.gmt.gtype is GridType.GEOGRAPHIC

--- a/pygmt/tests/test_xarray_accessor.py
+++ b/pygmt/tests/test_xarray_accessor.py
@@ -24,7 +24,7 @@ def test_xarray_accessor_gridline_cartesian():
     Cartesian, gridline-registered grid.
     """
     grid = xr.load_dataarray("@test.dat.nc", engine="gmt", raster_kind="grid")
-    assert grid.gmt.registration == GridRegistration.GRIDLINE
+    assert grid.gmt.registration is GridRegistration.GRIDLINE
     assert grid.gmt.gtype is GridType.CARTESIAN
 
 
@@ -34,7 +34,7 @@ def test_xarray_accessor_pixel_geographic():
     geographic, pixel-registered grid.
     """
     grid = xr.load_dataarray("@earth_relief_01d_p", engine="gmt", raster_kind="grid")
-    assert grid.gmt.registration == GridRegistration.PIXEL
+    assert grid.gmt.registration is GridRegistration.PIXEL
     assert grid.gmt.gtype is GridType.GEOGRAPHIC
 
 
@@ -44,23 +44,23 @@ def test_xarray_accessor_set_registration():
     """
     grid = xr.DataArray(data=[[0.1, 0.2], [0.3, 0.4]])
     # Default to gridline registration
-    assert grid.gmt.registration == GridRegistration.GRIDLINE == 0
+    assert grid.gmt.registration is GridRegistration.GRIDLINE == 0
 
     # Set the registration to pixel
     grid.gmt.registration = GridRegistration.PIXEL
-    assert grid.gmt.registration == GridRegistration.PIXEL == 1
+    assert grid.gmt.registration is GridRegistration.PIXEL == 1
 
     # Set the registration to gridline
     grid.gmt.registration = GridRegistration.GRIDLINE
-    assert grid.gmt.registration == GridRegistration.GRIDLINE == 0
+    assert grid.gmt.registration is GridRegistration.GRIDLINE == 0
 
     # Set the registration to pixel but using a numerical value
     grid.gmt.registration = 1
-    assert grid.gmt.registration == GridRegistration.PIXEL == 1
+    assert grid.gmt.registration is GridRegistration.PIXEL == 1
 
     # Set the registration to gridline but using a numerical value
     grid.gmt.registration = 0
-    assert grid.gmt.registration == GridRegistration.GRIDLINE == 0
+    assert grid.gmt.registration is GridRegistration.GRIDLINE == 0
 
 
 @pytest.mark.benchmark
@@ -126,7 +126,7 @@ def test_xarray_accessor_sliced_datacube():
         with xr.open_dataset(fname, engine="netcdf4") as dataset:
             grid = dataset.sel(level=500, month=1, drop=True).z
 
-        assert grid.gmt.registration == GridRegistration.GRIDLINE
+        assert grid.gmt.registration is GridRegistration.GRIDLINE
         assert grid.gmt.gtype is GridType.GEOGRAPHIC
     finally:
         Path(fname).unlink()
@@ -142,7 +142,7 @@ def test_xarray_accessor_grid_source_file_not_exist():
         resolution="05m", region=[0, 5, -5, 5], registration="pixel"
     )
     # Registration and gtype are correct.
-    assert grid.gmt.registration == GridRegistration.PIXEL
+    assert grid.gmt.registration is GridRegistration.PIXEL
     assert grid.gmt.gtype is GridType.GEOGRAPHIC
     # The source grid file is undefined.
     assert grid.encoding.get("source") is None
@@ -150,11 +150,11 @@ def test_xarray_accessor_grid_source_file_not_exist():
     # For a sliced grid, fallback to default registration and gtype, because the source
     # grid file doesn't exist.
     sliced_grid = grid[1:3, 1:3]
-    assert sliced_grid.gmt.registration == GridRegistration.GRIDLINE
+    assert sliced_grid.gmt.registration is GridRegistration.GRIDLINE
     assert sliced_grid.gmt.gtype is GridType.CARTESIAN
 
     # Still possible to manually set registration and gtype.
     sliced_grid.gmt.registration = GridRegistration.PIXEL
     sliced_grid.gmt.gtype = GridType.GEOGRAPHIC
-    assert sliced_grid.gmt.registration == GridRegistration.PIXEL
+    assert sliced_grid.gmt.registration is GridRegistration.PIXEL
     assert sliced_grid.gmt.gtype is GridType.GEOGRAPHIC

--- a/pygmt/tests/test_xarray_backend.py
+++ b/pygmt/tests/test_xarray_backend.py
@@ -32,7 +32,7 @@ def test_xarray_backend_load_dataarray():
 
         dataarray = xr.load_dataarray(tmpfile.name, engine="gmt", raster_kind="grid")
 
-        assert dataarray.gmt.gtype == GridType.CARTESIAN
+        assert dataarray.gmt.gtype is GridType.CARTESIAN
         assert dataarray.gmt.registration == GridRegistration.PIXEL
         # ensure data array can be saved back to a NetCDF file
         dataarray.to_netcdf(tmpfile.name)
@@ -48,7 +48,7 @@ def test_xarray_backend_gmt_open_nc_grid():
     ) as da:
         assert da.sizes == {"lat": 14, "lon": 8}
         assert da.dtype == "float32"
-        assert da.gmt.gtype == GridType.GEOGRAPHIC
+        assert da.gmt.gtype is GridType.GEOGRAPHIC
         assert da.gmt.registration == GridRegistration.PIXEL
 
 
@@ -60,7 +60,7 @@ def test_xarray_backend_gmt_open_tif_image():
     with xr.open_dataarray("@earth_day_01d", engine="gmt", raster_kind="image") as da:
         assert da.sizes == {"band": 3, "y": 180, "x": 360}
         assert da.dtype == "uint8"
-        assert da.gmt.gtype == GridType.GEOGRAPHIC
+        assert da.gmt.gtype is GridType.GEOGRAPHIC
         assert da.gmt.registration == GridRegistration.PIXEL
 
 
@@ -77,7 +77,7 @@ def test_xarray_backend_gmt_load_grd_grid():
     npt.assert_allclose(da.min(), -4929.5)
     assert da.sizes == {"lat": 31, "lon": 31}
     assert da.dtype == "float32"
-    assert da.gmt.gtype == GridType.GEOGRAPHIC
+    assert da.gmt.gtype is GridType.GEOGRAPHIC
     assert da.gmt.registration == GridRegistration.GRIDLINE
 
 

--- a/pygmt/tests/test_xarray_backend.py
+++ b/pygmt/tests/test_xarray_backend.py
@@ -33,7 +33,7 @@ def test_xarray_backend_load_dataarray():
         dataarray = xr.load_dataarray(tmpfile.name, engine="gmt", raster_kind="grid")
 
         assert dataarray.gmt.gtype is GridType.CARTESIAN
-        assert dataarray.gmt.registration == GridRegistration.PIXEL
+        assert dataarray.gmt.registration is GridRegistration.PIXEL
         # ensure data array can be saved back to a NetCDF file
         dataarray.to_netcdf(tmpfile.name)
 
@@ -49,7 +49,7 @@ def test_xarray_backend_gmt_open_nc_grid():
         assert da.sizes == {"lat": 14, "lon": 8}
         assert da.dtype == "float32"
         assert da.gmt.gtype is GridType.GEOGRAPHIC
-        assert da.gmt.registration == GridRegistration.PIXEL
+        assert da.gmt.registration is GridRegistration.PIXEL
 
 
 def test_xarray_backend_gmt_open_tif_image():
@@ -61,7 +61,7 @@ def test_xarray_backend_gmt_open_tif_image():
         assert da.sizes == {"band": 3, "y": 180, "x": 360}
         assert da.dtype == "uint8"
         assert da.gmt.gtype is GridType.GEOGRAPHIC
-        assert da.gmt.registration == GridRegistration.PIXEL
+        assert da.gmt.registration is GridRegistration.PIXEL
 
 
 def test_xarray_backend_gmt_load_grd_grid():
@@ -78,7 +78,7 @@ def test_xarray_backend_gmt_load_grd_grid():
     assert da.sizes == {"lat": 31, "lon": 31}
     assert da.dtype == "float32"
     assert da.gmt.gtype is GridType.GEOGRAPHIC
-    assert da.gmt.registration == GridRegistration.GRIDLINE
+    assert da.gmt.registration is GridRegistration.GRIDLINE
 
 
 def test_xarray_backend_gmt_read_invalid_kind():

--- a/pygmt/tests/test_xyz2grd.py
+++ b/pygmt/tests/test_xyz2grd.py
@@ -50,7 +50,7 @@ def test_xyz2grd_input_array(array_func, ship_data, expected_grid):
     output = xyz2grd(data=array_func(ship_data), spacing=5, region=[245, 255, 20, 30])
     assert isinstance(output, xr.DataArray)
     assert output.gmt.registration == GridRegistration.GRIDLINE
-    assert output.gmt.gtype == GridType.CARTESIAN
+    assert output.gmt.gtype is GridType.CARTESIAN
     xr.testing.assert_allclose(a=output, b=expected_grid)
 
 

--- a/pygmt/tests/test_xyz2grd.py
+++ b/pygmt/tests/test_xyz2grd.py
@@ -49,7 +49,7 @@ def test_xyz2grd_input_array(array_func, ship_data, expected_grid):
     """
     output = xyz2grd(data=array_func(ship_data), spacing=5, region=[245, 255, 20, 30])
     assert isinstance(output, xr.DataArray)
-    assert output.gmt.registration == GridRegistration.GRIDLINE
+    assert output.gmt.registration is GridRegistration.GRIDLINE
     assert output.gmt.gtype is GridType.CARTESIAN
     xr.testing.assert_allclose(a=output, b=expected_grid)
 

--- a/pygmt/xarray/accessor.py
+++ b/pygmt/xarray/accessor.py
@@ -137,9 +137,11 @@ class GMTDataArrayAccessor:
         # two columns of the shortened summary information of grdinfo.
         if (_source := self._obj.encoding.get("source")) and Path(_source).exists():
             with contextlib.suppress(ValueError):
-                self._registration, self._gtype = map(  # type: ignore[assignment]
+                _registration, _gtype = map(
                     int, grdinfo(_source, per_column="n").split()[-2:]
                 )
+                self._registration = GridRegistration(_registration)
+                self._gtype = GridType(_gtype)
 
     @property
     def registration(self) -> GridRegistration:

--- a/pygmt/xarray/accessor.py
+++ b/pygmt/xarray/accessor.py
@@ -140,8 +140,8 @@ class GMTDataArrayAccessor:
                 _registration, _gtype = map(
                     int, grdinfo(_source, per_column="n").split()[-2:]
                 )
-                self._registration = GridRegistration(_registration)
-                self._gtype = GridType(_gtype)
+            self._registration = GridRegistration(_registration)
+            self._gtype = GridType(_gtype)
 
     @property
     def registration(self) -> GridRegistration:


### PR DESCRIPTION
**Description of proposed changes**

Set `.gmt.registration` and `.gmt.gtype` accessor values as enums instead of int, for the case when reading from a source file, thereby removing the `# type: ignore[assignment]` statement.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Also updates tests so that enum member comparison is done using `is` instead of `==`, e.g.:

```diff
- assert data.gmt.gtype == GridType.GEOGRAPHIC
+ assert data.gmt.gtype is GridType.GEOGRAPHIC

- assert data.gmt.registration == GridRegistration.PIXEL
+ assert data.gmt.registration is GridRegistration.PIXEL
```

References:
- https://docs.python.org/3/howto/enum.html#comparisons
- https://stackoverflow.com/questions/25858497/should-enum-instances-be-compared-by-identity-or-equality

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes https://github.com/GenericMappingTools/pygmt/pull/3932#discussion_r2078781423, patches #3696.


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
