### PR TITLE
DOC: Fix typo in deprecation note for "map_scale" of Figure.coast

### DIFF
--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -141,7 +141,7 @@ def coast(  # noqa: PLR0913
             This parameter is deprecated. Use :meth:`pygmt.Figure.scalebar` instead,
             which provides a more comprehensive and flexible API for adding scale bars
             to plots. This parameter still accepts raw GMT CLI strings for the ``-L``
-            option of the ``basemap`` module for backward compatibility.
+            option of the ``coast`` module for backward compatibility.
     box
         Draw a background box behind the map scale or rose. If set to ``True``, a simple
         rectangular box is drawn using :gmt-term:`MAP_FRAME_PEN`. To customize the box


### PR DESCRIPTION
**Description of proposed changes**

Fix a copy-past typo which was overlooked in PR #4337.

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
