### PR TITLE
CI: Combine the steps for building GMT source code in the 'GMT Dev Tests' workflow

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -104,8 +104,7 @@ jobs:
       # Build GMT from source on Linux/macOS, script is adapted from
       # https://github.com/GenericMappingTools/gmt/blob/6.5.0/ci/build-gmt.sh
       - name: Build GMT from source
-        # Use non-login shell on Windows and login shell on Linux/macOS
-        shell: ${{ runner.os == 'Windows' && 'bash' || 'bash -l {0}' }}
+        shell: bash
         run: |
           cd gmt/
           mkdir build


### PR DESCRIPTION
With changes in #4329, now it's possible to have a single step for building GMT source code on all platforms.