### PR TITLE
Add missing __doctest_skip__ directive in some methods/functions

### DIFF
--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -27,6 +27,7 @@ except ImportError:
 import numpy as np
 import xarray as xr
 
+__doctest_skip__ = ["load_tile_map"]
 __doctest_requires__ = {("load_tile_map"): ["contextily"]}
 
 

--- a/pygmt/params/position.py
+++ b/pygmt/params/position.py
@@ -12,6 +12,8 @@ from pygmt.exceptions import GMTValueError
 from pygmt.helpers import is_nonstr_iter
 from pygmt.params.base import BaseParam
 
+__doctest_skip__ = ["Position"]
+
 
 @dataclasses.dataclass(repr=False)
 class Position(BaseParam):

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -11,6 +11,8 @@ from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, use_alias
 
+__doctest_skip__ = ["grdfilter"]
+
 
 @fmt_docstring
 @use_alias(D="distance", F="filter", N="nans", f="coltypes")

--- a/pygmt/src/shift_origin.py
+++ b/pygmt/src/shift_origin.py
@@ -7,6 +7,8 @@ import contextlib
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list
 
+__doctest_skip__ = ["shift_origin"]
+
 
 def shift_origin(
     self, xshift: float | str | None = None, yshift: float | str | None = None


### PR DESCRIPTION
Some doctests are mainly intended to **demonstrate the usage** of functions or methods rather than for actual testing. Such tests can be skipped using the `__doctest_skip__` directive (initially introduced in PR #1790). However, it's easy to forget to add this directive to some methods or functions.

To help identify these cases, I asked ChatGPT to write a simple Python script that finds modules containing doctests but missing the `__doctest_skip__` directive. It works, but still flags modules that shouldn't be reported. Thus, we can't add it to our CI workflow, but we can sometimes run it and review the report manually.
```python
import doctest
import pkgutil
import pygmt

TARGETS = ("pygmt.src", "pygmt.datasets", "pygmt.params")

missing = []
for modinfo in pkgutil.walk_packages(pygmt.__path__, pygmt.__name__ + "."):
    name = modinfo.name
    if not name.startswith(TARGETS):
        continue

    module = __import__(name, fromlist=["*"])

    # Detect whether the module actually contains doctests
    finder = doctest.DocTestFinder()
    tests = finder.find(module)
    if not any(test.examples for test in tests):
        continue

    if "__doctest_skip__" not in module.__dict__:
        missing.append(name)

if missing:
    print(
        "__doctest_skip__ missing in modules that contain doctests:\n"
        + "\n".join(f"  - {m}" for m in missing)
    )
```

This PR adds the missing `__doctest_skip__` directives to the appropriate methods and functions.