### PR TITLE
Add gallery example for geopandas point geometry (cities in Europe from Natural Earth)

### DIFF
--- a/examples/gallery/symbols/points_cities.py
+++ b/examples/gallery/symbols/points_cities.py
@@ -28,7 +28,7 @@ cities_large = cities[cities["worldcity"] == 1].copy()
 
 fig = pygmt.Figure()
 fig.basemap(region=[-10, 32.7, 37, 57], projection="M12c", frame=True)
-fig.coast(land="gray95", shorelines="1/0.3p,gray50", borders="1/0.1p,black")
+fig.coast(land="gray95", shorelines="1/0.3p,gray50")
 
 # Plot the two subsets using squares with different sizes and fills.
 fig.plot(data=cities_small, style="s0.1c", fill="lightgray", pen="0.5p")


### PR DESCRIPTION
**Description of proposed changes**

This PR proposes to add a gallery example for plotting geopandas point geometry objects. Therefore cities of Europe are plotted and the larger cities are labeled by their names. The data is from Natural Earth (50 m) (see PR #4223). Currently the example is placed in the "Symbols and marker" section, but I feel this is not optimal.

Fixes #1374

**Preview**: https://pygmt-dev--4231.org.readthedocs.build/en/4231/gallery/symbols/points_cities.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
