### PR TITLE
Update the module request template to include related GMT configurations

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-module_request.md
+++ b/.github/ISSUE_TEMPLATE/3-module_request.md
@@ -27,6 +27,10 @@ labels: ["feature request"]
 - [ ] ~~`-X`/`-Y`~~: Use `Figure.shift_origin` instead.
 - [ ] ~~`--PAR=value`~~: Use `pygmt.config` instead.
 
+## Related GMT configurations
+
+*List any related GMT configurations that may affect the behavior.*
+
 ## Notes on Input Formats
 
 *Add any notes on the input formats, especially the meaning of columns.*


### PR DESCRIPTION
Inspired by https://github.com/GenericMappingTools/pygmt/pull/4010#issuecomment-3863679305, we may improve the API by wrapping some GMT configurations as method parameters. One such example is the `MAP_SCALE_HEIGHT` which is wrapped as the `height` parameter in `Figure.scalebar`.

So it would be better to list related GMT configurations in the wrapper tracker issues.