### PR TITLE
CI: Use macos-26 in the GMT Dev Tests workflow

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2025]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
         gmt_git_ref: [master]
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
xref: https://github.blog/changelog/2025-09-11-actions-macos-26-image-now-in-public-preview/