### PR TITLE
pygmt.project: Migrate the 'center'/'endpoint'/'pole'/'width'/'length' parameters to the new alias system

### DIFF
--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -220,8 +220,8 @@ def project(  # noqa: PLR0913
         - :class:`pandas.DataFrame` or :class:`numpy.ndarray` if ``outfile`` is not set
           (depends on ``output_type``)
     """
-    if kwargs.get("C") is None:
-        msg = "The 'center' parameter must be specified."
+    if kwargs.get("C", center) is None:
+        msg = "Parameter 'center' must be specified."
         raise GMTInvalidInput(msg)
     if kwargs.get("G") is None and data is None:
         msg = "The 'data' parameter must be specified unless 'generate' is used."


### PR DESCRIPTION
Parameters `center`/`endpoint`/`pole`/`width` all accept a tuple of two values. This PR migrates them to the new alias system.

The `length` parameter is slightly complicated in that it can accept a tuple or a string `"w"` (with the long name `"limit"` from https://github.com/GenericMappingTools/gmt/blob/88b836ea9f6429e4d94fbadd508ef97497671eb1/src/longopt/project_inc.h#L37). 