### PR TITLE
CI: Test NumPy 2.3 in the GMT Tests workflow

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -78,7 +78,7 @@ jobs:
             optional-packages: ' contextily geopandas ipython pyarrow-core rioxarray netCDF4 sphinx-gallery'
           # Python 3.13 + core packages (latest versions) + optional packages
           - python-version: '3.13'
-            numpy-version: '2.2'
+            numpy-version: '2.3'
             pandas-version: ''
             xarray-version: ''
             optional-packages: ' contextily geopandas ipython pyarrow-core rioxarray netCDF4 sphinx-gallery'


### PR DESCRIPTION
**Description of proposed changes**

Bumps [numpy](https://github.com/numpy/numpy) from 2.2 to 2.3. [NumPy 2.3.0](https://github.com/numpy/numpy/releases/tag/v2.3.0) was released in June 2025.

Note that the branch protection rules at [GenericMappingTools/pygmt/settings/branches](https://github.com/GenericMappingTools/pygmt/settings/branches) will need to be changed to use Python 3.13/Numpy 2.3 before this Pull Request is merged.

Supersedes #3677