### PR TITLE
[BREAKING] Figure.grdimage: Raise NotImplementedError instead of GMTInvalidInput for -A option

### DIFF
--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -6,13 +6,7 @@ import xarray as xr
 from pygmt._typing import PathLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import (
-    build_arg_list,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
+from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
 __doctest_skip__ = ["grdimage"]
 
@@ -165,7 +159,7 @@ def grdimage(self, grid: PathLike | xr.DataArray, projection=None, **kwargs):
             "Parameter 'img_out'/'A' is not implemented. "
             "Please consider submitting a feature request to us."
         )
-        raise GMTInvalidInput(msg)
+        raise NotImplementedError(msg)
 
     aliasdict = AliasSystem(
         J=Alias(projection, name="projection"),

--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -10,7 +10,7 @@ from pygmt import Figure
 from pygmt.clib import __gmt_version__
 from pygmt.datasets import load_earth_relief
 from pygmt.enums import GridRegistration, GridType
-from pygmt.exceptions import GMTInvalidInput, GMTTypeError
+from pygmt.exceptions import GMTTypeError
 from pygmt.helpers.testing import check_figures_equal
 
 
@@ -252,9 +252,9 @@ def test_grdimage_imgout_fails(grid):
     Test that an exception is raised if img_out/A is given.
     """
     fig = Figure()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(NotImplementedError):
         fig.grdimage(grid, img_out="out.png")
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(NotImplementedError):
         fig.grdimage(grid, A="out.png")
 
 


### PR DESCRIPTION
`grdimage` `-A` is not implemented in the `Figure.grdimage` wrapper. I think it makes more sense to raise `NotImplementedError` instead of `GMTInvalidInput`.