### PR TITLE
Tutorial "Plotting data points": Add legend for size coding

### DIFF
--- a/examples/tutorials/basics/plot.py
+++ b/examples/tutorials/basics/plot.py
@@ -10,6 +10,8 @@ the first time you use them (usually ``~/.gmt/cache``).
 """
 
 # %%
+import io
+
 import pygmt
 
 # %%
@@ -49,6 +51,11 @@ fig.show()
 # array to the ``size`` parameter. Because the magnitude is on a logarithmic
 # scale, it helps to show the differences by scaling the values using a power
 # law.
+#
+# A legend for the size of the circles can not be added automatically. But users can
+# create an :class:`io.StringIO` object, which can be passed to the ``spec`` parameter
+# of :meth:`pygmt.Figure.legend`. For details on creating legends, see the tutorial
+# :doc:`multiple-column legend </tutorials/advanced/legends>`.
 
 fig = pygmt.Figure()
 fig.basemap(region=region, projection="M15c", frame=True)
@@ -61,6 +68,10 @@ fig.plot(
     fill="white",
     pen="black",
 )
+legend = io.StringIO(
+    "\n".join(f"S 0.4 c {0.02 * 2**m:.2f} - 1p 1 Mw {m}" for m in [3, 4, 5])
+)
+fig.legend(spec=legend, position="jBR+o0.2c+l2", box=True)
 fig.show()
 
 # %%
@@ -75,7 +86,6 @@ fig.show()
 # the earthquakes using :func:`pygmt.makecpt`, then set ``cmap=True`` in
 # :meth:`pygmt.Figure.plot` to use the colormap. At the end of the plot, we
 # also plot a colorbar showing the colormap used in the plot.
-#
 
 fig = pygmt.Figure()
 fig.basemap(region=region, projection="M15c", frame=True)
@@ -91,6 +101,7 @@ fig.plot(
     pen="black",
 )
 fig.colorbar(frame="xaf+lDepth (km)")
+fig.legend(spec=legend, position="jBR+o0.2c+l2", box=True)
 fig.show()
 
 # sphinx_gallery_thumbnail_number = 3


### PR DESCRIPTION
**Description of proposed changes**

So far we do not add a legend for the size-coding in the tutorial "Plotting data points". This PR extends the tutorial by adding such a legend via an ``io.StringIO`` object. There is also issue #3675 by @maxrjones suggesting to add an example showing how to create a legend for size-coding, as this can not be done automatically in GMT.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**: https://pygmt-dev--4214.org.readthedocs.build/en/4214/tutorials/basics/plot.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
