### PR TITLE
[BREAKING] Figure.text: Raise GMTTypeError if text is a sequence when position is given

### DIFF
--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -197,9 +197,16 @@ def text_(  # noqa: PLR0912, PLR0913, PLR0915
     data_is_required = position is None
     kind = data_kind(textfiles, required=data_is_required)
 
-    if position is not None and (text is None or is_nonstr_iter(text)):
-        msg = "'text' can't be None or array when 'position' is given."
-        raise GMTInvalidInput(msg)
+    if position is not None:
+        if text is None:
+            msg = "'text' can't be None when 'position' is given."
+            raise GMTInvalidInput(msg)
+        if is_nonstr_iter(text):
+            raise GMTTypeError(
+                type(text),
+                reason="Parameter 'text' can't be a sequence when 'position' is given.",
+            )
+
     if textfiles is not None and text is not None:
         msg = "'text' can't be specified when 'textfiles' is given."
         raise GMTInvalidInput(msg)

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from pygmt import Figure, config
-from pygmt.exceptions import GMTCLibError, GMTInvalidInput
+from pygmt.exceptions import GMTCLibError, GMTInvalidInput, GMTTypeError
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import skip_if_no
 
@@ -154,7 +154,7 @@ def test_text_invalid_inputs(region):
         fig.text(region=region, projection="x1c", textfiles="file.txt", text="text")
     with pytest.raises(GMTInvalidInput):
         fig.text(region=region, projection="x1c", position="MC", text=None)
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTTypeError):
         fig.text(
             region=region, projection="x1c", position="MC", text=["text1", "text2"]
         )


### PR DESCRIPTION
In `Figure.text`, when `position` is given, `text` is required. If `text` is not given, it should raise a GMTParameterError (i.e., #4003). If `text` is a list/tuple, it should raise the `GMTTypeError` instead.

This PR makes the change and raise `GMTTypeError` when a list/tuple is passed to `text`.