### PR TITLE
pygmt.show_versions: Report GDAL version by calling the GDAL C function

### DIFF
--- a/pygmt/_show_versions.py
+++ b/pygmt/_show_versions.py
@@ -53,11 +53,15 @@ def _get_gdal_version() -> str | None:
         case _:
             return None
 
-    lib = ctypes.CDLL(libname)
-    # Define return type of GDALVersionInfo
-    lib.GDALVersionInfo.restype = ctypes.c_char_p
-    # Call with "RELEASE_NAME" to get human-readable version
-    return lib.GDALVersionInfo(b"RELEASE_NAME").decode("utf-8")
+    try:
+        lib = ctypes.CDLL(libname)
+        lib.GDALVersionInfo.restype = ctypes.c_char_p
+        version = lib.GDALVersionInfo(b"RELEASE_NAME")  # e.g., 3.6.3
+        if version is not None:
+            return version.decode("utf-8")
+    except (OSError, AttributeError):
+        return None
+    return None
 
 
 def _get_ghostscript_version() -> str | None:

--- a/pygmt/_show_versions.py
+++ b/pygmt/_show_versions.py
@@ -56,8 +56,7 @@ def _get_gdal_version() -> str | None:
     try:
         lib = ctypes.CDLL(libname)
         lib.GDALVersionInfo.restype = ctypes.c_char_p
-        version = lib.GDALVersionInfo(b"RELEASE_NAME")  # e.g., 3.6.3
-        return version.decode("utf-8")
+        return lib.GDALVersionInfo(b"RELEASE_NAME").decode("utf-8")  # e.g., 3.6.3
     except (OSError, AttributeError):
         return None
 

--- a/pygmt/_show_versions.py
+++ b/pygmt/_show_versions.py
@@ -118,6 +118,7 @@ def show_versions(file: TextIO | None = sys.stdout) -> None:
     - PyGMT itself
     - System information (Python version, Operating System)
     - Core dependency versions (NumPy, pandas, Xarray, etc)
+    - GDAL and Ghostscript versions
     - GMT library information
 
     It also warns users if the installed Ghostscript version has serious bugs or is

--- a/pygmt/_show_versions.py
+++ b/pygmt/_show_versions.py
@@ -57,11 +57,9 @@ def _get_gdal_version() -> str | None:
         lib = ctypes.CDLL(libname)
         lib.GDALVersionInfo.restype = ctypes.c_char_p
         version = lib.GDALVersionInfo(b"RELEASE_NAME")  # e.g., 3.6.3
-        if version is not None:
-            return version.decode("utf-8")
+        return version.decode("utf-8")
     except (OSError, AttributeError):
         return None
-    return None
 
 
 def _get_ghostscript_version() -> str | None:

--- a/pygmt/tests/test_show_versions.py
+++ b/pygmt/tests/test_show_versions.py
@@ -22,7 +22,11 @@ def test_show_versions():
     assert "System information:" in output
     assert "Dependency information:" in output
     assert "GMT library information:" in output
-    assert "WARNING:" not in output  # No GMT-Ghostscript incompatibility warnings.
+    # No GMT-Ghostscript incompatibility warnings.
+    assert "WARNING:" not in output
+    # GDAL version is correctly reported.
+    assert "gdal:" in output
+    assert "gdal: None" not in output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Description of proposed changes**

Query the GDAL version by calling the GDAL C function `GDALVersionInfo` (https://gdal.org/en/stable/api/raster_c_api.html#_CPPv415GDALVersionInfoPKc).

Fixes #4102.
