### PR TITLE
DOC: Update naming convention in contributors guide: separate words in parameter names by underscores

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -489,7 +489,7 @@ Even better, you can just write `/format` in the first line of any comment in a
 pull request to lint the code automatically.
 
 When introducing a new parameter name, use an underscore to separate words. This improves
-the readability and aligns with the [PEP 8 style guide](https://peps.python.org/pep-0008/).
+readability and aligns with the [PEP 8 style guide](https://peps.python.org/pep-0008/).
 For common shortcuts no underscore is needed, e.g., `surftype`, `outgrid`, or `timefmt`.
 This convention is not applied by the code checking tools, but the PyGMT maintainers
 will comment on any pull requests as needed.


### PR DESCRIPTION
**Description of proposed changes**

Related to #2014.
Update contributors guide to use underscores between words in alias names to improve the readablity. This aligns with the [PEP 8 style guide](https://peps.python.org/pep-0008/).

Fixes #

**Preview**:

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
