### PR TITLE
TYP: Use Mapping instead of dict to support dict-like objects

### DIFF
--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -5,7 +5,7 @@ Functions to convert data types into ctypes friendly formats.
 import contextlib
 import ctypes as ctp
 import warnings
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import Any
 
 import numpy as np

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -164,7 +164,7 @@ def _to_numpy(data: Any) -> np.ndarray:
         The C contiguous NumPy array.
     """
     # Mapping of unsupported dtypes to expected NumPy dtypes.
-    dtypes: Mapping[str, type | str] = {
+    dtypes: dict[str, type | str] = {
         # For string dtypes.
         "large_string": np.str_,  # pa.large_string and pa.large_utf8
         "string": np.str_,  # pa.string, pa.utf8, pd.StringDtype

--- a/pygmt/clib/conversion.py
+++ b/pygmt/clib/conversion.py
@@ -5,7 +5,7 @@ Functions to convert data types into ctypes friendly formats.
 import contextlib
 import ctypes as ctp
 import warnings
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import numpy as np
@@ -164,7 +164,7 @@ def _to_numpy(data: Any) -> np.ndarray:
         The C contiguous NumPy array.
     """
     # Mapping of unsupported dtypes to expected NumPy dtypes.
-    dtypes: dict[str, type | str] = {
+    dtypes: Mapping[str, type | str] = {
         # For string dtypes.
         "large_string": np.str_,  # pa.large_string and pa.large_utf8
         "string": np.str_,  # pa.string, pa.utf8, pd.StringDtype

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -3,7 +3,7 @@ Internal function to load GMT remote datasets.
 """
 
 import contextlib
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, Literal, NamedTuple
 
 import xarray as xr
@@ -58,8 +58,8 @@ class GMTRemoteDataset(NamedTuple):
     description: str
     kind: Literal["grid", "image"]
     units: str | None
-    resolutions: dict[str, Resolution]
-    extra_attributes: dict[str, Any]
+    resolutions: Mapping[str, Resolution]
+    extra_attributes: Mapping[str, Any]
     crs: str | None = None
 
 

--- a/pygmt/datatypes/header.py
+++ b/pygmt/datatypes/header.py
@@ -3,6 +3,7 @@ Wrapper for the GMT_GRID_HEADER data structure and related utility functions.
 """
 
 import ctypes as ctp
+from collections.abc import Mapping
 from typing import Any, ClassVar
 
 import numpy as np
@@ -199,7 +200,7 @@ class _GMT_GRID_HEADER(ctp.Structure):  # noqa: N801
         return "z"
 
     @property
-    def data_attrs(self) -> dict[str, Any]:
+    def data_attrs(self) -> Mapping[str, Any]:
         """
         Attributes for the data variable from the grid header.
         """

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -481,7 +481,7 @@ def non_ascii_to_octal(argstr: str, encoding: Encoding = "ISOLatin1+") -> str:
 
 
 def build_arg_list(  # noqa: PLR0912
-    kwdict: dict[str, Any],
+    kwdict: Mapping[str, Any],
     confdict: Mapping[str, Any] | None = None,
     infile: PathLike | Sequence[PathLike] | None = None,
     outfile: PathLike | None = None,


### PR DESCRIPTION
Static type check in https://github.com/GenericMappingTools/pygmt/actions/runs/16590102722/job/46923410788?pr=4025 reports the following error:
```
mypy pygmt
pygmt/src/directional_rose.py:65: error: Argument 1 to "build_arg_list" has incompatible type "AliasSystem"; expected "dict[str, Any]"  [arg-type]
Found 1 error in 1 file (checked 117 source files)
make: *** [Makefile:74: typecheck] Error 1
```
Although AliasSystem is a subclass of UserDict, mymy cannot recognize it correctly. This PR fixes the issue by replacing `dict` with `Mapping`, which supports more dict-like objects.