### PR TITLE
Reformat the manually maintained aliases in docstrings

### DIFF
--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -39,7 +39,7 @@ def basemap(self, projection=None, **kwargs):
     Full GMT docs at :gmt-docs:`basemap.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -65,7 +65,7 @@ def binstats(
     Full GMT docs at :gmt-docs:`gmtbinstats.html`.
 
     {aliases}
-       - C=statistic
+       - C = statistic
 
     Parameters
     ----------

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -66,8 +66,8 @@ def coast(
     Full GMT docs at :gmt-docs:`coast.html`.
 
     {aliases}
-       - D=resolution
-       - J=projection
+       - D = resolution
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -45,7 +45,7 @@ def colorbar(self, projection=None, **kwargs):
     Full GMT docs at :gmt-docs:`colorbar.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -58,7 +58,7 @@ def contour(
     Full GMT docs at :gmt-docs:`contour.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -52,10 +52,10 @@ def grdclip(
     Full GMT docs at :gmt-docs:`grdclip.html`.
 
     {aliases}
-       - Sa=above
-       - Sb=below
-       - Si=between
-       - Sr=replace
+       - Sa = above
+       - Sb = below
+       - Si = between
+       - Sr = replace
 
     Parameters
     ----------

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -47,7 +47,7 @@ def grdcontour(self, grid: PathLike | xr.DataArray, projection=None, **kwargs):
     Full GMT docs at :gmt-docs:`grdcontour.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -52,7 +52,7 @@ def grdcut(
     Full GMT docs at :gmt-docs:`grdcut.html`.
 
     {aliases}
-      - J=projection
+      - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -101,11 +101,11 @@ def grdfill(
     Full GMT docs at :gmt-docs:`grdfill.html`.
 
     {aliases}
-       - Ac=constantfill
-       - Ag=gridfill
-       - An=neighborfill
-       - As=splinefill
-       - L=inquire
+       - Ac = constantfill
+       - Ag = gridfill
+       - An = neighborfill
+       - As = splinefill
+       - L = inquire
 
     Parameters
     ----------

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -73,7 +73,7 @@ def grdimage(self, grid: PathLike | xr.DataArray, projection=None, **kwargs):
     Full GMT docs at :gmt-docs:`grdimage.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -51,9 +51,9 @@ def grdlandmask(
     Full GMT docs at :gmt-docs:`grdlandmask.html`.
 
     {aliases}
-       - D=resolution
-       - E=bordervalues
-       - N=maskvalues
+       - D = resolution
+       - E = bordervalues
+       - N = maskvalues
 
     Parameters
     ----------

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -53,7 +53,7 @@ def grdproject(
     Full GMT docs at :gmt-docs:`grdproject.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -46,7 +46,7 @@ def grdview(self, grid: PathLike | xr.DataArray, projection=None, **kwargs):
     Full GMT docs at :gmt-docs:`grdview.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -47,7 +47,7 @@ def histogram(self, data: PathLike | TableLike, projection=None, **kwargs):
     Full GMT docs at :gmt-docs:`histogram.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -31,7 +31,7 @@ def image(self, imagefile: PathLike, projection=None, **kwargs):
     Full GMT docs at :gmt-docs:`image.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -33,7 +33,7 @@ def inset(self, projection=None, **kwargs):
     Full GMT docs at :gmt-docs:`inset.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -49,7 +49,7 @@ def legend(
     Full GMT docs at :gmt-docs:`legend.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -30,7 +30,7 @@ def logo(self, projection=None, **kwargs):
     Full GMT docs at :gmt-docs:`gmtlogo.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -202,7 +202,7 @@ def meca(  # noqa: PLR0913
     Full GMT docs at :gmt-docs:`supplements/seis/meca.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -87,7 +87,7 @@ def plot(  # noqa: PLR0912
     Full GMT docs at :gmt-docs:`plot.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -89,7 +89,7 @@ def plot3d(  # noqa: PLR0912
     Full GMT docs at :gmt-docs:`plot3d.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -76,8 +76,8 @@ def select(
     Full GMT docs at :gmt-docs:`gmtselect.html`.
 
     {aliases}
-       - D=resolution
-       - J=projection
+       - D = resolution
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -41,8 +41,8 @@ def solar(
     Full GMT docs at :gmt-docs:`solar.html`.
 
     {aliases}
-       - J=projection
-       - T=terminator, **+d**: terminator_datetime
+       - J = projection
+       - T = terminator, **+d**: terminator_datetime
 
     Parameters
     ----------

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -44,7 +44,7 @@ def subplot(self, nrows=1, ncols=1, projection=None, **kwargs):
     Full GMT docs at :gmt-docs:`subplot.html#synopsis-begin-mode`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -47,7 +47,7 @@ def ternary(
     Full GMT docs at :gmt-docs:`ternary.html`.
 
     {aliases}
-       - L=alabel/blabel/clabel
+       - L = alabel/blabel/clabel
 
     Parameters
     ----------

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -73,7 +73,7 @@ def text_(  # noqa: PLR0912
     Full GMT docs at :gmt-docs:`text.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -57,7 +57,7 @@ def tilemap(
     provide Spherical Mercator (EPSG:3857) coordinates to the ``region`` parameter.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -98,7 +98,7 @@ class triangulate:  # noqa: N801
         Full GMT docs at :gmt-docs:`triangulate.html`.
 
         {aliases}
-           - J=projection
+           - J = projection
 
         Parameters
         ----------
@@ -205,7 +205,7 @@ class triangulate:  # noqa: N801
         Full GMT docs at :gmt-docs:`triangulate.html`
 
         {aliases}
-           - J=projection
+           - J = projection
 
         Parameters
         ----------

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -58,7 +58,7 @@ def velo(self, data: PathLike | TableLike | None = None, projection=None, **kwar
     Full GMT docs at :gmt-docs:`supplements/geodesy/velo.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -53,7 +53,7 @@ def wiggle(
     Full GMT docs at :gmt-docs:`wiggle.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -50,7 +50,7 @@ def xyz2grd(
     Full GMT docs at :gmt-docs:`xyz2grd.html`.
 
     {aliases}
-       - J=projection
+       - J = projection
 
     Parameters
     ----------


### PR DESCRIPTION
Add whitespaces around `=` for aliases in docstrings, i.e., changing `J=projection` to `J = projection`, so the format of the aliases is consistent with the ones inserted by the `{aliases}` placeholder.