### PR TITLE
Add doctest_skips for xarray<2025.10.1 and update output DataArray repr

### DIFF
--- a/pygmt/datatypes/image.py
+++ b/pygmt/datatypes/image.py
@@ -10,9 +10,9 @@ import xarray as xr
 from packaging.version import Version
 from pygmt.datatypes.header import _GMT_GRID_HEADER
 
-# TODO(xarray>=2025.10.0): Remove the __doctest_skip__ on _GMT_IMAGE.to_xarray
+# TODO(xarray>=2025.10.1): Remove the __doctest_skip__ on _GMT_IMAGE.to_xarray
 __doctest_skip__ = (
-    ["_GMT_IMAGE.to_xarray"] if Version(xr.__version__) < Version("2025.10.0") else []
+    ["_GMT_IMAGE.to_xarray"] if Version(xr.__version__) < Version("2025.10.1") else []
 )
 
 

--- a/pygmt/xarray/backend.py
+++ b/pygmt/xarray/backend.py
@@ -14,9 +14,9 @@ from pygmt.helpers import build_arg_list, kwargs_to_strings
 from pygmt.src.which import which
 from xarray.backends import BackendEntrypoint
 
-# TODO(xarray>=2025.10.0): Remove the __doctest_skip__ on GMTBackendEntrypoint
+# TODO(xarray>=2025.10.1): Remove the __doctest_skip__ on GMTBackendEntrypoint
 __doctest_skip__ = (
-    ["GMTBackendEntrypoint"] if Version(xr.__version__) < Version("2025.10.0") else []
+    ["GMTBackendEntrypoint"] if Version(xr.__version__) < Version("2025.10.1") else []
 )
 
 


### PR DESCRIPTION
**Description of proposed changes**

Skip doctests using `__doctest_skip__` on `_GMT_IMAGE.to_xarray` and `GMTBackendEntrypoint`, due to changes in xarray=2025.10.1 from repr changes to the coords ordering, xref https://github.com/pydata/xarray/pull/10778.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Also removed ellipsis and added the size of the DataArray and coordinates in kB.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #4143

<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**: https://pygmt-dev--4145.org.readthedocs.build/en/4145/api/generated/pygmt.GMTBackendEntrypoint.html

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
- [ ] If adding new functionality, add an example to docstrings or tutorials.

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
