### PR TITLE
pygmt.grdhisteq: Raise GMTParameterError when 'header' is used with output_type!="file"

### DIFF
--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -11,7 +11,7 @@ import xarray as xr
 from pygmt._typing import PathLike
 from pygmt.alias import AliasSystem
 from pygmt.clib import Session
-from pygmt.exceptions import GMTInvalidInput
+from pygmt.exceptions import GMTParameterError
 from pygmt.helpers import (
     build_arg_list,
     fmt_docstring,
@@ -235,8 +235,10 @@ class grdhisteq:  # noqa: N801
         output_type = validate_output_table_type(output_type, outfile=outfile)
 
         if kwargs.get("h") is not None and output_type != "file":
-            msg = "'header' is only allowed with output_type='file'."
-            raise GMTInvalidInput(msg)
+            raise GMTParameterError(
+                conflicts_with=("header", [f"output_type={output_type!r}"]),
+                reason="'header' is allowed only when 'output_type' is 'file'.",
+            )
 
         aliasdict = AliasSystem().add_common(
             R=region,

--- a/pygmt/tests/test_grdhisteq.py
+++ b/pygmt/tests/test_grdhisteq.py
@@ -10,7 +10,7 @@ import pytest
 import xarray as xr
 from pygmt import grdhisteq
 from pygmt.enums import GridRegistration, GridType
-from pygmt.exceptions import GMTInvalidInput, GMTValueError
+from pygmt.exceptions import GMTParameterError, GMTValueError
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import load_static_earth_relief
 
@@ -138,5 +138,5 @@ def test_compute_bins_invalid_format(grid):
     """
     with pytest.raises(GMTValueError):
         grdhisteq.compute_bins(grid=grid, output_type=1)
-    with pytest.raises(GMTInvalidInput):
+    with pytest.raises(GMTParameterError):
         grdhisteq.compute_bins(grid=grid, output_type="pandas", header="o+c")


### PR DESCRIPTION
See https://github.com/GenericMappingTools/pygmt/issues/3707#issuecomment-3863883197 and https://github.com/GenericMappingTools/pygmt/pull/4397.