### PR TITLE
pygmt.grdinfo: Migrate the 'tiles'/'spacing' parameters to the new alias system

### DIFF
--- a/pygmt/src/grdinfo.py
+++ b/pygmt/src/grdinfo.py
@@ -7,13 +7,12 @@ from typing import Literal
 
 import xarray as xr
 from pygmt._typing import PathLike
-from pygmt.alias import AliasSystem
+from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import (
     GMTTempFile,
     build_arg_list,
     fmt_docstring,
-    kwargs_to_strings,
     use_alias,
 )
 
@@ -21,17 +20,16 @@ from pygmt.helpers import (
 @fmt_docstring
 @use_alias(
     C="per_column",
-    D="tiles",
     F="geographic",
-    I="spacing",
     L="force_scan",
     M="minmax_pos",
     T="nearest_multiple",
     f="coltypes",
 )
-@kwargs_to_strings(D="sequence", I="sequence")
 def grdinfo(
     grid: PathLike | xr.DataArray,
+    spacing: Sequence[float] | str | None = None,
+    tiles: Sequence[float] | str | bool = False,
     region: Sequence[float | str] | str | None = None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
@@ -45,6 +43,8 @@ def grdinfo(
     Full GMT docs at :gmt-docs:`grdinfo.html`.
 
     {aliases}
+       - D = tiles
+       - I = spacing
        - R = region
        - V = verbose
 
@@ -63,7 +63,7 @@ def grdinfo(
         columns. The registration is either 0 (gridline) or 1 (pixel), while
         gtype is either 0 (Cartesian) or 1 (geographic). The default value is
         ``False``. This cannot be called if ``geographic`` is also set.
-    tiles : str or list
+    tiles
         *xoff*\ [/*yoff*][**+i**].
         Divide a single grid's domain (or the ``region`` domain, if no grid
         given) into tiles of size dx times dy (set via ``spacing``). You can
@@ -122,7 +122,10 @@ def grdinfo(
     info : str
         A string with information about the grid.
     """
-    aliasdict = AliasSystem().add_common(
+    aliasdict = AliasSystem(
+        D=Alias(tiles, name="tiles", sep="/", size=2),
+        I=Alias(spacing, name="spacing", sep="/", size=2),
+    ).add_common(
         R=region,
         V=verbose,
     )


### PR DESCRIPTION
Just normal migration. Docstrings are not updated.