### PR TITLE
DOC: Add missing descriptions for colorbar `position` parameter

### DIFF
--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -104,7 +104,7 @@ def colorbar(  # noqa: PLR0913
         can be changed by appending **+j** followed by a
         :doc:`2-character justification code </techref/justification_codes>`
         *justify*. Append **+m** to move text to opposite side as per arguments
-        [**a**|**c**|**l**|**u**]. Horizontal scale bars: Move annotations and
+        [**a**\|\ **c**\|\ **l**\|\ **u**]. Horizontal scale bars: Move annotations and
         labels above the scale bar [Default is below]; the unit remains on the
         left. Vertical scale bars: Move annotations and labels to the left of
         the scale bar [Default is to the right]; the unit remains below.


### PR DESCRIPTION
**Description of proposed changes**

Although there will be some changes (see #4168), this PR adds the description for missing settings of the `position` parameter. 

To become more Pythonic I propose that some of the parameters (like the sidebar triangles) deserve an standalone definition in the future, sth. like:

```python
colorbar(..., sidebar = "foreground")
colorbar(..., sidebar = "background")
colorbar(..., sidebar = "both")
```


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:

https://pygmt-dev--4290.org.readthedocs.build/en/4290/api/generated/pygmt.Figure.colorbar.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
