### PR TITLE
DOC: Add import of pygmt.clib.Session to inline example

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -148,7 +148,7 @@ class Session:
     Examples
     --------
 
-    >>> from pygmt.clip import Session
+    >>> from pygmt.clib import Session
     >>> from pygmt.helpers.testing import load_static_earth_relief
     >>> from pygmt.helpers import GMTTempFile
     >>> grid = load_static_earth_relief()


### PR DESCRIPTION
**Description of proposed changes**

Adding `from pygmt.clib import Session` to the inline example for `pygmt.clib.Session` to make the example directly executable.

**Preview**: https://pygmt-dev--4215.org.readthedocs.build/en/4215/api/generated/pygmt.clib.Session.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
