### PR TITLE
CI: Remove the .dvc/cache directory before downloading dvc-cache from GitHub

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -174,6 +174,7 @@ jobs:
       - name: Download DVC cache as artifacts from GitHub
         if: steps.dvc-pull.outcome == 'failure'
         run: |
+          rm -rvf .dvc/cache/
           gh run download --name dvc-cache --dir .dvc/cache/
           uv run dvc checkout --verbose
         env:

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -172,6 +172,7 @@ jobs:
       - name: Download DVC cache as artifacts from GitHub
         if: steps.dvc-pull.outcome == 'failure'
         run: |
+          rm -rvf .dvc/cache/
           gh run download --name dvc-cache --dir .dvc/cache/
           dvc checkout --verbose
         env:


### PR DESCRIPTION
https://github.com/GenericMappingTools/pygmt/actions/runs/19216573097/job/54926872192

This CI job failed during the "Download DVC cache as artifacts from GitHub" step. This issue arose because the previous step, "Pull baseline images from DVC remote," successfully fetched a few files.

As a result, errors occurred, such as:

```
error downloading dvc-cache: error extracting zip archive: error extracting "15/2085fd81de3ad78b5c7ffb3cf0d080": open D:\a\pygmt\pygmt\.dvc\cache\15\2085fd81de3ad78b5c7ffb3cf0d080: The file exists.
```
This PR fixes the issue by forcing deleting the `.dvc/cache` directory before trying to download the dvc cache.