### PR TITLE
Drop GMT 6.4 support 

### DIFF
--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -84,11 +84,7 @@ jobs:
           # Download cached files to ~/.gmt directory and list them
           gh run download --name gmt-cache --dir ~/.gmt/
           # Change modification times of the two files, so GMT won't refresh it.
-          # The two files are in the `~/.gmt/server` directory for GMT<=6.4, and in the
-          # `~/.gmt` directory for GMT>=6.5.
-          mkdir -p ~/.gmt/server/
-          mv ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt ~/.gmt/server/
-          touch ~/.gmt/server/gmt_data_server.txt ~/.gmt/server/gmt_hash_server.txt
+          touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
           ls -lhR ~/.gmt
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -60,7 +60,7 @@ jobs:
           create-args: >-
             python=3.11
             gmt=${{ matrix.gmt_version }}
-            ghostscript<10
+            ghostscript
             numpy=1.26
             pandas=2.2
             xarray=2023.10

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14, windows-2022]
-        gmt_version: ['6.4', '6.5']
+        gmt_version: ['6.5']
     timeout-minutes: 30
     defaults:
       run:

--- a/pygmt/clib/__init__.py
+++ b/pygmt/clib/__init__.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 from pygmt.clib.session import Session, __gmt_version__
 from pygmt.exceptions import GMTVersionError
 
-required_gmt_version = "6.4.0"
+required_gmt_version = "6.5.0"
 
 # Check if the GMT version is older than the required version.
 if Version(__gmt_version__) < Version(required_gmt_version):


### PR DESCRIPTION
Following our [support policy](https://www.pygmt.org/v0.16.0/minversions.html), we should drop support for GMT versions older than three years.

Address https://github.com/GenericMappingTools/pygmt/issues/4017.