### PR TITLE
DOC: Improve highlighting for pygmt.nearneighbor

### DIFF
--- a/pygmt/src/nearneighbor.py
+++ b/pygmt/src/nearneighbor.py
@@ -45,7 +45,7 @@ def nearneighbor(
     r"""
     Grid table data using a "Nearest neighbor" algorithm.
 
-    **nearneighbor** reads arbitrarily located (*x*, *y*, *z*\ [, *w*])
+    :func:`pygmt.nearneighbor` reads arbitrarily located (*x*, *y*, *z*\ [, *w*])
     triplets [quadruplets] and uses a nearest neighbor algorithm to assign a
     weighted average value to each node that has one or more data points within
     a search radius centered on the node with adequate coverage across a subset


### PR DESCRIPTION
**Description of proposed changes**

Improve highlighting in docs of `pygmt.nearneighbor`:

| old | new |
| --- | --- | 
| <img width="1034" height="324" alt="nn_old" src="https://github.com/user-attachments/assets/2af71f0a-1575-4547-bcb4-8800386f5531" /> | <img width="1079" height="327" alt="nn_new" src="https://github.com/user-attachments/assets/363ab025-c315-41a5-9261-4a339570af7a" /> |


**Preview**: https://pygmt-dev--4424.org.readthedocs.build/en/4424/api/generated/pygmt.nearneighbor.html#pygmt.nearneighbor

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
