### PR TITLE
Migrate the parameter 'verbose' to the new alias system and let it support descriptive arguments

### DIFF
--- a/doc/techref/common_parameters.md
+++ b/doc/techref/common_parameters.md
@@ -24,7 +24,7 @@
 
     Choose among 7 levels of verbosity [Default is ``"warning"``]:
 
-    - ``"quite"``: Quiet, not even fatal error messages are produced
+    - ``"quiet"``: Quiet, not even fatal error messages are produced
     - ``"error"``: Error messages only
     - ``"warning"``: Warnings [Default]
     - ``"timing"``: Timings (report runtimes for time-intensive algorithms)

--- a/doc/techref/common_parameters.md
+++ b/doc/techref/common_parameters.md
@@ -28,7 +28,7 @@
     - ``"error"``: Error messages only
     - ``"warning"``: Warnings [Default]
     - ``"timing"``: Timings (report runtimes for time-intensive algorithms)
-    - ``"information"``: Informational messages (same as ``verbose=True``)
-    - ``"compatibility"``: Compatibility warnings
+    - ``"info"``: Informational messages (same as ``verbose=True``)
+    - ``"compat"``: Compatibility warnings
     - ``"debug"``: Debugging messages
 ```

--- a/doc/techref/common_parameters.md
+++ b/doc/techref/common_parameters.md
@@ -22,13 +22,13 @@
 ``verbose``
     Select verbosity level, which modulates the messages written to stderr.
 
-    Choose among 7 levels of verbosity [Default is ``"w"``]:
+    Choose among 7 levels of verbosity [Default is ``"warning"``]:
 
-    - ``"q"``: Quiet, not even fatal error messages are produced
-    - ``"e"``: Error messages only
-    - ``"w"``: Warnings [Default]
-    - ``"t"``: Timings (report runtimes for time-intensive algorithms)
-    - ``"i"``: Informational messages (same as ``verbose=True``)
-    - ``"c"``: Compatibility warnings
-    - ``"d"``: Debugging messages
+    - ``"quite"``: Quiet, not even fatal error messages are produced
+    - ``"error"``: Error messages only
+    - ``"warning"``: Warnings [Default]
+    - ``"timing"``: Timings (report runtimes for time-intensive algorithms)
+    - ``"information"``: Informational messages (same as ``verbose=True``)
+    - ``"compatibility"``: Compatibility warnings
+    - ``"debug"``: Debugging messages
 ```

--- a/pygmt/alias.py
+++ b/pygmt/alias.py
@@ -299,7 +299,7 @@ class AliasSystem(UserDict):
                         },
                     )
                 case _:
-                    raise GMTValueError(value, description="common parameter")
+                    raise GMTValueError(key, description="common parameter")
 
             self.aliasdict[key] = alias
             self[key] = alias._value

--- a/pygmt/alias.py
+++ b/pygmt/alias.py
@@ -294,8 +294,8 @@ class AliasSystem(UserDict):
                             "error": "e",
                             "warning": "w",
                             "timing": "t",
