### PR TITLE
Store first tile as source encoding for tiled grids

### DIFF
--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -593,7 +593,7 @@ def _load_remote_dataset(
             )
 
     # Full path to the grid
-    source: str | list = which(fname, download="a", verbose="q")
+    source: str | list = which(fname, verbose="q")
     if resinfo.tiled:
         source = sorted(source)[0]  # get first grid for tiled grids
     # Manually add source to xarray.DataArray encoding to make the GMT accessors work.

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -595,7 +595,7 @@ def _load_remote_dataset(
     # Full path to the grid
     source: str | list = which(fname, download="a")
     if resinfo.tiled:
-        source = source[0]  # get first grid for tiled grids
+        source = sorted(source)[0]  # get first grid for tiled grids
     # Manually add source to xarray.DataArray encoding to make the GMT accessors work.
     if source:
         grid.encoding["source"] = source

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -597,8 +597,7 @@ def _load_remote_dataset(
     if resinfo.tiled:
         source = sorted(source)[0]  # get first grid for tiled grids
     # Manually add source to xarray.DataArray encoding to make the GMT accessors work.
-    if source:
-        grid.encoding["source"] = source
+    grid.encoding["source"] = source
 
     # Add some metadata to the grid
     grid.attrs["description"] = dataset.description

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -592,8 +592,10 @@ def _load_remote_dataset(
                 kind=dataset.kind, outgrid=None, vfname=voutgrd
             )
 
-    # Full path to the grid if not tiled grids.
-    source = which(fname, download="a") if not resinfo.tiled else None
+    # Full path to the grid
+    source: str | list = which(fname, download="a")
+    if resinfo.tiled:
+        source = source[0]  # get first grid for tiled grids
     # Manually add source to xarray.DataArray encoding to make the GMT accessors work.
     if source:
         grid.encoding["source"] = source

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -593,7 +593,7 @@ def _load_remote_dataset(
             )
 
     # Full path to the grid
-    source: str | list = which(fname, download="a")
+    source: str | list = which(fname, download="a", verbose="q")
     if resinfo.tiled:
         source = sorted(source)[0]  # get first grid for tiled grids
     # Manually add source to xarray.DataArray encoding to make the GMT accessors work.

--- a/pygmt/tests/test_xarray_accessor.py
+++ b/pygmt/tests/test_xarray_accessor.py
@@ -157,7 +157,7 @@ def test_xarray_accessor_tiled_grid_slice_and_add():
     assert sliced_grid.gmt.registration is GridRegistration.PIXEL
     assert sliced_grid.gmt.gtype is GridType.GEOGRAPHIC
 
-    # For a grid that underwent mathematical operations, fallback to  default
+    # For a grid that underwent mathematical operations, fallback to default
     # registration and gtype, because the source grid file doesn't exist.
     added_grid = sliced_grid + 9
     assert added_grid.encoding == {}

--- a/pygmt/tests/test_xarray_accessor.py
+++ b/pygmt/tests/test_xarray_accessor.py
@@ -132,10 +132,13 @@ def test_xarray_accessor_sliced_datacube():
         Path(fname).unlink()
 
 
-def test_xarray_accessor_grid_source_file_not_exist():
+def test_xarray_accessor_tiled_grid_slice_and_add():
     """
-    Check that the accessor fallbacks to the default registration and gtype when the
-    grid source file (i.e., grid.encoding["source"]) doesn't exist.
+    Check that the accessor works to get the registration and gtype when the grid source
+    file is from a tiled grid, that slicing doesn't affect registration/gtype, but math
+    operations do return the default registration/gtype as a fallback.
+
+    Unit test to track https://github.com/GenericMappingTools/pygmt/issues/524
     """
     # Load the 05m earth relief grid, which is stored as tiles.
     grid = load_earth_relief(
@@ -144,17 +147,25 @@ def test_xarray_accessor_grid_source_file_not_exist():
     # Registration and gtype are correct.
     assert grid.gmt.registration is GridRegistration.PIXEL
     assert grid.gmt.gtype is GridType.GEOGRAPHIC
-    # The source grid file is undefined.
-    assert grid.encoding.get("source") is None
+    # The source grid file for tiled grids is the first tile
+    assert grid.encoding["source"].endswith("S90E000.earth_relief_05m_p.nc")
 
-    # For a sliced grid, fallback to default registration and gtype, because the source
-    # grid file doesn't exist.
+    # For a sliced grid, ensure we don't fallback to the default registration (gridline)
+    # and gtype (cartesian), because the source grid file should still exist.
     sliced_grid = grid[1:3, 1:3]
-    assert sliced_grid.gmt.registration is GridRegistration.GRIDLINE
-    assert sliced_grid.gmt.gtype is GridType.CARTESIAN
-
-    # Still possible to manually set registration and gtype.
-    sliced_grid.gmt.registration = GridRegistration.PIXEL
-    sliced_grid.gmt.gtype = GridType.GEOGRAPHIC
+    assert sliced_grid.encoding["source"].endswith("S90E000.earth_relief_05m_p.nc")
     assert sliced_grid.gmt.registration is GridRegistration.PIXEL
     assert sliced_grid.gmt.gtype is GridType.GEOGRAPHIC
+
+    # For a grid that underwent mathematical operations, fallback to  default
+    # registration and gtype, because the source grid file doesn't exist.
+    added_grid = sliced_grid + 9
+    assert added_grid.encoding == {}
+    assert added_grid.gmt.registration is GridRegistration.GRIDLINE
+    assert added_grid.gmt.gtype is GridType.CARTESIAN
+
+    # Still possible to manually set registration and gtype.
+    added_grid.gmt.registration = GridRegistration.PIXEL
+    added_grid.gmt.gtype = GridType.GEOGRAPHIC
+    assert added_grid.gmt.registration is GridRegistration.PIXEL
+    assert added_grid.gmt.gtype is GridType.GEOGRAPHIC


### PR DESCRIPTION
**Description of proposed changes**

Tiled [remote dataset](https://www.generic-mapping-tools.org/remote-datasets/) grids used to have an undefined `grid.encoding["source"]` because there was a list of grids returned from `pygmt.which`, and we did not select any one. The change here means that we set `grid.encoding["source"]` to the first grid in the list (sorted alphabetically).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This means that slicing `xarray.DataArray` tiled grids should return proper GMT Accessor `GridType` and `GridRegistration` values, because the source file can be queried using `grdinfo` to get the values.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses https://github.com/GenericMappingTools/pygmt/pull/3932#issuecomment-2868773168 and #524


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
