### PR TITLE
Figure.coast: Migrate the shorelines parameter to the new alias system and improve docstrings

### DIFF
--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -162,11 +162,11 @@ def coast(  # noqa: PLR0913
     shorelines
         Draw shorelines. Specify the pen attributes for shorelines [Default pen is
         ``"0.25p,black,solid"``]. Shorelines have four levels; by default, the same pen
-        is used for all levels. To specify the shoreline level
-        use the format *level*\ /*pen*. Pass a sequence of *level*\ /*pen* strings to
-        draw different shoreline levels with different pens. When specific level pens
-        are set, those not listed will not be drawn [Default draws all levels]. 
-        ``shorelines=True`` draws all levels with the default pen.
+        is used for all levels. To specify the shoreline level, use the format
+        *level*\ /*pen*. Pass a sequence of *level*\ /*pen* strings to draw different
+        shoreline levels with different pens. When specific level pens are set, those
+        not listed will not be drawn [Default draws all levels]. ``shorelines=True``
+        draws all levels with the default pen.
 
         Choose from the following shoreline levels:
 


### PR DESCRIPTION
Almost exactly the same as https://github.com/GenericMappingTools/pygmt/pull/4242 but for the `shorelines` parameter.

**GMT documentation**: https://docs.generic-mapping-tools.org/6.6/coast.html#w

**Preview**: https://pygmt-dev--4258.org.readthedocs.build/en/4258/api/generated/pygmt.Figure.coast.html#pygmt.Figure.coast

Related to https://github.com/GenericMappingTools/pygmt/issues/4240.