-                            "information": "i",
-                            "compatibility": "c",
+                            "info": "i",
+                            "compat": "c",
                             "debug": "d",
                         },
                     )

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -54,8 +54,8 @@ def basemap(
     Full GMT docs at :gmt-docs:`basemap.html`.
 
     {aliases}
-       - J=projection
-       - V=verbose
+       - J = projection
+       - V = verbose
 
     Parameters
     ----------

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -27,15 +27,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
 def basemap(
     self,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -2,6 +2,8 @@
 basemap - Plot base maps and frames.
 """
 
+from typing import Literal
+
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
@@ -23,7 +25,21 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
-def basemap(self, projection=None, verbose=None, **kwargs):
+def basemap(
+    self,
+    projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Plot base maps and frames.
 
@@ -86,19 +102,10 @@ def basemap(self, projection=None, verbose=None, **kwargs):
     self._activate_figure()
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-        V=Alias(
-            verbose,
-            name="verbose",
-            mapping={
-                "quiet": "q",
-                "error": "e",
-                "warning": "w",
-                "timing": "t",
-                "information": "i",
-                "compatibility": "c",
-                "debug": "d",
-            },
-        ),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         lib.call_module(module="basemap", args=build_arg_list(aliasdict))

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -17,14 +17,13 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     F="box",
     Td="rose",
     Tm="compass",
-    V="verbose",
     c="panel",
     f="coltypes",
     p="perspective",
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
-def basemap(self, projection=None, **kwargs):
+def basemap(self, projection=None, verbose=None, **kwargs):
     r"""
     Plot base maps and frames.
 
@@ -40,6 +39,7 @@ def basemap(self, projection=None, **kwargs):
 
     {aliases}
        - J=projection
+       - V=verbose
 
     Parameters
     ----------
@@ -86,6 +86,19 @@ def basemap(self, projection=None, **kwargs):
     self._activate_figure()
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
+        V=Alias(
+            verbose,
+            name="verbose",
+            mapping={
+                "quiet": "q",
+                "error": "e",
+                "warning": "w",
+                "timing": "t",
+                "information": "i",
+                "compatibility": "c",
+                "debug": "d",
+            },
+        ),
     ).merge(kwargs)
     with Session() as lib:
         lib.call_module(module="basemap", args=build_arg_list(aliasdict))

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -18,7 +18,6 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     N="normalize",
     R="region",
     S="search_radius",
-    V="verbose",
     W="weight",
     a="aspatial",
     b="binary",
@@ -49,6 +48,16 @@ def binstats(
         "sum",
     ] = "number",
     quantile_value: float = 50,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:
     r"""
@@ -66,6 +75,7 @@ def binstats(
 
     {aliases}
        - C = statistic
+       - V = verbose
 
     Parameters
     ----------
@@ -151,7 +161,10 @@ def binstats(
                 "sum": "z",
             },
         ),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
     if statistic == "quantile":
         aliasdict["C"] += f"{quantile_value}"
 

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -48,15 +48,7 @@ def binstats(
         "sum",
     ] = "number",
     quantile_value: float = 50,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -7,6 +7,7 @@ from typing import Literal
 import numpy as np
 import pandas as pd
 from pygmt._typing import PathLike, TableLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_list,
@@ -74,7 +75,6 @@ def _blockm(
     I="spacing",
     R="region",
     S="summary",
-    V="verbose",
     a="aspatial",
     b="binary",
     d="nodata",
@@ -94,6 +94,16 @@ def blockmean(
     z=None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""
@@ -111,6 +121,7 @@ def blockmean(
     Full GMT docs at :gmt-docs:`blockmean.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -162,6 +173,11 @@ def blockmean(
     >>> # Calculate block mean values within 5 by 5 arc-minute bins
     >>> data_bmean = pygmt.blockmean(data=data, region=[245, 255, 20, 30], spacing="5m")
     """
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     return _blockm(
         block_method="blockmean",
         data=data,
@@ -170,7 +186,7 @@ def blockmean(
         z=z,
         output_type=output_type,
         outfile=outfile,
-        **kwargs,
+        **aliasdict,
     )
 
 
@@ -178,7 +194,6 @@ def blockmean(
 @use_alias(
     I="spacing",
     R="region",
-    V="verbose",
     a="aspatial",
     b="binary",
     d="nodata",
@@ -198,6 +213,16 @@ def blockmedian(
     z=None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""
@@ -215,6 +240,7 @@ def blockmedian(
     Full GMT docs at :gmt-docs:`blockmedian.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -260,6 +286,11 @@ def blockmedian(
     ...     data=data, region=[245, 255, 20, 30], spacing="5m"
     ... )
     """
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     return _blockm(
         block_method="blockmedian",
         data=data,
@@ -268,7 +299,7 @@ def blockmedian(
         z=z,
         output_type=output_type,
         outfile=outfile,
-        **kwargs,
+        **aliasdict,
     )
 
 
@@ -276,7 +307,6 @@ def blockmedian(
 @use_alias(
     I="spacing",
     R="region",
-    V="verbose",
     a="aspatial",
     b="binary",
     d="nodata",
@@ -296,6 +326,16 @@ def blockmode(
     z=None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""
@@ -313,6 +353,7 @@ def blockmode(
     Full GMT docs at :gmt-docs:`blockmode.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -356,6 +397,11 @@ def blockmode(
     >>> # Calculate block mode values within 5 by 5 arc-minute bins
     >>> data_bmode = pygmt.blockmode(data=data, region=[245, 255, 20, 30], spacing="5m")
     """
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     return _blockm(
         block_method="blockmode",
         data=data,
@@ -364,5 +410,5 @@ def blockmode(
         z=z,
         output_type=output_type,
         outfile=outfile,
-        **kwargs,
+        **aliasdict,
     )

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -94,15 +94,7 @@ def blockmean(
     z=None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
@@ -213,15 +205,7 @@ def blockmedian(
     z=None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
@@ -326,15 +310,7 @@ def blockmode(
     z=None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -42,15 +42,7 @@ def coast(
     resolution: Literal[
         "auto", "full", "high", "intermediate", "low", "crude", None
     ] = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -31,7 +31,6 @@ __doctest_skip__ = ["coast"]
     N="borders",
     R="region",
     S="water",
-    V="verbose",
     W="shorelines",
     c="panel",
     p="perspective",

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -44,6 +44,16 @@ def coast(
     resolution: Literal[
         "auto", "full", "high", "intermediate", "low", "crude", None
     ] = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ):
     r"""
@@ -66,8 +76,9 @@ def coast(
     Full GMT docs at :gmt-docs:`coast.html`.
 
     {aliases}
-       - D=resolution
-       - J=projection
+       - D = resolution
+       - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -227,7 +238,10 @@ def coast(
             },
         ),
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         lib.call_module(module="coast", args=build_arg_list(aliasdict))

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -2,6 +2,8 @@
 colorbar - Plot gray scale or color scale bar.
 """
 
+from typing import Literal
+
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
@@ -20,7 +22,6 @@ __doctest_skip__ = ["colorbar"]
     L="equalsize",
     Q="log",
     R="region",
-    V="verbose",
     W="scale",
     Z="zfile",
     c="panel",
@@ -30,7 +31,21 @@ __doctest_skip__ = ["colorbar"]
 @kwargs_to_strings(
     R="sequence", G="sequence", I="sequence", c="sequence_comma", p="sequence"
 )
-def colorbar(self, projection=None, **kwargs):
+def colorbar(
+    self,
+    projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Plot gray scale or color scale bar.
 
@@ -46,6 +61,7 @@ def colorbar(self, projection=None, **kwargs):
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -149,6 +165,10 @@ def colorbar(self, projection=None, **kwargs):
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         lib.call_module(module="colorbar", args=build_arg_list(aliasdict))

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -31,15 +31,7 @@ __doctest_skip__ = ["colorbar"]
 def colorbar(
     self,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -2,6 +2,8 @@
 contour - Contour table data by direct triangulation.
 """
 
+from typing import Literal
+
 from pygmt._typing import PathLike, TableLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
@@ -24,7 +26,6 @@ from pygmt.helpers import (
     N="no_clip",
     R="region",
     S="skip",
-    V="verbose",
     W="pen",
     b="binary",
     c="panel",
@@ -45,6 +46,16 @@ def contour(
     y=None,
     z=None,
     projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ):
     r"""
@@ -59,6 +70,7 @@ def contour(
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -155,7 +167,10 @@ def contour(
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with lib.virtualfile_in(

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -45,15 +45,7 @@ def contour(
     y=None,
     z=None,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -26,15 +26,7 @@ __doctest_skip__ = ["dimfilter"]
 def dimfilter(
     grid: PathLike | xr.DataArray,
     outgrid: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -2,8 +2,11 @@
 dimfilter - Directional filtering of grids in the space domain.
 """
 
+from typing import Literal
+
 import xarray as xr
 from pygmt._typing import PathLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
@@ -18,11 +21,22 @@ __doctest_skip__ = ["dimfilter"]
     I="spacing",
     N="sectors",
     R="region",
-    V="verbose",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
 def dimfilter(
-    grid: PathLike | xr.DataArray, outgrid: PathLike | None = None, **kwargs
+    grid: PathLike | xr.DataArray,
+    outgrid: PathLike | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
 ) -> xr.DataArray | None:
     r"""
     Directional filtering of grids in the space domain.
@@ -46,6 +60,7 @@ def dimfilter(
     Full GMT docs at :gmt-docs:`dimfilter.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -143,13 +158,19 @@ def dimfilter(
             "distance, filters, or sectors."
         )
         raise GMTInvalidInput(msg)
+
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with (
             lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
             lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
         ):
-            kwargs["G"] = voutgrd
+            aliasdict["G"] = voutgrd
             lib.call_module(
-                module="dimfilter", args=build_arg_list(kwargs, infile=vingrd)
+                module="dimfilter", args=build_arg_list(aliasdict, infile=vingrd)
             )
             return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/filter1d.py
+++ b/pygmt/src/filter1d.py
@@ -7,6 +7,7 @@ from typing import Literal
 import numpy as np
 import pandas as pd
 from pygmt._typing import PathLike, TableLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -18,15 +19,21 @@ from pygmt.helpers import (
 
 
 @fmt_docstring
-@use_alias(
-    E="end",
-    F="filter_type",
-    N="time_col",
-)
+@use_alias(E="end", F="filter_type", N="time_col")
 def filter1d(
     data: PathLike | TableLike,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""
@@ -43,6 +50,7 @@ def filter1d(
     Full GMT docs at :gmt-docs:`filter1d.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -117,6 +125,11 @@ def filter1d(
 
     output_type = validate_output_table_type(output_type, outfile=outfile)
 
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with (
             lib.virtualfile_in(check_kind="vector", data=data) as vintbl,
@@ -124,6 +137,6 @@ def filter1d(
         ):
             lib.call_module(
                 module="filter1d",
-                args=build_arg_list(kwargs, infile=vintbl, outfile=vouttbl),
+                args=build_arg_list(aliasdict, infile=vintbl, outfile=vouttbl),
             )
         return lib.virtualfile_to_dataset(vfname=vouttbl, output_type=output_type)

--- a/pygmt/src/filter1d.py
+++ b/pygmt/src/filter1d.py
@@ -24,15 +24,7 @@ def filter1d(
     data: PathLike | TableLike,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -2,8 +2,11 @@
 grd2cpt - Make linear or histogram-equalized color palette table from grid.
 """
 
+from typing import Literal
+
 import xarray as xr
 from pygmt._typing import PathLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
@@ -27,13 +30,25 @@ __doctest_skip__ = ["grd2cpt"]
     Q="log",
     R="region",
     T="series",
-    V="verbose",
     W="categorical",
     Ww="cyclic",
     Z="continuous",
 )
 @kwargs_to_strings(G="sequence", L="sequence", R="sequence", T="sequence")
-def grd2cpt(grid: PathLike | xr.DataArray, **kwargs):
+def grd2cpt(
+    grid: PathLike | xr.DataArray,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Make linear or histogram-equalized color palette table from grid.
 
@@ -190,9 +205,14 @@ def grd2cpt(grid: PathLike | xr.DataArray, **kwargs):
     if (output := kwargs.pop("H", None)) is not None:
         kwargs["H"] = True
 
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
             lib.call_module(
                 module="grd2cpt",
-                args=build_arg_list(kwargs, infile=vingrd, outfile=output),
+                args=build_arg_list(aliasdict, infile=vingrd, outfile=output),
             )

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -37,15 +37,7 @@ __doctest_skip__ = ["grd2cpt"]
 @kwargs_to_strings(G="sequence", L="sequence", R="sequence", T="sequence")
 def grd2cpt(
     grid: PathLike | xr.DataArray,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ):

--- a/pygmt/src/grd2xyz.py
+++ b/pygmt/src/grd2xyz.py
@@ -40,15 +40,7 @@ def grd2xyz(
     grid: PathLike | xr.DataArray,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:

--- a/pygmt/src/grd2xyz.py
+++ b/pygmt/src/grd2xyz.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from pygmt._typing import PathLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTValueError
 from pygmt.helpers import (
@@ -25,7 +26,6 @@ __doctest_skip__ = ["grd2xyz"]
 @use_alias(
     C="cstyle",
     R="region",
-    V="verbose",
     W="weight",
     Z="convention",
     b="binary",
@@ -40,6 +40,16 @@ def grd2xyz(
     grid: PathLike | xr.DataArray,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""
@@ -51,6 +61,7 @@ def grd2xyz(
     Full GMT docs at :gmt-docs:`grd2xyz.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -157,6 +168,11 @@ def grd2xyz(
         # Reverse the dims because it is rows, columns ordered.
         column_names = [str(grid.dims[1]), str(grid.dims[0]), str(grid.name)]
 
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with (
             lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
@@ -164,7 +180,7 @@ def grd2xyz(
         ):
             lib.call_module(
                 module="grd2xyz",
-                args=build_arg_list(kwargs, infile=vingrd, outfile=vouttbl),
+                args=build_arg_list(aliasdict, infile=vingrd, outfile=vouttbl),
             )
             return lib.virtualfile_to_dataset(
                 vfname=vouttbl, output_type=output_type, column_names=column_names

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -33,15 +33,7 @@ def grdclip(
     below: Sequence[float] | None = None,
     between: Sequence[float] | Sequence[Sequence[float]] | None = None,
     replace: Sequence[float] | Sequence[Sequence[float]] | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -3,6 +3,7 @@ grdclip - Clip the range of grid values.
 """
 
 from collections.abc import Sequence
+from typing import Literal
 
 import xarray as xr
 from pygmt._typing import PathLike
@@ -32,6 +33,16 @@ def grdclip(
     below: Sequence[float] | None = None,
     between: Sequence[float] | Sequence[Sequence[float]] | None = None,
     replace: Sequence[float] | Sequence[Sequence[float]] | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:
     """
@@ -56,6 +67,7 @@ def grdclip(
        - Sb = below
        - Si = between
        - Sr = replace
+       - V = verbose
 
     Parameters
     ----------
@@ -120,7 +132,10 @@ def grdclip(
         Sb=Alias(below, name="below", sep="/", size=2),
         Si=Alias(between, name="between", sep="/", size=3, ndim=2),
         Sr=Alias(replace, name="replace", sep="/", size=2, ndim=2),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with (

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -24,7 +24,7 @@ __doctest_skip__ = ["grdclip"]
 # TODO(PyGMT>=0.19.0): Remove the deprecated "new" parameter.
 @fmt_docstring
 @deprecate_parameter("new", "replace", "v0.15.0", remove_version="v0.19.0")
-@use_alias(R="region", V="verbose")
+@use_alias(R="region")
 @kwargs_to_strings(R="sequence")
 def grdclip(
     grid: PathLike | xr.DataArray,

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -2,6 +2,8 @@
 grdcontour - Make contour map using a grid.
 """
 
+from typing import Literal
+
 import xarray as xr
 from pygmt._typing import PathLike
 from pygmt.alias import Alias, AliasSystem
@@ -29,7 +31,6 @@ __doctest_skip__ = ["grdcontour"]
     Q="cut",
     R="region",
     S="resample",
-    V="verbose",
     W="pen",
     l="label",
     c="panel",
@@ -38,7 +39,22 @@ __doctest_skip__ = ["grdcontour"]
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", L="sequence", c="sequence_comma", p="sequence")
-def grdcontour(self, grid: PathLike | xr.DataArray, projection=None, **kwargs):
+def grdcontour(
+    self,
+    grid: PathLike | xr.DataArray,
+    projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Make contour map using a grid.
 
@@ -48,6 +64,7 @@ def grdcontour(self, grid: PathLike | xr.DataArray, projection=None, **kwargs):
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -154,7 +171,10 @@ def grdcontour(self, grid: PathLike | xr.DataArray, projection=None, **kwargs):
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -42,15 +42,7 @@ def grdcontour(
     self,
     grid: PathLike | xr.DataArray,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -25,7 +25,6 @@ __doctest_skip__ = ["grdcut"]
     R="region",
     N="extend",
     S="circ_subregion",
-    V="verbose",
     Z="z_subregion",
     f="coltypes",
 )
@@ -35,6 +34,16 @@ def grdcut(
     kind: Literal["grid", "image"] = "grid",
     outgrid: PathLike | None = None,
     projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:
     r"""
@@ -53,6 +62,7 @@ def grdcut(
 
     {aliases}
       - J = projection
+      - V = verbose
 
     Parameters
     ----------
@@ -128,7 +138,10 @@ def grdcut(
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with (

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -34,15 +34,7 @@ def grdcut(
     kind: Literal["grid", "image"] = "grid",
     outgrid: PathLike | None = None,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -88,15 +88,7 @@ def grdfill(
     splinefill: float | bool | None = None,
     inquire: bool = False,
     mode: str | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | np.ndarray | None:

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -3,6 +3,7 @@ grdfill - Interpolate across holes in a grid.
 """
 
 import warnings
+from typing import Literal
 
 import numpy as np
 import xarray as xr
@@ -76,7 +77,7 @@ def _validate_params(
 # TODO(PyGMT>=0.19.0): Remove the deprecated 'no_data' parameter.
 # TODO(PyGMT>=0.19.0): Remove the deprecated 'mode' parameter.
 @deprecate_parameter("no_data", "hole", "v0.15.0", remove_version="v0.19.0")
-@use_alias(N="hole", R="region", V="verbose", f="coltypes")
+@use_alias(N="hole", R="region", f="coltypes")
 @kwargs_to_strings(R="sequence")
 def grdfill(
     grid: PathLike | xr.DataArray,
@@ -87,6 +88,16 @@ def grdfill(
     splinefill: float | bool | None = None,
     inquire: bool = False,
     mode: str | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> xr.DataArray | np.ndarray | None:
     r"""
@@ -106,6 +117,7 @@ def grdfill(
        - An = neighborfill
        - As = splinefill
        - L = inquire
+       - V = verbose
 
     Parameters
     ----------
@@ -183,7 +195,10 @@ def grdfill(
         An=Alias(neighborfill, name="neighborfill"),
         As=Alias(splinefill, name="splinefill"),
         L=Alias(inquire, name="inquire"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -2,8 +2,11 @@
 grdfilter - Filter a grid in the space (or time) domain.
 """
 
+from typing import Literal
+
 import xarray as xr
 from pygmt._typing import PathLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -16,14 +19,25 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     N="nans",
     R="region",
     T="toggle",
-    V="verbose",
     f="coltypes",
     r="registration",
     x="cores",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
 def grdfilter(
-    grid: PathLike | xr.DataArray, outgrid: PathLike | None = None, **kwargs
+    grid: PathLike | xr.DataArray,
+    outgrid: PathLike | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
 ) -> xr.DataArray | None:
     r"""
     Filter a grid in the space (or time) domain.
@@ -41,6 +55,7 @@ def grdfilter(
     Full GMT docs at :gmt-docs:`grdfilter.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -128,13 +143,18 @@ def grdfilter(
     >>> grid = pygmt.datasets.load_earth_relief()
     >>> smooth_field = pygmt.grdfilter(grid=grid, filter="g600", distance="4")
     """
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with (
             lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
             lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
         ):
-            kwargs["G"] = voutgrd
+            aliasdict["G"] = voutgrd
             lib.call_module(
-                module="grdfilter", args=build_arg_list(kwargs, infile=vingrd)
+                module="grdfilter", args=build_arg_list(aliasdict, infile=vingrd)
             )
             return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -27,15 +27,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
 def grdfilter(
     grid: PathLike | xr.DataArray,
     outgrid: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -2,8 +2,11 @@
 grdgradient - Compute directional gradients from a grid.
 """
 
+from typing import Literal
+
 import xarray as xr
 from pygmt._typing import PathLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -26,13 +29,24 @@ __doctest_skip__ = ["grdgradient"]
     Q="tiles",
     R="region",
     S="slope_file",
-    V="verbose",
     f="coltypes",
     n="interpolation",
 )
 @kwargs_to_strings(A="sequence", E="sequence", R="sequence")
 def grdgradient(
-    grid: PathLike | xr.DataArray, outgrid: PathLike | None = None, **kwargs
+    grid: PathLike | xr.DataArray,
+    outgrid: PathLike | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
 ) -> xr.DataArray | None:
     r"""
     Compute directional gradients from a grid.
@@ -170,13 +184,19 @@ def grdgradient(
             "azimuth, direction, or radiance."
         )
         raise GMTInvalidInput(msg)
+
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with (
             lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
             lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
         ):
-            kwargs["G"] = voutgrd
+            aliasdict["G"] = voutgrd
             lib.call_module(
-                module="grdgradient", args=build_arg_list(kwargs, infile=vingrd)
+                module="grdgradient", args=build_arg_list(aliasdict, infile=vingrd)
             )
             return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -36,15 +36,7 @@ __doctest_skip__ = ["grdgradient"]
 def grdgradient(
     grid: PathLike | xr.DataArray,
     outgrid: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -49,6 +49,7 @@ def grdgradient(
     Full GMT docs at :gmt-docs:`grdgradient.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -130,7 +130,9 @@ class grdhisteq:  # noqa: N801
         This method does a weighted histogram equalization for geographic
         grids to account for node area varying with latitude.
         """
-        aliasdict = AliasSystem().add_common(V=verbose)
+        aliasdict = AliasSystem().add_common(
+            V=verbose,
+        )
         aliasdict.merge(kwargs)
 
         with Session() as lib:

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -67,13 +67,7 @@ class grdhisteq:  # noqa: N801
         grid: PathLike | xr.DataArray,
         outgrid: PathLike | None = None,
         verbose: Literal[
-            "quiet",
-            "error",
-            "warning",
-            "timing",
-            "information",
-            "compatibility",
-            "debug",
+            "quiet", "error", "warning", "timing", "info", "compat", "debug"
         ]
         | bool = False,
         **kwargs,
@@ -165,13 +159,7 @@ class grdhisteq:  # noqa: N801
         output_type: Literal["pandas", "numpy", "file"] = "pandas",
         outfile: PathLike | None = None,
         verbose: Literal[
-            "quiet",
-            "error",
-            "warning",
-            "timing",
-            "information",
-            "compatibility",
-            "debug",
+            "quiet", "error", "warning", "timing", "info", "compat", "debug"
         ]
         | bool = False,
         **kwargs,

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -42,15 +42,7 @@ def grdimage(
     self,
     grid: PathLike | xr.DataArray,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -2,6 +2,8 @@
 grdimage - Project and plot grids or images.
 """
 
+from typing import Literal
+
 import xarray as xr
 from pygmt._typing import PathLike
 from pygmt.alias import Alias, AliasSystem
@@ -29,7 +31,6 @@ __doctest_skip__ = ["grdimage"]
     N="no_clip",
     Q="nan_transparent",
     R="region",
-    V="verbose",
     n="interpolation",
     c="panel",
     f="coltypes",
@@ -38,7 +39,22 @@ __doctest_skip__ = ["grdimage"]
     x="cores",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
-def grdimage(self, grid: PathLike | xr.DataArray, projection=None, **kwargs):
+def grdimage(
+    self,
+    grid: PathLike | xr.DataArray,
+    projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Project and plot grids or images.
 
@@ -74,6 +90,7 @@ def grdimage(self, grid: PathLike | xr.DataArray, projection=None, **kwargs):
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -169,7 +186,10 @@ def grdimage(self, grid: PathLike | xr.DataArray, projection=None, **kwargs):
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with (

--- a/pygmt/src/grdinfo.py
+++ b/pygmt/src/grdinfo.py
@@ -32,15 +32,7 @@ from pygmt.helpers import (
 @kwargs_to_strings(D="sequence", I="sequence", R="sequence")
 def grdinfo(
     grid: PathLike | xr.DataArray,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> str:

--- a/pygmt/src/grdinfo.py
+++ b/pygmt/src/grdinfo.py
@@ -2,8 +2,11 @@
 grdinfo - Extract information from 2-D grids or 3-D cubes.
 """
 
+from typing import Literal
+
 import xarray as xr
 from pygmt._typing import PathLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,
@@ -24,11 +27,23 @@ from pygmt.helpers import (
     M="minmax_pos",
     R="region",
     T="nearest_multiple",
-    V="verbose",
     f="coltypes",
 )
 @kwargs_to_strings(D="sequence", I="sequence", R="sequence")
-def grdinfo(grid: PathLike | xr.DataArray, **kwargs) -> str:
+def grdinfo(
+    grid: PathLike | xr.DataArray,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+) -> str:
     r"""
     Extract information from 2-D grids or 3-D cubes.
 
@@ -37,6 +52,7 @@ def grdinfo(grid: PathLike | xr.DataArray, **kwargs) -> str:
     Full GMT docs at :gmt-docs:`grdinfo.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -112,12 +128,17 @@ def grdinfo(grid: PathLike | xr.DataArray, **kwargs) -> str:
     info : str
         A string with information about the grid.
     """
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with GMTTempFile() as outfile:
         with Session() as lib:
             with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
                 lib.call_module(
                     module="grdinfo",
-                    args=build_arg_list(kwargs, infile=vingrd, outfile=outfile.name),
+                    args=build_arg_list(aliasdict, infile=vingrd, outfile=outfile.name),
                 )
         result = outfile.read()
     return result

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -36,15 +36,7 @@ def grdlandmask(
     resolution: Literal[
         "auto", "full", "high", "intermediate", "low", "crude", None
     ] = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -25,7 +25,6 @@ __doctest_skip__ = ["grdlandmask"]
     A="area_thresh",
     I="spacing",
     R="region",
-    V="verbose",
     r="registration",
     x="cores",
 )
@@ -37,6 +36,16 @@ def grdlandmask(
     resolution: Literal[
         "auto", "full", "high", "intermediate", "low", "crude", None
     ] = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:
     r"""
@@ -54,6 +63,7 @@ def grdlandmask(
        - D = resolution
        - E = bordervalues
        - N = maskvalues
+       - V = verbose
 
     Parameters
     ----------
@@ -132,7 +142,10 @@ def grdlandmask(
         ),
         N=Alias(maskvalues, name="maskvalues", sep="/", size=(2, 5)),
         E=Alias(bordervalues, name="bordervalues", sep="/", size=4),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd:

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -2,6 +2,8 @@
 grdproject - Forward and inverse map transformation of grids.
 """
 
+from typing import Literal
+
 import xarray as xr
 from pygmt._typing import PathLike
 from pygmt.alias import Alias, AliasSystem
@@ -21,7 +23,6 @@ __doctest_skip__ = ["grdproject"]
     I="inverse",
     M="unit",
     R="region",
-    V="verbose",
     n="interpolation",
     r="registration",
 )
@@ -30,6 +31,16 @@ def grdproject(
     grid: PathLike | xr.DataArray,
     outgrid: PathLike | None = None,
     projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:
     r"""
@@ -54,6 +65,7 @@ def grdproject(
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -115,7 +127,10 @@ def grdproject(
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with (

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -31,15 +31,7 @@ def grdproject(
     grid: PathLike | xr.DataArray,
     outgrid: PathLike | None = None,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -27,15 +27,7 @@ __doctest_skip__ = ["grdsample"]
 def grdsample(
     grid: PathLike | xr.DataArray,
     outgrid: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -2,8 +2,11 @@
 grdsample - Resample a grid onto a new lattice.
 """
 
+from typing import Literal
+
 import xarray as xr
 from pygmt._typing import PathLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -15,7 +18,6 @@ __doctest_skip__ = ["grdsample"]
     I="spacing",
     R="region",
     T="translate",
-    V="verbose",
     f="coltypes",
     n="interpolation",
     r="registration",
@@ -23,7 +25,19 @@ __doctest_skip__ = ["grdsample"]
 )
 @kwargs_to_strings(I="sequence", R="sequence")
 def grdsample(
-    grid: PathLike | xr.DataArray, outgrid: PathLike | None = None, **kwargs
+    grid: PathLike | xr.DataArray,
+    outgrid: PathLike | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
 ) -> xr.DataArray | None:
     r"""
     Resample a grid onto a new lattice.
@@ -44,6 +58,7 @@ def grdsample(
     Full GMT docs at :gmt-docs:`grdsample.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -83,13 +98,18 @@ def grdsample(
     >>> # and set both x- and y-spacings to 0.5 arc-degrees
     >>> new_grid = pygmt.grdsample(grid=grid, translate=True, spacing=[0.5, 0.5])
     """
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with (
             lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
             lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
         ):
-            kwargs["G"] = voutgrd
+            aliasdict["G"] = voutgrd
             lib.call_module(
-                module="grdsample", args=build_arg_list(kwargs, infile=vingrd)
+                module="grdsample", args=build_arg_list(aliasdict, infile=vingrd)
             )
             return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from pygmt._typing import PathLike, TableLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -32,7 +33,6 @@ __doctest_skip__ = ["grdtrack"]
     N="no_skip",
     S="stack",
     T="radius",
-    V="verbose",
     Z="z_only",
     a="aspatial",
     b="binary",
@@ -55,6 +55,16 @@ def grdtrack(
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
     newcolname=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""
@@ -77,6 +87,7 @@ def grdtrack(
     Full GMT docs at :gmt-docs:`grdtrack.html`.
 
     {aliases}
+        - V = verbose
 
     Parameters
     ----------
@@ -309,6 +320,11 @@ def grdtrack(
     if output_type == "pandas" and isinstance(points, pd.DataFrame):
         column_names = [*points.columns.to_list(), newcolname]
 
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with (
             lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
@@ -317,10 +333,10 @@ def grdtrack(
             ) as vintbl,
             lib.virtualfile_out(kind="dataset", fname=outfile) as vouttbl,
         ):
-            kwargs["G"] = vingrd
+            aliasdict["G"] = vingrd
             lib.call_module(
                 module="grdtrack",
-                args=build_arg_list(kwargs, infile=vintbl, outfile=vouttbl),
+                args=build_arg_list(aliasdict, infile=vintbl, outfile=vouttbl),
             )
         return lib.virtualfile_to_dataset(
             vfname=vouttbl,

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -55,15 +55,7 @@ def grdtrack(
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
     newcolname=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -37,15 +37,7 @@ def grdview(
     self,
     grid: PathLike | xr.DataArray,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -2,6 +2,8 @@
 grdview - Create 3-D perspective image or surface mesh from a grid.
 """
 
+from typing import Literal
+
 import xarray as xr
 from pygmt._typing import PathLike
 from pygmt.alias import Alias, AliasSystem
@@ -25,7 +27,6 @@ __doctest_skip__ = ["grdview"]
     Wm="meshpen",
     Wf="facadepen",
     I="shading",
-    V="verbose",
     c="panel",
     f="coltypes",
     n="interpolation",
@@ -33,7 +34,22 @@ __doctest_skip__ = ["grdview"]
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
-def grdview(self, grid: PathLike | xr.DataArray, projection=None, **kwargs):
+def grdview(
+    self,
+    grid: PathLike | xr.DataArray,
+    projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Create 3-D perspective image or surface mesh from a grid.
 
@@ -47,6 +63,7 @@ def grdview(self, grid: PathLike | xr.DataArray, projection=None, **kwargs):
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -145,7 +162,10 @@ def grdview(self, grid: PathLike | xr.DataArray, projection=None, **kwargs):
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with (

--- a/pygmt/src/grdvolume.py
+++ b/pygmt/src/grdvolume.py
@@ -28,15 +28,7 @@ def grdvolume(
     grid: PathLike | xr.DataArray,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:

--- a/pygmt/src/grdvolume.py
+++ b/pygmt/src/grdvolume.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from pygmt._typing import PathLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_list,
@@ -21,17 +22,22 @@ __doctest_skip__ = ["grdvolume"]
 
 
 @fmt_docstring
-@use_alias(
-    C="contour",
-    R="region",
-    S="unit",
-    V="verbose",
-)
+@use_alias(C="contour", R="region", S="unit")
 @kwargs_to_strings(C="sequence", R="sequence")
 def grdvolume(
     grid: PathLike | xr.DataArray,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""
@@ -46,6 +52,7 @@ def grdvolume(
     Full GMT docs at :gmt-docs:`grdvolume.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -104,6 +111,11 @@ def grdvolume(
     """
     output_type = validate_output_table_type(output_type, outfile=outfile)
 
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with (
             lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,
@@ -111,6 +123,6 @@ def grdvolume(
         ):
             lib.call_module(
                 module="grdvolume",
-                args=build_arg_list(kwargs, infile=vingrd, outfile=vouttbl),
+                args=build_arg_list(aliasdict, infile=vingrd, outfile=vouttbl),
             )
             return lib.virtualfile_to_dataset(vfname=vouttbl, output_type=output_type)

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -42,15 +42,7 @@ def histogram(
     self,
     data: PathLike | TableLike,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -2,6 +2,8 @@
 Histogram - Calculate and plot histograms.
 """
 
+from typing import Literal
+
 from pygmt._typing import PathLike, TableLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
@@ -23,7 +25,6 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     R="region",
     S="stairs",
     T="series",
-    V="verbose",
     W="pen",
     Z="histtype",
     b="binary",
@@ -40,7 +41,22 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
 @kwargs_to_strings(
     R="sequence", T="sequence", c="sequence_comma", i="sequence_comma", p="sequence"
 )
-def histogram(self, data: PathLike | TableLike, projection=None, **kwargs):
+def histogram(
+    self,
+    data: PathLike | TableLike,
+    projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Calculate and plot histograms.
 
@@ -48,6 +64,7 @@ def histogram(self, data: PathLike | TableLike, projection=None, **kwargs):
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -140,7 +157,10 @@ def histogram(self, data: PathLike | TableLike, projection=None, **kwargs):
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -2,6 +2,8 @@
 image - Plot raster or EPS images.
 """
 
+from typing import Literal
+
 from pygmt._typing import PathLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
@@ -15,13 +17,27 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     G="bitcolor",
     M="monochrome",
     R="region",
-    V="verbose",
     c="panel",
     p="perspective",
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
-def image(self, imagefile: PathLike, projection=None, **kwargs):
+def image(
+    self,
+    imagefile: PathLike,
+    projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Plot raster or EPS images.
 
@@ -32,6 +48,7 @@ def image(self, imagefile: PathLike, projection=None, **kwargs):
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -73,7 +90,10 @@ def image(self, imagefile: PathLike, projection=None, **kwargs):
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         lib.call_module(

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -25,15 +25,7 @@ def image(
     self,
     imagefile: PathLike,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -53,6 +53,7 @@ def info(
     Full GMT docs at :gmt-docs:`gmtinfo.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -2,8 +2,11 @@
 info - Get information about data tables.
 """
 
+from typing import Literal
+
 import numpy as np
 from pygmt._typing import PathLike, TableLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,
@@ -19,14 +22,26 @@ from pygmt.helpers import (
     C="per_column",
     I="spacing",
     T="nearest_multiple",
-    V="verbose",
     a="aspatial",
     f="coltypes",
     i="incols",
     r="registration",
 )
 @kwargs_to_strings(I="sequence", i="sequence_comma")
-def info(data: PathLike | TableLike, **kwargs) -> np.ndarray | str:
+def info(
+    data: PathLike | TableLike,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+) -> np.ndarray | str:
     r"""
     Get information about data tables.
 
@@ -81,12 +96,17 @@ def info(data: PathLike | TableLike, **kwargs) -> np.ndarray | str:
         - :class:`numpy.ndarray` if either of the above parameters are used.
         - str if none of the above parameters are used.
     """
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with GMTTempFile() as tmpfile:
             with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
                 lib.call_module(
                     module="info",
-                    args=build_arg_list(kwargs, infile=vintbl, outfile=tmpfile.name),
+                    args=build_arg_list(aliasdict, infile=vintbl, outfile=tmpfile.name),
                 )
             result = tmpfile.read()
 

--- a/pygmt/src/info.py
+++ b/pygmt/src/info.py
@@ -30,15 +30,7 @@ from pygmt.helpers import (
 @kwargs_to_strings(I="sequence", i="sequence_comma")
 def info(
     data: PathLike | TableLike,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> np.ndarray | str:

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -3,6 +3,7 @@ inset - Manage figure inset setup and completion.
 """
 
 import contextlib
+from typing import Literal
 
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
@@ -19,10 +20,23 @@ __doctest_skip__ = ["inset"]
     M="margin",
     N="no_clip",
     R="region",
-    V="verbose",
 )
 @kwargs_to_strings(D="sequence", M="sequence", R="sequence")
-def inset(self, projection=None, **kwargs):
+def inset(
+    self,
+    projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Manage figure inset setup and completion.
 
@@ -34,6 +48,7 @@ def inset(self, projection=None, **kwargs):
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -139,7 +154,10 @@ def inset(self, projection=None, **kwargs):
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         try:

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -25,15 +25,7 @@ __doctest_skip__ = ["inset"]
 def inset(
     self,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ):

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -3,6 +3,7 @@ legend - Plot a legend.
 """
 
 import io
+from typing import Literal
 
 from pygmt._typing import PathLike
 from pygmt.alias import Alias, AliasSystem
@@ -23,7 +24,6 @@ from pygmt.helpers import (
     R="region",
     D="position",
     F="box",
-    V="verbose",
     c="panel",
     p="perspective",
     t="transparency",
@@ -35,6 +35,16 @@ def legend(
     projection=None,
     position="JTR+jTR+o0.2c",
     box="+gwhite+p1p",
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ):
     r"""
@@ -50,6 +60,7 @@ def legend(
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -101,7 +112,10 @@ def legend(
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with lib.virtualfile_in(data=spec, required=False) as vintbl:

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -34,15 +34,7 @@ def legend(
     projection=None,
     position="JTR+jTR+o0.2c",
     box="+gwhite+p1p",
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -21,15 +21,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
 def logo(
     self,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -2,6 +2,8 @@
 logo - Plot the GMT logo.
 """
 
+from typing import Literal
+
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
@@ -13,12 +15,25 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     D="position",
     F="box",
     S="style",
-    V="verbose",
     c="panel",
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
-def logo(self, projection=None, **kwargs):
+def logo(
+    self,
+    projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Plot the GMT logo.
 
@@ -31,6 +46,7 @@ def logo(self, projection=None, **kwargs):
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -59,7 +75,10 @@ def logo(self, projection=None, **kwargs):
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         lib.call_module(module="logo", args=build_arg_list(aliasdict))

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -2,6 +2,9 @@
 makecpt - Make GMT color palette tables.
 """
 
+from typing import Literal
+
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
@@ -20,13 +23,24 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     N="no_bg",
     Q="log",
     T="series",
-    V="verbose",
     W="categorical",
     Ww="cyclic",
     Z="continuous",
 )
 @kwargs_to_strings(T="sequence", G="sequence")
-def makecpt(**kwargs):
+def makecpt(
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Make GMT color palette tables.
 
@@ -67,6 +81,7 @@ def makecpt(**kwargs):
     Full GMT docs at :gmt-docs:`makecpt.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -162,5 +177,12 @@ def makecpt(**kwargs):
     if (output := kwargs.pop("H", None)) is not None:
         kwargs["H"] = True
 
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
-        lib.call_module(module="makecpt", args=build_arg_list(kwargs, outfile=output))
+        lib.call_module(
+            module="makecpt", args=build_arg_list(aliasdict, outfile=output)
+        )

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -29,15 +29,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
 )
 @kwargs_to_strings(T="sequence", G="sequence")
 def makecpt(
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ):

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -145,15 +145,7 @@ def meca(  # noqa: PLR0913
     plot_latitude: float | Sequence[float] | None = None,
     event_name: str | Sequence[str] | None = None,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -127,7 +127,6 @@ def _auto_offset(spec) -> bool:
     N="no_clip",
     R="region",
     T="nodal",
-    V="verbose",
     W="pen",
     c="panel",
     p="perspective",
@@ -147,6 +146,16 @@ def meca(  # noqa: PLR0913
     plot_latitude: float | Sequence[float] | None = None,
     event_name: str | Sequence[str] | None = None,
     projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ):
     r"""
@@ -203,6 +212,7 @@ def meca(  # noqa: PLR0913
     {aliases}
        - J = projection
        - S = scale/convention/component
+       - V = verbose
 
     Parameters
     ----------
@@ -367,7 +377,10 @@ def meca(  # noqa: PLR0913
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with lib.virtualfile_in(check_kind="vector", data=spec) as vintbl:

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -2,8 +2,11 @@
 nearneighbor - Grid table data using a "Nearest neighbor" algorithm.
 """
 
+from typing import Literal
+
 import xarray as xr
 from pygmt._typing import PathLike, TableLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -17,7 +20,6 @@ __doctest_skip__ = ["nearneighbor"]
     N="sectors",
     R="region",
     S="search_radius",
-    V="verbose",
     a="aspatial",
     b="binary",
     d="nodata",
@@ -36,6 +38,16 @@ def nearneighbor(
     y=None,
     z=None,
     outgrid: PathLike | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:
     r"""
@@ -75,6 +87,7 @@ def nearneighbor(
     Full GMT docs at :gmt-docs:`nearneighbor.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -144,6 +157,11 @@ def nearneighbor(
     ...     search_radius="10m",
     ... )
     """
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with (
             lib.virtualfile_in(
@@ -151,8 +169,8 @@ def nearneighbor(
             ) as vintbl,
             lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
         ):
-            kwargs["G"] = voutgrd
+            aliasdict["G"] = voutgrd
             lib.call_module(
-                module="nearneighbor", args=build_arg_list(kwargs, infile=vintbl)
+                module="nearneighbor", args=build_arg_list(aliasdict, infile=vintbl)
             )
             return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -38,15 +38,7 @@ def nearneighbor(
     y=None,
     z=None,
     outgrid: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -59,15 +59,7 @@ def plot(  # noqa: PLR0912, PLR0913
     direction=None,
     straight_line: bool | Literal["x", "y"] = False,  # noqa: ARG001
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -33,7 +33,6 @@ from pygmt.src._common import _data_geometry_is_point
     N="no_clip",
     R="region",
     S="style",
-    V="verbose",
     W="pen",
     Z="zvalue",
     a="aspatial",
@@ -61,6 +60,16 @@ def plot(  # noqa: PLR0912
     direction=None,
     straight_line: bool | Literal["x", "y"] = False,  # noqa: ARG001
     projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ):
     r"""
@@ -88,6 +97,7 @@ def plot(  # noqa: PLR0912
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -285,7 +295,10 @@ def plot(  # noqa: PLR0912
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -34,7 +34,6 @@ from pygmt.src._common import _data_geometry_is_point
     Q="no_sort",
     R="region",
     S="style",
-    V="verbose",
     W="pen",
     Z="zvalue",
     a="aspatial",
@@ -52,7 +51,7 @@ from pygmt.src._common import _data_geometry_is_point
     w="wrap",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
-def plot3d(  # noqa: PLR0912
+def plot3d(  # noqa: PLR0912, PLR0913
     self,
     data: PathLike | TableLike | None = None,
     x=None,
@@ -63,6 +62,16 @@ def plot3d(  # noqa: PLR0912
     direction=None,
     straight_line: bool | Literal["x", "y"] = False,  # noqa: ARG001
     projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ):
     r"""
@@ -90,6 +99,7 @@ def plot3d(  # noqa: PLR0912
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -264,7 +274,10 @@ def plot3d(  # noqa: PLR0912
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with lib.virtualfile_in(check_kind="vector", data=data, mincols=3) as vintbl:

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -61,15 +61,7 @@ def plot3d(  # noqa: PLR0912, PLR0913
     direction=None,
     straight_line: bool | Literal["x", "y"] = False,  # noqa: ARG001
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -43,15 +43,7 @@ def project(
     z=None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -7,6 +7,7 @@ from typing import Literal
 import numpy as np
 import pandas as pd
 from pygmt._typing import PathLike, TableLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
@@ -30,7 +31,6 @@ from pygmt.helpers import (
     Q="unit",
     S="sort",
     T="pole",
-    V="verbose",
     W="width",
     Z="ellipse",
     f="coltypes",
@@ -43,6 +43,16 @@ def project(
     z=None,
     output_type: Literal["pandas", "numpy", "file"] = "pandas",
     outfile: PathLike | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""
@@ -110,6 +120,7 @@ def project(
     Full GMT docs at :gmt-docs:`project.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -238,6 +249,11 @@ def project(
     if output_type == "pandas" and kwargs.get("G") is not None:
         column_names = list("rsp")
 
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with (
             lib.virtualfile_in(
@@ -253,7 +269,7 @@ def project(
         ):
             lib.call_module(
                 module="project",
-                args=build_arg_list(kwargs, infile=vintbl, outfile=vouttbl),
+                args=build_arg_list(aliasdict, infile=vintbl, outfile=vouttbl),
             )
         return lib.virtualfile_to_dataset(
             vfname=vouttbl,

--- a/pygmt/src/psconvert.py
+++ b/pygmt/src/psconvert.py
@@ -3,7 +3,9 @@ psconvert - Convert [E]PS file(s) to other formats using Ghostscript.
 """
 
 from pathlib import Path
+from typing import Literal
 
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTValueError
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
@@ -20,10 +22,22 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     N="bb_style",
     T="fmt",
     Q="anti_aliasing",
-    V="verbose",
 )
 @kwargs_to_strings()
-def psconvert(self, **kwargs):
+def psconvert(
+    self,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Convert [E]PS file(s) to other formats using Ghostscript.
 
@@ -37,6 +51,7 @@ def psconvert(self, **kwargs):
     Full GMT docs at :gmt-docs:`psconvert.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -127,5 +142,10 @@ def psconvert(self, **kwargs):
         msg = f"No such directory: '{prefix_path}', please create it first."
         raise FileNotFoundError(msg)
 
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
-        lib.call_module(module="psconvert", args=build_arg_list(kwargs))
+        lib.call_module(module="psconvert", args=build_arg_list(aliasdict))

--- a/pygmt/src/psconvert.py
+++ b/pygmt/src/psconvert.py
@@ -20,15 +20,7 @@ def psconvert(
     dpi: int | None = None,
     gs_option: str | Sequence[str] | None = None,
     gs_path: str | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ):

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -2,7 +2,10 @@
 rose - Plot a polar histogram (rose, sector, windrose diagrams).
 """
 
+from typing import Literal
+
 from pygmt._typing import PathLike, TableLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_list,
@@ -29,7 +32,6 @@ from pygmt.helpers import (
     R="region",
     S="norm",
     T="orientation",
-    V="verbose",
     W="pen",
     Z="scale",
     b="binary",
@@ -44,7 +46,21 @@ from pygmt.helpers import (
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
 def rose(
-    self, data: PathLike | TableLike | None = None, length=None, azimuth=None, **kwargs
+    self,
+    data: PathLike | TableLike | None = None,
+    length=None,
+    azimuth=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
 ):
     """
     Plot a polar histogram (rose, sector, windrose diagrams).
@@ -62,6 +78,7 @@ def rose(
     Full GMT docs at :gmt-docs:`rose.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -201,8 +218,15 @@ def rose(
     """
     self._activate_figure()
 
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with lib.virtualfile_in(
             check_kind="vector", data=data, x=length, y=azimuth
         ) as vintbl:
-            lib.call_module(module="rose", args=build_arg_list(kwargs, infile=vintbl))
+            lib.call_module(
+                module="rose", args=build_arg_list(aliasdict, infile=vintbl)
+            )

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -44,15 +44,7 @@ def rose(
     data: PathLike | TableLike | None = None,
     length=None,
     azimuth=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -51,15 +51,7 @@ def select(
         "auto", "full", "high", "intermediate", "low", "crude", None
     ] = None,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:

--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -30,7 +30,6 @@ __doctest_skip__ = ["select"]
     L="dist2line",
     N="mask",
     R="region",
-    V="verbose",
     Z="z_subregion",
     b="binary",
     d="nodata",
@@ -52,6 +51,16 @@ def select(
         "auto", "full", "high", "intermediate", "low", "crude", None
     ] = None,
     projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> pd.DataFrame | np.ndarray | None:
     r"""
@@ -78,6 +87,7 @@ def select(
     {aliases}
        - D = resolution
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -230,7 +240,10 @@ def select(
             },
         ),
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with (

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -18,7 +18,6 @@ __doctest_skip__ = ["solar"]
     B="frame",
     G="fill",
     R="region",
-    V="verbose",
     W="pen",
     c="panel",
     p="perspective",
@@ -30,6 +29,16 @@ def solar(
     terminator: Literal["astronomical", "civil", "day_night", "nautical"] = "day_night",
     terminator_datetime=None,
     projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ):
     r"""
@@ -43,6 +52,7 @@ def solar(
     {aliases}
        - J = projection
        - T = terminator, **+d**: terminator_datetime
+       - V = verbose
 
     Parameters
     ----------
@@ -124,7 +134,10 @@ def solar(
             ),
             Alias(datetime_string, name="terminator_datetime", prefix="+d"),
         ],
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         lib.call_module(module="solar", args=build_arg_list(aliasdict))

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -28,15 +28,7 @@ def solar(
     terminator: Literal["astronomical", "civil", "day_night", "nautical"] = "day_night",
     terminator_datetime=None,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/sph2grd.py
+++ b/pygmt/src/sph2grd.py
@@ -27,15 +27,7 @@ __doctest_skip__ = ["sph2grd"]
 def sph2grd(
     data: PathLike | TableLike,
     outgrid: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/sph2grd.py
+++ b/pygmt/src/sph2grd.py
@@ -2,8 +2,11 @@
 sph2grd - Compute grid from spherical harmonic coefficients.
 """
 
+from typing import Literal
+
 import xarray as xr
 from pygmt._typing import PathLike, TableLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -14,7 +17,6 @@ __doctest_skip__ = ["sph2grd"]
 @use_alias(
     I="spacing",
     R="region",
-    V="verbose",
     b="binary",
     h="header",
     i="incols",
@@ -23,7 +25,19 @@ __doctest_skip__ = ["sph2grd"]
 )
 @kwargs_to_strings(I="sequence", R="sequence", i="sequence_comma")
 def sph2grd(
-    data: PathLike | TableLike, outgrid: PathLike | None = None, **kwargs
+    data: PathLike | TableLike,
+    outgrid: PathLike | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
 ) -> xr.DataArray | None:
     r"""
     Compute grid from spherical harmonic coefficients.
@@ -35,6 +49,7 @@ def sph2grd(
     Full GMT docs at :gmt-docs:`sph2grd.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -68,13 +83,18 @@ def sph2grd(
     >>> # set the grid spacing to 1 arc-degree, and the region to global ("g")
     >>> new_grid = pygmt.sph2grd(data="@EGM96_to_36.txt", spacing=1, region="g")
     """
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with (
             lib.virtualfile_in(check_kind="vector", data=data) as vintbl,
             lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
         ):
-            kwargs["G"] = voutgrd
+            aliasdict["G"] = voutgrd
             lib.call_module(
-                module="sph2grd", args=build_arg_list(kwargs, infile=vintbl)
+                module="sph2grd", args=build_arg_list(aliasdict, infile=vintbl)
             )
             return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -32,15 +32,7 @@ def sphdistance(
     x=None,
     y=None,
     outgrid: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/sphinterpolate.py
+++ b/pygmt/src/sphinterpolate.py
@@ -19,15 +19,7 @@ __doctest_skip__ = ["sphinterpolate"]
 def sphinterpolate(
     data: PathLike | TableLike,
     outgrid: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -36,15 +36,7 @@ def subplot(
     nrows=1,
     ncols=1,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ):
@@ -210,15 +202,7 @@ def subplot(
 def set_panel(
     self,
     panel=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ):

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -3,6 +3,7 @@ subplot - Manage figure subplot configuration and selection.
 """
 
 import contextlib
+from typing import Literal
 
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
@@ -28,10 +29,25 @@ from pygmt.helpers import (
     SC="sharex",
     SR="sharey",
     T="title",
-    V="verbose",
 )
 @kwargs_to_strings(Ff="sequence", Fs="sequence", M="sequence", R="sequence")
-def subplot(self, nrows=1, ncols=1, projection=None, **kwargs):
+def subplot(
+    self,
+    nrows=1,
+    ncols=1,
+    projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Manage figure subplot configuration and selection.
 
@@ -45,6 +61,7 @@ def subplot(self, nrows=1, ncols=1, projection=None, **kwargs):
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -162,7 +179,10 @@ def subplot(self, nrows=1, ncols=1, projection=None, **kwargs):
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     # Need to use separate sessions for "subplot begin" and "subplot end".
     # Otherwise, "subplot end" will use the last session, which may cause
@@ -185,9 +205,23 @@ def subplot(self, nrows=1, ncols=1, projection=None, **kwargs):
 
 @fmt_docstring
 @contextlib.contextmanager
-@use_alias(A="fixedlabel", C="clearance", V="verbose")
+@use_alias(A="fixedlabel", C="clearance")
 @kwargs_to_strings(panel="sequence_comma")
-def set_panel(self, panel=None, **kwargs):
+def set_panel(
+    self,
+    panel=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Set the current subplot panel to plot on.
 
@@ -200,6 +234,7 @@ def set_panel(self, panel=None, **kwargs):
     ``projection="X"`` will fill the subplot by using unequal scales].
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -237,8 +272,13 @@ def set_panel(self, panel=None, **kwargs):
     """
     self._activate_figure()
 
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         lib.call_module(
-            module="subplot", args=["set", str(panel), *build_arg_list(kwargs)]
+            module="subplot", args=["set", str(panel), *build_arg_list(aliasdict)]
         )
         yield

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -39,15 +39,7 @@ def surface(
     y=None,
     z=None,
     outgrid: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -2,8 +2,11 @@
 surface - Grid table data using adjustable tension continuous curvature splines.
 """
 
+from typing import Literal
+
 import xarray as xr
 from pygmt._typing import PathLike, TableLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -19,7 +22,6 @@ __doctest_skip__ = ["surface"]
     M="maxradius",
     R="region",
     T="tension",
-    V="verbose",
     a="aspatial",
     b="binary",
     d="nodata",
@@ -37,6 +39,16 @@ def surface(
     y=None,
     z=None,
     outgrid: PathLike | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:
     r"""
@@ -72,6 +84,7 @@ def surface(
     Full GMT docs at :gmt-docs:`surface.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -158,6 +171,11 @@ def surface(
     >>> # Perform gridding of topography data
     >>> grid = pygmt.surface(data=topography, spacing=1, region=[0, 4, 0, 8])
     """
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with (
             lib.virtualfile_in(
@@ -165,8 +183,8 @@ def surface(
             ) as vintbl,
             lib.virtualfile_out(kind="grid", fname=outgrid) as voutgrd,
         ):
-            kwargs["G"] = voutgrd
+            aliasdict["G"] = voutgrd
             lib.call_module(
-                module="surface", args=build_arg_list(kwargs, infile=vintbl)
+                module="surface", args=build_arg_list(aliasdict, infile=vintbl)
             )
             return lib.virtualfile_to_raster(vfname=voutgrd, outgrid=outgrid)

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -2,6 +2,8 @@
 ternary - Plot data on ternary diagrams.
 """
 
+from typing import Literal
+
 import pandas as pd
 from packaging.version import Version
 from pygmt._typing import PathLike, TableLike
@@ -18,7 +20,6 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     JX="width",
     R="region",
     S="style",
-    V="verbose",
     W="pen",
     c="panel",
     p="perspective",
@@ -31,6 +32,16 @@ def ternary(
     alabel: str | None = None,
     blabel: str | None = None,
     clabel: str | None = None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ):
     r"""
@@ -48,6 +59,7 @@ def ternary(
 
     {aliases}
        - L = alabel/blabel/clabel
+       - V = verbose
 
     Parameters
     ----------
@@ -91,7 +103,10 @@ def ternary(
 
     aliasdict = AliasSystem(
         L=Alias(labels, name="alabel/blabel/clabel", sep="/", size=3),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     # TODO(GMT>=6.5.0): Remove the patch for upstream bug fixed in GMT 6.5.0.
     # See https://github.com/GenericMappingTools/pygmt/pull/2138

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -31,15 +31,7 @@ def ternary(
     alabel: str | None = None,
     blabel: str | None = None,
     clabel: str | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -52,15 +52,7 @@ def text_(  # noqa: PLR0912, PLR0913, PLR0915
     font=None,
     justify: bool | None | AnchorCode | Sequence[AnchorCode] = None,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -3,6 +3,7 @@ text - Plot or typeset text.
 """
 
 from collections.abc import Sequence
+from typing import Literal
 
 import numpy as np
 from pygmt._typing import AnchorCode, PathLike, StringArrayTypes, TableLike
@@ -29,7 +30,6 @@ from pygmt.helpers import (
     D="offset",
     G="fill",
     N="no_clip",
-    V="verbose",
     W="pen",
     a="aspatial",
     c="panel",
@@ -42,7 +42,7 @@ from pygmt.helpers import (
     w="wrap",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", p="sequence")
-def text_(  # noqa: PLR0912
+def text_(  # noqa: PLR0912, PLR0913, PLR0915
     self,
     textfiles: PathLike | TableLike | None = None,
     x=None,
@@ -53,6 +53,16 @@ def text_(  # noqa: PLR0912
     font=None,
     justify: bool | None | AnchorCode | Sequence[AnchorCode] = None,
     projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ):
     r"""
@@ -74,6 +84,7 @@ def text_(  # noqa: PLR0912
     {aliases}
        - F = **+a**: angle, **+c**: position, **+j**: justify, **+f**: font
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -266,7 +277,10 @@ def text_(  # noqa: PLR0912
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with lib.virtualfile_in(

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -25,7 +25,6 @@ except ImportError:
     N="no_clip",
     Q="nan_transparent",
     # R="region",
-    V="verbose",
     c="panel",
     p="perspective",
     t="transparency",
@@ -41,6 +40,16 @@ def tilemap(
     max_retries: int = 2,
     zoom_adjust: int | None = None,
     projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ):
     r"""
@@ -58,6 +67,7 @@ def tilemap(
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -129,7 +139,10 @@ def tilemap(
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with lib.virtualfile_in(check_kind="raster", data=raster) as vingrd:

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -39,15 +39,7 @@ def tilemap(  # noqa: PLR0913
     max_retries: int = 2,
     zoom_adjust: int | None = None,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -2,6 +2,8 @@
 velo - Plot velocity vectors, crosses, anisotropy bars, and wedges.
 """
 
+from typing import Literal
+
 import numpy as np
 import pandas as pd
 from pygmt._typing import PathLike, TableLike
@@ -30,7 +32,6 @@ from pygmt.helpers import (
     N="no_clip",
     R="region",
     S="spec",
-    V="verbose",
     W="pen",
     Z="zvalue",
     c="panel",
@@ -42,7 +43,22 @@ from pygmt.helpers import (
     t="transparency",
 )
 @kwargs_to_strings(R="sequence", c="sequence_comma", i="sequence_comma", p="sequence")
-def velo(self, data: PathLike | TableLike | None = None, projection=None, **kwargs):
+def velo(
+    self,
+    data: PathLike | TableLike | None = None,
+    projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Plot velocity vectors, crosses, anisotropy bars, and wedges.
 
@@ -59,6 +75,7 @@ def velo(self, data: PathLike | TableLike | None = None, projection=None, **kwar
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -259,7 +276,10 @@ def velo(self, data: PathLike | TableLike | None = None, projection=None, **kwar
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -46,15 +46,7 @@ def velo(
     self,
     data: PathLike | TableLike | None = None,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/which.py
+++ b/pygmt/src/which.py
@@ -15,15 +15,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, is_nonstr_iter, use_ali
 @use_alias(G="download")
 def which(
     fname: PathLike | Sequence[PathLike],
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> str | list[str]:

--- a/pygmt/src/which.py
+++ b/pygmt/src/which.py
@@ -3,15 +3,30 @@ which - Find full path to specified files.
 """
 
 from collections.abc import Sequence
+from typing import Literal
 
 from pygmt._typing import PathLike
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, is_nonstr_iter, use_alias
 
 
 @fmt_docstring
-@use_alias(G="download", V="verbose")
-def which(fname: PathLike | Sequence[PathLike], **kwargs) -> str | list[str]:
+@use_alias(G="download")
+def which(
+    fname: PathLike | Sequence[PathLike],
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+) -> str | list[str]:
     r"""
     Find full path to specified files.
 
@@ -30,6 +45,7 @@ def which(fname: PathLike | Sequence[PathLike], **kwargs) -> str | list[str]:
     Full GMT docs at :gmt-docs:`gmtwhich.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -60,11 +76,16 @@ def which(fname: PathLike | Sequence[PathLike], **kwargs) -> str | list[str]:
     FileNotFoundError
         If the file is not found.
     """
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
         with lib.virtualfile_out(kind="dataset") as vouttbl:
             lib.call_module(
                 module="which",
-                args=build_arg_list(kwargs, infile=fname, outfile=vouttbl),
+                args=build_arg_list(aliasdict, infile=fname, outfile=vouttbl),
             )
             paths = lib.virtualfile_to_dataset(vfname=vouttbl, output_type="strings")
 

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -66,15 +66,7 @@ def wiggle(
     fillpositive=None,
     fillnegative=None,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | tuple[int, int] | bool = False,
     **kwargs,

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -2,6 +2,8 @@
 wiggle - Plot z=f(x,y) anomalies along tracks.
 """
 
+from typing import Literal
+
 from pygmt._typing import PathLike, TableLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
@@ -41,7 +43,6 @@ def _parse_fills(fillpositive, fillnegative):
     D="position",
     R="region",
     T="track",
-    V="verbose",
     W="pen",
     Z="scale",
     b="binary",
@@ -66,6 +67,16 @@ def wiggle(
     fillpositive=None,
     fillnegative=None,
     projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ):
     r"""
@@ -81,6 +92,7 @@ def wiggle(
     {aliases}
        - G = **+p**: fillpositive, **+n**: fillnegative
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -133,7 +145,10 @@ def wiggle(
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
         G=Alias(_fills, name="fillpositive/fillnegative"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with lib.virtualfile_in(

--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -74,15 +74,7 @@ def tempfile_from_dftrack(track, suffix):
 def x2sys_cross(
     tracks=None,
     outfile: PathLike | None = None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> pd.DataFrame | None:

--- a/pygmt/src/x2sys_init.py
+++ b/pygmt/src/x2sys_init.py
@@ -24,15 +24,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
 @kwargs_to_strings(I="sequence", R="sequence")
 def x2sys_init(
     tag,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ):

--- a/pygmt/src/x2sys_init.py
+++ b/pygmt/src/x2sys_init.py
@@ -2,6 +2,9 @@
 x2sys_init - Initialize a new x2sys track database.
 """
 
+from typing import Literal
+
+from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -15,12 +18,24 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
     I="spacing",
     N="units",
     R="region",
-    V="verbose",
     W="gap",
     j="distcalc",
 )
 @kwargs_to_strings(I="sequence", R="sequence")
-def x2sys_init(tag, **kwargs):
+def x2sys_init(
+    tag,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
+    **kwargs,
+):
     r"""
     Initialize a new x2sys track database.
 
@@ -37,6 +52,7 @@ def x2sys_init(tag, **kwargs):
     Full GMT docs at :gmt-docs:`supplements/x2sys/x2sys_init.html`.
 
     {aliases}
+       - V = verbose
 
     Parameters
     ----------
@@ -110,5 +126,10 @@ def x2sys_init(tag, **kwargs):
 
     {distcalc}
     """
+    aliasdict = AliasSystem().add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
+
     with Session() as lib:
-        lib.call_module(module="x2sys_init", args=build_arg_list(kwargs, infile=tag))
+        lib.call_module(module="x2sys_init", args=build_arg_list(aliasdict, infile=tag))

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -37,15 +37,7 @@ def xyz2grd(
     z=None,
     outgrid: PathLike | None = None,
     projection=None,
-    verbose: Literal[
-        "quiet",
-        "error",
-        "warning",
-        "timing",
-        "information",
-        "compatibility",
-        "debug",
-    ]
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -2,6 +2,8 @@
 xyz2grd - Convert data table to a grid.
 """
 
+from typing import Literal
+
 import xarray as xr
 from pygmt._typing import PathLike, TableLike
 from pygmt.alias import Alias, AliasSystem
@@ -17,7 +19,6 @@ __doctest_skip__ = ["xyz2grd"]
     A="duplicate",
     I="spacing",
     R="region",
-    V="verbose",
     Z="convention",
     b="binary",
     d="nodata",
@@ -36,6 +37,16 @@ def xyz2grd(
     z=None,
     outgrid: PathLike | None = None,
     projection=None,
+    verbose: Literal[
+        "quiet",
+        "error",
+        "warning",
+        "timing",
+        "information",
+        "compatibility",
+        "debug",
+    ]
+    | bool = False,
     **kwargs,
 ) -> xr.DataArray | None:
     r"""
@@ -51,6 +62,7 @@ def xyz2grd(
 
     {aliases}
        - J = projection
+       - V = verbose
 
     Parameters
     ----------
@@ -156,7 +168,10 @@ def xyz2grd(
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
 
     with Session() as lib:
         with (

--- a/pygmt/tests/test_alias_system.py
+++ b/pygmt/tests/test_alias_system.py
@@ -15,6 +15,7 @@ def func(
     label=None,
     text=None,
     offset=None,
+    verbose=None,
     **kwargs,
 ):
     """
@@ -29,7 +30,10 @@ def func(
             Alias(text, name="text", prefix="+t"),
             Alias(offset, name="offset", prefix="+o", sep="/"),
         ],
-    ).merge(kwargs)
+    ).add_common(
+        V=verbose,
+    )
+    aliasdict.merge(kwargs)
     return build_arg_list(aliasdict)
 
 
@@ -95,3 +99,18 @@ def test_alias_system_multiple_aliases_short_form():
 
     with pytest.raises(GMTInvalidInput, match=msg):
         func(text="efg", U="efg")
+
+
+def test_alias_system_parameter_verbose():
+    """
+    Test that the alias system works with common parameters.
+    """
+    # Test the verbose parameter.
+    assert func(verbose="quiet") == ["-Vq"]
+    assert func(verbose="error") == ["-Ve"]
+    assert func(verbose="warning") == ["-Vw"]
+    assert func(verbose="timing") == ["-Vt"]
+    assert func(verbose="information") == ["-Vi"]
+    assert func(verbose="compatibility") == ["-Vc"]
+    assert func(verbose=True) == ["-V"]
+    assert func(verbose="debug") == ["-Vd"]

--- a/pygmt/tests/test_alias_system.py
+++ b/pygmt/tests/test_alias_system.py
@@ -101,7 +101,7 @@ def test_alias_system_multiple_aliases_short_form():
         func(text="efg", U="efg")
 
 
-def test_alias_system_parameter_verbose():
+def test_alias_system_common_parameter_verbose():
     """
     Test that the alias system works with common parameters.
     """

--- a/pygmt/tests/test_alias_system.py
+++ b/pygmt/tests/test_alias_system.py
@@ -113,7 +113,7 @@ def test_alias_system_common_parameter_verbose():
     assert func(verbose="warning") == ["-Vw"]
     assert func(verbose="timing") == ["-Vt"]
     assert func(verbose="info") == ["-Vi"]
-    assert func(verbose="compati") == ["-Vc"]
+    assert func(verbose="compat") == ["-Vc"]
     assert func(verbose=True) == ["-V"]
     assert func(verbose="debug") == ["-Vd"]
 

--- a/pygmt/tests/test_alias_system.py
+++ b/pygmt/tests/test_alias_system.py
@@ -112,8 +112,8 @@ def test_alias_system_common_parameter_verbose():
     assert func(verbose="error") == ["-Ve"]
     assert func(verbose="warning") == ["-Vw"]
     assert func(verbose="timing") == ["-Vt"]
-    assert func(verbose="information") == ["-Vi"]
-    assert func(verbose="compatibility") == ["-Vc"]
+    assert func(verbose="info") == ["-Vi"]
+    assert func(verbose="compati") == ["-Vc"]
     assert func(verbose=True) == ["-V"]
     assert func(verbose="debug") == ["-Vd"]
 

--- a/pygmt/tests/test_config.py
+++ b/pygmt/tests/test_config.py
@@ -136,10 +136,10 @@ def test_config_map_grid_cross_size():
             region=["2020-1-24T21:00", "2020-1-25T00:00", 0, 1],
             projection="X6c/2c",
             frame=["pa1Hg", "sa45mg45m", "NWse"],
-            verbose="e",
+            verbose="error",
         )
     fig.shift_origin(yshift=-3)
-    fig.basemap(frame=["pa1Hg", "sa45mg45m", "nwSE"], verbose="e")
+    fig.basemap(frame=["pa1Hg", "sa45mg45m", "nwSE"], verbose="error")
     return fig
 
 
@@ -155,10 +155,10 @@ def test_config_map_grid_pen():
             region=["2020-1-24T21:00", "2020-1-25T00:00", 0, 1],
             projection="X6c/2c",
             frame=["pa1Hg", "sa45mg45m", "NWse"],
-            verbose="e",
+            verbose="error",
         )
     fig.shift_origin(yshift=-3)
-    fig.basemap(frame=["pa1Hg", "sa45mg45m", "nwSE"], verbose="e")
+    fig.basemap(frame=["pa1Hg", "sa45mg45m", "nwSE"], verbose="error")
     return fig
 
 
@@ -174,10 +174,10 @@ def test_config_map_tick_length():
             region=["2020-1-24T21:00", "2020-1-25T00:00", 0, 1],
             projection="X6c/2c",
             frame=["pa1Hg", "sa45mg45m", "NWse"],
-            verbose="e",
+            verbose="error",
         )
     fig.shift_origin(yshift=-3)
-    fig.basemap(frame=["pa1Hg", "sa45mg45m", "nwSE"], verbose="e")
+    fig.basemap(frame=["pa1Hg", "sa45mg45m", "nwSE"], verbose="error")
     return fig
 
 
@@ -193,8 +193,8 @@ def test_config_map_tick_pen():
             region=["2020-1-24T21:00", "2020-1-25T00:00", 0, 1],
             projection="X6c/2c",
             frame=["pa1Hg", "sa45mg45m", "NWse"],
-            verbose="e",
+            verbose="error",
         )
     fig.shift_origin(yshift=-3)
-    fig.basemap(frame=["pa1Hg", "sa45mg45m", "nwSE"], verbose="e")
+    fig.basemap(frame=["pa1Hg", "sa45mg45m", "nwSE"], verbose="error")
     return fig

--- a/pygmt/tests/test_surface.py
+++ b/pygmt/tests/test_surface.py
@@ -86,7 +86,7 @@ def test_surface_input_file(region, spacing, expected_grid):
         data="@Table_5_11_mean.xyz",
         spacing=spacing,
         region=region,
-        verbose="e",  # Suppress warnings for IEEE 754 rounding
+        verbose="error",  # Suppress warnings for IEEE 754 rounding
     )
     check_values(output, expected_grid)
 
@@ -100,7 +100,7 @@ def test_surface_input_data_array(data, region, spacing, expected_grid):
         data=data,
         spacing=spacing,
         region=region,
-        verbose="e",  # Suppress warnings for IEEE 754 rounding
+        verbose="error",  # Suppress warnings for IEEE 754 rounding
     )
     check_values(output, expected_grid)
 
@@ -116,7 +116,7 @@ def test_surface_input_xyz(data, region, spacing, expected_grid):
         z=data.z,
         spacing=spacing,
         region=region,
-        verbose="e",  # Suppress warnings for IEEE 754 rounding
+        verbose="error",  # Suppress warnings for IEEE 754 rounding
     )
     check_values(output, expected_grid)
 
@@ -141,7 +141,7 @@ def test_surface_with_outgrid_param(data, region, spacing, expected_grid):
             spacing=spacing,
             region=region,
             outgrid=tmpfile.name,
-            verbose="e",  # Suppress warnings for IEEE 754 rounding
+            verbose="error",  # Suppress warnings for IEEE 754 rounding
         )
         assert output is None  # check that output is None since outgrid is set
         assert Path(tmpfile.name).stat().st_size > 0  # check that outgrid exists

--- a/pygmt/xarray/backend.py
+++ b/pygmt/xarray/backend.py
@@ -146,7 +146,7 @@ class GMTBackendEntrypoint(BackendEntrypoint):
                     vfname=voutfile, kind=raster_kind
                 )
                 # Add "source" encoding
-                source: str | list = which(fname=filename_or_obj, verbose="q")
+                source: str | list = which(fname=filename_or_obj, verbose="quiet")
                 raster.encoding["source"] = (
                     sorted(source)[0] if isinstance(source, list) else source
                 )


### PR DESCRIPTION
This PR migrates the `verbose` parameter to the new alias system and let it support descriptive arguments. The long names come from https://github.com/GenericMappingTools/gmt/blob/dd32dd35573e0c54b5b5eb5616f039ab9f6d3614/src/gmt_common_longoptions.h#L91.