### PR TITLE
DOC: Use a different image in the draping surface tutorial

### DIFF
--- a/examples/tutorials/advanced/draping_on_3d_surface.py
+++ b/examples/tutorials/advanced/draping_on_3d_surface.py
@@ -98,7 +98,7 @@ region_3d = [*region_2d, grd_relief.min().to_numpy(), grd_relief.max().to_numpy(
 
 # Download an PNG image of the flag of the EU using rasterio and load it into a
 # xarray.DataArray
-url_to_image = "https://upload.wikimedia.org/wikipedia/commons/b/b7/Flag_of_Europe.svg"
+url_to_image = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b7/Flag_of_Europe.svg/1024px-Flag_of_Europe.svg.png"
 with rasterio.open(url_to_image) as dataset:
     data = dataset.read()
     drape_grid = xr.DataArray(data, dims=("band", "y", "x"))


### PR DESCRIPTION
Recently, the docs building has been failing frequently (xref: https://github.com/GenericMappingTools/pygmt/actions/workflows/ci_docs.yml):
```
    Unexpected failing examples (1):
    
        ../examples/tutorials/advanced/draping_on_3d_surface.py failed leaving traceback:
    
        Traceback (most recent call last):
          File "/home/runner/work/pygmt/pygmt/examples/tutorials/advanced/draping_on_3d_surface.py", line 102, in <module>
            with rasterio.open(url_to_image) as dataset:
                 ~~~~~~~~~~~~~^^^^^^^^^^^^^^
          File "/home/runner/micromamba/envs/pygmt/lib/python3.14/site-packages/rasterio/env.py", line 464, in wrapper
            return f(*args, **kwds)
          File "/home/runner/micromamba/envs/pygmt/lib/python3.14/site-packages/rasterio/__init__.py", line 367, in open
            dataset = DatasetReader(path, driver=driver, sharing=sharing, thread_safe=thread_safe, **kwargs)
          File "rasterio/_base.pyx", line 329, in rasterio._base.DatasetBase.__init__
        rasterio.errors.RasterioIOError: HTTP response code: 429
```

It seems the 1000ppx image used by this example no longer exists, and is redirected to another resolution, which causes the 429 (Too many requests) error. This PR replaces it with the 1024px image instead.