### PR TITLE
DOC: Fix synthax of aliases list for pygmt.grdcut

### DIFF
--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -52,7 +52,7 @@ def grdcut(
     Full GMT docs at :gmt-docs:`grdcut.html`.
 
     {aliases}
-      - J = projection
+       - J = projection
 
     Parameters
     ----------


### PR DESCRIPTION
**Description of proposed changes**

The aliases list of `pygmt.grdcut` is displayed incorrectly (see https://www.pygmt.org/dev/api/generated/pygmt.grdcut.html)
There is one whitespace missing for the indent.

Fixes #

**Preview**: https://pygmt-dev--4028.org.readthedocs.build/en/4028/api/generated/pygmt.grdcut.html#pygmt.grdcut

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
