### PR TITLE
Migrate the 'no_clip' parameter to the new alias system

### DIFF
--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -5,7 +5,7 @@ contour - Contour table data by direct triangulation.
 from typing import Literal
 
 from pygmt._typing import PathLike, TableLike
-from pygmt.alias import AliasSystem
+from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_list,
@@ -23,7 +23,6 @@ from pygmt.helpers import (
     C="levels",
     G="label_placement",
     L="triangular_mesh_pen",
-    N="no_clip",
     R="region",
     S="skip",
     W="pen",
@@ -43,6 +42,7 @@ def contour(
     x=None,
     y=None,
     z=None,
+    no_clip: bool = False,
     projection=None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
@@ -62,6 +62,7 @@ def contour(
 
     {aliases}
        - J = projection
+       - N = no_clip
        - V = verbose
        - c = panel
        - t = transparency
@@ -109,9 +110,9 @@ def contour(
         Color the triangles using CPT.
     triangular_mesh_pen : str
         Pen to draw the underlying triangulation [Default is ``None``].
-    no_clip : bool
-        Do **not** clip contours or image at the frame boundaries
-        [Default is ``False`` to fit inside ``region``].
+    no_clip
+        Do **not** clip contours or image at the frame boundaries [Default is ``False``
+        to fit inside ``region``].
     Q : float or str
         [*cut*][**+z**].
         Do not draw contours with less than *cut* number of points.
@@ -159,7 +160,9 @@ def contour(
             else:  # Multiple levels
                 kwargs[arg] = ",".join(f"{item}" for item in kwargs[arg])
 
-    aliasdict = AliasSystem().add_common(
+    aliasdict = AliasSystem(
+        N=Alias(no_clip, name="no_clip"),
+    ).add_common(
         J=projection,
         V=verbose,
         c=panel,

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -107,7 +107,7 @@ def contour(
         five controlling algorithms. See :gmt-docs:`contour.html#g` for
         details.
     I : bool
-        Color the triangles using CPT.
+        Color the triangles using the CPT if given via ``levels``.
     triangular_mesh_pen : str
         Pen to draw the underlying triangulation [Default is ``None``].
     no_clip

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -111,8 +111,8 @@ def contour(
     triangular_mesh_pen : str
         Pen to draw the underlying triangulation [Default is ``None``].
     no_clip
-        Do **not** clip contours or image at the frame boundaries [Default is ``False``
-        to fit inside ``region``].
+        Do **not** clip contours or colored triangles at the frame boundaries [Default
+        is ``False`` to fit inside ``region``].
     Q : float or str
         [*cut*][**+z**].
         Do not draw contours with less than *cut* number of points.

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 import xarray as xr
 from pygmt._typing import PathLike
-from pygmt.alias import AliasSystem
+from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -22,7 +22,6 @@ __doctest_skip__ = ["grdimage"]
     G="bitcolor",
     I="shading",
     M="monochrome",
-    N="no_clip",
     Q="nan_transparent",
     R="region",
     n="interpolation",
@@ -34,6 +33,7 @@ __doctest_skip__ = ["grdimage"]
 def grdimage(
     self,
     grid: PathLike | xr.DataArray,
+    no_clip: bool = False,
     projection=None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
@@ -76,6 +76,7 @@ def grdimage(
 
     {aliases}
        - J = projection
+       - N = no_clip
        - V = verbose
        - c = panel
        - t = transparency
@@ -130,9 +131,9 @@ def grdimage(
     monochrome : bool
         Force conversion to monochrome image using the (television) YIQ
         transformation. Cannot be used with ``nan_transparent``.
-    no_clip : bool
-        Do **not** clip the image at the frame boundaries (only relevant
-        for non-rectangular maps) [Default is ``False``].
+    no_clip
+        Do **not** clip the image at the frame boundaries (only relevant for
+        non-rectangular maps) [Default is ``False``].
     nan_transparent : bool or str
         [**+z**\ *value*][*color*]
         Make grid nodes with z = NaN transparent, using the color-masking
@@ -172,7 +173,9 @@ def grdimage(
         )
         raise NotImplementedError(msg)
 
-    aliasdict = AliasSystem().add_common(
+    aliasdict = AliasSystem(
+        N=Alias(no_clip, name="no_clip"),
+    ).add_common(
         J=projection,
         V=verbose,
         c=panel,

--- a/pygmt/src/hlines.py
+++ b/pygmt/src/hlines.py
@@ -59,8 +59,8 @@ def hlines(
     label
         Label for the line(s), to be displayed in the legend.
     no_clip
-        If ``True``, do not clip lines outside the plot region. Only makes sense in the
-        Cartesian coordinate system.
+        Do **not** clip lines outside the plot region. Only makes sense in the Cartesian
+        coordinate system. [Default is ``False`` to clip lines at the plot region.]
     perspective
         Select perspective view and set the azimuth and elevation angle of the
         viewpoint. Refer to :meth:`pygmt.Figure.plot` for details.

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -15,12 +15,13 @@ __doctest_skip__ = ["inset"]
 
 @fmt_docstring
 @contextlib.contextmanager
-@use_alias(D="position", M="margin", N="no_clip", R="region")
+@use_alias(D="position", M="margin", R="region")
 @kwargs_to_strings(D="sequence", M="sequence", R="sequence")
 def inset(
     self,
     projection=None,
     box: Box | bool = False,
+    no_clip: bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     **kwargs,
@@ -37,6 +38,7 @@ def inset(
     {aliases}
        - F = box
        - J = projection
+       - N = no_clip
        - V = verbose
 
     Parameters
@@ -94,9 +96,9 @@ def inset(
         margins). When passing multiple values, it can be either a list or
         a string with the values separated by forward
         slashes [Default is no margins].
-    no_clip : bool
-        Do **not** clip features extruding outside the inset frame
-        boundaries [Default is ``False``].
+    no_clip
+        Do **not** clip features extruding outside the inset frame boundaries [Default
+        is ``False``].
     {region}
     {projection}
     {verbose}
@@ -130,6 +132,7 @@ def inset(
 
     aliasdict = AliasSystem(
         F=Alias(box, name="box"),
+        N=Alias(no_clip, name="no_clip"),
     ).add_common(
         J=projection,
         V=verbose,

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -8,7 +8,7 @@ from typing import Literal
 import numpy as np
 import pandas as pd
 from pygmt._typing import PathLike, TableLike
-from pygmt.alias import AliasSystem
+from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput, GMTValueError
 from pygmt.helpers import (
@@ -124,7 +124,6 @@ def _auto_offset(spec) -> bool:
     Fr="labelbox",
     G="compressionfill",
     L="outline",
-    N="no_clip",
     R="region",
     T="nodal",
     W="pen",
@@ -143,6 +142,7 @@ def meca(  # noqa: PLR0913
     plot_longitude: float | Sequence[float] | None = None,
     plot_latitude: float | Sequence[float] | None = None,
     event_name: str | Sequence[str] | None = None,
+    no_clip: bool = False,
     projection=None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
@@ -203,6 +203,7 @@ def meca(  # noqa: PLR0913
 
     {aliases}
        - J = projection
+       - N = no_clip
        - S = scale/convention/component
        - V = verbose
        - c = panel
@@ -336,9 +337,9 @@ def meca(  # noqa: PLR0913
         automatically. The color of the compressive quadrants is determined by the
         z-value (i.e., event depth or the third column for an input file). This setting
         also applies to the fill of the circle defined via ``offset``.
-    no_clip : bool
+    no_clip
         Do **not** skip symbols that fall outside the frame boundaries [Default is
-       ``False``, i.e., plot symbols inside the frame boundaries only].
+        ``False``, i.e., plot symbols inside the frame boundaries only].
     {projection}
     {region}
     {frame}
@@ -369,7 +370,9 @@ def meca(  # noqa: PLR0913
         kwargs["A"] = _auto_offset(spec)
     kwargs["S"] = f"{_convention.code}{scale}"
 
-    aliasdict = AliasSystem().add_common(
+    aliasdict = AliasSystem(
+        N=Alias(no_clip, name="no_clip"),
+    ).add_common(
         J=projection,
         V=verbose,
         c=panel,

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 import numpy as np
 from pygmt._typing import AnchorCode, PathLike, StringArrayTypes, TableLike
-from pygmt.alias import AliasSystem
+from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput, GMTTypeError
 from pygmt.helpers import (
@@ -29,7 +29,6 @@ from pygmt.helpers import (
     C="clearance",
     D="offset",
     G="fill",
-    N="no_clip",
     W="pen",
     a="aspatial",
     e="find",
@@ -50,6 +49,7 @@ def text_(  # noqa: PLR0912, PLR0913, PLR0915
     angle=None,
     font=None,
     justify: bool | None | AnchorCode | Sequence[AnchorCode] = None,
+    no_clip: bool = False,
     projection=None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
@@ -76,6 +76,7 @@ def text_(  # noqa: PLR0912, PLR0913, PLR0915
     {aliases}
        - F = **+a**: angle, **+c**: position, **+j**: justify, **+f**: font
        - J = projection
+       - N = no_clip
        - V = verbose
        - c = panel
        - t = transparency
@@ -163,9 +164,8 @@ def text_(  # noqa: PLR0912, PLR0913, PLR0915
     pen : str
         Set the pen used to draw a rectangle around the text string
         (see ``clearance``) [Default is ``"0.25p,black,solid"``].
-    no_clip : bool
-        Do **not** clip text at the frame boundaries [Default is
-        ``False``].
+    no_clip
+        Do **not** clip text at the frame boundaries [Default is ``False``].
     {verbose}
     {aspatial}
     {panel}
@@ -271,7 +271,9 @@ def text_(  # noqa: PLR0912, PLR0913, PLR0915
                     reason=f"Parameter {name!r} expects a single value or True.",
                 )
 
-    aliasdict = AliasSystem().add_common(
+    aliasdict = AliasSystem(
+        N=Alias(no_clip, name="no_clip"),
+    ).add_common(
         J=projection,
         V=verbose,
         c=panel,

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -35,7 +35,7 @@ def tilemap(  # noqa: PLR0913
     wait: int = 0,
     max_retries: int = 2,
     zoom_adjust: int | None = None,
-    monochrome: bool = False,  
+    monochrome: bool = False,
     no_clip: bool = False,
     projection=None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -4,7 +4,7 @@ tilemap - Plot XYZ tile maps.
 
 from typing import Literal
 
-from pygmt.alias import AliasSystem
+from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.datasets.tile_map import load_tile_map
 from pygmt.enums import GridType
@@ -22,7 +22,6 @@ except ImportError:
     E="dpi",
     I="shading",
     M="monochrome",
-    N="no_clip",
     Q="nan_transparent",
     # R="region",
     p="perspective",
@@ -37,6 +36,7 @@ def tilemap(  # noqa: PLR0913
     wait: int = 0,
     max_retries: int = 2,
     zoom_adjust: int | None = None,
+    no_clip: bool = False,
     projection=None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
@@ -59,6 +59,7 @@ def tilemap(  # noqa: PLR0913
 
     {aliases}
        - J = projection
+       - N = no_clip
        - V = verbose
        - c = panel
        - t = transparency
@@ -128,10 +129,12 @@ def tilemap(  # noqa: PLR0913
 
     # Only set region if no_clip is None or False, so that plot is clipped to exact
     # bounding box region
-    if kwargs.get("N") in {None, False}:
+    if no_clip is False:
         kwargs["R"] = "/".join(str(coordinate) for coordinate in region)
 
-    aliasdict = AliasSystem().add_common(
+    aliasdict = AliasSystem(
+        N=Alias(no_clip, name="no_clip"),
+    ).add_common(
         J=projection,
         V=verbose,
         c=panel,

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -129,7 +129,7 @@ def tilemap(  # noqa: PLR0913
 
     # Only set region if no_clip is None or False, so that plot is clipped to exact
     # bounding box region
-    if no_clip is False:
+    if kwargs.get("N", no_clip) in {None, False}:
         kwargs["R"] = "/".join(str(coordinate) for coordinate in region)
 
     aliasdict = AliasSystem(

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -7,15 +7,10 @@ from typing import Literal
 import numpy as np
 import pandas as pd
 from pygmt._typing import PathLike, TableLike
-from pygmt.alias import AliasSystem
+from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput, GMTTypeError
-from pygmt.helpers import (
-    build_arg_list,
-    fmt_docstring,
-    kwargs_to_strings,
-    use_alias,
-)
+from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
 
 @fmt_docstring
@@ -29,7 +24,6 @@ from pygmt.helpers import (
     H="scale",
     I="shading",
     L="line",
-    N="no_clip",
     R="region",
     S="spec",
     W="pen",
@@ -44,6 +38,7 @@ from pygmt.helpers import (
 def velo(
     self,
     data: PathLike | TableLike | None = None,
+    no_clip: bool = False,
     projection=None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
@@ -67,6 +62,7 @@ def velo(
 
     {aliases}
        - J = projection
+       - N = no_clip
        - V = verbose
        - c = panel
        - t = transparency
@@ -221,10 +217,9 @@ def velo(
         ``cmap``). If instead modifier **+cf** is appended then the color from
         the cpt file is applied to error fill only [Default]. Use just **+c**
         to set both pen and fill color.
-    no_clip: bool
-        Do **not** skip symbols that fall outside the frame boundaries
-        [Default is ``False``, i.e., plot symbols inside the frame
-        boundaries only].
+    no_clip
+        Do **not** skip symbols that fall outside the frame boundaries [Default is
+        ``False``, i.e., plot symbols inside the frame boundaries only].
     {verbose}
     pen : str
         [*pen*][**+c**\ [**f**\|\ **l**]].
@@ -268,7 +263,9 @@ def velo(
             ),
         )
 
-    aliasdict = AliasSystem().add_common(
+    aliasdict = AliasSystem(
+        N=Alias(no_clip, name="no_clip"),
+    ).add_common(
         J=projection,
         V=verbose,
         c=panel,

--- a/pygmt/src/vlines.py
+++ b/pygmt/src/vlines.py
@@ -59,8 +59,8 @@ def vlines(
     label
         Label for the line(s), to be displayed in the legend.
     no_clip
-        If ``True``, do not clip lines outside the plot region. Only makes sense in the
-        Cartesian coordinate system.
+        Do **not** clip lines outside the plot region. Only makes sense in the Cartesian
+        coordinate system. [Default is ``False`` to clip lines at the plot region.]
     perspective
         Select perspective view and set the azimuth and elevation angle of the
         viewpoint. Refer to :meth:`pygmt.Figure.plot` for details.


### PR DESCRIPTION
Some wrappers have the `no_clip` parameter, which can be either False or True. This PR migrates the parameter to the new alias system.

`no_clip` in `Figure.plot` and `Figure.plot3d` are not updated in this PR, because in these two methods, `no_clip` can be False, True, `"c"` or `"r"` and we need to discuss the long-form arguments for "c"/"r". So leave it to a separate PR instead.