### PR TITLE
x2sys_cross: Fix IndexError to allow empty dataframe outputs

### DIFF
--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -250,9 +250,12 @@ def x2sys_cross(
                     unit = time_unit.upper() if time_unit in "wd" else time_unit
                     scale = 1.0
 
-            columns = result.columns[2:4]
-            result[columns] *= scale
-            result[columns] = result[columns].apply(pd.to_timedelta, unit=unit)
-            if columns[0][0] == "t":  # "t" or "i":
-                result[columns] += pd.Timestamp(lib.get_default("TIME_EPOCH"))
+            if len(result) > 0:  # if crossovers exist (more than one output row)
+                columns: pd.Index = result.columns[2:4]  # i_1/i_2 or t_1/t_2 columns
+                result[columns] *= scale
+                result[columns] = result[columns].apply(pd.to_timedelta, unit=unit)
+
+                if columns[0][0] == "t":  # "t" or "i":
+                    result[columns] += pd.Timestamp(lib.get_default("TIME_EPOCH"))
+
             return result

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -308,3 +308,27 @@ def test_x2sys_cross_trackvalues():
             assert output.shape == (14338, 12)
             npt.assert_allclose(output.z_1.mean(), -2422.418556, rtol=1e-4)
             npt.assert_allclose(output.z_2.mean(), -2402.268364, rtol=1e-4)
+
+
+@pytest.mark.benchmark
+@pytest.mark.usefixtures("mock_x2sys_home")
+def test_x2sys_cross_output_dataframe_empty(tracks):
+    """
+    Test that x2sys_cross can output an empty dataframe (when there are no crossovers)
+    without any errors.
+
+    Regression test for
+    https://forum.generic-mapping-tools.org/t/issue-with-x2sys-in-pygmt-solved/6154
+    """
+    with TemporaryDirectory(prefix="X2SYS", dir=Path.cwd()) as tmpdir:
+        tag = Path(tmpdir).name
+        x2sys_init(tag=tag, fmtfile="xyz", force=True)
+
+        tracks = [tracks[0][:5]]  # subset to less rows so there won't be crossovers
+        output = x2sys_cross(tracks=tracks, tag=tag, coe="i")
+
+        assert isinstance(output, pd.DataFrame)
+        assert output.shape == (0, 0)
+        assert output.empty
+        columns = list(output.columns)
+        assert columns == []

--- a/pygmt/tests/test_x2sys_cross.py
+++ b/pygmt/tests/test_x2sys_cross.py
@@ -310,7 +310,6 @@ def test_x2sys_cross_trackvalues():
             npt.assert_allclose(output.z_2.mean(), -2402.268364, rtol=1e-4)
 
 
-@pytest.mark.benchmark
 @pytest.mark.usefixtures("mock_x2sys_home")
 def test_x2sys_cross_output_dataframe_empty(tracks):
     """


### PR DESCRIPTION
**Description of proposed changes**

Fixes `IndexError: index 0 is out of bounds for axis 0 with size 0` when `x2sys_cross` returns no crossovers. An empty dataframe should be returned instead.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Full traceback:

```python-traceback
___________________ test_x2sys_cross_output_dataframe_empty ____________________

self = RangeIndex(start=0, stop=0, step=1), key = 0

    def __getitem__(self, key):
        """
        Conserve RangeIndex type for scalar and slice keys.
        """
        if isinstance(key, slice):
            return self._getitem_slice(key)
        elif is_integer(key):
            new_key = int(key)
            try:
>               return self._range[new_key]
                       ^^^^^^^^^^^^^^^^^^^^
E               IndexError: range object index out of range

../../../../micromamba/envs/pygmt/lib/python3.11/site-packages/pandas/core/indexes/range.py:982: IndexError

The above exception was the direct cause of the following exception:

tracks = [              x         y     z
4152  251.11450  25.22122 -19.0
4380  249.61510  24.30340 -19.0
5033  249.36575  27.34900 -19.0
5034  249.36971  27.34747 -19.0
9589  249.72477  24.39497 -13.0]

    @pytest.mark.benchmark
    @pytest.mark.usefixtures("mock_x2sys_home")
    def test_x2sys_cross_output_dataframe_empty(tracks):
        """
        Test that x2sys_cross can output an empty dataframe (when there are no crossovers)
        without any errors.
    
        Regression test for
        https://forum.generic-mapping-tools.org/t/issue-with-x2sys-in-pygmt-solved/6154
        """
        with TemporaryDirectory(prefix="X2SYS", dir=Path.cwd()) as tmpdir:
            tag = Path(tmpdir).name
            x2sys_init(tag=tag, fmtfile="xyz", force=True)
    
            tracks = [tracks[0][:5]]  # subset to less rows so there won't be crossovers
>           output = x2sys_cross(tracks=tracks, tag=tag, coe="i")
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

../pygmt/tests/test_x2sys_cross.py:328: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../pygmt/helpers/decorators.py:590: in new_module
    return module_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../pygmt/helpers/decorators.py:756: in new_module
    return module_func(*bound.args, **bound.kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../pygmt/src/x2sys_cross.py:256: in x2sys_cross
    if columns[0][0] == "t":  # "t" or "i":
       ^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = RangeIndex(start=0, stop=0, step=1), key = 0

    def __getitem__(self, key):
        """
        Conserve RangeIndex type for scalar and slice keys.
        """
        if isinstance(key, slice):
            return self._getitem_slice(key)
        elif is_integer(key):
            new_key = int(key)
            try:
                return self._range[new_key]
            except IndexError as err:
>               raise IndexError(
                    f"index {key} is out of bounds for axis 0 with size {len(self)}"
E                   IndexError: index 0 is out of bounds for axis 0 with size 0

../../../../micromamba/envs/pygmt/lib/python3.11/site-packages/pandas/core/indexes/range.py:984: IndexError
```

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes https://forum.generic-mapping-tools.org/t/issue-with-x2sys-in-pygmt-solved/6154, patches bug introduced in #3182 (pygmt v0.13.0 - v0.16.0)


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
