### PR TITLE
Exclude naturalearth URL in gallery examples from workflow check links

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -63,6 +63,7 @@ jobs:
           --exclude "^https://hackmd.io/@pygmt"
           --exclude "^https://test.pypi.org/simple/"
           --exclude "^https://www.adobe.com/jp/print/postscript/pdfs/PLRM.pdf"
+          --exclude "^https://naciscdn.org/naturalearth"
           --exclude "^https://www.generic-mapping-tools.org/remote-datasets/%s$"
           --exclude "^https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html"
           --exclude "^https://www.pygmt.org/%7B%7Bpath%7D%7D"


### PR DESCRIPTION
**Description of proposed changes**

Exclude naturalearth URL in gallery examples from workflow check links.

Fixes: #4350.

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
