### PR TITLE
Regression test to ensure gmt accessor info is kept after file deletion

### DIFF
--- a/pygmt/tests/test_xarray_backend.py
+++ b/pygmt/tests/test_xarray_backend.py
@@ -9,6 +9,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 import xarray as xr
+from pygmt.clib import Session
 from pygmt.enums import GridRegistration, GridType
 from pygmt.exceptions import GMTValueError
 from pygmt.helpers import GMTTempFile
@@ -36,6 +37,28 @@ def test_xarray_backend_load_dataarray():
         assert dataarray.gmt.registration is GridRegistration.PIXEL
         # ensure data array can be saved back to a NetCDF file
         dataarray.to_netcdf(tmpfile.name)
+
+
+def test_xarray_backend_load_dataarray_temp_nc_grid():
+    """
+    Check that xarray.load_dataarray works to read a temporary netCDF grid, and ensure
+    that GMTDataArrayAccessor information is retained after original file is deleted.
+
+    This is a regression test for
+    https://github.com/GenericMappingTools/pygmt/issues/4005
+    """
+
+    with Session() as lib:
+        with GMTTempFile(suffix=".nc") as tmpfile:
+            args = f"@earth_relief_01d_g -T -G{tmpfile.name}"  # change from gridline to pixel registration
+            lib.call_module(module="grdedit", args=args)
+            dataarray = xr.load_dataarray(
+                tmpfile.name, engine="gmt", raster_kind="grid"
+            )
+
+        # Ensure GMTDataArrayAccessor info is preserved after tempfile is deleted
+        assert dataarray.gmt.registration is GridRegistration.PIXEL
+        assert dataarray.gmt.gtype is GridType.CARTESIAN
 
 
 def test_xarray_backend_gmt_open_nc_grid():


### PR DESCRIPTION
**Description of proposed changes**

Ensure that using `load_dataarray/open_dataarray(..., engine="gmt", ...)` caches the `GMTDataArrayAccessor` info, so that the correct registration/gtype is returned even if the original source NetCDF file is deleted.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

TODO:
- [x] Add regression test
- [ ] Fix bug by caching the accessor values properly

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #4005

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
