### PR TITLE
Figure.inset: width is not required when projection and region are given

### DIFF
--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -74,8 +74,8 @@ def inset(
         If not specified, defaults to the Bottom Left corner of the plot.
     width
     height
-        Width and height of the inset. Width must be specified and height is set to be
-        equal to width if not specified.
+        Width and height of the inset. Width must be specified unless ``projection`` and
+        ``region`` are given, and height is set to be equal to width if not specified.
     box
         Draw a background box behind the inset. If set to ``True``, a simple rectangular
         box is drawn using :gmt-term:`MAP_FRAME_PEN`. To customize the box appearance,
@@ -132,8 +132,12 @@ def inset(
         default=Position((0, 0), cstype="plotcoords"),  # Default to (0,0) in plotcoords
     )
 
-    # width is mandatory.
-    if width is None and not isinstance(position, str):
+    # width is mandatory unless both projection and region are given.
+    if (
+        not isinstance(position, str)
+        and width is None
+        and (projection is None or region is None)
+    ):
         msg = "Parameter 'width' must be specified."
         raise GMTInvalidInput(msg)
 

--- a/pygmt/tests/test_inset.py
+++ b/pygmt/tests/test_inset.py
@@ -54,6 +54,18 @@ def test_inset_default_position():
     return fig
 
 
+@pytest.mark.mpl_image_compare(filename="test_inset_default_position.png")
+def test_inset_width_from_projection_region():
+    """
+    Test that the inset can infer width from projection and region.
+    """
+    fig = Figure()
+    fig.basemap(region="MG+r2", frame="afg")
+    with fig.inset(projection="G47/-20/3.5c", region="g", box=True):
+        fig.basemap(region="g", projection="G47/-20/?", frame="afg")
+    return fig
+
+
 @pytest.mark.mpl_image_compare(filename="test_inset_aliases.png")
 def test_inset_deprecated_position():
     """


### PR DESCRIPTION
Patches #4047.