### PR TITLE
Switch from pre-commit to prek

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -38,7 +38,7 @@ jobs:
       # Install formatting tools
       - name: Install formatting tools
         run: |
-          python -m pip install ruff pre-commit
+          python -m pip install ruff prek
           python -m pip list
 
       # Run "make format" and commit the change to the PR branch

--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -38,13 +38,13 @@ jobs:
 
       - name: Install packages
         run: |
-          python -m pip install ruff pre-commit
+          python -m pip install ruff prek
           python -m pip list
 
-      - name: Formatting check (ruff + pre-commit)
+      - name: Formatting check (ruff + prek)
         run: |
            make check
-           pre-commit run --all-files
+           prek run --all-files
 
       - name: Ensure example scripts have at least one code block separator
         run: |

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test_no_images: _runtest
 format:
 	ruff check --fix --exit-zero $(FORMAT_FILES)
 	ruff format $(FORMAT_FILES)
-	pre-commit run --all-files
+	prek run --all-files
 
 check:
 	ruff check $(FORMAT_FILES)

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -481,10 +481,10 @@ the code yourself. Before committing, run it to automatically format your code:
 make format
 ```
 
-For consistency, we also use `pre-commit` hooks to enforce UNIX-style line endings
-(`\n`) and file permission 644 (`-rw-r--r--`) throughout the whole project.
-Don't worry if you forget to do it. Our continuous integration systems will
-warn us and you can make a new commit with the formatted code.
+For consistency, we also use `pre-commit` hooks (via [`prek`](https://prek.j178.dev/))
+to enforce UNIX-style line endings (`\n`) and file permission 644 (`-rw-r--r--`)
+throughout the whole project. Don't worry if you forget to do it. Our continuous
+integration systems will warn us and you can make a new commit with the formatted code.
 Even better, you can just write `/format` in the first line of any comment in a
 pull request to lint the code automatically.
 

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
     - python-build
     # Dev dependencies (style checks)
     - codespell
-    - pre-commit
+    - prek
     - ruff>=0.12.0
     # Dev dependencies (unit testing)
     - matplotlib-base


### PR DESCRIPTION
**Description of proposed changes**

Better `pre-commit`, re-engineered in Rust. https://prek.j178.dev/

Benchmarks on Style Checks workflow:

| [Before (27s)](https://github.com/GenericMappingTools/pygmt/actions/runs/17594774699/job/49984248350) | [After (14s)](https://github.com/GenericMappingTools/pygmt/actions/runs/17598027441/job/49994498553?pr=4082) |
|--|--|
| <img width="612" height="600" alt="image" src="https://github.com/user-attachments/assets/613571c8-23a0-4d32-ba58-f9bda72b4248" /> | <img width="612" height="600" alt="image" src="https://github.com/user-attachments/assets/3d160313-e5de-4cac-80e1-1b474f08f745" /> |
| 4s install + 17s run | 5s install + 3s run |

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Replace `pre-commit` with `prek` in these files:
- [x] .github/workflows/style_checks.yaml
- [x] .github/workflows/format-command.yml
- [x] environment.yml
- [x] Makefile

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Supersedes #3283


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
