### PR TITLE
Fix one failing test related to earth_relief dataset update

### DIFF
--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -211,4 +211,4 @@ def test_earth_relief_03s_default_registration():
     npt.assert_allclose(data.coords["lon"].data.min(), -10)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.8)
     npt.assert_allclose(data.min(), -2069.85, atol=0.5)
-    npt.assert_allclose(data.max(), -923.5, atol=0.5)
+    npt.assert_allclose(data.max(), -921.5, atol=0.5)


### PR DESCRIPTION
We forgot to update one earth-relief test, since the test was marked as xfail for GMT>=6.5.0, but the test fails in the "GMT Legacy Tests" CI.

https://github.com/GenericMappingTools/pygmt/actions/runs/15126193285/job/42518596185

```
=================================== FAILURES ===================================
__________________ test_earth_relief_03s_default_registration __________________

    @pytest.mark.xfail(
        condition=Version(__gmt_version__) >= Version("6.5.0"),
        reason="Upstream bug tracked in https://github.com/GenericMappingTools/pygmt/issues/2511",
    )
    def test_earth_relief_03s_default_registration():
        """
        Test that the grid returned by default for the 3 arc-second resolution has a
        "gridline" registration.
        """
        data = load_earth_relief(resolution="03s", region=[-10, -9.8, 4.9, 5])
        assert data.shape == (121, 241)
        assert data.gmt.registration is GridRegistration.GRIDLINE
        npt.assert_allclose(data.coords["lat"].data.min(), 4.9)
        npt.assert_allclose(data.coords["lat"].data.max(), 5)
        npt.assert_allclose(data.coords["lon"].data.min(), -10)
        npt.assert_allclose(data.coords["lon"].data.max(), -9.8)
        npt.assert_allclose(data.min(), -2069.85, atol=0.5)
>       npt.assert_allclose(data.max(), -923.5, atol=0.5)

../pygmt/tests/test_datasets_earth_relief.py:214: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

args = (<function assert_allclose.<locals>.compare at 0x7f4c6c587880>, array(-921.53516, dtype=float32), array(-923.5))
kwds = {'equal_nan': True, 'err_msg': '', 'header': 'Not equal to tolerance rtol=1e-07, atol=0.5', 'verbose': True}

    @wraps(func)
    def inner(*args, **kwds):
        with self._recreate_cm():
>           return func(*args, **kwds)
E           AssertionError: 
E           Not equal to tolerance rtol=1e-07, atol=0.5
E           
E           Mismatched elements: 1 / 1 (100%)
E           Max absolute difference: 1.96484375
E           Max relative difference: 0.00212761
E            x: array(-921.53516, dtype=float32)
E            y: array(-923.5)
```