### PR TITLE
Check for invalid non-int values passed to Pattern class

### DIFF
--- a/pygmt/params/pattern.py
+++ b/pygmt/params/pattern.py
@@ -69,7 +69,7 @@ class Pattern(BaseParam):
     >>> fig.show()
     """
 
-    pattern: int | PathLike
+    pattern: int | PathLike = None
     dpi: int | None = None
     bgcolor: str | None = None
     fgcolor: str | None = None
@@ -80,7 +80,9 @@ class Pattern(BaseParam):
         Validate the parameters.
         """
         # Integer pattern number must be in the range 1-90.
-        if isinstance(self.pattern, int) and not (1 <= self.pattern <= 90):
+        if self.pattern is not PathLike or (
+            isinstance(self.pattern, int) and not (1 <= self.pattern <= 90)
+        ):
             raise GMTValueError(
                 self.pattern,
                 description="pattern number",

--- a/pygmt/tests/test_params_pattern.py
+++ b/pygmt/tests/test_params_pattern.py
@@ -35,8 +35,12 @@ def test_pattern():
 
 def test_pattern_invalid_pattern():
     """
-    Test that an invalid pattern number raises a GMTValueError.
+    Test that an invalid pattern value or number raises a GMTValueError.
     """
+    with pytest.raises(GMTValueError):
+        _ = Pattern()  # Default value None
+    with pytest.raises(GMTValueError):
+        _ = Pattern([])  # non-PathLike value
     with pytest.raises(GMTValueError):
         _ = str(Pattern(0))
     with pytest.raises(GMTValueError):


### PR DESCRIPTION
**Description of proposed changes**

Set default pattern value as None to fix autodoc warning about `AttributeError: type object 'Pattern' has no attribute 'pattern'`. Add proper validation to ensure non-int and non-PathLike values will raise a GMTValueError.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Addresses https://github.com/GenericMappingTools/pygmt/issues/4100#issuecomment-3353642301, patches #4020


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
