### PR TITLE
test of grdview: Adjust code for maximum line length

### DIFF
--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -179,7 +179,9 @@ def test_grdview_surface_plot_styled_with_contourpen(xrgrid):
     surface plot.
     """
     fig = Figure()
-    fig.grdview(grid=xrgrid, cmap="relief", surftype="s", contour_pen="0.5p,black,dashed")
+    fig.grdview(
+        grid=xrgrid, cmap="relief", surftype="s", contour_pen="0.5p,black,dashed"
+    )
     return fig
 
 


### PR DESCRIPTION
**Description of proposed changes**

Fixes the failing style checks due to a too long line in the tests for `grdview`. Patches #4260.

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
