### PR TITLE
DOC: Fix typo in gallery example "Vertical and horizontal bars"

### DIFF
--- a/examples/gallery/symbols/bars.py
+++ b/examples/gallery/symbols/bars.py
@@ -7,7 +7,7 @@ horizontal (**B**) bars by passing the corresponding shortcut to
 the ``style`` parameter. By default, *base* = 0 meaning that the
 bar is starting from 0. Append **+b**\[*base*] to change this
 value. To plot multi-band bars, please append
-**+v**\|\ **i**\ *ny* (for verticals bars) or **+v**\|\ **i**\ *nx*
+**+v**\|\ **i**\ *ny* (for vertical bars) or **+v**\|\ **i**\ *nx*
 (for horizontal ones), where *ny* or *nx* indicate the total
 number of bands in the bar (and hence the number of values required
 to follow the *x,y* coordinate pair in the input). Here, **+i**


### PR DESCRIPTION
**Description of proposed changes**

Just a small typo fix in the gallery example "Vertical and horizontal bars"; no code changes.

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
