### PR TITLE
BREAKING: Raise GMTValueError exception for invalid values. Previously raise GMTInvalidInput

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -283,6 +283,7 @@ All custom exceptions are derived from :class:`pygmt.exceptions.GMTError`.
     exceptions.GMTCLibError
     exceptions.GMTCLibNoSessionError
     exceptions.GMTCLibNotFoundError
+    exceptions.GMTValueError
 
 
 .. currentmodule:: pygmt

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -24,7 +24,12 @@ from pygmt.clib.conversion import (
 )
 from pygmt.clib.loading import get_gmt_version, load_libgmt
 from pygmt.datatypes import _GMT_DATASET, _GMT_GRID, _GMT_IMAGE
-from pygmt.exceptions import GMTCLibError, GMTCLibNoSessionError, GMTInvalidInput
+from pygmt.exceptions import (
+    GMTCLibError,
+    GMTCLibNoSessionError,
+    GMTInvalidInput,
+    GMTValueError,
+)
 from pygmt.helpers import (
     _validate_data_input,
     data_kind,
@@ -560,11 +565,13 @@ class Session:
         ...     lib.get_common("A")
         Traceback (most recent call last):
         ...
-        pygmt.exceptions.GMTInvalidInput: Unknown GMT common option flag 'A'.
+        pygmt.exceptions.GMTValueError: Invalid GMT common option: 'A'. Expected ...
         """
-        if option not in "BIJRUVXYabfghinoprst:":
-            msg = f"Unknown GMT common option flag '{option}'."
-            raise GMTInvalidInput(msg)
+        valid_options = "BIJRUVXYabfghinoprst:"
+        if option not in valid_options:
+            raise GMTValueError(
+                option, description="GMT common option", choices=valid_options
+            )
 
         c_get_common = self.get_libgmt_func(
             "GMT_Get_Common",
@@ -847,7 +854,7 @@ class Session:
         their values are added.
 
         If no valid modifiers are given, then will assume that modifiers are not
-        allowed. In this case, will raise a :class:`pygmt.exceptions.GMTInvalidInput`
+        allowed. In this case, will raise a :class:`pygmt.exceptions.GMTValueError`
         exception if given a modifier.
 
         Parameters
@@ -855,7 +862,7 @@ class Session:
         constant
             The name of a valid GMT API constant, with an optional modifier.
         valid
-            A list of valid values for the constant. Will raise a GMTInvalidInput
+            A list of valid values for the constant. Will raise a GMTValueError
             exception if the given value is not in the list.
         valid_modifiers
             A list of valid modifiers that can be added to the constant. If ``None``,
@@ -866,28 +873,23 @@ class Session:
         nmodifiers = len(parts) - 1
 
         if name not in valid:
-            msg = f"Invalid constant name '{name}'. Must be one of {valid}."
-            raise GMTInvalidInput(msg)
+            raise GMTValueError(name, description="constant name", choices=valid)
 
         match nmodifiers:
             case 1 if valid_modifiers is None:
-                msg = (
-                    f"Constant modifiers are not allowed since valid values "
-                    f"were not given: '{constant}'."
+                raise GMTValueError(
+                    constant,
+                    reason="Constant modifiers are not allowed since valid values were not given.",
                 )
-                raise GMTInvalidInput(msg)
             case 1 if valid_modifiers is not None and parts[1] not in valid_modifiers:
-                msg = (
-                    f"Invalid constant modifier '{parts[1]}'. "
-                    f"Must be one of {valid_modifiers}."
+                raise GMTValueError(
+                    parts[1], description="constant modifier", choices=valid_modifiers
                 )
-                raise GMTInvalidInput(msg)
             case n if n > 1:
-                msg = (
-                    f"Only one modifier is allowed in constants, "
-                    f"{nmodifiers} given: '{constant}'."
+                raise GMTValueError(
+                    constant,
+                    reason=f"Only one modifier is allowed in constants but {nmodifiers} given.",
                 )
-                raise GMTInvalidInput(msg)
 
         integer_value = sum(self[part] for part in parts)
         return integer_value

--- a/pygmt/datasets/earth_magnetic_anomaly.py
+++ b/pygmt/datasets/earth_magnetic_anomaly.py
@@ -10,7 +10,7 @@ from typing import Literal
 
 import xarray as xr
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTValueError
 
 __doctest_skip__ = ["load_earth_magnetic_anomaly"]
 
@@ -135,11 +135,11 @@ def load_earth_magnetic_anomaly(
         "wdmam": "earth_wdmam",
     }.get(data_source)
     if prefix is None:
-        msg = (
-            f"Invalid earth magnetic anomaly data source '{data_source}'. "
-            "Valid values are 'emag2', 'emag2_4km', and 'wdmam'."
+        raise GMTValueError(
+            data_source,
+            description="earth magnetic anomaly data source",
+            choices=["emag2", "emag2_4km", "wdmam"],
         )
-        raise GMTInvalidInput(msg)
     grid = _load_remote_dataset(
         name="earth_wdmam" if data_source == "wdmam" else "earth_mag",
         prefix=prefix,

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -10,7 +10,7 @@ from typing import Literal
 
 import xarray as xr
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
-from pygmt.exceptions import GMTInvalidInput, GMTValueError
+from pygmt.exceptions import GMTValueError
 
 __doctest_skip__ = ["load_earth_relief"]
 
@@ -162,11 +162,14 @@ def load_earth_relief(
     # Use SRTM or not.
     if use_srtm and resolution in land_only_srtm_resolutions:
         if data_source != "igpp":
-            msg = (
-                f"Option 'use_srtm=True' doesn't work with data source '{data_source}'. "
-                "Please set 'data_source' to 'igpp'."
+            raise GMTValueError(
+                data_source,
+                description="data source",
+                reason=(
+                    "Option 'use_srtm=True' doesn't work with data source "
+                    f"{data_source!r}. Please set 'data_source' to 'igpp'.",
+                ),
             )
-            raise GMTInvalidInput(msg)
         prefix = "srtm_relief"
     # Choose earth relief dataset
     match data_source:

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -10,7 +10,7 @@ from typing import Literal
 
 import xarray as xr
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 
 __doctest_skip__ = ["load_earth_relief"]
 
@@ -154,11 +154,11 @@ def load_earth_relief(
         "synbath": "earth_synbath",
     }.get(data_source)
     if prefix is None:
-        msg = (
-            f"Invalid earth relief data source '{data_source}'. "
-            "Valid values are 'igpp', 'gebco', 'gebcosi', and 'synbath'."
+        raise GMTValueError(
+            data_source,
+            description="earth relief data source",
+            choices=["igpp", "gebco", "gebcosi", "synbath"],
         )
-        raise GMTInvalidInput(msg)
     # Use SRTM or not.
     if use_srtm and resolution in land_only_srtm_resolutions:
         if data_source != "igpp":

--- a/pygmt/datasets/earth_relief.py
+++ b/pygmt/datasets/earth_relief.py
@@ -167,7 +167,7 @@ def load_earth_relief(
                 description="data source",
                 reason=(
                     "Option 'use_srtm=True' doesn't work with data source "
-                    f"{data_source!r}. Please set 'data_source' to 'igpp'.",
+                    f"{data_source!r}. Please set 'data_source' to 'igpp'."
                 ),
             )
         prefix = "srtm_relief"

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -547,7 +547,7 @@ def _load_remote_dataset(
     # Check resolution
     if resolution not in dataset.resolutions:
         raise GMTValueError(
-            value=resolution,
+            resolution,
             description=f"resolution for {dataset.description} dataset",
             choices=dataset.resolutions.keys(),
         )

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from typing import Any, Literal, NamedTuple
 
 import xarray as xr
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 
 with contextlib.suppress(ImportError):
     # rioxarray is needed to register the rio accessor
@@ -546,11 +546,11 @@ def _load_remote_dataset(
 
     # Check resolution
     if resolution not in dataset.resolutions:
-        msg = (
-            f"Invalid resolution '{resolution}' for {dataset.description} dataset. "
-            f"Available resolutions are: {', '.join(dataset.resolutions)}."
+        raise GMTValueError(
+            value=resolution,
+            description=f"resolution for {dataset.description} dataset",
+            choices=dataset.resolutions.keys(),
         )
-        raise GMTInvalidInput(msg)
     resinfo = dataset.resolutions[resolution]
 
     # Check registration
@@ -559,13 +559,15 @@ def _load_remote_dataset(
             # Use gridline registration unless only pixel registration is available
             reg = "g" if "gridline" in resinfo.registrations else "p"
         case x if x not in resinfo.registrations:
-            msg = (
-                f"Invalid grid registration '{registration}' for the {resolution} "
-                f"{dataset.description} dataset. Should be either 'pixel', 'gridline' "
-                "or None. Default is None, where a gridline-registered grid is "
-                "returned unless only the pixel-registered grid is available."
+            raise GMTValueError(
+                registration,
+                description=f"grid registration for the {resolution} {dataset.description} dataset",
+                choices=[*resinfo.registrations, None],
+                reason=(
+                    "Default is None, where a gridline-registered grid is returned "
+                    "unless only the pixel-registered grid is available."
+                ),
             )
-            raise GMTInvalidInput(msg)
         case _:
             reg = registration[0]
 

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -7,7 +7,7 @@ from typing import Literal, NamedTuple
 
 import pandas as pd
 import xarray as xr
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTValueError
 from pygmt.src import which
 
 
@@ -346,6 +346,5 @@ def load_sample_data(
     >>> data = load_sample_data("bathymetry")
     """  # noqa: W505
     if name not in datasets:
-        msg = f"Invalid dataset name '{name}'."
-        raise GMTInvalidInput(msg)
+        raise GMTValueError(name, choices=datasets.keys(), description="dataset name")
     return datasets[name].func()

--- a/pygmt/exceptions.py
+++ b/pygmt/exceptions.py
@@ -4,6 +4,9 @@ Custom exception types used throughout the library.
 All exceptions derive from GMTError.
 """
 
+from collections.abc import Iterable
+from typing import Any
+
 
 class GMTError(Exception):
     """
@@ -51,3 +54,57 @@ class GMTImageComparisonFailure(AssertionError):  # noqa: N818
     """
     Raised when a comparison between two images fails.
     """
+
+
+class GMTValueError(GMTError):
+    """
+    Raised when an invalid value is passed to a function/method.
+
+    Parameters
+    ----------
+    value
+        The invalid value.
+    description
+        The description of the value.
+    choices
+        The valid choices for the value.
+    reason
+        The detailed reason why the value is invalid.
+
+    Examples
+    --------
+    >>> raise GMTValueError("invalid")
+    Traceback (most recent call last):
+        ...
+    pygmt...GMTValueError: Invalid value: 'invalid'.
+    >>> raise GMTValueError("invalid", description="constant name")
+    Traceback (most recent call last):
+    ...
+    pygmt...GMTValueError: Invalid constant name: 'invalid'.
+    >>> raise GMTValueError("invalid", choices=["a", "b", 1, 2])
+    Traceback (most recent call last):
+        ...
+    pygmt...GMTValueError: Invalid value: 'invalid'. Expected one of: 'a', 'b', 1, 2.
+    >>> raise GMTValueError("invalid", choices=["a", 0, True, False, None])
+    Traceback (most recent call last):
+        ...
+    pygmt...GMTValueError: Invalid .... Expected one of: 'a', 0, True, False, None.
+    >>> raise GMTValueError("invalid", reason="Explain why it's invalid.")
+    Traceback (most recent call last):
+        ...
+    pygmt...GMTValueError: Invalid .... Explain why it's invalid.
+    """
+
+    def __init__(
+        self,
+        value: Any,
+        description: str = "value",
+        choices: Iterable[Any] | None = None,
+        reason: str | None = None,
+    ):
+        msg = f"Invalid {description}: {value!r}."
+        if choices:
+            msg += f" Expected one of: {', '.join(repr(c) for c in choices)}."
+        if reason:
+            msg += f" {reason}"
+        super().__init__(msg)

--- a/pygmt/exceptions.py
+++ b/pygmt/exceptions.py
@@ -89,11 +89,17 @@ class GMTValueError(GMTError):
     Traceback (most recent call last):
         ...
     pygmt...GMTValueError: Invalid .... Expected one of: 'a', 0, True, False, None.
+
+    >>> from pygmt.enums import GridType
+    >>> raise GMTValueError("invalid", choices=GridType)
+    Traceback (most recent call last):
+        ...
+    pygmt...GMTValueError: Invalid value: 'invalid'. Expected one of: <GridType.CARTESIAN: 0>, <GridType.GEOGRAPHIC: 1>.
     >>> raise GMTValueError("invalid", reason="Explain why it's invalid.")
     Traceback (most recent call last):
         ...
     pygmt...GMTValueError: Invalid .... Explain why it's invalid.
-    """
+    """  # noqa: W505
 
     def __init__(
         self,

--- a/pygmt/exceptions.py
+++ b/pygmt/exceptions.py
@@ -56,7 +56,7 @@ class GMTImageComparisonFailure(AssertionError):  # noqa: N818
     """
 
 
-class GMTValueError(GMTError):
+class GMTValueError(GMTError, ValueError):
     """
     Raised when an invalid value is passed to a function/method.
 

--- a/pygmt/exceptions.py
+++ b/pygmt/exceptions.py
@@ -76,29 +76,29 @@ class GMTValueError(GMTError):
     >>> raise GMTValueError("invalid")
     Traceback (most recent call last):
         ...
-    pygmt...GMTValueError: Invalid value: 'invalid'.
+    pygmt.exceptions.GMTValueError: Invalid value: 'invalid'.
     >>> raise GMTValueError("invalid", description="constant name")
     Traceback (most recent call last):
     ...
-    pygmt...GMTValueError: Invalid constant name: 'invalid'.
+    pygmt.exceptions.GMTValueError: Invalid constant name: 'invalid'.
     >>> raise GMTValueError("invalid", choices=["a", "b", 1, 2])
     Traceback (most recent call last):
         ...
-    pygmt...GMTValueError: Invalid value: 'invalid'. Expected one of: 'a', 'b', 1, 2.
+    pygmt.exceptions.GMTValueError: Invalid value: 'invalid'. Expected one of: 'a', 'b', 1, 2.
     >>> raise GMTValueError("invalid", choices=["a", 0, True, False, None])
     Traceback (most recent call last):
         ...
-    pygmt...GMTValueError: Invalid .... Expected one of: 'a', 0, True, False, None.
+    pygmt.exceptions.GMTValueError: Invalid value: 'invalid'. Expected one of: 'a', 0, True, False, None.
 
     >>> from pygmt.enums import GridType
     >>> raise GMTValueError("invalid", choices=GridType)
     Traceback (most recent call last):
         ...
-    pygmt...GMTValueError: Invalid value: 'invalid'. Expected one of: <GridType.CARTESIAN: 0>, <GridType.GEOGRAPHIC: 1>.
+    pygmt.exceptions.GMTValueError: Invalid value: 'invalid'. Expected one of: <GridType.CARTESIAN: 0>, <GridType.GEOGRAPHIC: 1>.
     >>> raise GMTValueError("invalid", reason="Explain why it's invalid.")
     Traceback (most recent call last):
         ...
-    pygmt...GMTValueError: Invalid .... Explain why it's invalid.
+    pygmt.exceptions.GMTValueError: Invalid value: 'invalid'. Explain why it's invalid.
     """  # noqa: W505
 
     def __init__(

--- a/pygmt/exceptions.py
+++ b/pygmt/exceptions.py
@@ -98,6 +98,7 @@ class GMTValueError(GMTError):
     def __init__(
         self,
         value: Any,
+        /,
         description: str = "value",
         choices: Iterable[Any] | None = None,
         reason: str | None = None,

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -20,7 +20,7 @@ except ImportError:
 
 import numpy as np
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 from pygmt.helpers import launch_external_viewer, unique_name
 
 
@@ -234,11 +234,15 @@ class Figure:
             case "kml":  # KML
                 kwargs["W"] = "+k"
             case "ps":
-                msg = "Extension '.ps' is not supported. Use '.eps' or '.pdf' instead."
-                raise GMTInvalidInput(msg)
+                raise GMTValueError(
+                    ext,
+                    description="file extension",
+                    reason="Extension '.ps' is not supported. Use '.eps' or '.pdf' instead.",
+                )
             case ext if ext not in fmts:
-                msg = f"Unknown extension '.{ext}'."
-                raise GMTInvalidInput(msg)
+                raise GMTValueError(
+                    ext, description="file extension", choices=fmts.keys()
+                )
 
         if transparent and ext not in {"kml", "png"}:
             msg = f"Transparency unavailable for '{ext}', only for png and kml."
@@ -249,8 +253,12 @@ class Figure:
 
         if worldfile:
             if ext in {"eps", "kml", "pdf", "tiff"}:
-                msg = f"Saving a world file is not supported for '{ext}' format."
-                raise GMTInvalidInput(msg)
+                raise GMTValueError(
+                    ext,
+                    description="file extension",
+                    choices=["eps", "kml", "pdf", "tiff"],
+                    reason="Saving a world file is not supported for this format.",
+                )
             kwargs["W"] = True
 
         # pytest-mpl v0.17.0 added the "metadata" parameter to Figure.savefig, which is
@@ -358,11 +366,11 @@ class Figure:
             case "none":
                 pass  # Do nothing
             case _:
-                msg = (
-                    f"Invalid display method '{method}'. "
-                    "Valid values are 'external', 'notebook', 'none' or None."
+                raise GMTValueError(
+                    method,
+                    description="display method",
+                    choices=["external", "notebook", "none", None],
                 )
-                raise GMTInvalidInput(msg)
 
     @overload
     def _preview(
@@ -494,8 +502,8 @@ def set_display(method: Literal["external", "notebook", "none", None] = None) ->
         case None:
             SHOW_CONFIG["method"] = _get_default_display_method()
         case _:
-            msg = (
-                f"Invalid display method '{method}'. "
-                "Valid values are 'external', 'notebook', 'none' or None."
+            raise GMTValueError(
+                method,
+                description="display method",
+                choices=["external", "notebook", "none", None],
             )
-            raise GMTInvalidInput(msg)

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -20,7 +20,7 @@ except ImportError:
 
 import numpy as np
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput, GMTValueError
+from pygmt.exceptions import GMTValueError
 from pygmt.helpers import launch_external_viewer, unique_name
 
 
@@ -245,8 +245,11 @@ class Figure:
                 )
 
         if transparent and ext not in {"kml", "png"}:
-            msg = f"Transparency unavailable for '{ext}', only for png and kml."
-            raise GMTInvalidInput(msg)
+            raise GMTValueError(
+                transparent,
+                description="value for parameter 'transparent'",
+                reason=f"Transparency unavailable for '{ext}', only for png and kml.",
+            )
         if anti_alias:
             kwargs["Qt"] = 2
             kwargs["Qg"] = 2

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -12,7 +12,7 @@ import warnings
 from inspect import Parameter, signature
 
 import numpy as np
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 from pygmt.helpers.utils import is_nonstr_iter
 
 COMMON_DOCSTRINGS = {
@@ -732,8 +732,11 @@ def kwargs_to_strings(**conversions):
 
     for arg, fmt in conversions.items():
         if fmt not in separators:
-            msg = f"Invalid conversion type '{fmt}' for argument '{arg}'."
-            raise GMTInvalidInput(msg)
+            raise GMTValueError(
+                fmt,
+                description=f"conversion type for parameter '{arg}'",
+                choices=separators.keys(),
+            )
 
     # Make the actual decorator function
     def converter(module_func):

--- a/pygmt/src/_common.py
+++ b/pygmt/src/_common.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, ClassVar, Literal
 
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 from pygmt.src.which import which
 
 
@@ -115,12 +115,12 @@ class _FocalMechanismConvention:
     >>> conv = _FocalMechanismConvention(convention="invalid")
     Traceback (most recent call last):
         ...
-    pygmt.exceptions.GMTInvalidInput: Invalid focal mechanism ...'.
+    pygmt.exceptions.GMTValueError: Invalid focal mechanism convention: ...
 
     >>> conv = _FocalMechanismConvention("mt", component="invalid")
     Traceback (most recent call last):
         ...
-    pygmt.exceptions.GMTInvalidInput: Invalid focal mechanism ...'.
+    pygmt.exceptions.GMTValueError: Invalid focal mechanism convention: ...
 
     >>> _FocalMechanismConvention.from_params(["strike", "dip", "rake"])
     Traceback (most recent call last):
@@ -198,11 +198,8 @@ class _FocalMechanismConvention:
         else:  # Convention is specified via "convention" and "component".
             name = f"{convention.upper()}_{component.upper()}"  # e.g., "AKI_DC"
             if name not in _FocalMechanismConventionCode.__members__:
-                msg = (
-                    "Invalid focal mechanism convention with "
-                    f"convention='{convention}' and component='{component}'."
-                )
-                raise GMTInvalidInput(msg)
+                _value = f"convention='{convention}', component='{component}'"
+                raise GMTValueError(_value, description="focal mechanism convention")
             self.code = _FocalMechanismConventionCode[name]
             self._convention = convention
 
@@ -287,7 +284,7 @@ def _parse_coastline_resolution(
     >>> _parse_coastline_resolution("invalid")
     Traceback (most recent call last):
     ...
-    pygmt.exceptions.GMTInvalidInput: Invalid resolution: 'invalid'. Valid values ...
+    pygmt...GMTValueError: Invalid .... Expected ....
     """
     if resolution is None:
         return None
@@ -300,7 +297,6 @@ def _parse_coastline_resolution(
     if resolution in {_res[0] for _res in _valid_res}:  # Short-form arguments.
         return resolution  # type: ignore[return-value]
 
-    msg = (
-        f"Invalid resolution: '{resolution}'. Valid values are {', '.join(_valid_res)}."
+    raise GMTValueError(
+        resolution, choices=_valid_res, description="GSHHG coastline resolution"
     )
-    raise GMTInvalidInput(msg)

--- a/pygmt/src/_common.py
+++ b/pygmt/src/_common.py
@@ -271,7 +271,7 @@ def _parse_coastline_resolution(
 
     Raises
     ------
-    GMTInvalidInput
+    GMTValueError
         If the resolution is invalid.
 
     Examples

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -7,7 +7,7 @@ from typing import Literal
 import xarray as xr
 from pygmt._typing import PathLike
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 from pygmt.helpers import (
     build_arg_list,
     data_kind,
@@ -113,8 +113,7 @@ def grdcut(
     >>> new_grid = pygmt.grdcut(grid=grid, region=[12, 15, 21, 24])
     """
     if kind not in {"grid", "image"}:
-        msg = f"Invalid raster kind: '{kind}'. Valid values are 'grid' and 'image'."
-        raise GMTInvalidInput(msg)
+        raise GMTValueError(kind, description="raster kind", choices=["grid", "image"])
 
     # Determine the output data kind based on the input data kind.
     match inkind := data_kind(grid):

--- a/pygmt/src/psconvert.py
+++ b/pygmt/src/psconvert.py
@@ -5,7 +5,7 @@ psconvert - Convert [E]PS file(s) to other formats using Ghostscript.
 from pathlib import Path
 
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTValueError
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
 
@@ -115,8 +115,11 @@ def psconvert(self, **kwargs):
 
     prefix = kwargs.get("F")
     if prefix in {"", None, False, True}:
-        msg = "The 'prefix' parameter must be specified with a valid value."
-        raise GMTInvalidInput(msg)
+        raise GMTValueError(
+            prefix,
+            description="output file name",
+            reason="Parameter 'prefix' can't be None, bool, or an empty string.",
+        )
 
     # Check if the parent directory exists
     prefix_path = Path(prefix).parent

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 import pandas as pd
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["solar"]
@@ -103,11 +103,9 @@ def solar(
 
     valid_terminators = ["day_night", "civil", "nautical", "astronomical"]
     if terminator not in valid_terminators and terminator not in "dcna":
-        msg = (
-            f"Unrecognized solar terminator type '{terminator}'. "
-            f"Valid values are {valid_terminators}."
+        raise GMTValueError(
+            terminator, description="solar terminator type", choices=valid_terminators
         )
-        raise GMTInvalidInput(msg)
     kwargs["T"] = terminator[0]
     if terminator_datetime:
         try:

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -5,7 +5,7 @@ subplot - Manage figure subplot configuration and selection.
 import contextlib
 
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 from pygmt.helpers import (
     build_arg_list,
     fmt_docstring,
@@ -148,8 +148,13 @@ def subplot(self, nrows=1, ncols=1, **kwargs):
     self._activate_figure()
 
     if nrows < 1 or ncols < 1:
-        msg = "Please ensure that both 'nrows'>=1 and 'ncols'>=1."
-        raise GMTInvalidInput(msg)
+        _value = f"{nrows=}, {ncols=}"
+        raise GMTValueError(
+            _value,
+            description="number of rows/columns",
+            reason="Expect positive integers.",
+        )
+
     if kwargs.get("Ff") and kwargs.get("Fs"):
         msg = "Please provide either one of 'figsize' or 'subsize' only."
         raise GMTInvalidInput(msg)

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -13,7 +13,7 @@ from pygmt.clib.session import FAMILIES, VIAS
 from pygmt.exceptions import (
     GMTCLibError,
     GMTCLibNoSessionError,
-    GMTInvalidInput,
+    GMTValueError,
     GMTVersionError,
 )
 
@@ -170,7 +170,7 @@ def test_parse_constant_fails():
         "NOT_A_PROPER_FAMILY|ALSO_INVALID",
     ]
     for test_case in test_cases:
-        with pytest.raises(GMTInvalidInput):
+        with pytest.raises(GMTValueError):
             lib._parse_constant(test_case, valid=FAMILIES, valid_modifiers=VIAS)
 
     # Should also fail if not given valid modifiers but is using them anyway.
@@ -179,7 +179,7 @@ def test_parse_constant_fails():
         "GMT_IS_DATASET|GMT_VIA_MATRIX", valid=FAMILIES, valid_modifiers=VIAS
     )
     # But this shouldn't.
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         lib._parse_constant(
             "GMT_IS_DATASET|GMT_VIA_MATRIX", valid=FAMILIES, valid_modifiers=None
         )

--- a/pygmt/tests/test_clib_create_data.py
+++ b/pygmt/tests/test_clib_create_data.py
@@ -4,7 +4,7 @@ Test the Session.create_data method.
 
 import pytest
 from pygmt import clib
-from pygmt.exceptions import GMTCLibError, GMTInvalidInput
+from pygmt.exceptions import GMTCLibError, GMTValueError
 from pygmt.tests.test_clib import mock
 
 
@@ -64,7 +64,7 @@ def test_create_data_fails():
     Check that create_data raises exceptions for invalid input and output.
     """
     # Passing in invalid mode
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         with clib.Session() as lib:
             lib.create_data(
                 family="GMT_IS_DATASET",
@@ -75,7 +75,7 @@ def test_create_data_fails():
                 inc=[0.1, 0.2],
             )
     # Passing in invalid geometry
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         with clib.Session() as lib:
             lib.create_data(
                 family="GMT_IS_GRID",

--- a/pygmt/tests/test_clib_virtualfiles.py
+++ b/pygmt/tests/test_clib_virtualfiles.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 from pygmt import clib
 from pygmt.clib.session import DTYPES_NUMERIC
-from pygmt.exceptions import GMTCLibError, GMTInvalidInput
+from pygmt.exceptions import GMTCLibError, GMTValueError
 from pygmt.helpers import GMTTempFile
 from pygmt.tests.test_clib import mock
 
@@ -104,6 +104,6 @@ def test_open_virtualfile_bad_direction():
             "GMT_IS_GRID",  # The invalid direction argument
             0,
         )
-        with pytest.raises(GMTInvalidInput):
+        with pytest.raises(GMTValueError):
             with lib.open_virtualfile(*vfargs):
                 pass

--- a/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_magnetic_anomaly.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 import pytest
 from pygmt.datasets import load_earth_magnetic_anomaly
 from pygmt.enums import GridRegistration
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTValueError
 
 
 def test_earth_mag_01d():
@@ -169,5 +169,5 @@ def test_earth_mag_data_source_error():
     """
     Test that an error is raised when an invalid argument is passed to 'data_source'.
     """
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         load_earth_magnetic_anomaly(resolution="01d", data_source="invalid")

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 from pygmt.clib import __gmt_version__
 from pygmt.datasets import load_earth_relief
 from pygmt.enums import GridRegistration
-from pygmt.exceptions import GMTInvalidInput, GMTValueError
+from pygmt.exceptions import GMTValueError
 
 
 # Only test 01d and 30m to avoid downloading large datasets in CI
@@ -167,7 +167,7 @@ def test_earth_relief_invalid_data_source_with_use_srtm():
     Test loading earth relief with use_srtm=True and an incompatible data_source
     argument.
     """
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         load_earth_relief(
             resolution="03s",
             region=[135, 136, 35, 36],

--- a/pygmt/tests/test_datasets_earth_relief.py
+++ b/pygmt/tests/test_datasets_earth_relief.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 from pygmt.clib import __gmt_version__
 from pygmt.datasets import load_earth_relief
 from pygmt.enums import GridRegistration
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 
 
 # Only test 01d and 30m to avoid downloading large datasets in CI
@@ -156,7 +156,7 @@ def test_earth_relief_invalid_data_source():
     """
     Test loading earth relief with invalid data_source argument.
     """
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         load_earth_relief(
             resolution="01d", registration="gridline", data_source="invalid_source"
         )

--- a/pygmt/tests/test_datasets_load_remote_datasets.py
+++ b/pygmt/tests/test_datasets_load_remote_datasets.py
@@ -5,7 +5,7 @@ Test the _load_remote_dataset function.
 import pytest
 from pygmt.datasets.load_remote_dataset import _load_remote_dataset
 from pygmt.enums import GridRegistration
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 
 
 def load_remote_dataset_wrapper(resolution="01d", region=None, registration=None):
@@ -44,7 +44,7 @@ def test_load_remote_dataset_invalid_resolutions():
     resolutions = ["1m", "1d", "bla", "60d", "001m", "03"]
     resolutions.append(60)
     for resolution in resolutions:
-        with pytest.raises(GMTInvalidInput):
+        with pytest.raises(GMTValueError):
             load_remote_dataset_wrapper(resolution=resolution)
 
 
@@ -52,7 +52,7 @@ def test_load_remote_dataset_invalid_registration():
     """
     Make sure _load_remote_dataset fails for invalid registrations.
     """
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         load_remote_dataset_wrapper(registration="improper_type")
 
 
@@ -70,7 +70,7 @@ def test_load_remote_dataset_incorrect_resolution_registration():
     Make sure _load_remote_dataset fails when trying to load a grid registration with an
     unavailable resolution.
     """
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         load_remote_dataset_wrapper(
             resolution="01m", region=[0, 1, 3, 5], registration="pixel"
         )

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -6,14 +6,14 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from pygmt.datasets import list_sample_data, load_sample_data
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTValueError
 
 
 def test_load_sample_invalid():
     """
     Check that the function raises error for unsupported filenames.
     """
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         load_sample_data(name="bad.filename")
 
 

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -12,7 +12,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 from pygmt import Figure, set_display
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 from pygmt.figure import SHOW_CONFIG, _get_default_display_method
 from pygmt.helpers import GMTTempFile
 
@@ -185,7 +185,7 @@ def test_figure_savefig_unknown_extension():
     fig = Figure()
     fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
     fname = "test_figure_savefig_unknown_extension.test"
-    with pytest.raises(GMTInvalidInput, match="Unknown extension '.test'."):
+    with pytest.raises(GMTValueError, match="Invalid file extension: 'test'."):
         fig.savefig(fname)
 
 
@@ -196,7 +196,7 @@ def test_figure_savefig_ps_extension():
     fig = Figure()
     fig.basemap(region="10/70/-300/800", projection="X3c/5c", frame="af")
     fname = "test_figure_savefig_ps_extension.ps"
-    with pytest.raises(GMTInvalidInput, match="Extension '.ps' is not supported."):
+    with pytest.raises(GMTValueError, match="Extension '.ps' is not supported."):
         fig.savefig(fname)
 
 
@@ -280,7 +280,7 @@ def test_figure_savefig_worldfile():
     # unsupported formats
     for fmt in [".eps", ".kml", ".pdf", ".tiff"]:
         with GMTTempFile(prefix="pygmt-worldfile", suffix=fmt) as imgfile:
-            with pytest.raises(GMTInvalidInput):
+            with pytest.raises(GMTValueError):
                 fig.savefig(fname=imgfile.name, worldfile=True)
 
 
@@ -313,7 +313,7 @@ def test_figure_show_invalid_method():
     """
     fig = Figure()
     fig.basemap(region="10/70/-300/800", projection="X3i/5i", frame="af")
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         fig.show(method="test")
 
 
@@ -398,7 +398,7 @@ class TestSetDisplay:
         """
         Test if an error is raised when an invalid method is passed.
         """
-        with pytest.raises(GMTInvalidInput):
+        with pytest.raises(GMTValueError):
             set_display(method="invalid")
 
 

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -12,7 +12,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 from pygmt import Figure, set_display
-from pygmt.exceptions import GMTInvalidInput, GMTValueError
+from pygmt.exceptions import GMTValueError
 from pygmt.figure import SHOW_CONFIG, _get_default_display_method
 from pygmt.helpers import GMTTempFile
 
@@ -209,7 +209,7 @@ def test_figure_savefig_transparent():
     prefix = "test_figure_savefig_transparent"
     for fmt in ["pdf", "jpg", "bmp", "eps", "tif"]:
         fname = f"{prefix}.{fmt}"
-        with pytest.raises(GMTInvalidInput):
+        with pytest.raises(GMTValueError):
             fig.savefig(fname, transparent=True)
 
     # PNG should support transparency and should not raise an error.

--- a/pygmt/tests/test_grdcut.py
+++ b/pygmt/tests/test_grdcut.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from pygmt import grdcut
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import load_static_earth_relief
 
@@ -76,5 +76,5 @@ def test_grdcut_invalid_kind(grid, region):
     """
     Check that grdcut fails with incorrect 'kind'.
     """
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         grdcut(grid, kind="invalid", region=region)

--- a/pygmt/tests/test_helpers.py
+++ b/pygmt/tests/test_helpers.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import pytest
 import xarray as xr
 from pygmt import Figure
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 from pygmt.helpers import (
     GMTTempFile,
     args_in_kwargs,
@@ -65,7 +65,7 @@ def test_kwargs_to_strings_fails():
     """
     Make sure it fails for invalid conversion types.
     """
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         kwargs_to_strings(bla="blablabla")
 
 

--- a/pygmt/tests/test_psconvert.py
+++ b/pygmt/tests/test_psconvert.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 from pygmt import Figure
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTValueError
 
 
 @pytest.mark.benchmark
@@ -47,7 +47,7 @@ def test_psconvert_without_prefix():
     Call psconvert without the 'prefix' parameter.
     """
     fig = Figure()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         fig.psconvert(fmt="g")
 
 
@@ -57,5 +57,5 @@ def test_psconvert_invalid_prefix(prefix):
     Call psconvert with an invalid 'prefix' argument.
     """
     fig = Figure()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         fig.psconvert(fmt="g", prefix=prefix)

--- a/pygmt/tests/test_solar.py
+++ b/pygmt/tests/test_solar.py
@@ -6,7 +6,7 @@ import datetime
 
 import pytest
 from pygmt import Figure
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 
 
 @pytest.mark.mpl_image_compare
@@ -69,7 +69,7 @@ def test_invalid_terminator_type():
     Test if solar fails when it receives an invalid terminator type.
     """
     fig = Figure()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         fig.solar(
             region="d",
             projection="W0/15c",

--- a/pygmt/tests/test_subplot.py
+++ b/pygmt/tests/test_subplot.py
@@ -4,7 +4,7 @@ Test Figure.subplot.
 
 import pytest
 from pygmt import Figure
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTValueError
 
 
 @pytest.mark.benchmark
@@ -99,7 +99,7 @@ def test_subplot_nrows_ncols_less_than_one_error():
     Check that an error is raised when nrows or ncols is less than one.
     """
     fig = Figure()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         with fig.subplot(nrows=0, ncols=-1, figsize=("2c", "1c")):
             pass
 

--- a/pygmt/tests/test_xarray_accessor.py
+++ b/pygmt/tests/test_xarray_accessor.py
@@ -13,7 +13,7 @@ from pygmt import which
 from pygmt.clib import __gmt_version__
 from pygmt.datasets import load_earth_relief
 from pygmt.enums import GridRegistration, GridType
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTValueError
 
 _HAS_NETCDF4 = bool(importlib.util.find_spec("netCDF4"))
 
@@ -94,13 +94,13 @@ def test_xarray_accessor_set_invalid_registration_and_gtype():
     """
     grid = xr.DataArray(data=[[0.1, 0.2], [0.3, 0.4]])
 
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         grid.gmt.registration = "2"
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         grid.gmt.registration = "pixel"
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         grid.gmt.gtype = 2
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         grid.gmt.gtype = "geographic"
 
 

--- a/pygmt/tests/test_xarray_backend.py
+++ b/pygmt/tests/test_xarray_backend.py
@@ -10,7 +10,7 @@ import numpy.testing as npt
 import pytest
 import xarray as xr
 from pygmt.enums import GridRegistration, GridType
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTValueError
 from pygmt.helpers import GMTTempFile
 
 _HAS_NETCDF4 = bool(importlib.util.find_spec("netCDF4"))
@@ -127,7 +127,7 @@ def test_xarray_backend_gmt_read_invalid_kind():
     ):
         xr.open_dataarray("nokind.nc", engine="gmt")
 
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTValueError):
         xr.open_dataarray(
             filename_or_obj="invalid.tif", engine="gmt", raster_kind="invalid"
         )

--- a/pygmt/xarray/accessor.py
+++ b/pygmt/xarray/accessor.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import xarray as xr
 from pygmt.enums import GridRegistration, GridType
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTValueError
 from pygmt.src.grdinfo import grdinfo
 
 
@@ -180,11 +180,9 @@ class GMTDataArrayAccessor:
     def registration(self, value: GridRegistration | int):
         # TODO(Python>=3.12): Simplify to `if value not in GridRegistration`.
         if value not in GridRegistration.__members__.values():
-            msg = (
-                f"Invalid grid registration: '{value}'. Should be either "
-                "GridRegistration.GRIDLINE (0) or GridRegistration.PIXEL (1)."
+            raise GMTValueError(
+                value, description="grid registration", choices=GridRegistration
             )
-            raise GMTInvalidInput(msg)
         self._registration = GridRegistration(value)
 
     @property
@@ -198,9 +196,7 @@ class GMTDataArrayAccessor:
     def gtype(self, value: GridType | int):
         # TODO(Python>=3.12): Simplify to `if value not in GridType`.
         if value not in GridType.__members__.values():
-            msg = (
-                f"Invalid grid coordinate system type: '{value}'. "
-                "Should be either GridType.CARTESIAN (0) or GridType.GEOGRAPHIC (1)."
+            raise GMTValueError(
+                value, description="grid coordinate system type", choices=GridType
             )
-            raise GMTInvalidInput(msg)
         self._gtype = GridType(value)

--- a/pygmt/xarray/backend.py
+++ b/pygmt/xarray/backend.py
@@ -8,7 +8,7 @@ from typing import Literal
 import xarray as xr
 from pygmt._typing import PathLike
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTValueError
 from pygmt.helpers import build_arg_list, kwargs_to_strings
 from pygmt.src.which import which
 from xarray.backends import BackendEntrypoint
@@ -130,8 +130,9 @@ class GMTBackendEntrypoint(BackendEntrypoint):
             [*xmin*, *xmax*, *ymin*, *ymax*] or an ISO country code.
         """
         if raster_kind not in {"grid", "image"}:
-            msg = f"Invalid raster kind: '{raster_kind}'. Valid values are 'grid' or 'image'."
-            raise GMTInvalidInput(msg)
+            raise GMTValueError(
+                raster_kind, description="raster kind", choices=["grid", "image"]
+            )
 
         with Session() as lib:
             with lib.virtualfile_out(kind=raster_kind) as voutfile:


### PR DESCRIPTION
Add new exception GMTValueError. The error message will be like

> Invalid value: 'xxx'. Expected one of: "a", "b", 0, 1. Detailed reasons explaining why it's invalid.

Address #3984 and #3707.