### PR TITLE
CI: Fix the "Resource not accessible by integration" error in the DVC Diff workflow

### DIFF
--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -14,7 +14,9 @@ on:
     paths:
       - 'pygmt/tests/baseline/*.png.dvc'
 
-permissions: {}
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   dvc-diff:
@@ -55,7 +57,7 @@ jobs:
     # Report last updated at commit abcdef
     - name: Generate the image diff report
       env:
-        repo_token: ${{ github.token }}
+        REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         DAGSHUB_TOKEN: ${{ secrets.DAGSHUB_TOKEN }}
       run: |


### PR DESCRIPTION
The "DVC diff" workflow is failing in PR #4112 (https://github.com/GenericMappingTools/pygmt/actions/runs/17891120941/job/50871638629?pr=4112) with an error like "Resource not accessible by integration". 

This PR fixes the issue following https://github.com/iterative/cml/issues/1421.

The changes work now, as can be verified in https://github.com/GenericMappingTools/pygmt/pull/4112.