### PR TITLE
Add legend background color in tutorial "Plotting data points"

### DIFF
--- a/examples/tutorials/basics/plot.py
+++ b/examples/tutorials/basics/plot.py
@@ -75,7 +75,7 @@ legend = io.StringIO(
 fig.legend(
     spec=legend,
     position=Position("BR", offset=0.2),
-    line_spacing=2.0,
+    line_spacing=2,
     box=Box(fill="white", pen="black"),
 )
 fig.show()
@@ -112,7 +112,7 @@ fig.colorbar(frame="xaf+lDepth (km)")
 fig.legend(
     spec=legend,
     position=Position("BR", offset=0.2),
-    line_spacing=2.0,
+    line_spacing=2,
     box=Box(fill="white", pen="black"),
 )
 fig.show()


### PR DESCRIPTION
**Description of proposed changes**

Add a white background in the legends so they stand out from the blue ocean fill.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->



<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:
https://pygmt-dev--4354.org.readthedocs.build/en/4354/tutorials/basics/plot.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
