### PR TITLE
Figure.grdtrack: Deprecate parameter crossprofile to cross_profile (Will be removed in v0.2X.0)

### DIFF
--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -25,7 +25,9 @@ __doctest_skip__ = ["grdtrack"]
 
 
 @fmt_docstring
-@deprecate_parameter("crossprofile", "cross_profile", "v0.18.0", remove_version="v0.20.0")
+@deprecate_parameter(
+    "crossprofile", "cross_profile", "v0.18.0", remove_version="v0.20.0"
+)
 @use_alias(
     A="resample",
     C="cross_profile",


### PR DESCRIPTION
**Description of proposed changes**

Use underscores between words in parameter names; related to #2014.
Or do we prefer to keep this without underscore?

**Preview**: https://pygmt-dev--4278.org.readthedocs.build/en/4278/api/generated/pygmt.grdtrack.htm

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
