### PR TITLE
Fix the link to Paul

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,7 +2,7 @@
 
 This project was started in 2017 by [Leonardo Uieda](https://www.leouieda.com)
 during [an NSF funded postdoc](https://www.leouieda.com/blog/hawaii-gmt-postdoc)
-with [Paul Wessel](https://www.soest.hawaii.edu/wessel) at the University of
+with [Paul Wessel](https://en.wikipedia.org/wiki/Pål_Wessel) at the University of
 Hawaiʻi at Mānoa.
 
 The following people have contributed code and/or documentation to the project

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -19,9 +19,9 @@ contact with the original PostScript files and get only the more convenient form
 PDF and PNG.
 
 The project was started in 2017 by [Leonardo Uieda](https://www.leouieda.com) and
-[Paul Wessel](https://www.soest.hawaii.edu/wessel) (the co-creator and main developer of
-GMT) at the University of Hawaiʻi at Mānoa. The development of PyGMT has been supported
-by NSF grants [OCE-1558403](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1558403)
+[Paul Wessel](https://en.wikipedia.org/wiki/Pål_Wessel) (the co-creator and main
+developer of GMT) at the University of Hawaiʻi at Mānoa. The development of PyGMT
+has been supported by NSF grants [OCE-1558403](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1558403)
 and [EAR-1948602](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1948602).
 
 We welcome any feedback and ideas! Let us know by submitting


### PR DESCRIPTION
As reported in #4085, the link https://www.soest.hawaii.edu/wessel no longer works. I think the wikipedia page (https://en.wikipedia.org/wiki/Pål_Wessel) is a good replacement.

Closes #4085.