### PR TITLE
DOC: Fix "triangles_height" to "triangle_height" in docs of Figure.colorbar

### DIFF
--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -214,9 +214,9 @@ def colorbar(  # noqa: PLR0913
         and **F** entries in the CPT. If no such entries exist, then the system default
         colors for **B** and **F** are used instead (:gmt-term:`COLOR_BACKGROUND` and
         :gmt-term:`COLOR_FOREGROUND`).
-    triangles_height
-        Height of the triangles for back- and foreground colors [Default is half
-        of the bar width].
+    triangle_height
+        Height of the triangles for back- and foreground colors [Default is half of the
+        bar width].
     move_text
         Move text (annotations, label, and unit) to opposite side. Accept a sequence of
         strings containing one or more of ``"annotations"``, ``"label"``, and


### PR DESCRIPTION
**Description of proposed changes**

Fix `triangles_height` to `triangle_height` in docs of Figure.colorbar. The code uses the singular version.

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
