### PR TITLE
DOC: Add outgrid (-G) to the alias list in docstrings

### DIFF
--- a/pygmt/src/binstats.py
+++ b/pygmt/src/binstats.py
@@ -68,6 +68,7 @@ def binstats(
 
     $aliases
        - C = statistic
+       - G = outgrid
        - I = spacing
        - R = region
        - V = verbose

--- a/pygmt/src/dimfilter.py
+++ b/pygmt/src/dimfilter.py
@@ -48,6 +48,7 @@ def dimfilter(
     Full GMT docs at :gmt-docs:`dimfilter.html`.
 
     $aliases
+       - G = outgrid
        - I = spacing
        - R = region
        - V = verbose

--- a/pygmt/src/grdclip.py
+++ b/pygmt/src/grdclip.py
@@ -50,6 +50,7 @@ def grdclip(
     .. hlist::
        :columns: 3
 
+       - G = outgrid
        - R = region
        - Sa = above
        - Sb = below

--- a/pygmt/src/grdcut.py
+++ b/pygmt/src/grdcut.py
@@ -47,6 +47,7 @@ def grdcut(
     Full GMT docs at :gmt-docs:`grdcut.html`.
 
     $aliases
+       - G = outgrid
        - J = projection
        - R = region
        - V = verbose

--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -105,6 +105,7 @@ def grdfill(
        - Ag = grid_fill
        - An = neighbor_fill
        - As = spline_fill
+       - G = outgrid
        - L = inquire
        - N = hole
        - R = region

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -45,6 +45,7 @@ def grdfilter(
     Full GMT docs at :gmt-docs:`grdfilter.html`.
 
     $aliases
+       - G = outgrid
        - I = spacing
        - N = nans
        - R = region

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -45,6 +45,7 @@ def grdgradient(
     $aliases
        - A = azimuth
        - E = radiance
+       - G = outgrid
        - R = region
        - V = verbose
 

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -78,6 +78,7 @@ class grdhisteq:  # noqa: N801
         Full GMT docs at :gmt-docs:`grdhisteq.html`.
 
         $aliases
+           - G = outgrid
            - R = region
            - V = verbose
 

--- a/pygmt/src/grdlandmask.py
+++ b/pygmt/src/grdlandmask.py
@@ -52,6 +52,7 @@ def grdlandmask(
     $aliases
        - D = resolution
        - E = border_values
+       - G = outgrid
        - I = spacing
        - N = mask_values
        - R = region

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -57,6 +57,7 @@ def grdproject(  # noqa: PLR0913
        - D = spacing
        - E = dpi
        - F = scaling
+       - G = outgrid
        - I = inverse
        - J = projection
        - M = unit

--- a/pygmt/src/grdsample.py
+++ b/pygmt/src/grdsample.py
@@ -55,6 +55,7 @@ def grdsample(
     Full GMT docs at :gmt-docs:`grdsample.html`.
 
     $aliases
+       - G = outgrid
        - I = spacing
        - R = region
        - V = verbose

--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -79,6 +79,7 @@ def nearneighbor(
     Full GMT docs at :gmt-docs:`nearneighbor.html`.
 
     $aliases
+       - G = outgrid
        - I = spacing
        - R = region
        - V = verbose

--- a/pygmt/src/sph2grd.py
+++ b/pygmt/src/sph2grd.py
@@ -38,6 +38,7 @@ def sph2grd(
     Full GMT docs at :gmt-docs:`sph2grd.html`.
 
     $aliases
+       - G = outgrid
        - I = spacing
        - R = region
        - V = verbose

--- a/pygmt/src/sphdistance.py
+++ b/pygmt/src/sphdistance.py
@@ -47,6 +47,7 @@ def sphdistance(
     Full GMT docs at :gmt-docs:`sphdistance.html`.
 
     $aliases
+       - G = outgrid
        - I = spacing
        - R = region
        - V = verbose

--- a/pygmt/src/sphinterpolate.py
+++ b/pygmt/src/sphinterpolate.py
@@ -40,6 +40,7 @@ def sphinterpolate(
     .. hlist:
        :columns: 2
 
+       - G = outgrid
        - I = spacing
        - R = region
        - V = verbose

--- a/pygmt/src/surface.py
+++ b/pygmt/src/surface.py
@@ -78,6 +78,7 @@ def surface(
     Full GMT docs at :gmt-docs:`surface.html`.
 
     $aliases
+       - G = outgrid
        - I = spacing
        - R = region
        - V = verbose

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -100,6 +100,7 @@ class triangulate:  # noqa: N801
         Full GMT docs at :gmt-docs:`triangulate.html`.
 
         $aliases
+           - G = outgrid
            - I = spacing
            - J = projection
            - R = region

--- a/pygmt/src/xyz2grd.py
+++ b/pygmt/src/xyz2grd.py
@@ -53,6 +53,7 @@ def xyz2grd(
     Full GMT docs at :gmt-docs:`xyz2grd.html`.
 
     $aliases
+       - G = outgrid
        - I = spacing
        - J = projection
        - R = region


### PR DESCRIPTION
For grid-operating modules, `-G` is typically aliased to `outgrid` but didn't appear in the alias list. 
This is mainly because the alias is not explicitly defined in either the old and the new alias systems; instead, it is set later when the virtual file is created. 

I thin `outgrid` should be included in the alias list for completeness. 
