### PR TITLE
Improve decorators @use_alias/@fmt_docstrings to list non-aliased aliases

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -555,7 +555,15 @@ def use_alias(**aliases):
             for short_param, long_alias in aliases.items():
                 if long_alias.endswith("-"):
                     # Trailing dash means it's not aliased but should be listed.
+                    if short_param in kwargs:
+                        msg = (
+                            f"Short-form parameter ({short_param}) is not recognized. "
+                            f"Use long-form parameter(s) '{long_alias.strip('-')}' "
+                            "instead."
+                        )
+                        raise GMTInvalidInput(msg)
                     continue
+
                 if long_alias in kwargs and short_param in kwargs:
                     msg = (
                         f"Parameters in short-form ({short_param}) and "

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -452,7 +452,7 @@ def fmt_docstring(module_func):
             alias = module_func.aliases[arg]
             # Trailing dash means it's not aliased but should be listed.
             # Remove the trailing dash if it exists.
-            aliases.append(f"   - {arg} = {alias.rstrip('-')}")
+            aliases.append(f"   - {arg} = *{alias.rstrip('-')}*")
         filler_text["aliases"] = "\n".join(aliases)
 
     filler_text["table-classes"] = (

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -554,15 +554,16 @@ def use_alias(**aliases):
             """
             for short_param, long_alias in aliases.items():
                 if long_alias.endswith("-"):
+                    _long_alias = long_alias.rstrip("-")
                     # Trailing dash means it's not aliased but should be listed.
-                    _alias_list = long_alias.rstrip("-").split("/")
+                    _alias_list = _long_alias.split("/")
                     if (
                         any(_alias in kwargs for _alias in _alias_list)
                         and short_param in kwargs
                     ):  # Both long- and short- forms are given.
                         msg = (
                             f"Parameters in short-form ({short_param}) and "
-                            f"long-form ({long_alias.strip('-')}) can't coexist."
+                            f"long-form ({_long_alias}) can't coexist."
                         )
                         raise GMTInvalidInput(msg)
                     if short_param in kwargs:  # Only short-alias is given
@@ -570,11 +571,11 @@ def use_alias(**aliases):
                             msg = (
                                 f"Short-form parameter ({short_param}) is not "
                                 f"recognized. Use long-form parameter(s) "
-                                f"'{long_alias.strip('-')}' instead."
+                                f"'{_long_alias}' instead."
                             )
                             raise GMTInvalidInput(msg)
                         # If there is only one long-form parameter, use it.
-                        kwargs[long_alias] = kwargs.pop(short_param)
+                        kwargs[_long_alias] = kwargs.pop(short_param)
                     continue
 
                 if long_alias in kwargs and short_param in kwargs:

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -452,7 +452,7 @@ def fmt_docstring(module_func):
             alias = module_func.aliases[arg]
             # Trailing dash means it's not aliased but should be listed.
             # Remove the trailing dash if it exists.
-            aliases.append(f"   - {arg} = *{alias.rstrip('-')}*")
+            aliases.append(f"   - {arg} = {alias.rstrip('-')}")
         filler_text["aliases"] = "\n".join(aliases)
 
     filler_text["table-classes"] = (

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -450,7 +450,9 @@ def fmt_docstring(module_func):
         aliases.append("   :columns: 3\n")
         for arg in sorted(module_func.aliases):
             alias = module_func.aliases[arg]
-            aliases.append(f"   - {arg} = {alias}")
+            # Trailing dash means it's not aliased but should be listed.
+            # Remove the trailing dash if it exists.
+            aliases.append(f"   - {arg} = {alias.rstrip('-')}")
         filler_text["aliases"] = "\n".join(aliases)
 
     filler_text["table-classes"] = (
@@ -484,6 +486,9 @@ def _insert_alias(module_func, default_value=None):
     kwargs_param = wrapped_params.pop(-1)
     # Add new parameters from aliases
     for alias in module_func.aliases.values():
+        if alias.endswith("-"):
+            # Trailing dash means it's not aliased but should be listed.
+            continue
         if alias not in sig.parameters:
             new_param = Parameter(
                 alias, kind=Parameter.KEYWORD_ONLY, default=default_value
@@ -548,6 +553,9 @@ def use_alias(**aliases):
             New module that parses and replaces the registered aliases.
             """
             for short_param, long_alias in aliases.items():
+                if long_alias.endswith("-"):
+                    # Trailing dash means it's not aliased but should be listed.
+                    continue
                 if long_alias in kwargs and short_param in kwargs:
                     msg = (
                         f"Parameters in short-form ({short_param}) and "

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -23,6 +23,7 @@ __doctest_skip__ = ["coast"]
     A="area_thresh",
     B="frame",
     C="lakes",
+    D="resolution-",
     E="dcw",
     F="box",
     G="land",

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -23,7 +23,9 @@ __doctest_skip__ = ["grdclip"]
 # TODO(PyGMT>=0.19.0): Remove the deprecated "new" parameter.
 @fmt_docstring
 @deprecate_parameter("new", "replace", "v0.15.0", remove_version="v0.19.0")
-@use_alias(R="region", V="verbose")
+@use_alias(
+    R="region", Sa="above-", Sb="below-", Si="between-", Sr="replace-", V="verbose"
+)
 @kwargs_to_strings(R="sequence")
 def grdclip(
     grid: PathLike | xr.DataArray,

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -109,7 +109,14 @@ def _parse_fill_mode(
 # TODO(PyGMT>=0.19.0): Remove the deprecated 'no_data' parameter.
 # TODO(PyGMT>=0.19.0): Remove the deprecated 'mode' parameter.
 @deprecate_parameter("no_data", "hole", "v0.15.0", remove_version="v0.19.0")
-@use_alias(N="hole", R="region", V="verbose", f="coltypes")
+@use_alias(
+    A="constantfill/gridfill/neighborfill/splinefill/mode-",
+    L="inquire-",
+    N="hole",
+    R="region",
+    V="verbose",
+    f="coltypes",
+)
 @kwargs_to_strings(R="sequence")
 def grdfill(
     grid: PathLike | xr.DataArray,

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -17,6 +17,7 @@ __doctest_skip__ = ["grdlandmask"]
 @fmt_docstring
 @use_alias(
     A="area_thresh",
+    D="resolution-",
     E="bordervalues",
     I="spacing",
     N="maskvalues",

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -123,6 +123,7 @@ def _auto_offset(spec) -> bool:
     L="outline",
     N="no_clip",
     R="region",
+    S="scale/convention/component-",
     T="nodal",
     V="verbose",
     W="pen",

--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -24,6 +24,7 @@ __doctest_skip__ = ["select"]
 @use_alias(
     A="area_thresh",
     C="dist2pt",
+    D="resolution-",
     F="polygon",
     G="gridmask",
     I="reverse",

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -18,6 +18,7 @@ __doctest_skip__ = ["solar"]
     G="fill",
     J="projection",
     R="region",
+    T="terminator/terminator_datetime-",
     V="verbose",
     W="pen",
     c="panel",

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -14,6 +14,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     B="frame",
     C="cmap",
     G="fill",
+    L="alabel/blabel/clabel-",
     JX="width",
     R="region",
     S="style",

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -27,6 +27,7 @@ from pygmt.helpers import (
     B="frame",
     C="clearance",
     D="offset",
+    F="position/angle/font/justify-",
     G="fill",
     N="no_clip",
     V="verbose",

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -11,6 +11,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
 @use_alias(
     B="frame",
     D="position",
+    G="fillpositive/fillnegative-",
     J="projection",
     R="region",
     T="track",

--- a/pygmt/tests/test_coast.py
+++ b/pygmt/tests/test_coast.py
@@ -74,3 +74,41 @@ def test_coast_dcw_list():
         dcw=["ES+gbisque+pgreen", "IT+gcyan+pblue"],
     )
     return fig
+
+
+@pytest.mark.mpl_image_compare(filename="test_coast_world_mercator.png")
+def test_coast_resolution_short_form():
+    """
+    Test using the short form of the 'resolution' parameter.
+
+    This test is the same as test_coast_world_mercator, but uses the short form of
+    the 'resolution' parameter.
+    """
+    fig = Figure()
+    fig.coast(
+        region=[-180, 180, -80, 80],
+        projection="M15c",
+        frame="af",
+        land="#aaaaaa",
+        D="crude",
+        water="white",
+    )
+    return fig
+
+
+def test_coast_resolution_long_short_form_conflict():
+    """
+    Test that using the short form of the 'resolution' parameter conflicts with
+    using the long form.
+    """
+    fig = Figure()
+    with pytest.raises(GMTInvalidInput):
+        fig.coast(
+            region=[-180, 180, -80, 80],
+            projection="M15c",
+            frame="af",
+            land="#aaaaaa",
+            resolution="high",
+            D="crude",
+            water="white",
+        )


### PR DESCRIPTION
This is another approach to addressing the 2nd issue raised in https://github.com/GenericMappingTools/pygmt/issues/3881.

This PR improves the `@use_alias` decorator to support non-aliased aliases. Here, non-aliased aliases are marked by a trailing dash, e.g., `D="resolution"` vs `D="resolution-"`.

Non-aliased aliases mean that the alias will be shown in the alias list, but the long-form parameters won't be converted to short-form flags, so that we can still use `resolution` rather than `kwargs["D"]` in the codes.

Please note that this is just a temporary fix, and we need to find a different way to list aliases when we start to remove `@use_alias`.

Supersedes #3945.

**Preview**: https://pygmt-dev--3965.org.readthedocs.build/en/3965/api/generated/pygmt.grdfill.html