### PR TITLE
CI: Test NumPy 2.4 in the GMT Tests workflow

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -78,7 +78,7 @@ jobs:
             optional-packages: ' contextily geopandas ipython pyarrow-core rioxarray netCDF4 sphinx-gallery'
           # Python 3.14 + core packages (latest versions) + optional packages
           - python-version: '3.14'
-            numpy-version: '2.3'
+            numpy-version: '2.4'
             pandas-version: ''
             xarray-version: ''
             optional-packages: ' contextily geopandas ipython pyarrow-core rioxarray netCDF4 sphinx-gallery'


### PR DESCRIPTION
**Description of proposed changes**

Bumps [numpy](https://github.com/numpy/numpy) from 2.3 to 2.4. [NumPy 2.4.0](https://github.com/numpy/numpy/releases/tag/v2.4.0) was released in Dec 2025.

Supersedes #3968