### PR TITLE
Figure.basemap/Figure.grdview/Figure.plot3d: Migrate the 'zsize'/'zscale' parameters to the new alias system

### DIFF
--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -5,15 +5,13 @@ basemap - Plot base maps and frames.
 from collections.abc import Sequence
 from typing import Literal
 
-from pygmt.alias import AliasSystem
+from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
 
 @fmt_docstring
 @use_alias(
-    Jz="zscale",
-    JZ="zsize",
     L="map_scale",
     F="box",
     Td="rose",
@@ -25,6 +23,8 @@ from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_
 def basemap(
     self,
     projection: str | None = None,
+    zsize: float | str | None = None,
+    zscale: float | str | None = None,
     frame: str | Sequence[str] | bool = False,
     region: Sequence[float | str] | str | None = None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
@@ -49,6 +49,8 @@ def basemap(
     {aliases}
        - B = frame
        - J = projection
+       - Jz = zscale
+       - JZ = zsize
        - R = region
        - V = verbose
        - c = panel
@@ -57,7 +59,7 @@ def basemap(
     Parameters
     ----------
     {projection}
-    zscale/zsize : float or str
+    zscale/zsize
         Set z-axis scaling or z-axis size.
     {region}
         *Required if this is the first plot command.*
@@ -98,7 +100,10 @@ def basemap(
     """
     self._activate_figure()
 
-    aliasdict = AliasSystem().add_common(
+    aliasdict = AliasSystem(
+        Jz=Alias(zscale, name="zscale"),
+        JZ=Alias(zsize, name="zsize"),
+    ).add_common(
         B=frame,
         J=projection,
         R=region,

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 import xarray as xr
 from pygmt._typing import PathLike
-from pygmt.alias import AliasSystem
+from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, kwargs_to_strings, use_alias
 
@@ -16,8 +16,6 @@ __doctest_skip__ = ["grdview"]
 
 @fmt_docstring
 @use_alias(
-    Jz="zscale",
-    JZ="zsize",
     C="cmap",
     G="drapegrid",
     N="plane",
@@ -35,6 +33,8 @@ def grdview(
     self,
     grid: PathLike | xr.DataArray,
     projection: str | None = None,
+    zscale: float | str | None = None,
+    zsize: float | str | None = None,
     frame: str | Sequence[str] | bool = False,
     region: Sequence[float | str] | str | None = None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
@@ -57,6 +57,8 @@ def grdview(
     {aliases}
        - B = frame
        - J = projection
+       - Jz = zscale
+       - JZ = zsize
        - R = region
        - V = verbose
        - c = panel
@@ -71,7 +73,7 @@ def grdview(
         with ``perspective``, optionally append */zmin/zmax* to indicate the range to
         use for the 3-D axes [Default is the region given by the input grid].
     {projection}
-    zscale/zsize : float or str
+    zscale/zsize
         Set z-axis scaling or z-axis size.
     {frame}
     cmap : str
@@ -157,7 +159,10 @@ def grdview(
     """
     self._activate_figure()
 
-    aliasdict = AliasSystem().add_common(
+    aliasdict = AliasSystem(
+        Jz=Alias(zscale, name="zscale"),
+        JZ=Alias(zsize, name="zsize"),
+    ).add_common(
         B=frame,
         J=projection,
         R=region,

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -26,8 +26,6 @@ from pygmt.src._common import _data_geometry_is_point
     D="offset",
     G="fill",
     I="intensity",
-    Jz="zscale",
-    JZ="zsize",
     L="close",
     N="no_clip",
     Q="no_sort",
@@ -58,6 +56,8 @@ def plot3d(  # noqa: PLR0912, PLR0913
     direction=None,
     straight_line: bool | Literal["x", "y"] = False,
     projection: str | None = None,
+    zscale: float | str | None = None,
+    zsize: float | str | None = None,
     frame: str | Sequence[str] | bool = False,
     region: Sequence[float | str] | str | None = None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
@@ -93,6 +93,8 @@ def plot3d(  # noqa: PLR0912, PLR0913
        - A = straight_line
        - B = frame
        - J = projection
+       - Jz = zscale
+       - JZ = zsize
        - R = region
        - V = verbose
        - c = panel
@@ -118,7 +120,7 @@ def plot3d(  # noqa: PLR0912, PLR0913
         can be angle and length, azimuth and length, or x and y components,
         depending on the style options chosen.
     {projection}
-    zscale/zsize : float or str
+    zscale/zsize
         Set z-axis scaling or z-axis size.
     {region}
     straight_line
@@ -273,6 +275,8 @@ def plot3d(  # noqa: PLR0912, PLR0913
 
     aliasdict = AliasSystem(
         A=Alias(straight_line, name="straight_line"),
+        Jz=Alias(zscale, name="zscale"),
+        JZ=Alias(zsize, name="zsize"),
     ).add_common(
         B=frame,
         J=projection,


### PR DESCRIPTION
Technically speaking, `-Jz`/`-JZ` are common options and should be added to the `AliasSystem.add_common` method, but they're only used in a few wrappers. So, this PR doesn't add them as common parameters.