### PR TITLE
Figure.coast: Migrate the land/water parameters to the new alias system

### DIFF
--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -211,7 +211,7 @@ def coast(  # noqa: PLR0913
     ):
         msg = (
             "At least one of the following parameters must be specified: "
-            "lakes, land, water, rivers, borders, dcw, Q, or shorelines."
+            "land, water, lakes, rivers, borders, dcw, Q, or shorelines."
         )
         raise GMTInvalidInput(msg)
 


### PR DESCRIPTION
Migrate `land`/`water` (`-G`/`-S`) to the new alias system.

`-G`/`-S` can be used to clip the land/dry area. It will be implemented in #3878 instead.

Related to #4240.