### PR TITLE
Migrate the 'projection' parameter to the new alias system

### DIFF
--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -2,6 +2,7 @@
 basemap - Plot base maps and frames.
 """
 
+from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -9,7 +10,6 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
 @fmt_docstring
 @use_alias(
     R="region",
-    J="projection",
     Jz="zscale",
     JZ="zsize",
     B="frame",
@@ -24,7 +24,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
-def basemap(self, **kwargs):
+def basemap(self, projection=None, **kwargs):
     r"""
     Plot base maps and frames.
 
@@ -39,6 +39,7 @@ def basemap(self, **kwargs):
     Full GMT docs at :gmt-docs:`basemap.html`.
 
     {aliases}
+       - J=projection
 
     Parameters
     ----------
@@ -83,5 +84,8 @@ def basemap(self, **kwargs):
     {transparency}
     """
     self._activate_figure()
+    aliasdict = AliasSystem(
+        J=Alias(projection, name="projection"),
+    ).merge(kwargs)
     with Session() as lib:
-        lib.call_module(module="basemap", args=build_arg_list(kwargs))
+        lib.call_module(module="basemap", args=build_arg_list(aliasdict))


### PR DESCRIPTION
This PR will migrate the `projection` parameter in all wrappers to the new alias system.

Currently, only one file is updated. I'll apply the same change to all wrappers if approved.