### PR TITLE
Figure.basemap/Figure.coast: Recommend to use the Figure.scalebar method to add a scalebar

### DIFF
--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -69,15 +69,10 @@ def basemap(  # noqa: PLR0913
 
         .. deprecated:: v0.19.0
 
-            The ``map_scale`` parameter is deprecated. Use :meth:`pygmt.Figure.scalebar`
-            instead, which provides a more comprehensive and flexible API for adding
-            scale bars to plots.
-
-        .. note::
-
-            This parameter accepts raw GMT CLI strings for the ``-L`` option of
-            the ``basemap`` module for backward compatibility.
-
+            This parameter is deprecated. Use :meth:`pygmt.Figure.scalebar` instead,
+            which provides a more comprehensive and flexible API for adding scale bars
+            to plots. This parameter still accepts raw GMT CLI strings for the ``-L``
+            option of the ``basemap`` module for backward compatibility.
     box : bool or str
         [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]]\
         [**+p**\ [*pen*]][**+r**\ [*radius*]][**+s**\ [[*dx*/*dy*/][*shade*]]].

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -138,15 +138,10 @@ def coast(  # noqa: PLR0913
 
         .. deprecated:: v0.19.0
 
-            The ``map_scale`` parameter is deprecated. Use :meth:`pygmt.Figure.scalebar`
-            instead, which provides a more comprehensive and flexible API for adding
-            scale bars to plots.
-
-        .. note::
-
-            This parameter accepts raw GMT CLI strings for the ``-L`` option of
-            the ``basemap`` module for backward compatibility.
-
+            This parameter is deprecated. Use :meth:`pygmt.Figure.scalebar` instead,
+            which provides a more comprehensive and flexible API for adding scale bars
+            to plots. This parameter still accepts raw GMT CLI strings for the ``-L``
+            option of the ``basemap`` module for backward compatibility.
     box
         Draw a background box behind the map scale or rose. If set to ``True``, a simple
         rectangular box is drawn using :gmt-term:`MAP_FRAME_PEN`. To customize the box


### PR DESCRIPTION
With the new `Figure.scalebar` method, we can deprecate the `map_scale` parameter in `Figure.basemap`/`Figure.coast`.

Please note that `map_scale` is only marked as deprecated in the docstrings, no warning will be raised.

**Preview**: