### PR TITLE
Remove the support of non-aliased aliases in use_alias/fmt_docstrings

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -450,9 +450,7 @@ def fmt_docstring(module_func):
         aliases.append("   :columns: 3\n")
         for arg in sorted(module_func.aliases):
             alias = module_func.aliases[arg]
-            # Trailing dash means it's not aliased but should be listed.
-            # Remove the trailing dash if it exists.
-            aliases.append(f"   - {arg} = {alias.rstrip('-')}")
+            aliases.append(f"   - {arg} = {alias}")
         filler_text["aliases"] = "\n".join(aliases)
 
     filler_text["table-classes"] = (
@@ -486,9 +484,6 @@ def _insert_alias(module_func, default_value=None):
     kwargs_param = wrapped_params.pop(-1)
     # Add new parameters from aliases
     for alias in module_func.aliases.values():
-        if alias.endswith("-"):
-            # Trailing dash means it's not aliased but should be listed.
-            continue
         if alias not in sig.parameters:
             new_param = Parameter(
                 alias, kind=Parameter.KEYWORD_ONLY, default=default_value
@@ -553,31 +548,6 @@ def use_alias(**aliases):
             New module that parses and replaces the registered aliases.
             """
             for short_param, long_alias in aliases.items():
-                if long_alias.endswith("-"):
-                    _long_alias = long_alias.rstrip("-")
-                    # Trailing dash means it's not aliased but should be listed.
-                    _alias_list = _long_alias.split("/")
-                    if (
-                        any(_alias in kwargs for _alias in _alias_list)
-                        and short_param in kwargs
-                    ):  # Both long- and short- forms are given.
-                        msg = (
-                            f"Parameters in short-form ({short_param}) and "
-                            f"long-form ({_long_alias}) can't coexist."
-                        )
-                        raise GMTInvalidInput(msg)
-                    if short_param in kwargs:  # Only short-alias is given
-                        if len(_alias_list) > 1:  # Aliased to multiple long-forms
-                            msg = (
-                                f"Short-form parameter ({short_param}) is not "
-                                f"recognized. Use long-form parameter(s) "
-                                f"'{_long_alias}' instead."
-                            )
-                            raise GMTInvalidInput(msg)
-                        # If there is only one long-form parameter, use it.
-                        kwargs[_long_alias] = kwargs.pop(short_param)
-                    continue
-
                 if long_alias in kwargs and short_param in kwargs:
                     msg = (
                         f"Parameters in short-form ({short_param}) and "

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -126,7 +126,6 @@ def _auto_offset(spec) -> bool:
     L="outline",
     N="no_clip",
     R="region",
-    S="scale/convention/component-",
     T="nodal",
     V="verbose",
     W="pen",
@@ -203,6 +202,7 @@ def meca(  # noqa: PLR0913
 
     {aliases}
        - J=projection
+       - S=scale/convention/component
 
     Parameters
     ----------

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -27,7 +27,6 @@ from pygmt.helpers import (
     B="frame",
     C="clearance",
     D="offset",
-    F="position/angle/font/justify-",
     G="fill",
     N="no_clip",
     V="verbose",
@@ -73,6 +72,7 @@ def text_(  # noqa: PLR0912
     Full GMT docs at :gmt-docs:`text.html`.
 
     {aliases}
+       - F=**+a**: angle, **+c**: position, **+j**: justify, **+f**: font
        - J=projection
 
     Parameters


### PR DESCRIPTION
In PR #3965, we modified the `use_alias`/`fmt_docstrings` decorators to automatically list the non-aliased aliases in docstrings. The workarounds work as expected but have some limitations (e.g., https://github.com/GenericMappingTools/pygmt/pull/3965#discussion_r2134997663).

Since we're slowly migrating to the new alias system (#3239), and getting rid of the `{aliases}` placeholder, the workarounds are no longer needed and can be removed.

This PR reverts the changes in #3965.

