### PR TITLE
Fix failing test with the upcoming pandas 3.0 dev

### DIFF
--- a/pygmt/tests/test_datatypes_dataset.py
+++ b/pygmt/tests/test_datatypes_dataset.py
@@ -29,6 +29,7 @@ def dataframe_from_pandas(filepath_or_buffer, sep=r"\s+", comment="#", header=No
     # string columns and combine them into a single string column.
     # For pandas<3.0, string columns have dtype="object".
     # For pandas>=3.0, string columns have dtype="str".
+    # TODO(pandas>=3.0): Remove the pandas version check.
     dtype = "object" if Version(pd.__version__) < Version("3.0.0.dev0") else "str"
     string_columns = df.select_dtypes(include=[dtype]).columns
     if len(string_columns) > 1:


### PR DESCRIPTION
The GMT Dev tests are failing recently (https://github.com/GenericMappingTools/pygmt/actions/runs/16459150298/job/46522841380).

```
    def test_dataset():
        """
        Test the basic functionality of GMT_DATASET.
        """
        with GMTTempFile(suffix=".txt") as tmpfile:
            with Path(tmpfile.name).open(mode="w", encoding="utf-8") as fp:
                print(">", file=fp)
                print("1.0 2.0 3.0 TEXT1 TEXT23", file=fp)
                print("4.0 5.0 6.0 TEXT4 TEXT567", file=fp)
                print(">", file=fp)
                print("7.0 8.0 9.0 TEXT8 TEXT90", file=fp)
                print("10.0 11.0 12.0 TEXT123 TEXT456789", file=fp)
    
            df = dataframe_from_gmt(tmpfile.name)
            expected_df = dataframe_from_pandas(tmpfile.name, comment=">")
>           pd.testing.assert_frame_equal(df, expected_df)
E           AssertionError: DataFrame are different
E           
E           DataFrame shape mismatch
E           [left]:  (4, 4)
E           [right]: (4, 5)
```
Above is a failing test. By default, pandas reads text strings with whitespaces as multiple columns, but GMT concatenates all trailing text as a single string column. So, in the `dataframe_from_pandas` function, we try to find all string columns by `df.select_dtypes(include=["object"]).columns` and combine them into a single string column. This line doesn't work for pandas>=3.0, because string columns have `dtype="str"` in pandas>=3.0 but have `dtype="object"` in pandas<3. See https://pandas.pydata.org/docs/user_guide/migration-3-strings.html for details if interested.

This can be verified below with pandas 3.0-dev:
```
In [1]: import pandas as pd

In [2]: df = pd.read_csv("data.txt", sep=r"\s+", comment=">")

In [3]: df
Out[3]: 
    1.0   2.0   3.0    TEXT1      TEXT23
0   4.0   5.0   6.0    TEXT4     TEXT567
1   7.0   8.0   9.0    TEXT8      TEXT90
2  10.0  11.0  12.0  TEXT123  TEXT456789

In [4]: df.dtypes
Out[4]: 
1.0       float64
2.0       float64
3.0       float64
TEXT1         str
TEXT23        str
dtype: object
```
This PR fixes the issue so that it works for both pandas 2 and 3.