### PR TITLE
Remove compatibility codes for Python<3.12

### DIFF
--- a/pygmt/src/_common.py
+++ b/pygmt/src/_common.py
@@ -190,8 +190,7 @@ class _FocalMechanismConvention:
 
             Doesn't apply to the conventions ``"aki"``, ``"gcmt"``, and ``"partial"``.
         """
-        # TODO(Python>=3.12): Simplify to "convention in _FocalMechanismConventionCode".
-        if convention in _FocalMechanismConventionCode.__members__.values():
+        if convention in _FocalMechanismConventionCode:
             # Convention is specified via the actual single-letter convention code.
             self.code = _FocalMechanismConventionCode(convention)
             # Parse the convention from the convention code name.

--- a/pygmt/xarray/accessor.py
+++ b/pygmt/xarray/accessor.py
@@ -209,8 +209,7 @@ class GMTDataArrayAccessor:
 
     @registration.setter
     def registration(self, value: GridRegistration | int):
-        # TODO(Python>=3.12): Simplify to `if value not in GridRegistration`.
-        if value not in GridRegistration.__members__.values():
+        if value not in GridRegistration:
             raise GMTValueError(
                 value, description="grid registration", choices=GridRegistration
             )
@@ -225,8 +224,7 @@ class GMTDataArrayAccessor:
 
     @gtype.setter
     def gtype(self, value: GridType | int):
-        # TODO(Python>=3.12): Simplify to `if value not in GridType`.
-        if value not in GridType.__members__.values():
+        if value not in GridType:
             raise GMTValueError(
                 value, description="grid coordinate system type", choices=GridType
             )


### PR DESCRIPTION
Since Python 3.12, it's possible to check if a value is in a Enum type using the `value in Enum` syntax. xref: https://docs.python.org/3/library/enum.html#enum.EnumType.__contains__

Patches after https://github.com/GenericMappingTools/pygmt/pull/4248.