### PR TITLE
pygmt.select: Remove 'resolution' from the use_alias decorator

### DIFF
--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -24,7 +24,6 @@ __doctest_skip__ = ["select"]
 @use_alias(
     A="area_thresh",
     C="dist2pt",
-    D="resolution-",
     F="polygon",
     G="gridmask",
     I="reverse",


### PR DESCRIPTION
Forgot to remove ` D="resolution-"` in #4013.

Patches #4013.