### PR TITLE
Figure.colorbar: Move tests related to option -D as doctests

### DIFF
--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -33,6 +33,59 @@ def _alias_option_D(  # noqa: N802, PLR0913
 ):
     """
     Return a list of Alias objects for the -D option.
+
+    Examples
+    --------
+    >>> def parse(**kwargs):
+    ...     return AliasSystem(D=_alias_option_D(**kwargs)).get("D")
+    >>> parse(position=Position("TL", offset=0.2), length=4, width=0.5)
+    'jTL+o0.2+w4/0.5'
+    >>> parse(orientation="horizontal")
+    '+h'
+    >>> parse(orientation="vertical")
+    '+v'
+    >>> parse(reverse=True)
+    '+r'
+    >>> parse(nan=True)
+    '+n'
+    >>> parse(nan=True, nan_position="end")
+    '+N'
+    >>> parse(fg_triangle=True, bg_triangle=True)
+    '+e'
+    >>> parse(fg_triangle=True)
+    '+ef'
+    >>> parse(bg_triangle=True)
+    '+eb'
+    >>> parse(fg_triangle=True, triangle_height=0.4)
+    '+ef0.4'
+    >>> parse(fg_triangle=True, bg_triangle=True, triangle_height=0.3)
+    '+e0.3'
+    >>> parse(move_text="annotations")
+    '+ma'
+    >>> parse(move_text="label")
+    '+ml'
+    >>> parse(move_text="unit")
+    '+mu'
+    >>> parse(move_text=["annotations", "label", "unit"])
+    '+malu'
+    >>> parse(label_as_column=True)
+    '+mc'
+    >>> parse(move_text=["annotations", "label"], label_as_column=True)
+    '+malc'
+    >>> parse(
+    ...     position=Position("BR", offset=(0.1, 0.2)),
+    ...     length=5,
+    ...     width=0.4,
+    ...     orientation="vertical",
+    ...     reverse=True,
+    ...     nan=True,
+    ...     nan_position="start",
+    ...     bg_triangle=True,
+    ...     triangle_height=0.2,
+    ...     move_text=["annotations", "unit"],
+    ...     label_as_column=True,
+    ... )
+    'jBR+o0.1/0.2+w5/0.4+v+r+n+eb0.2+mauc'
     """
     # Build the +e modifier from fg_triangle/bg_triangle/triangle_height
     if fg_triangle and bg_triangle:

--- a/pygmt/tests/test_colorbar.py
+++ b/pygmt/tests/test_colorbar.py
@@ -4,10 +4,8 @@ Test Figure.colorbar.
 
 import pytest
 from pygmt import Figure
-from pygmt.alias import AliasSystem
 from pygmt.exceptions import GMTInvalidInput
 from pygmt.params.position import Position
-from pygmt.src.colorbar import _alias_option_D
 
 
 @pytest.mark.benchmark
@@ -35,59 +33,6 @@ def test_colorbar_shading_list():
     fig.basemap(region=[0, 10, 0, 2], projection="X10c/2c", frame="a")
     fig.colorbar(cmap="gmt/geo", shading=[-0.7, 0.2], frame=True)
     return fig
-
-
-def test_colorbar_alias_D():  # noqa: N802
-    """
-    Test the parameters for the -D option.
-    """
-
-    def alias_wrapper(**kwargs):
-        """
-        A wrapper function for testing the parameters of -D option.
-        """
-        return AliasSystem(D=_alias_option_D(**kwargs)).get("D")
-
-    argstr = alias_wrapper(position=Position("TL", offset=0.2), length=4, width=0.5)
-    assert argstr == "jTL+o0.2+w4/0.5"
-
-    assert alias_wrapper(orientation="horizontal") == "+h"
-    assert alias_wrapper(orientation="vertical") == "+v"
-
-    assert alias_wrapper(reverse=True) == "+r"
-
-    assert alias_wrapper(nan=True) == "+n"
-    assert alias_wrapper(nan=True, nan_position="end") == "+N"
-
-    assert alias_wrapper(fg_triangle=True, bg_triangle=True) == "+e"
-    assert alias_wrapper(fg_triangle=True) == "+ef"
-    assert alias_wrapper(bg_triangle=True) == "+eb"
-    assert alias_wrapper(fg_triangle=True, triangle_height=0.4) == "+ef0.4"
-    argstr = alias_wrapper(fg_triangle=True, bg_triangle=True, triangle_height=0.3)
-    assert argstr == "+e0.3"
-
-    assert alias_wrapper(move_text="annotations") == "+ma"
-    assert alias_wrapper(move_text="label") == "+ml"
-    assert alias_wrapper(move_text="unit") == "+mu"
-    assert alias_wrapper(move_text=["annotations", "label", "unit"]) == "+malu"
-    assert alias_wrapper(label_as_column=True) == "+mc"
-    argstr = alias_wrapper(move_text=["annotations", "label"], label_as_column=True)
-    assert argstr == "+malc"
-
-    argstr = alias_wrapper(
-        position=Position("BR", offset=(0.1, 0.2)),
-        length=5,
-        width=0.4,
-        orientation="vertical",
-        reverse=True,
-        nan=True,
-        nan_position="start",
-        bg_triangle=True,
-        triangle_height=0.2,
-        move_text=["annotations", "unit"],
-        label_as_column=True,
-    )
-    assert argstr == "jBR+o0.1/0.2+w5/0.4+v+r+n+eb0.2+mauc"
 
 
 @pytest.mark.mpl_image_compare(filename="test_colorbar.png")


### PR DESCRIPTION
For complicated options like `colorbar`'s `-D`, we encapsulate the parsing logic in private helper functions such as `_alias_option_D`. These helpers let us test argument strings directly for any combination of parameters, rather than testing each combination through `Figure.colorbar` calls, which would mean a growing collection of tests and baseline images.

Previously, we added dedicated tests like `test_colorbar_alias_D` in `pygmt/tests/test_colorbar.py`. This PR moves those tests inline as doctests within `_alias_option_D` instead. The benefits are:

1. Tests can be written without switching between source and test files.
2. Test files no longer need to import private functions or the `AliasSystem` class.