### PR TITLE
Fix typos TM->MC in two legend tests

### DIFF
--- a/pygmt/tests/test_legend.py
+++ b/pygmt/tests/test_legend.py
@@ -112,7 +112,7 @@ def test_legend_stringio(legend_spec):
     spec = io.StringIO(legend_spec)
     fig = Figure()
     fig.basemap(projection="x6i", region=[0, 1, 0, 1], frame=True)
-    fig.legend(spec, position="JMC+jCM+w5i")
+    fig.legend(spec, position="JMC+jMC+w5i")
     return fig
 
 


### PR DESCRIPTION
`TM` is not a valid anchor code. GMT defaults to "MC" when an invalid anchor code is given.
This PR fixes `TM` to `MC` so that we don't need to update baseline images.

xref: https://www.pygmt.org/dev/techref/justification_codes.html