### PR TITLE
mailmap: Add comments to explain the use of the mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,4 +1,4 @@
-# Map author/committer names and/or E-Mail addresses for Git.
+# Map author/committer names and/or email addresses for git.
 # Reference: https://git-scm.com/docs/gitmailmap
 Dongdong Tian <seisman.info@gmail.com>
 Dongdong Tian <seisman.info@gmail.com> <seisman@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,5 @@
+# Map author/committer names and/or E-Mail addresses for Git.
+# Reference: https://git-scm.com/docs/gitmailmap
 Dongdong Tian <seisman.info@gmail.com>
 Dongdong Tian <seisman.info@gmail.com> <seisman@users.noreply.github.com>
 Jiayuan Yao <coreman.seism@gmail.com>


### PR DESCRIPTION
`.mailmap` was initially added in https://github.com/GenericMappingTools/pygmt/pull/3905. This PR add some comments so that we don't forget why this file exists.