### PR TITLE
Add gallery example for 3-D bar plot

### DIFF
--- a/examples/gallery/3d_plots/3d_bar.py
+++ b/examples/gallery/3d_plots/3d_bar.py
@@ -7,7 +7,8 @@ data points can lie on a regular grid or be irregularly scattered. A special cas
 creating such a 3-D bar plot based on a grid. This can be done in two steps:
 
 1. Converting the grid into a table via :func:`pygmt.grd2xyz`, with columns "x", "y",
-   and "z" for longitude, latitude, and the quantity displayed by the grid, respectively.
+   and "z" for longitude, latitude, and the quantity displayed by the grid,
+   respectively.
 2. Plotting this table as bars in 3-D using :meth:`pygmt.Figure.plot3d`.
 
 The bars can be outlined, and the fill can be one color or based on a quantity using a


### PR DESCRIPTION
**Description of proposed changes**

This PR tests to create a 3-D bar plot in PyGMT and addes a gallery example.

**Preview**: https://pygmt-dev--4315.org.readthedocs.build/en/4315/gallery/3d_plots/3d_bar.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
