### PR TITLE
DOC: Fix bold style in docstring for panel of Figure.set_panel

### DIFF
--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -234,7 +234,7 @@ def set_panel(
         0, not 1. If not given we go to the next subplot by order specified via
         ``autolabel`` in :meth:`pygmt.Figure.subplot`. As an alternative, you may bypass
         using :meth:`pygmt.Figure.set_panel` and instead supply the common option
-        **panel**=(*row*, *col*) to the first plot command you issue in that subplot.
+        **panel**\ =(*row*, *col*) to the first plot command you issue in that subplot.
         GMT maintains information about the current figure and subplot. Also, you may
         give the one-dimensional *index* instead which starts at 0 and follows the row
         or column order set via ``autolabel`` in :meth:`pygmt.Figure.subplot`.


### PR DESCRIPTION
**Description of proposed changes**

Fix bold style in docstring for `panel` of `Figure.set_panel`.  Without using a "\\" the bold style is not correctly displayed:
<img width="1015" height="255" alt="bold_style" src="https://github.com/user-attachments/assets/9108fd1a-da6f-4eb4-8128-8009de9cd22b" />

**Preview**: https://pygmt-dev--4305.org.readthedocs.build/en/4305/api/generated/pygmt.Figure.set_panel.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
