### PR TITLE
Deprecate parameter skiprows to skip_rows (Will be removed in v0.20.0)

### DIFF
--- a/pygmt/src/grd2xyz.py
+++ b/pygmt/src/grd2xyz.py
@@ -14,6 +14,7 @@ from pygmt.clib import Session
 from pygmt.exceptions import GMTValueError
 from pygmt.helpers import (
     build_arg_list,
+    deprecate_parameter,
     fmt_docstring,
     use_alias,
     validate_output_table_type,
@@ -23,6 +24,7 @@ __doctest_skip__ = ["grd2xyz"]
 
 
 @fmt_docstring
+@deprecate_parameter("skiprows", "skip_rows", "v0.18.0", remove_version="v0.20.0")
 @use_alias(
     C="cstyle",
     W="weight",
@@ -31,7 +33,7 @@ __doctest_skip__ = ["grd2xyz"]
     d="nodata",
     f="coltypes",
     h="header",
-    s="skiprows",
+    s="skip_rows",
 )
 def grd2xyz(
     grid: PathLike | xr.DataArray,
@@ -119,7 +121,7 @@ def grd2xyz(
     $coltypes
     $header
     $outcols
-    $skiprows
+    $skip_rows
 
     Returns
     -------

--- a/pygmt/src/grdtrack.py
+++ b/pygmt/src/grdtrack.py
@@ -14,6 +14,7 @@ from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.helpers import (
     build_arg_list,
+    deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
@@ -24,6 +25,7 @@ __doctest_skip__ = ["grdtrack"]
 
 
 @fmt_docstring
+@deprecate_parameter("skiprows", "skip_rows", "v0.18.0", remove_version="v0.20.0")
 @use_alias(
     A="resample",
     C="crossprofile",
@@ -43,7 +45,7 @@ __doctest_skip__ = ["grdtrack"]
     h="header",
     j="distcalc",
     n="interpolation",
-    s="skiprows",
+    s="skip_rows",
     w="wrap",
 )
 @kwargs_to_strings(S="sequence")
@@ -269,7 +271,7 @@ def grdtrack(
     $distcalc
     $interpolation
     $outcols
-    $skiprows
+    $skip_rows
     $wrap
 
     Returns

--- a/pygmt/src/select.py
+++ b/pygmt/src/select.py
@@ -25,6 +25,7 @@ __doctest_skip__ = ["select"]
 @fmt_docstring
 @deprecate_parameter("mask", "mask_values", "v0.18.0", remove_version="v0.20.0")
 @deprecate_parameter("gridmask", "mask_grid", "v0.18.0", remove_version="v0.20.0")
+@deprecate_parameter("skiprows", "skip_rows", "v0.18.0", remove_version="v0.20.0")
 @use_alias(
     A="area_thresh",
     C="dist2pt",
@@ -40,7 +41,7 @@ __doctest_skip__ = ["select"]
     f="coltypes",
     g="gap",
     h="header",
-    s="skiprows",
+    s="skip_rows",
     w="wrap",
 )
 @kwargs_to_strings(N="sequence")
@@ -171,7 +172,7 @@ def select(
     z_subregion : str or list
         *min*\ [/*max*]\ [**+a**]\ [**+c**\ *col*]\ [**+i**].
         Pass all records whose 3rd column (*z*; *col* = 2) lies within the
-        given range or is NaN (use ``skiprows`` to skip NaN records). If *max*
+        given range or is NaN (use ``skip_rows`` to skip NaN records). If *max*
         is omitted then we test if *z* equals *min* instead. This means
         equality within 5 ULPs (unit of least precision;
         https://en.wikipedia.org/wiki/Unit_in_the_last_place). Input file must
@@ -195,7 +196,7 @@ def select(
     $header
     $incols
     $outcols
-    $skiprows
+    $skip_rows
     $wrap
 
     Returns

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -14,6 +14,7 @@ from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import (
     build_arg_list,
+    deprecate_parameter,
     fmt_docstring,
     use_alias,
     validate_output_table_type,
@@ -50,13 +51,14 @@ class triangulate:  # noqa: N801
 
     @staticmethod
     @fmt_docstring
+    @deprecate_parameter("skiprows", "skip_rows", "v0.18.0", remove_version="v0.20.0")
     @use_alias(
         b="binary",
         d="nodata",
         e="find",
         f="coltypes",
         h="header",
-        s="skiprows",
+        s="skip_rows",
         w="wrap",
     )
     def regular_grid(  # noqa: PLR0913
@@ -132,7 +134,7 @@ class triangulate:  # noqa: N801
         $header
         $incols
         $registration
-        $skiprows
+        $skip_rows
         $wrap
 
         Returns
@@ -176,13 +178,14 @@ class triangulate:  # noqa: N801
 
     @staticmethod
     @fmt_docstring
+    @deprecate_parameter("skiprows", "skip_rows", "v0.18.0", remove_version="v0.20.0")
     @use_alias(
         b="binary",
         d="nodata",
         e="find",
         f="coltypes",
         h="header",
-        s="skiprows",
+        s="skip_rows",
         w="wrap",
     )
     def delaunay_triples(  # noqa: PLR0913
@@ -247,7 +250,7 @@ class triangulate:  # noqa: N801
         $coltypes
         $header
         $incols
-        $skiprows
+        $skip_rows
         $wrap
 
         Returns


### PR DESCRIPTION
**Description of proposed changes**

Use underscores between words in parameter names; related to #2014.

**Preview**:
* https://pygmt-dev--4295.org.readthedocs.build/en/4295/api/generated/pygmt.select.html#pygmt.select
* https://pygmt-dev--4295.org.readthedocs.build/en/4295/api/generated/pygmt.triangulate.regular_grid.html
* https://pygmt-dev--4295.org.readthedocs.build/en/4295/api/generated/pygmt.triangulate.delaunay_triples.html
* https://pygmt-dev--4295.org.readthedocs.build/en/4295/api/generated/pygmt.grdtrack.html
* https://pygmt-dev--4295.org.readthedocs.build/en/4295/api/generated/pygmt.grd2xyz.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
