### PR TITLE
Remove the unnecessary which call in load_static_earth_relief

### DIFF
--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import xarray as xr
 from pygmt.exceptions import GMTImageComparisonFailure
-from pygmt.src import which
 
 
 def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_images"):
@@ -144,17 +143,18 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
     return decorator
 
 
-def load_static_earth_relief():
+def load_static_earth_relief() -> xr.DataArray:
     """
-    Load the static_earth_relief file for internal testing.
+    Load the static_earth_relief.nc file for internal testing.
 
     Returns
     -------
-    data : xarray.DataArray
+    data
         A grid of Earth relief for internal tests.
     """
-    fname = which("@static_earth_relief.nc", download="c")
-    return xr.load_dataarray(fname, engine="gmt", raster_kind="grid")
+    return xr.load_dataarray(
+        "@static_earth_relief.nc", engine="gmt", raster_kind="grid"
+    )
 
 
 def skip_if_no(package):


### PR DESCRIPTION
`xr.load_dataarray` with the "gmt" engine can read GMT remote dataset directly, so the `which` call is no longer needed.