### PR TITLE
DOC: Fix syntax of aliases list for pygmt.grdtrack, pygmt.x2sys_cross

### DIFF
--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -79,7 +79,7 @@ def grdtrack(
     Full GMT docs at :gmt-docs:`grdtrack.html`.
 
     {aliases}
-        - V = verbose
+       - V = verbose
 
     Parameters
     ----------

--- a/pygmt/src/x2sys_cross.py
+++ b/pygmt/src/x2sys_cross.py
@@ -92,7 +92,7 @@ def x2sys_cross(
     Full GMT docs at :gmt-docs:`supplements/x2sys/x2sys_cross.html`.
 
     {aliases}
-        - V = verbose
+       - V = verbose
 
     Parameters
     ----------


### PR DESCRIPTION
**Description of proposed changes**

Fix the syntax for the aliases lists of `pygmt.grdtrack` and `pygmt.x2sys_cross`, use three instead of four white spaces.
Similar to #4059.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
