### PR TITLE
Fix the failing tests for the updated gravimetric grids

### DIFF
--- a/pygmt/tests/test_datasets_earth_deflection.py
+++ b/pygmt/tests/test_datasets_earth_deflection.py
@@ -23,8 +23,8 @@ def test_earth_edefl_01d():
     assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -142.64, atol=0.04)
-    npt.assert_allclose(data.max(), 178.32, atol=0.04)
+    npt.assert_allclose(data.min(), -143.4, atol=0.04)
+    npt.assert_allclose(data.max(), 177.36, atol=0.04)
 
 
 def test_earth_edefl_01d_with_region():
@@ -37,7 +37,7 @@ def test_earth_edefl_01d_with_region():
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
     npt.assert_allclose(data.min(), -28.92, atol=0.04)
-    npt.assert_allclose(data.max(), 24.72, atol=0.04)
+    npt.assert_allclose(data.max(), 24.8, atol=0.04)
 
 
 def test_earth_edefl_01m_default_registration():
@@ -52,8 +52,8 @@ def test_earth_edefl_01m_default_registration():
     npt.assert_allclose(data.coords["lat"].data.max(), 4.991666666)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.99166666)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.00833333)
-    npt.assert_allclose(data.min(), -62.24, atol=0.04)
-    npt.assert_allclose(data.max(), 15.52, atol=0.04)
+    npt.assert_allclose(data.min(), -62.84, atol=0.04)
+    npt.assert_allclose(data.max(), 15.16, atol=0.04)
 
 
 def test_earth_ndefl_01d():
@@ -85,8 +85,8 @@ def test_earth_ndefl_01d_with_region():
     assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -48.08, atol=0.04)
-    npt.assert_allclose(data.max(), 18.92, atol=0.04)
+    npt.assert_allclose(data.min(), -48.38, atol=0.04)
+    npt.assert_allclose(data.max(), 18.84, atol=0.04)
 
 
 def test_earth_ndefl_01m_default_registration():
@@ -103,5 +103,5 @@ def test_earth_ndefl_01m_default_registration():
     npt.assert_allclose(data.coords["lat"].data.max(), 4.991666666)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.99166666)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.00833333)
-    npt.assert_allclose(data.min(), -107.04, atol=0.04)
-    npt.assert_allclose(data.max(), 20.28, atol=0.04)
+    npt.assert_allclose(data.min(), -108.04, atol=0.04)
+    npt.assert_allclose(data.max(), 20.16, atol=0.04)

--- a/pygmt/tests/test_datasets_earth_free_air_anomaly.py
+++ b/pygmt/tests/test_datasets_earth_free_air_anomaly.py
@@ -22,8 +22,8 @@ def test_earth_faa_01d():
     assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -188.85, atol=0.025)
-    npt.assert_allclose(data.max(), 161.25, atol=0.025)
+    npt.assert_allclose(data.min(), -188.625, atol=0.025)
+    npt.assert_allclose(data.max(), 161.1, atol=0.025)
 
 
 def test_earth_faa_01d_with_region():
@@ -35,8 +35,8 @@ def test_earth_faa_01d_with_region():
     assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), -36.125, atol=0.025)
-    npt.assert_allclose(data.max(), 45.3, atol=0.025)
+    npt.assert_allclose(data.min(), -36.075, atol=0.025)
+    npt.assert_allclose(data.max(), 45.45, atol=0.025)
 
 
 def test_earth_faa_01m_default_registration():
@@ -51,8 +51,8 @@ def test_earth_faa_01m_default_registration():
     npt.assert_allclose(data.coords["lat"].data.max(), 4.991666666)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.99166666)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.00833333)
-    npt.assert_allclose(data.min(), -49.225, atol=0.025)
-    npt.assert_allclose(data.max(), 115.0, atol=0.025)
+    npt.assert_allclose(data.min(), -49.85, atol=0.025)
+    npt.assert_allclose(data.max(), 114.125, atol=0.025)
 
 
 def test_earth_faaerror_01d():
@@ -70,7 +70,7 @@ def test_earth_faaerror_01d():
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
     npt.assert_allclose(data.min(), 0.0, atol=0.04)
-    npt.assert_allclose(data.max(), 49.16, atol=0.04)
+    npt.assert_allclose(data.max(), 51.52, atol=0.04)
 
 
 def test_earth_faaerror_01d_with_region():
@@ -84,8 +84,8 @@ def test_earth_faaerror_01d_with_region():
     assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-5, 6, 1))
     npt.assert_allclose(data.lon, np.arange(-10, 11, 1))
-    npt.assert_allclose(data.min(), 0.72, atol=0.04)
-    npt.assert_allclose(data.max(), 21.04, atol=0.04)
+    npt.assert_allclose(data.min(), 0.60, atol=0.04)
+    npt.assert_allclose(data.max(), 18.56, atol=0.04)
 
 
 def test_earth_faaerror_01m_default_registration():
@@ -103,4 +103,4 @@ def test_earth_faaerror_01m_default_registration():
     npt.assert_allclose(data.coords["lon"].data.min(), -9.99166666)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.00833333)
     npt.assert_allclose(data.min(), 0.40, atol=0.04)
-    npt.assert_allclose(data.max(), 13.36, atol=0.04)
+    npt.assert_allclose(data.max(), 6.96, atol=0.04)

--- a/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
+++ b/pygmt/tests/test_datasets_earth_vertical_gravity_gradient.py
@@ -22,7 +22,7 @@ def test_earth_vertical_gravity_gradient_01d():
     assert data.gmt.registration is GridRegistration.GRIDLINE
     npt.assert_allclose(data.lat, np.arange(-90, 91, 1))
     npt.assert_allclose(data.lon, np.arange(-180, 181, 1))
-    npt.assert_allclose(data.min(), -40.1875, atol=1 / 32)
+    npt.assert_allclose(data.min(), -40.0625, atol=1 / 32)
     npt.assert_allclose(data.max(), 45.96875, atol=1 / 32)
     assert data[1, 1].isnull()
 
@@ -56,5 +56,5 @@ def test_earth_vertical_gravity_gradient_01m_default_registration():
     npt.assert_allclose(data.coords["lat"].data.max(), 4.991666666)
     npt.assert_allclose(data.coords["lon"].data.min(), -9.99166666)
     npt.assert_allclose(data.coords["lon"].data.max(), -9.00833333)
-    npt.assert_allclose(data.min(), -37.5625, atol=1 / 32)
-    npt.assert_allclose(data.max(), 82.59375, atol=1 / 32)
+    npt.assert_allclose(data.min(), -36.21875, atol=1 / 32)
+    npt.assert_allclose(data.max(), 78.34375, atol=1 / 32)


### PR DESCRIPTION
**Description of proposed changes**

Specifically the `earth_faa`, `earth_faaerror`, `earth_ndefl`, `earth_edefl` and `earth_vgg` grids. Xref https://github.com/GenericMappingTools/gmtserver-admin/issues/291

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
