### PR TITLE
DOC: Add gallery example for using EPSG codes

### DIFF
--- a/examples/gallery/maps/epsg_codes.py
+++ b/examples/gallery/maps/epsg_codes.py
@@ -15,7 +15,7 @@ import pygmt
 
 fig = pygmt.Figure()
 
-# Pass the desired EPSG code and the width of the map, here 10 centimeters, to the
+# Pass the desired EPSG code and the width of the map (separated by a slash) to the
 # projection parameter
 fig.basemap(region=[-180, 180, -60, 60], projection="EPSG:3857/10c", frame=30)
 fig.coast(land="gray", shorelines="1/0.1p,gray10")


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to add a gallery example showing the usage of EPSG codes with the `projection` parameter.
At the moment the example is listed in the gallery under "Maps and map elements"; *Edit* "Projections".

Fixes #2004

**Preview**: https://pygmt-dev--3973.org.readthedocs.build/en/3973/gallery/maps/epsg_codes.html


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
