### PR TITLE
Fix the bug when passing a sequence that contains True to a parameter

### DIFF
--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -524,6 +524,8 @@ def build_arg_list(  # noqa: PLR0912
     ['-A1/2/3/4', '-BWSen', '-Bxaf', '-Byaf', '-C1p', '-C2p']
     >>> build_arg_list(dict(B=["af", "WSne+tBlank Space"]))
     ['-BWSne+tBlank Space', '-Baf']
+    >>> build_arg_list(dict(B=[True, "+tTitle"]))
+    ['-B', '-B+tTitle']
     >>> build_arg_list(dict(F='+t"Empty Spaces"'))
     ['-F+t"Empty Spaces"']
     >>> build_arg_list(dict(l="'Void Space'"))
@@ -565,7 +567,10 @@ def build_arg_list(  # noqa: PLR0912
         elif value is True:
             gmt_args.append(f"-{key}")
         elif is_nonstr_iter(value):
-            gmt_args.extend(f"-{key}{_value}" for _value in value)
+            gmt_args.extend(
+                f"-{key}{_value}" if _value is not True else f"-{key}"
+                for _value in value
+            )
         else:
             gmt_args.append(f"-{key}{value}")
 

--- a/pygmt/tests/baseline/test_basemap_frame_sequence_true.png.dvc
+++ b/pygmt/tests/baseline/test_basemap_frame_sequence_true.png.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: b04af7fe4c42e405adb600cc3d6d3272
+  size: 11679
+  hash: md5
+  path: test_basemap_frame_sequence_true.png

--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -143,3 +143,15 @@ def test_basemap_subplot():
         with fig.set_panel(panel=1):
             fig.basemap(region=[0, 10, 0, 10], projection="X?")
     return fig
+
+
+@pytest.mark.mpl_image_compare
+def test_basemap_frame_sequence_true():
+    """
+    Test that passing a sequence with True works.
+
+    Test for https://github.com/GenericMappingTools/pygmt/issues/3981.
+    """
+    fig = Figure()
+    fig.basemap(region=[0, 10, 0, 10], projection="X10c", frame=[True, "WSen"])
+    return fig


### PR DESCRIPTION
See #3981 for the bug report. Syntax like `frame=[True, "+tThe Caribbean Sea"]` is not intuitive but is still valid. This PR fixes the issue by checking if a sequence contains True.

Other values like `False`/`None` are not checked, since they make no sense, e.g., `frame=[False, "+tThe Caribbean Sea"]`

Closes #3981.