### PR TITLE
pygmt.project: Deprecate parameter unit to units (Will be removed in v0.2X.0)

### DIFF
--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -10,14 +10,13 @@ from pygmt._typing import PathLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import build_arg_list, deprecate_parameter, fmt_docstring, use_alias
+from pygmt.helpers import build_arg_list, fmt_docstring, use_alias
 
 __doctest_skip__ = ["grdproject"]
 
 
 @fmt_docstring
-@deprecate_parameter("unit", "units", "v0.18.0", remove_version="v0.20.0")
-@use_alias(E="dpi", F="scaling", I="inverse", M="units", n="interpolation")
+@use_alias(E="dpi", F="scaling", I="inverse", M="unit", n="interpolation")
 def grdproject(
     grid: PathLike | xr.DataArray,
     outgrid: PathLike | None = None,
@@ -84,7 +83,7 @@ def grdproject(
         **k** (kilometers), **M** (statute miles), **n** (nautical miles),
         **u** (US survey feet), **i** (inches), **c** (centimeters), or
         **p** (points).
-    units : str
+    unit : str
         Append **c**, **i**, or **p** to indicate that centimeters, inches, or
         points should be the projected measure unit. Cannot be used with
         ``scaling``.

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -11,18 +11,17 @@ from pygmt._typing import PathLike, TableLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTInvalidInput
-from pygmt.helpers import build_arg_list, deprecate_parameter, fmt_docstring, use_alias
+from pygmt.helpers import build_arg_list, fmt_docstring, use_alias
 
 __doctest_skip__ = ["sphdistance"]
 
 
 @fmt_docstring
-@deprecate_parameter("unit", "units", "v0.18.0", remove_version="v0.20.0")
 @use_alias(
     C="single_form",
     D="duplicate",
     E="quantity",
-    L="units",
+    L="unit",
     N="node_table",
     Q="voronoi",
 )
@@ -86,7 +85,7 @@ def sphdistance(
 
         Optionally, append the resampling interval along Voronoi arcs in
         spherical degrees.
-    units : str
+    unit : str
         Specify the unit used for distance calculations. Choose among **d**
         (spherical degrees), **e** (meters), **f** (feet), **k** (kilometers),
         **M** (miles), **n** (nautical miles), or **u** (survey feet).


### PR DESCRIPTION
**Description of proposed changes**

Use the plural `units` if the units of multiple quanities can be adjusted; related to #2014.

**Preview**:

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
