### PR TITLE
pygmt.surface: Deprecate parameter maxradius to max_radius (Will be removed in v0.20.0) 

### DIFF
--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -9,17 +9,18 @@ import xarray as xr
 from pygmt._typing import PathLike, TableLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
-from pygmt.helpers import build_arg_list, fmt_docstring, use_alias
+from pygmt.helpers import build_arg_list, deprecate_parameter, fmt_docstring, use_alias
 
 __doctest_skip__ = ["surface"]
 
 
 @fmt_docstring
+@deprecate_parameter("maxradius", "max_radius", "v0.18.0", remove_version="v0.20.0")
 @use_alias(
     C="convergence",
     Ll="lower",
     Lu="upper",
-    M="maxradius",
+    M="max_radius",
     T="tension",
     a="aspatial",
     b="binary",
@@ -104,9 +105,9 @@ def surface(
         This is the final convergence limit at the desired grid spacing;
         for intermediate (coarser) grids the effective convergence limit is
         divided by the grid spacing multiplier.
-    maxradius : float or str
+    max_radius : float or str
         Optional. After solving for the surface, apply a mask so that nodes
-        farther than ``maxradius`` away from a data constraint are set to NaN
+        farther than ``max_radius`` away from a data constraint are set to NaN
         [Default is no masking]. Append a distance unit (see
         :gmt-docs:`Units <surface.html#units>`) if needed. One can also
         select the nodes to mask by using the *n_cells*\ **c** form. Here


### PR DESCRIPTION
**Description of proposed changes**

Use underscores between words in parameter names; related to #2014.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
