### PR TITLE
DOC: Fix typo in documentation of projection polar

### DIFF
--- a/examples/projections/nongeo/polar.py
+++ b/examples/projections/nongeo/polar.py
@@ -34,7 +34,7 @@ The following customizing modifiers are available:
 
   - Append **e** to indicate that the r-axis is an elevation angle, and the range of the
     r-axis should be between 0° and 90°.
-  - Appending **p** sets the current Earth radius (determined by
+  - Appending **p** sets the current Earth's radius (determined by
     :gmt-term:`PROJ_ELLIPSOID`) to the maximum value of the r-axis when the r-axis is
     reversed.
   - Append *radius* to set the maximum value of the r-axis.
@@ -42,7 +42,7 @@ The following customizing modifiers are available:
 - **+z**: indicates that the r-axis is marked as depth instead of radius (e.g.,
   *r = radius - z*).
 
-  - Append **p** to set radius to the current Earth radius.
+  - Append **p** to set radius to the current Earth's radius.
   - Append *radius* to set the value of the radius.
 """
 


### PR DESCRIPTION
**Description of proposed changes**

Just a typo fix to consistently use "Earth's radius"; no code changes.

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
