### PR TITLE
pygmt.select: parameter 'mask' accepts a sequence of strings

### DIFF
--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -44,7 +44,7 @@ __doctest_skip__ = ["select"]
     s="skiprows",
     w="wrap",
 )
-@kwargs_to_strings(M="sequence", R="sequence", i="sequence_comma", o="sequence_comma")
+@kwargs_to_strings(N="sequence", R="sequence", i="sequence_comma", o="sequence_comma")
 def select(
     data: PathLike | TableLike | None = None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",


### PR DESCRIPTION
Upstream documentation at https://docs.generic-mapping-tools.org/dev/gmtselect.html.

It must be a typo. `gmtselect` has no `-M` option, only `-N` option.