### PR TITLE
DOC: Typo fixes (singular-plural)

### DIFF
--- a/examples/gallery/histograms/blockm.py
+++ b/examples/gallery/histograms/blockm.py
@@ -18,7 +18,7 @@ data = data[["longitude", "latitude", "depth_km"]]
 
 # Set the region for the plot
 region = [130, 152.5, 32.5, 52.5]
-# Define spacing in x- and y-direction (150x150 arc-minute blocks)
+# Define spacing in x- and y-directions (150x150 arc-minute blocks)
 spacing = "150m"
 
 fig = pygmt.Figure()

--- a/examples/gallery/images/grdlandmask.py
+++ b/examples/gallery/images/grdlandmask.py
@@ -17,7 +17,7 @@ region = [-65, -40, -40, -20]
 # Assign a value of 0 for all water masses and a value of 1 for all land
 # masses.
 # Use shoreline data with (l)ow resolution and set the grid spacing to
-# 5 arc-minutes in x- and y-direction.
+# 5 arc-minutes in x- and y-directions.
 grid = pygmt.grdlandmask(region=region, spacing="5m", maskvalues=[0, 1], resolution="l")
 
 # Plot clipped grid

--- a/examples/tutorials/advanced/3d_perspective_image.py
+++ b/examples/tutorials/advanced/3d_perspective_image.py
@@ -27,8 +27,7 @@ fig.grdview(
     # Sets the view azimuth as 130 degrees, and the view elevation as 30
     # degrees
     perspective=[130, 30],
-    # Sets the x- and y-axis labels, and annotates the west, south, and east
-    # axes
+    # Sets the x- and y-axis labels, and annotates the west, south, and east axes
     frame=["xa", "ya", "WSnE"],
     # Sets a Mercator projection on a 15-centimeter figure
     projection="M15c",

--- a/examples/tutorials/advanced/cartesian_histograms.py
+++ b/examples/tutorials/advanced/cartesian_histograms.py
@@ -79,7 +79,7 @@ fig.histogram(
     fill="red3",
     pen="1p,darkgray,solid",
     histtype=0,
-    # Use horizontal bars. Note that the x- and y-axis are flipped, with the x-axis
+    # Use horizontal bars. Note that the x- and y-axes are flipped, with the x-axis
     # plotted vertically and the y-axis plotted horizontally.
     horizontal=True,
 )

--- a/examples/tutorials/advanced/insets.py
+++ b/examples/tutorials/advanced/insets.py
@@ -57,7 +57,7 @@ fig.show()
 # %%
 # When using **j** to set the anchor of the inset, the default location is in
 # contact with the nearby axis or axes. The offset of the inset can be set with
-# **+o**, followed by the offsets along the x- and y-axis. If only one offset
+# **+o**, followed by the offsets along the x- and y-axes. If only one offset
 # is passed, it is applied to both axes. Each offset can have its own unit. In
 # the example below, the inset is shifted 0.5 centimeters on the x-axis and
 # 0.2 centimeters on the y-axis.

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -60,12 +60,12 @@ def basemap(self, **kwargs):
         **+p**\ *pen*. Add **+g**\ *fill* to fill the scale panel [Default is
         no fill]. Append **+c**\ *clearance* where *clearance* is either gap,
         xgap/ygap, or lgap/rgap/bgap/tgap where these items are uniform,
-        separate in x- and y-direction, or individual side spacings between
-        scale and border. Append **+i** to draw a secondary, inner border as
-        well. We use a uniform gap between borders of 2p and the
+        separate x and y, or individual side spacings between scale and
+        border. Append **+i** to draw a secondary, inner border as well.
+        We use a uniform gap between borders of 2 points and the
         :gmt-term:`MAP_DEFAULTS_PEN` unless other values are specified. Append
-        **+r** to draw rounded rectangular borders instead, with a 6p corner
-        radius. You can override this radius by appending another value.
+        **+r** to draw rounded rectangular borders instead, with a 6-points
+        corner radius. You can override this radius by appending another value.
         Finally, append **+s** to draw an offset background shaded region.
         Here, *dx/dy* indicates the shift relative to the foreground frame
         [Default is ``"4p/-4p"``] and shade sets the fill style to use for

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -129,12 +129,12 @@ def coast(
         **+p**\ *pen*. Add **+g**\ *fill* to fill the scale panel [Default is
         no fill]. Append **+c**\ *clearance* where *clearance* is either gap,
         xgap/ygap, or lgap/rgap/bgap/tgap where these items are uniform,
-        separate in x- and y-direction, or individual side spacings between
-        scale and border. Append **+i** to draw a secondary, inner border as
-        well. We use a uniform gap between borders of 2p and the
+        separate x and y, or individual side spacings between scale and
+        border. Append **+i** to draw a secondary, inner border as well.
+        We use a uniform gap between borders of 2 points and the
         :gmt-term:`MAP_DEFAULTS_PEN` unless other values are specified. Append
-        **+r** to draw rounded rectangular borders instead, with a 6p corner
-        radius. You can override this radius by appending another value.
+        **+r** to draw rounded rectangular borders instead, with a 6-points
+        corner radius. You can override this radius by appending another value.
         Finally, append **+s** to draw an offset background shaded region.
         Here, *dx/dy* indicates the shift relative to the foreground frame
         [Default is ``"4p/-4p"``] and shade sets the fill style to use for

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -80,7 +80,7 @@ def grdsample(
     ...     resolution="30m", region=[10, 30, 15, 25]
     ... )
     >>> # Create a new grid from an input grid, change the registration,
-    >>> # and set both x- and y-spacing to 0.5 arc-degrees
+    >>> # and set both x- and y-spacings to 0.5 arc-degrees
     >>> new_grid = pygmt.grdsample(grid=grid, translate=True, spacing=[0.5, 0.5])
     """
     with Session() as lib:


### PR DESCRIPTION
**Description of proposed changes**

Fix some typos regarding singular-plural usage, to make the docs more consistent.

**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
