### PR TITLE
Figure.grdview: Raise GMTParameterError when parameter conflicts with specific surftype

### DIFF
--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -10,7 +10,7 @@ from packaging.version import Version
 from pygmt._typing import PathLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session, __gmt_version__
-from pygmt.exceptions import GMTInvalidInput, GMTParameterError
+from pygmt.exceptions import GMTParameterError
 from pygmt.helpers import build_arg_list, deprecate_parameter, fmt_docstring, use_alias
 from pygmt.src.grdinfo import grdinfo
 
@@ -80,17 +80,20 @@ def _alias_option_Q(  # noqa: N802
         )
 
     if dpi is not None and surftype != "image":
-        msg = "Parameter 'dpi' can only be used when 'surftype' is 'image'."
-        raise GMTInvalidInput(msg)
-    if nan_transparent and surftype != "image":
-        msg = "Parameter 'nan_transparent' can only be used when 'surftype' is 'image'."
-        raise GMTInvalidInput(msg)
-    if mesh_fill is not None and surftype not in {"mesh", "waterfall_x", "waterfall_y"}:
-        msg = (
-            "Parameter 'mesh_fill' can only be used when 'surftype' is 'mesh', "
-            "'waterfall_x', or 'waterfall_y'."
+        raise GMTParameterError(
+            conflicts_with=("dpi", [f"surftype={surftype!r}"]),
+            reason="'dpi' is allowed only when 'surftype' is 'image'.",
         )
-        raise GMTInvalidInput(msg)
+    if nan_transparent and surftype != "image":
+        raise GMTParameterError(
+            conflicts_with=("nan_transparent", [f"surftype={surftype!r}"]),
+            reason="'nan_transparent' is allowed only when 'surftype' is 'image'.",
+        )
+    if mesh_fill is not None and surftype not in {"mesh", "waterfall_x", "waterfall_y"}:
+        raise GMTParameterError(
+            conflicts_with=("mesh_fill", [f"surftype={surftype!r}"]),
+            reason="'mesh_fill' is allowed only when 'surftype' is 'mesh', 'waterfall_x', or 'waterfall_y'.",
+        )
 
     return [
         Alias(

--- a/pygmt/tests/test_grdview.py
+++ b/pygmt/tests/test_grdview.py
@@ -4,7 +4,7 @@ Test Figure.grdview.
 
 import pytest
 from pygmt import Figure, grdcut
-from pygmt.exceptions import GMTInvalidInput, GMTParameterError, GMTTypeError
+from pygmt.exceptions import GMTParameterError, GMTTypeError
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import load_static_earth_relief
 
@@ -330,11 +330,11 @@ def test_grdview_invalid_surftype(gridfile):
     parameters.
     """
     fig = Figure()
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTParameterError):
         fig.grdview(grid=gridfile, surftype="surface", dpi=300)
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTParameterError):
         fig.grdview(grid=gridfile, surftype="surface", nan_transparent=True)
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTParameterError):
         fig.grdview(grid=gridfile, surftype="surface", mesh_fill="red")
 
 


### PR DESCRIPTION
See https://github.com/GenericMappingTools/pygmt/issues/3707#issuecomment-3863883197 for context. I think it makes more sense to raise `GMTParameterError` in this case.

The error message looks like:
```
In [1]: import pygmt
    
In [2]: fig = pygmt.Figure()

In [3]: fig.grdview(grid="@earth_relief_01d", surftype="surface", dpi=300)

GMTParameterError: Conflicting parameters: 'dpi' cannot be used with "surftype='surface'".
'dpi' is allowed only when 'surftype' is 'image'.
```