### PR TITLE
BREAKING: Raise GMTTypeError exception for invalid types. Previously raise GMTInvalidInput

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -283,8 +283,8 @@ All custom exceptions are derived from :class:`pygmt.exceptions.GMTError`.
     exceptions.GMTCLibError
     exceptions.GMTCLibNoSessionError
     exceptions.GMTCLibNotFoundError
-    exceptions.GMTValueError
     exceptions.GMTTypeError
+    exceptions.GMTValueError
 
 
 .. currentmodule:: pygmt

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -284,6 +284,7 @@ All custom exceptions are derived from :class:`pygmt.exceptions.GMTError`.
     exceptions.GMTCLibNoSessionError
     exceptions.GMTCLibNotFoundError
     exceptions.GMTValueError
+    exceptions.GMTTypeError
 
 
 .. currentmodule:: pygmt

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1874,7 +1874,8 @@ class Session:
                 valid_kinds += ("empty", "matrix", "vectors", "geojson")
             if kind not in valid_kinds:
                 raise GMTTypeError(
-                    type(data), reason=f"Unrecognized data type for {check_kind!r} kind."
+                    type(data),
+                    reason=f"Unrecognized data type for {check_kind!r} kind.",
                 )
 
         # Decide which virtualfile_from_ function to use

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1869,7 +1869,7 @@ class Session:
                 valid_kinds += ("empty", "matrix", "vectors", "geojson")
             if kind not in valid_kinds:
                 raise GMTTypeError(
-                    type(data), reason="Unrecognized for {check_kind!r} kind."
+                    type(data), reason=f"Unrecognized for {check_kind!r} kind."
                 )
 
         # Decide which virtualfile_from_ function to use

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -28,6 +28,7 @@ from pygmt.exceptions import (
     GMTCLibError,
     GMTCLibNoSessionError,
     GMTInvalidInput,
+    GMTTypeError,
     GMTValueError,
 )
 from pygmt.helpers import (
@@ -629,7 +630,7 @@ class Session:
 
         Raises
         ------
-        GMTInvalidInput
+        GMTTypeError
             If the ``args`` argument is not a string or a list of strings.
         GMTCLibError
             If the returned status code of the function is non-zero.
@@ -658,8 +659,10 @@ class Session:
             mode = self["GMT_MODULE_CMD"]
             argv = args.encode()
         else:
-            msg = "'args' must either be a list of strings (recommended) or a string."
-            raise GMTInvalidInput(msg)
+            raise GMTTypeError(
+                type(args),
+                reason="Parameter 'args' must either be a list of strings (recommended) or a string.",
+            )
 
         status = c_call_module(self.session_pointer, module.encode(), mode, argv)
         if status != 0:
@@ -913,9 +916,8 @@ class Session:
 
         Raises
         ------
-        GMTInvalidInput
-            If the array has the wrong number of dimensions or is an unsupported data
-            type.
+        GMTTypeError
+            If the array is an unsupported data type.
 
         Examples
         --------
@@ -939,8 +941,7 @@ class Session:
         # 1-D arrays can be numeric or text, 2-D arrays can only be numeric.
         valid_dtypes = DTYPES if ndim == 1 else DTYPES_NUMERIC
         if (dtype := array.dtype.type) not in valid_dtypes:
-            msg = f"Unsupported numpy data type '{dtype}'."
-            raise GMTInvalidInput(msg)
+            raise GMTTypeError(dtype)
         return self[DTYPES[dtype]]
 
     def put_vector(
@@ -1867,8 +1868,9 @@ class Session:
             elif check_kind == "vector":
                 valid_kinds += ("empty", "matrix", "vectors", "geojson")
             if kind not in valid_kinds:
-                msg = f"Unrecognized data type for {check_kind}: {type(data)}."
-                raise GMTInvalidInput(msg)
+                raise GMTTypeError(
+                    type(data), reason="Unrecognized for {check_kind!r} kind."
+                )
 
         # Decide which virtualfile_from_ function to use
         _virtualfile_from = {

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1874,7 +1874,7 @@ class Session:
                 valid_kinds += ("empty", "matrix", "vectors", "geojson")
             if kind not in valid_kinds:
                 raise GMTTypeError(
-                    type(data), reason=f"Unrecognized for {check_kind!r} kind."
+                    type(data), reason=f"Unrecognized data type for {check_kind!r} kind."
                 )
 
         # Decide which virtualfile_from_ function to use

--- a/pygmt/exceptions.py
+++ b/pygmt/exceptions.py
@@ -115,3 +115,18 @@ class GMTValueError(GMTError, ValueError):
         if reason:
             msg += f" {reason}"
         super().__init__(msg)
+
+
+class GMTTypeError(GMTError, TypeError):
+    """
+    Raised when an invalid type is passed to a function/method.
+
+    This exception is used to indicate that the type of an argument does not match
+    the expected type.
+    """
+
+    def __init__(self, dtype: object, /, reason: str | None = None):
+        msg = f"Unrecognized data type: {dtype!r}."
+        if reason:
+            msg += f" {reason}"
+        super().__init__(msg)

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -7,7 +7,7 @@ from typing import Literal
 import xarray as xr
 from pygmt._typing import PathLike
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput, GMTValueError
+from pygmt.exceptions import GMTTypeError, GMTValueError
 from pygmt.helpers import (
     build_arg_list,
     data_kind,
@@ -122,8 +122,7 @@ def grdcut(
         case "file":
             outkind = kind
         case _:
-            msg = f"Unsupported data type {type(grid)}."
-            raise GMTInvalidInput(msg)
+            raise GMTTypeError(type(grid))
 
     with Session() as lib:
         with (

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -6,7 +6,7 @@ import io
 
 from pygmt._typing import PathLike
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTTypeError
 from pygmt.helpers import (
     build_arg_list,
     data_kind,
@@ -91,11 +91,11 @@ def legend(
 
     kind = data_kind(spec)
     if kind not in {"empty", "file", "stringio"}:
-        msg = f"Unrecognized data type: {type(spec)}"
-        raise GMTInvalidInput(msg)
+        raise GMTTypeError(type(spec))
     if kind == "file" and is_nonstr_iter(spec):
-        msg = "Only one legend specification file is allowed."
-        raise GMTInvalidInput(msg)
+        raise GMTTypeError(
+            type(spec), reason="Only one legend specification file is allowed."
+        )
 
     with Session() as lib:
         with lib.virtualfile_in(data=spec, required=False) as vintbl:

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTTypeError
 from pygmt.helpers import (
     build_arg_list,
     data_kind,
@@ -272,8 +272,10 @@ def plot(  # noqa: PLR0912
             ("symbol", symbol),
         ]:
             if is_nonstr_iter(value):
-                msg = f"'{name}' can't be a 1-D array if 'data' is used."
-                raise GMTInvalidInput(msg)
+                raise GMTTypeError(
+                    type(value),
+                    reason=f"Parameter {name!r} can't be a 1-D array if 'data' is used.",
+                )
 
     # Set the default style if data has a geometry of Point or MultiPoint
     if kwargs.get("S") is None and _data_geometry_is_point(data, kind):

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTTypeError
 from pygmt.helpers import (
     build_arg_list,
     data_kind,
@@ -251,8 +251,10 @@ def plot3d(  # noqa: PLR0912
             ("symbol", symbol),
         ]:
             if is_nonstr_iter(value):
-                msg = f"'{name}' can't be a 1-D array if 'data' is used."
-                raise GMTInvalidInput(msg)
+                raise GMTTypeError(
+                    type(value),
+                    reason=f"Parameter {name!r} can't be a 1-D array if 'data' is used.",
+                )
 
     # Set the default style if data has a geometry of Point or MultiPoint
     if kwargs.get("S") is None and _data_geometry_is_point(data, kind):

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -259,7 +259,7 @@ def text_(  # noqa: PLR0912
             if is_nonstr_iter(arg):
                 raise GMTTypeError(
                     type(arg),
-                    reason=f"Parameter {name!r} expects a scalar value or True.",
+                    reason=f"Parameter {name!r} expects a single value or True.",
                 )
 
     with Session() as lib:

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 import numpy as np
 from pygmt._typing import AnchorCode, PathLike, StringArrayTypes, TableLike
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTTypeError
 from pygmt.helpers import (
     _check_encoding,
     build_arg_list,
@@ -257,8 +257,10 @@ def text_(  # noqa: PLR0912
 
         for arg, _, name in [*array_args, (kwargs.get("t"), "", "transparency")]:
             if is_nonstr_iter(arg):
-                msg = f"Argument of '{name}' must be a single value or True."
-                raise GMTInvalidInput(msg)
+                raise GMTTypeError(
+                    type(arg),
+                    reason=f"Parameter {name!r} expects a scalar value or True.",
+                )
 
     with Session() as lib:
         with lib.virtualfile_in(

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 from pygmt._typing import PathLike, TableLike
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTTypeError
 from pygmt.helpers import (
     build_arg_list,
     fmt_docstring,
@@ -248,11 +248,13 @@ def velo(self, data: PathLike | TableLike | None = None, **kwargs):
         raise GMTInvalidInput(msg)
 
     if isinstance(data, np.ndarray) and not pd.api.types.is_numeric_dtype(data):
-        msg = (
-            "Text columns are not supported with numpy.ndarray type inputs. "
-            "They are only supported with file or pandas.DataFrame inputs."
+        raise GMTTypeError(
+            type(data),
+            reason=(
+                "Text columns are not supported with numpy.ndarray type inputs. "
+                "They are only supported with file or pandas.DataFrame inputs."
+            ),
         )
-        raise GMTInvalidInput(msg)
 
     with Session() as lib:
         with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:

--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -10,7 +10,7 @@ from typing import Any
 import pandas as pd
 from pygmt._typing import PathLike
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTTypeError
 from pygmt.helpers import (
     build_arg_list,
     data_kind,
@@ -213,8 +213,7 @@ def x2sys_cross(
                 # Save pandas.DataFrame track data to temporary file
                 file_contexts.append(tempfile_from_dftrack(track=track, suffix=suffix))
             case _:
-                msg = f"Unrecognized data type: {type(track)}."
-                raise GMTInvalidInput(msg)
+                raise GMTTypeError(type(track))
 
     with Session() as lib:
         with lib.virtualfile_out(kind="dataset", fname=outfile) as vouttbl:

--- a/pygmt/tests/test_blockm.py
+++ b/pygmt/tests/test_blockm.py
@@ -11,7 +11,7 @@ import pytest
 import xarray as xr
 from pygmt import blockmean, blockmode
 from pygmt.datasets import load_sample_data
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTTypeError
 from pygmt.helpers import GMTTempFile
 
 
@@ -68,7 +68,7 @@ def test_blockmean_wrong_kind_of_input_table_grid(dataframe):
     Run blockmean using table input that is not a pandas.DataFrame or file but a grid.
     """
     invalid_table = dataframe.bathymetry.to_xarray()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         blockmean(data=invalid_table, spacing="5m", region=[245, 255, 20, 30])
 
 

--- a/pygmt/tests/test_blockmedian.py
+++ b/pygmt/tests/test_blockmedian.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 from pygmt import blockmedian
 from pygmt.datasets import load_sample_data
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTTypeError
 from pygmt.helpers import GMTTempFile
 
 
@@ -65,7 +65,7 @@ def test_blockmedian_wrong_kind_of_input_table_grid(dataframe):
     Run blockmedian using table input that is not a pandas.DataFrame or file but a grid.
     """
     invalid_table = dataframe.bathymetry.to_xarray()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         blockmedian(data=invalid_table, spacing="5m", region=[245, 255, 20, 30])
 
 

--- a/pygmt/tests/test_clib_call_module.py
+++ b/pygmt/tests/test_clib_call_module.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 from pygmt import Figure, clib
-from pygmt.exceptions import GMTCLibError, GMTInvalidInput
+from pygmt.exceptions import GMTCLibError, GMTTypeError
 from pygmt.helpers import GMTTempFile
 
 POINTS_DATA = Path(__file__).parent / "data" / "points.txt"
@@ -53,7 +53,7 @@ def test_call_module_invalid_argument_type():
     call_module only accepts a string or a list of strings as module arguments.
     """
     with clib.Session() as lib:
-        with pytest.raises(GMTInvalidInput):
+        with pytest.raises(GMTTypeError):
             lib.call_module("get", ("FONT_TITLE", "FONT_TAG"))
 
 

--- a/pygmt/tests/test_clib_put_vector.py
+++ b/pygmt/tests/test_clib_put_vector.py
@@ -225,7 +225,7 @@ def test_put_vector_invalid_dtype():
                 dim=[2, 3, 0, 0],  # ncolumns, nrows, dtype, unused
             )
             data = np.array([37, 12, 556], dtype=dtype)
-            with pytest.raises(GMTTypeError, match="Invalida data type"):
+            with pytest.raises(GMTTypeError, match="Invalid data type"):
                 lib.put_vector(dataset, column=0, vector=data)
 
 

--- a/pygmt/tests/test_clib_put_vector.py
+++ b/pygmt/tests/test_clib_put_vector.py
@@ -225,7 +225,7 @@ def test_put_vector_invalid_dtype():
                 dim=[2, 3, 0, 0],  # ncolumns, nrows, dtype, unused
             )
             data = np.array([37, 12, 556], dtype=dtype)
-            with pytest.raises(GMTTypeError, match="Invalid data type"):
+            with pytest.raises(GMTTypeError, match="Unrecognized data type"):
                 lib.put_vector(dataset, column=0, vector=data)
 
 

--- a/pygmt/tests/test_clib_put_vector.py
+++ b/pygmt/tests/test_clib_put_vector.py
@@ -10,7 +10,7 @@ import numpy.testing as npt
 import pytest
 from pygmt import clib
 from pygmt.clib.session import DTYPES_NUMERIC
-from pygmt.exceptions import GMTCLibError, GMTInvalidInput
+from pygmt.exceptions import GMTCLibError, GMTInvalidInput, GMTTypeError
 from pygmt.helpers import GMTTempFile
 
 
@@ -225,7 +225,7 @@ def test_put_vector_invalid_dtype():
                 dim=[2, 3, 0, 0],  # ncolumns, nrows, dtype, unused
             )
             data = np.array([37, 12, 556], dtype=dtype)
-            with pytest.raises(GMTInvalidInput, match="Unsupported numpy data type"):
+            with pytest.raises(GMTTypeError, match="Invalida data type"):
                 lib.put_vector(dataset, column=0, vector=data)
 
 

--- a/pygmt/tests/test_grd2cpt.py
+++ b/pygmt/tests/test_grd2cpt.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 from pygmt import Figure, grd2cpt
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTTypeError
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import load_static_earth_relief
 
@@ -62,7 +62,7 @@ def test_grd2cpt_unrecognized_data_type():
     """
     Test that an error will be raised if an invalid data type is passed to grid.
     """
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         grd2cpt(grid=0)
 
 

--- a/pygmt/tests/test_grdcontour.py
+++ b/pygmt/tests/test_grdcontour.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from pygmt import Figure
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTTypeError
 from pygmt.helpers.testing import load_static_earth_relief
 
 TEST_CONTOUR_FILE = Path(__file__).parent / "data" / "contours.txt"
@@ -123,5 +123,5 @@ def test_grdcontour_fails():
     Should fail for unrecognized input.
     """
     fig = Figure()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.grdcontour(np.arange(20).reshape((4, 5)))

--- a/pygmt/tests/test_grdcut.py
+++ b/pygmt/tests/test_grdcut.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from pygmt import grdcut
-from pygmt.exceptions import GMTInvalidInput, GMTValueError
+from pygmt.exceptions import GMTTypeError, GMTValueError
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import load_static_earth_relief
 
@@ -68,7 +68,7 @@ def test_grdcut_fails():
     """
     Check that grdcut fails correctly.
     """
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         grdcut(np.arange(10).reshape((5, 2)))
 
 

--- a/pygmt/tests/test_grdfilter.py
+++ b/pygmt/tests/test_grdfilter.py
@@ -9,7 +9,7 @@ import pytest
 import xarray as xr
 from pygmt import grdfilter
 from pygmt.enums import GridRegistration, GridType
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTTypeError
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import load_static_earth_relief
 
@@ -79,5 +79,5 @@ def test_grdfilter_fails():
     """
     Check that grdfilter fails correctly.
     """
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         grdfilter(np.arange(10).reshape((5, 2)))

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -10,7 +10,7 @@ from pygmt import Figure
 from pygmt.clib import __gmt_version__
 from pygmt.datasets import load_earth_relief
 from pygmt.enums import GridRegistration, GridType
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTTypeError
 from pygmt.helpers.testing import check_figures_equal
 
 
@@ -156,7 +156,7 @@ def test_grdimage_fails():
     Should fail for unrecognized input.
     """
     fig = Figure()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.grdimage(np.arange(20).reshape((4, 5)))
 
 

--- a/pygmt/tests/test_grdinfo.py
+++ b/pygmt/tests/test_grdinfo.py
@@ -5,7 +5,7 @@ Test pygmt.grdinfo.
 import numpy as np
 import pytest
 from pygmt import grdinfo
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTTypeError
 from pygmt.helpers.testing import load_static_earth_relief
 
 
@@ -30,7 +30,7 @@ def test_grdinfo_fails():
     """
     Check that grdinfo fails correctly.
     """
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         grdinfo(np.arange(10).reshape((5, 2)))
 
 

--- a/pygmt/tests/test_grdtrack.py
+++ b/pygmt/tests/test_grdtrack.py
@@ -9,7 +9,7 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from pygmt import grdtrack
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTTypeError
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import load_static_earth_relief
 
@@ -129,7 +129,7 @@ def test_grdtrack_wrong_kind_of_points_input(dataarray, dataframe):
     Run grdtrack using points input that is not a pandas.DataFrame or file.
     """
     invalid_points = dataframe.longitude.to_xarray()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         grdtrack(points=invalid_points, grid=dataarray, newcolname="bathymetry")
 
 
@@ -138,7 +138,7 @@ def test_grdtrack_wrong_kind_of_grid_input(dataarray, dataframe):
     Run grdtrack using grid input that is not an xarray.DataArray or file.
     """
     invalid_grid = dataarray.to_dataset()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         grdtrack(points=dataframe, grid=invalid_grid, newcolname="bathymetry")
 
 

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -4,7 +4,7 @@ Test Figure.grdview.
 
 import pytest
 from pygmt import Figure, grdcut
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTTypeError
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import load_static_earth_relief
 
@@ -59,7 +59,7 @@ def test_grdview_wrong_kind_of_grid(xrgrid):
     """
     dataset = xrgrid.to_dataset()  # convert xarray.DataArray to xarray.Dataset
     fig = Figure()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.grdview(grid=dataset)
 
 
@@ -237,5 +237,5 @@ def test_grdview_wrong_kind_of_drapegrid(xrgrid):
     """
     dataset = xrgrid.to_dataset()  # convert xarray.DataArray to xarray.Dataset
     fig = Figure()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.grdview(grid=xrgrid, drapegrid=dataset)

--- a/pygmt/tests/test_info.py
+++ b/pygmt/tests/test_info.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 from pygmt import info
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTTypeError
 from pygmt.helpers.testing import skip_if_no
 
 POINTS_DATA = Path(__file__).parent / "data" / "points.txt"
@@ -245,7 +245,7 @@ def test_info_fails():
     Make sure info raises an exception if not given either a file name, pandas
     DataFrame, or numpy ndarray.
     """
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         info(data=xr.DataArray(21))
 
 

--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 from pygmt import Figure
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTTypeError
 from pygmt.helpers import GMTTempFile
 
 
@@ -121,8 +121,8 @@ def test_legend_fails():
     Test legend fails with invalid spec.
     """
     fig = Figure()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.legend(spec=["@Table_5_11.txt"])
 
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.legend(spec=[1, 2])

--- a/pygmt/tests/test_nearneighbor.py
+++ b/pygmt/tests/test_nearneighbor.py
@@ -11,7 +11,7 @@ import xarray as xr
 from pygmt import nearneighbor
 from pygmt.datasets import load_sample_data
 from pygmt.enums import GridRegistration, GridType
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTTypeError
 from pygmt.helpers import GMTTempFile
 
 
@@ -62,7 +62,7 @@ def test_nearneighbor_wrong_kind_of_input(ship_data):
     Run nearneighbor using grid input that is not file/matrix/vectors.
     """
     data = ship_data.bathymetry.to_xarray()  # convert pandas.Series to xarray.DataArray
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         nearneighbor(
             data=data, spacing="5m", region=[245, 255, 20, 30], search_radius="10m"
         )

--- a/pygmt/tests/test_plot.py
+++ b/pygmt/tests/test_plot.py
@@ -10,7 +10,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 from pygmt import Figure, which
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTTypeError
 from pygmt.helpers import GMTTempFile
 
 POINTS_DATA = Path(__file__).parent / "data" / "points.txt"
@@ -98,15 +98,15 @@ def test_plot_fail_1d_array_with_data(data, region):
     """
     fig = Figure()
     kwargs = {"data": data, "region": region, "projection": "X10c", "frame": "afg"}
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.plot(style="c0.2c", fill=data[:, 2], **kwargs)
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.plot(style="cc", size=data[:, 2], fill="red", **kwargs)
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.plot(style="c0.2c", fill="red", intensity=data[:, 2], **kwargs)
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.plot(style="c0.2c", fill="red", transparency=data[:, 2] * 100, **kwargs)
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.plot(style="0.2c", fill="red", symbol=["c"] * data.shape[0], **kwargs)
 
 

--- a/pygmt/tests/test_plot3d.py
+++ b/pygmt/tests/test_plot3d.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from pygmt import Figure
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTTypeError
 from pygmt.helpers import GMTTempFile
 
 POINTS_DATA = Path(__file__).parent / "data" / "points.txt"
@@ -78,13 +78,13 @@ def test_plot3d_fail_1d_array_with_data(data, region):
     """
     fig = Figure()
     kwargs = {"data": data, "region": region, "projection": "X10c", "frame": "afg"}
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.plot3d(style="c0.2c", fill=data[:, 2], **kwargs)
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.plot3d(style="cc", size=data[:, 2], fill="red", **kwargs)
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.plot3d(style="cc", intensity=data[:, 2], fill="red", **kwargs)
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.plot3d(style="cc", fill="red", transparency=data[:, 2] * 100, **kwargs)
 
 

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -9,7 +9,7 @@ import pytest
 import xarray as xr
 from pygmt import surface, which
 from pygmt.enums import GridRegistration, GridType
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTTypeError
 from pygmt.helpers import GMTTempFile
 
 
@@ -126,7 +126,7 @@ def test_surface_wrong_kind_of_input(data, region, spacing):
     Run surface using grid input that is not file/matrix/vectors.
     """
     data = data.z.to_xarray()  # convert pandas.Series to xarray.DataArray
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         surface(data=data, spacing=spacing, region=region)
 
 

--- a/pygmt/tests/test_triangulate.py
+++ b/pygmt/tests/test_triangulate.py
@@ -10,7 +10,7 @@ import pytest
 import xarray as xr
 from pygmt import triangulate, which
 from pygmt.enums import GridRegistration, GridType
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTTypeError
 from pygmt.helpers import GMTTempFile
 
 
@@ -94,7 +94,7 @@ def test_delaunay_triples_wrong_kind_of_input(dataframe):
     Run triangulate.delaunay_triples using grid input that is not file/matrix/vectors.
     """
     data = dataframe.z.to_xarray()  # convert pandas.Series to xarray.DataArray
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         triangulate.delaunay_triples(data=data)
 
 

--- a/pygmt/tests/test_velo.py
+++ b/pygmt/tests/test_velo.py
@@ -5,7 +5,7 @@ Test Figure.velo.
 import pandas as pd
 import pytest
 from pygmt import Figure
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTInvalidInput, GMTTypeError
 
 
 @pytest.fixture(scope="module", name="dataframe")
@@ -47,7 +47,7 @@ def test_velo_numpy_array_text_column(dataframe):
     Check that velo fails when plotting a numpy.ndarray with a text column.
     """
     fig = Figure()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.velo(
             data=dataframe.to_numpy(),
             spec="e0.2/0.39/18",

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -16,7 +16,7 @@ from packaging.version import Version
 from pygmt import config, x2sys_cross, x2sys_init
 from pygmt.clib import __gmt_version__
 from pygmt.datasets import load_sample_data
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTTypeError
 
 
 @pytest.fixture(name="mock_x2sys_home")
@@ -239,11 +239,11 @@ def test_x2sys_cross_input_two_filenames():
 
 def test_x2sys_cross_invalid_tracks_input_type(tracks):
     """
-    Run x2sys_cross using tracks input that is not a pandas.DataFrame or str type,
-    which would raise a GMTInvalidInput error.
+    Run x2sys_cross using tracks input that is not a pandas.DataFrame or str type, which
+    would raise GMTTypeError.
     """
     invalid_tracks = tracks[0].to_xarray().z
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         x2sys_cross(tracks=[invalid_tracks])
 
 


### PR DESCRIPTION
Following PR #3985. Addressing #3707 and #3984.

This PR adds a new exception `GMTTypeError`. The error message is like:

> Unrecognized data type: xxxx. Explain the reason.