### PR TITLE
CI: Temporarily disable the Docs workflow on Windows

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -53,7 +53,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
+        # os: [ubuntu-latest, macos-latest, windows-latest]
         # Is it a draft Pull Request (true or false)?
         isDraft:
           - ${{ github.event.pull_request.draft }}


### PR DESCRIPTION
As mentioned in https://github.com/GenericMappingTools/pygmt/pull/4134#issuecomment-3354564312, the Docs workflow has been failing recently. It turns out it started to fail after commit a917dad8eae89303d21b7c9e7cb7a151baa234f4. It's likely caused by mysterious crashes on Windows, which are difficult to debug.

This PR disables the workflow on Windows, so that we can have CI jobs green. 

I'll open a separate PR reverting this change so that we won't forget to revisit the issue in the future.