### PR TITLE
Add links of contributing guidelines to the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,15 +11,11 @@ Fixes #
 <!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
 **Preview**:
 
+**Guidelines**
 
-**Reminders**
-
-- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
-- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
-- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
-- [ ] Write detailed docstrings for all functions/methods.
-- [ ] If wrapping a new module, open a 'Wrap new GMT module' issue and submit reasonably-sized PRs.
-- [ ] If adding new functionality, add an example to docstrings or tutorials.
+- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
+- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
+- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)
 
 **Slash Commands**
 


### PR DESCRIPTION
Following changes in https://github.com/GenericMappingTools/pygmt/pull/1687, this PR shortens the pull request, by adding a few links to contributing guidelines and remove the unnecessary checklist.

Address #1599.