### PR TITLE
pygmt.select: Deprecate parameter gridmask to mask_grid (Will be removed in v0.20.0) 

### DIFF
--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -23,12 +23,12 @@ __doctest_skip__ = ["select"]
 
 
 @fmt_docstring
-@deprecate_parameter("gridmask", "grid_mask", "v0.18.0", remove_version="v0.20.0")
+@deprecate_parameter("gridmask", "mask_grid", "v0.18.0", remove_version="v0.20.0")
 @use_alias(
     A="area_thresh",
     C="dist2pt",
     F="polygon",
-    G="grid_mask",
+    G="mask_grid",
     I="reverse",
     L="dist2line",
     N="mask",
@@ -130,9 +130,9 @@ def select(
         <reference/file-formats.html#optional-segment-header-records>`
         *polygonfile*. For spherical polygons (lon, lat), make sure no
         consecutive points are separated by 180 degrees or more in longitude.
-    grid_mask : str
+    mask_grid : str
         Pass all locations that are inside the valid data area of the grid
-        *gridmask*. Nodes that are outside are either NaN or zero.
+        *mask_grid*. Nodes that are outside are either NaN or zero.
     reverse : str
         [**cflrsz**].
         Reverse the sense of the test for each of the criteria specified:
@@ -140,7 +140,7 @@ def select(
         - **c** select records NOT inside any point's circle of influence.
         - **f** select records NOT inside any of the polygons.
         - **g** will pass records inside the cells with z equal zero of the
-          grid mask in ``grid_mask``.
+          *mask_grid* in ``mask_grid``.
         - **l** select records NOT within the specified distance of any line.
         - **r** select records NOT inside the specified rectangular region.
         - **s** select records NOT considered inside as specified by ``mask``


### PR DESCRIPTION
**Description of proposed changes**

Use underscores between words in parameter names; related to #2014.

**Preview**: https://pygmt-dev--4283.org.readthedocs.build/en/4283/api/generated/pygmt.select.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
