### PR TITLE
Figure.image / Figure.grdimage: Deprecate parameter bitcolor to bit_color (Will be removed in v0.2X.0) 

### DIFF
--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -9,17 +9,18 @@ import xarray as xr
 from pygmt._typing import PathLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
-from pygmt.helpers import build_arg_list, fmt_docstring, use_alias
+from pygmt.helpers import build_arg_list, deprecate_parameter, fmt_docstring, use_alias
 
 __doctest_skip__ = ["grdimage"]
 
 
 @fmt_docstring
+@deprecate_parameter("bitcolor", "bit_color", "v0.18.0", remove_version="v0.20.0")
 @use_alias(
     C="cmap",
     D="img_in",
     E="dpi",
-    G="bitcolor",
+    G="bit_color",
     I="shading",
     Q="nan_transparent",
     n="interpolation",
@@ -109,7 +110,7 @@ def grdimage(  # noqa: PLR0913
         same size (rows and columns) as the input file. Specify **i** to
         use the PostScript image operator to interpolate the image at the
         device resolution.
-    bitcolor : str
+    bit_color : str
         *color*\ [**+b**\|\ **f**\].
         This parameter only applies when a resulting 1-bit image otherwise
         would consist of only two colors: black (0) and white (255). If so,

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -8,12 +8,13 @@ from typing import Literal
 from pygmt._typing import PathLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
-from pygmt.helpers import build_arg_list, fmt_docstring, use_alias
+from pygmt.helpers import build_arg_list, deprecate_parameter, fmt_docstring, use_alias
 from pygmt.params import Box
 
 
 @fmt_docstring
-@use_alias(D="position", G="bitcolor")
+@deprecate_parameter("bitcolor", "bit_color", "v0.18.0", remove_version="v0.20.0")
+@use_alias(D="position", G="bit_color")
 def image(
     self,
     imagefile: PathLike,
@@ -74,7 +75,7 @@ def image(
         box is drawn using :gmt-term:`MAP_FRAME_PEN`. To customize the box appearance,
         pass a :class:`pygmt.params.Box` object to control style, fill, pen, and other
         box properties.
-    bitcolor : str or list
+    bit_color : str or list
         [*color*][**+b**\|\ **f**\|\ **t**].
         Change certain pixel values to another color or make them transparent.
         For 1-bit images you can specify an alternate *color* for the


### PR DESCRIPTION
**Description of proposed changes**

Use underscores between words in parameter names; related to #2014.

**Preview**:
* https://pygmt-dev--4280.org.readthedocs.build/en/4280/api/generated/pygmt.Figure.image.html
* https://pygmt-dev--4280.org.readthedocs.build/en/4280/api/generated/pygmt.Figure.grdimage.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
