### PR TITLE
CI: Access DagsHub repository via an access token

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -163,7 +163,11 @@ jobs:
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote
-        run: uv run dvc pull --no-run-cache --verbose && ls -lhR pygmt/tests/baseline/
+        run: |
+          uv run dvc remote modify upstream url https://${DAGSHUB_TOKEN}@dagshub.com/GenericMappingTools/pygmt.dvc --local
+          uv run dvc pull --no-run-cache --verbose && ls -lhR pygmt/tests/baseline/
+        env:
+          DAGSHUB_TOKEN: ${{ secrets.DAGSHUB_TOKEN }}
 
       # Install the package that we want to test
       - name: Install the package

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -161,7 +161,11 @@ jobs:
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote
-        run: dvc pull --no-run-cache --verbose && ls -lhR pygmt/tests/baseline/
+        run: |
+          dvc remote modify upstream url https://${DAGSHUB_TOKEN}@dagshub.com/GenericMappingTools/pygmt.dvc --local
+          dvc pull --no-run-cache --verbose && ls -lhR pygmt/tests/baseline/
+        env:
+          DAGSHUB_TOKEN: ${{ secrets.DAGSHUB_TOKEN }}
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub

--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -57,9 +57,13 @@ jobs:
       env:
         repo_token: ${{ github.token }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        DAGSHUB_TOKEN: ${{ secrets.DAGSHUB_TOKEN }}
       run: |
         echo -e "## Summary of changed images\n" > report.md
         echo -e "This is an auto-generated report of images that have changed on the DVC remote\n" >> report.md
+
+        # Configure DVC to use the DAGsHub remote via a token
+        dvc remote modify upstream url https://${DAGSHUB_TOKEN}@dagshub.com/GenericMappingTools/pygmt.dvc --local
 
         # Pull image data from cloud storage
         dvc pull --remote upstream

--- a/.github/workflows/release-baseline-images.yml
+++ b/.github/workflows/release-baseline-images.yml
@@ -31,7 +31,11 @@ jobs:
       uses: iterative/setup-dvc@175771be1dc3d119268e00a896b52a4b77decb5e # v1.2.0
 
     - name: Pull baseline image data from dvc remote
-      run: dvc pull && ls -lhR pygmt/tests/baseline/
+      run: |
+        dvc remote modify upstream url https://${DAGSHUB_TOKEN}@dagshub.com/GenericMappingTools/pygmt.dvc --local
+        dvc pull && ls -lhR pygmt/tests/baseline/
+      env:
+        DAGSHUB_TOKEN: ${{ secrets.DAGSHUB_TOKEN }}
 
     - name: Create the baseline image asset in zip format
       run: |


### PR DESCRIPTION
`dvc pull` started to fail recently with errors like:
```
2025-09-07 01:23:24,119 DEBUG: v3.63.0 (pip), CPython 3.11.13 on Linux-6.11.0-1018-azure-x86_64-with-glibc2.39
2025-09-07 01:23:24,119 DEBUG: command: /home/runner/work/pygmt/pygmt/.venv/bin/dvc pull --no-run-cache --verbose
2025-09-07 01:23:26,142 DEBUG: Preparing to transfer data from 'https://dagshub.com/GenericMappingTools/pygmt.dvc/files/md5' to '/home/runner/work/pygmt/pygmt/.dvc/cache/files/md5'
2025-09-07 01:23:26,142 DEBUG: Preparing to collect status from '/home/runner/work/pygmt/pygmt/.dvc/cache/files/md5'
2025-09-07 01:23:26,142 DEBUG: Collecting status from '/home/runner/work/pygmt/pygmt/.dvc/cache/files/md5'
2025-09-07 01:23:26,144 DEBUG: Preparing to collect status from 'https://dagshub.com/GenericMappingTools/pygmt.dvc/files/md5'
2025-09-07 01:23:26,144 DEBUG: Collecting status from 'https://dagshub.com/GenericMappingTools/pygmt.dvc/files/md5'
2025-09-07 01:23:26,144 DEBUG: Querying 172 oids via object_exists
2025-09-07 01:23:26,881 WARNING: Some of the cache files do not exist neither locally nor on remote. Missing cache files:
md5: b73351d7d37e5d56fbcab6d46132026a
md5: e4bc1a90f4f25220fe759cdb0a709db8
```

I still don't know why it failed suddenly, but it turns out that we can fix the dvc issue via an access token. 