### PR TITLE
pygmt.grdfill: Migrate the hole parameter to the new alias system and add a test

### DIFF
--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -77,7 +77,7 @@ def _validate_params(
 # TODO(PyGMT>=0.19.0): Remove the deprecated 'no_data' parameter.
 # TODO(PyGMT>=0.19.0): Remove the deprecated 'mode' parameter.
 @deprecate_parameter("no_data", "hole", "v0.15.0", remove_version="v0.19.0")
-@use_alias(N="hole", R="region", f="coltypes")
+@use_alias(R="region", f="coltypes")
 @kwargs_to_strings(R="sequence")
 def grdfill(
     grid: PathLike | xr.DataArray,
@@ -87,6 +87,7 @@ def grdfill(
     neighborfill: float | bool | None = None,
     splinefill: float | bool | None = None,
     inquire: bool = False,
+    hole: float | None = None,
     mode: str | None = None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
@@ -109,6 +110,7 @@ def grdfill(
        - An = neighborfill
        - As = splinefill
        - L = inquire
+       - N = hole
        - V = verbose
 
     Parameters
@@ -128,7 +130,7 @@ def grdfill(
     splinefill
         Fill the holes with a bicubic spline. Specify the tension value to use. If set
         to ``True``, no tension will be used.
-    hole : float
+    hole
         Set the node value used to identify a point as a member of a hole [Default is
         NaN].
     inquire
@@ -187,6 +189,7 @@ def grdfill(
         An=Alias(neighborfill, name="neighborfill"),
         As=Alias(splinefill, name="splinefill"),
         L=Alias(inquire, name="inquire"),
+        N=Alias(hole, name="hole"),
     ).add_common(
         V=verbose,
     )

--- a/pygmt/tests/test_grdfill.py
+++ b/pygmt/tests/test_grdfill.py
@@ -114,6 +114,31 @@ def test_grdfill_gridfill_dataarray(grid):
     npt.assert_array_equal(result[3:6, 3:5], bggrid[3:6, 3:5])
 
 
+def test_grdfill_hole(grid, expected_grid):
+    """
+    Test grdfill with different hole values.
+    """
+    # Prepare for a grid with -99999 as holes.
+    grid_no_nan = grdfill(grid=grid, constantfill=-99999)
+    assert not np.isnan(grid_no_nan).any()
+    assert -99999 in grid_no_nan
+    # Now that we have a grid with -99999 as holes, fill it with a constant value of 20.
+    result = grdfill(grid=grid_no_nan, constantfill=20, hole=-99999)
+
+    # check information of the output grid
+    assert isinstance(result, xr.DataArray)
+    assert result.gmt.gtype is GridType.GEOGRAPHIC
+    assert result.gmt.registration is GridRegistration.PIXEL
+    # check information of the output grid
+    xr.testing.assert_allclose(a=result, b=expected_grid)
+
+    # Test the deprecated 'no_data' parameter.
+    # TODO(PyGMT>=0.19.0): Remove the following lines.
+    with pytest.warns(FutureWarning):
+        result2 = grdfill(grid=grid_no_nan, constantfill=20, no_data=-99999)
+    xr.testing.assert_allclose(a=result2, b=expected_grid)
+
+
 def test_grdfill_inquire(grid):
     """
     Test grdfill with inquire mode.


### PR DESCRIPTION
Migrate the 'hole' parameter and add a test to ensure that both `hole` and `no_data` (deprecated) work as expected.