### PR TITLE
Change an error message from a tuple to a string in grdclip.py

### DIFF
--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -112,8 +112,8 @@ def grdclip(
     """
     if all(v is None for v in (above, below, between, replace)):
         msg = (
-            "Must specify at least one of the following parameters: ",
-            "'above', 'below', 'between', or 'replace'.",
+            "Must specify at least one of the following parameters: "
+            "'above', 'below', 'between', or 'replace'."
         )
         raise GMTInvalidInput(msg)
 


### PR DESCRIPTION
The `msg` variable in grdclip.py used error message when raising `GMTInvalidInput` is a tuple. This changes it to be a multi-line string, while still in accordance with PEP 8 line length requirements.