### PR TITLE
Example for geopandas line geometry: Use Natural Earth dataset, change to Asia

### DIFF
--- a/examples/gallery/lines/linestrings.py
+++ b/examples/gallery/lines/linestrings.py
@@ -29,29 +29,3 @@ fig.coast(land="gray95", shorelines="1/0.3p,gray50")
 fig.plot(data=rivers_asia, pen="1p,steelblue")
 
 fig.show()
-
-
-# %%
-rivers_australia = rivers.cx[111:155, -40:-9].copy()
-
-fig = pygmt.Figure()
-fig.basemap(region=[111, 155, -40, -9], projection="M10c", frame=True)
-fig.coast(land="gray95", shorelines="1/0.3p,gray50")
-
-# Add rivers to map
-fig.plot(data=rivers_australia, pen="1p,steelblue")
-
-fig.show()
-
-
-# %%
-rivers_sa = rivers.cx[-84.5:-33, -56.5:13].copy()
-
-fig = pygmt.Figure()
-fig.basemap(region=[-84.5, -33, -56.5, 13], projection="M10c", frame=True)
-fig.coast(land="gray95", shorelines="1/0.3p,gray50")
-
-# Add rivers to map
-fig.plot(data=rivers_sa, pen="1p,steelblue")
-
-fig.show()


### PR DESCRIPTION
**Description of proposed changes**

Use the Use the Natural Earth dataset in the example for geopandas line geometry. For details see https://github.com/GenericMappingTools/pygmt/issues/4223#issue-3658907831.
Let's hope the request / download is more stable and this will make our docs build less often fail :rocket:.

For the rivers there is only one river plotted for Europe. When changing to 50 m (instead of 110 m) I get the error
```
File C:\ProgramData\Anaconda3\envs\pygmt_env_dev_650\Lib\site-packages\pygmt\helpers\tempfile.py:148 in tempfile_from_geojson
    for col in geojson.columns:

  File C:\ProgramData\Anaconda3\envs\pygmt_env_dev_650\Lib\site-packages\pandas\core\generic.py:6321 in __getattr__
    return object.__getattribute__(self, name)

AttributeError: 'GeoSeries' object has no attribute 'columns'

RuntimeError: GDAL Error: Features without geometry not supported by GMT writer.. Failed to write record: <fiona.model.Feature object at 0x00000206E466CFB0>. 
```
When using the subset `rivers[rivers["scalerank"] != 5]` it works. Interestingly the subset `rivers_five = rivers[rivers["scalerank"] == 5]` is empty. For 10 m, I do not face such an error.

| Europe (currently) | Europe 110 m | Europe 50 m | Europe 10 m |
| --- | --- | --- | --- |
| <img width="1331" height="1027" alt="Image" src="https://github.com/user-attachments/assets/40f399ee-b8d5-4ee6-928e-615e7331c0b4" /> | <img width="1932" height="1508" alt="image" src="https://github.com/user-attachments/assets/ec931e04-26e8-4b7c-ab6f-ed0cb590be53" /> | <img width="1932" height="1508" alt="image" src="https://github.com/user-attachments/assets/8447f1d7-82b6-421f-854b-f3c7b5f5b240" /> | <img width="1932" height="1508" alt="image" src="https://github.com/user-attachments/assets/62be374a-a660-498e-b814-92ad04cdedbf" /> |

Related to 
* #4228
* #3711
* #2786
* #1374

Fixes #4223

**Preview**: https://pygmt-dev--4229.org.readthedocs.build/en/4229/gallery/lines/linestrings.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
