### PR TITLE
pygmt.grdfilter: Let the parameter 'nans' support descriptive arguments

### DIFF
--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -125,8 +125,8 @@ def grdfilter(
     --------
     >>> from pathlib import Path
     >>> import pygmt
-    >>> # Apply a filter of 600 km (full width) to the @earth_relief_30m_g file and
-    >>> # return a filtered field (saved as netCDF)
+    >>> # Apply a median filter of 600 km (full width) to the @earth_relief_30m_g grid
+    >>> # and return a filtered grid (saved as netCDF file).
     >>> pygmt.grdfilter(
     ...     grid="@earth_relief_30m_g",
     ...     filter="m600",


### PR DESCRIPTION
This PR migrates the `nans` parameter to the new alias system and also make it support descrptive arguments `ignore`, `replace` and `preserve`.

**Preview**: 

- GMT documentation: https://docs.generic-mapping-tools.org/6.6/grdfilter.html#n
- GMT.jl documentation: https://www.generic-mapping-tools.org/GMTjl_doc/documentation/modules/grdfilter.html

Currently, GMT recommends `ignore`/`coregnan`/`anynan`, but I feel they're not good. An upstream PR at https://github.com/GenericMappingTools/gmt/pull/8842.

Related to #4252.