### PR TITLE
Figure.colorbar: Migrate the 'shading' parameter to the new alias system

### DIFF
--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -112,7 +112,7 @@ def colorbar(
         Multiply all z-values in the CPT by the provided scale. By default,
         the CPT is used as is.
     shading
-        Add illumination effects. [Default is no illumination].
+        Add illumination effects [Default is no illumination].
 
         - If ``True``, a default intensity range of -1 to +1 is used.
         - Passing a single numerical value *max_intens* sets the range of intensities


### PR DESCRIPTION
Upstream documentation at: https://docs.generic-mapping-tools.org/6.6/colorbar.html#i

**Preview**: https://pygmt-dev--4197.org.readthedocs.build/en/4197/api/generated/pygmt.Figure.colorbar.html#pygmt.Figure.colorbar