### PR TITLE
WIP: Try using skipna=True in min() for test_binstats_quantile

### DIFF
--- a/pygmt/tests/test_binstats.py
+++ b/pygmt/tests/test_binstats.py
@@ -67,7 +67,8 @@ def test_binstats_quantile():
     assert temp_grid.dims == ("y", "x")
     assert temp_grid.gmt.gtype is GridType.CARTESIAN
     assert temp_grid.gmt.registration is GridRegistration.GRIDLINE
+    assert temp_grid.dtype == "float32"
     npt.assert_allclose(temp_grid.max(), 15047685)
-    npt.assert_allclose(temp_grid.min(), 53)
+    npt.assert_allclose(temp_grid.min(skipna=True), 53)
     npt.assert_allclose(temp_grid.median(), 543664.5)
     npt.assert_allclose(temp_grid.mean(), 1661363.6)


### PR DESCRIPTION
**Description of proposed changes**

The `test_binstats_quantile` test (introduced in #3012) is failing on the legacy CI tests. Trying to see if it's due to xarray/pandas/numpy or using old version of GMT 6.4.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Traceback from https://github.com/GenericMappingTools/pygmt/actions/runs/16895808645/job/47865247702#step:6:1098

```python-traceback
___________________________ test_binstats_quantile ____________________________
    def test_binstats_quantile():
        """
        Test binstats quantile statistic functionality.
        """
        temp_grid = binstats(
            data="@capitals.gmt",
            spacing=5,
            statistic="quantile",
            quantile_value=75,
            search_radius="1000k",
            aspatial="2=population",
            region="g",
        )
        assert temp_grid.dims == ("y", "x")
        assert temp_grid.gmt.gtype is GridType.CARTESIAN
        assert temp_grid.gmt.registration is GridRegistration.GRIDLINE
        npt.assert_allclose(temp_grid.max(), 15047685)
>       npt.assert_allclose(temp_grid.min(), 53)
..\pygmt\tests\test_binstats.py:71: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
args = (<function assert_allclose.<locals>.compare at 0x000001D761A02E80>, array(0., dtype=float32), array(53))
kwds = {'equal_nan': True, 'err_msg': '', 'header': 'Not equal to tolerance rtol=1e-07, atol=0', 'verbose': True}
    @wraps(func)
    def inner(*args, **kwds):
        with self._recreate_cm():
>           return func(*args, **kwds)
E           AssertionError: 
E           Not equal to tolerance rtol=1e-07, atol=0
E           
E           Mismatched elements: 1 / 1 (100%)
E           Max absolute difference: 53.
E           Max relative difference: 1.
E            x: array(0., dtype=float32)
E            y: array(53)
C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\contextlib.py:81: AssertionError
```

Output of pygmt.show_versions() from CI:

```
PyGMT information:
  version: v0.17.0.dev39+g354b50a0f
System information:
  python: 3.11.9 | packaged by conda-forge | (main, Apr 19 2024, 18:36:13) [GCC 12.3.0]
  executable: /home/runner/micromamba/envs/pygmt/bin/python
  machine: Linux-6.8.0-1031-azure-x86_64-with-glibc2.35
Dependency information:
  numpy: 1.26.4
  pandas: 2.3.1
  xarray: 2025.7.1
  packaging: 24.2
  contextily: 1.5.2
  geopandas: 1.0.1
  IPython: 9.4.0
  pyarrow: 16.1.0
  rioxarray: 0.19.0
  gdal: 3.8.5
  ghostscript: 9.56.1
GMT library information:
  version: 6.4.0
  padding: 2
  share dir: /home/runner/micromamba/envs/pygmt/share/gmt
  plugin dir: /home/runner/micromamba/envs/pygmt/lib/gmt/plugins
  library path: /home/runner/micromamba/envs/pygmt/lib/libgmt.so
  cores: 4
  grid layout: rows
  image layout: 
  binary version: 6.4.0
```


<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Patches https://github.com/GenericMappingTools/pygmt/pull/3012


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
