### PR TITLE
ruff: Fix ICN002 geopandas import alias

### DIFF
--- a/examples/gallery/lines/linestrings.py
+++ b/examples/gallery/lines/linestrings.py
@@ -12,13 +12,15 @@ the ``data`` parameter of :meth:`pygmt.Figure.plot`, and style the lines using t
 """
 
 # %%
-import geopandas as gpd
+import geopandas
 import pygmt
 
 # Read a sample dataset provided by Natural Earth. The dataset contains rivers stored
 # as LineString/MultiLineString geometry types. Here will focus on Asia.
 provider = "https://naciscdn.org/naturalearth"
-rivers = gpd.read_file(f"{provider}/50m/physical/ne_50m_rivers_lake_centerlines.zip")
+rivers = geopandas.read_file(
+    f"{provider}/50m/physical/ne_50m_rivers_lake_centerlines.zip"
+)
 rivers_asia = rivers.cx[57:125, 7:47].copy()
 
 fig = pygmt.Figure()

--- a/examples/gallery/maps/choropleth_map.py
+++ b/examples/gallery/maps/choropleth_map.py
@@ -14,12 +14,12 @@ the ``column`` parameter.
 """
 
 # %%
-import geopandas as gpd
+import geopandas
 import pygmt
 from pygmt.params.position import Position
 
 provider = "https://naciscdn.org/naturalearth"
-world = gpd.read_file(f"{provider}/110m/cultural/ne_110m_admin_0_countries.zip")
+world = geopandas.read_file(f"{provider}/110m/cultural/ne_110m_admin_0_countries.zip")
 
 # The dataset contains different attributes, here we focus on the population within
 # the different countries (column "POP_EST") for the continent "Africa".

--- a/examples/gallery/symbols/points_cities.py
+++ b/examples/gallery/symbols/points_cities.py
@@ -14,13 +14,15 @@ to label specific features.
 """
 
 # %%
-import geopandas as gpd
+import geopandas
 import pygmt
 
 # Read a sample dataset provided by Natural Earth. The dataset contains cities stored
 # as Point geometry type. In this example we focus on Europe.
 provider = "https://naciscdn.org/naturalearth"
-cities = gpd.read_file(f"{provider}/50m/cultural/ne_50m_populated_places_simple.zip")
+cities = geopandas.read_file(
+    f"{provider}/50m/cultural/ne_50m_populated_places_simple.zip"
+)
 cities = cities[cities["name"] != "Vatican City"].copy()  # No overlap with label Rome
 # Create two subsets for small and large cities
 cities_small = cities[cities["worldcity"] != 1].copy()

--- a/examples/intro/04_table_inputs.py
+++ b/examples/intro/04_table_inputs.py
@@ -22,7 +22,7 @@ and work more efficiently with PyGMT.
 # %%
 from pathlib import Path
 
-import geopandas as gpd
+import geopandas
 import numpy as np
 import pandas as pd
 import pygmt
@@ -98,9 +98,9 @@ fig.show()
 # GMT and PyGMT do not support natively.
 
 # Example GeoDataFrame
-gdf = gpd.GeoDataFrame(
+gdf = geopandas.GeoDataFrame(
     {
-        "geometry": gpd.points_from_xy([2, 5, 9], [2, 3, 4]),
+        "geometry": geopandas.points_from_xy([2, 5, 9], [2, 3, 4]),
         "value": [10, 20, 30],
     }
 )

--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -132,7 +132,7 @@ def tempfile_from_geojson(geojson):
         E.g. '1a2b3c4d5e6.gmt'.
     """
     with GMTTempFile(suffix=".gmt") as tmpfile:
-        import geopandas as gpd  # noqa: PLC0415
+        import geopandas  # noqa: PLC0415
 
         Path(tmpfile.name).unlink()  # Ensure file is deleted first
         ogrgmt_kwargs = {
@@ -165,7 +165,7 @@ def tempfile_from_geojson(geojson):
             import json  # noqa: PLC0415
 
             jsontext = json.dumps(geojson.__geo_interface__)
-            gpd.read_file(filename=io.StringIO(jsontext)).to_file(**ogrgmt_kwargs)
+            geopandas.read_file(filename=io.StringIO(jsontext)).to_file(**ogrgmt_kwargs)
 
         yield tmpfile.name
 

--- a/pygmt/src/choropleth.py
+++ b/pygmt/src/choropleth.py
@@ -40,9 +40,9 @@ def choropleth(
 
     Examples
     --------
-    >>> import geopandas as gpd
+    >>> import geopandas
     >>> import pygmt
-    >>> world = gpd.read_file(
+    >>> world = geopandas.read_file(
     ...     "https://naciscdn.org/naturalearth/110m/cultural/ne_110m_admin_0_countries.zip"
     ... )
     >>> world["POP_EST"] *= 1e-6  # Population in millions

--- a/pygmt/tests/test_choropleth.py
+++ b/pygmt/tests/test_choropleth.py
@@ -5,7 +5,7 @@ Test Figure.choropleth.
 import pytest
 from pygmt import Figure, makecpt
 
-gpd = pytest.importorskip("geopandas")
+geopandas = pytest.importorskip("geopandas")
 
 
 @pytest.fixture(scope="module", name="world")
@@ -13,7 +13,7 @@ def fixture_world():
     """
     Download and cache the Natural Earth countries dataset for testing.
     """
-    return gpd.read_file(
+    return geopandas.read_file(
         "https://naciscdn.org/naturalearth/110m/cultural/ne_110m_admin_0_countries.zip"
     )
 

--- a/pygmt/tests/test_geopandas.py
+++ b/pygmt/tests/test_geopandas.py
@@ -10,7 +10,7 @@ from pygmt import Figure, info, makecpt, which
 from pygmt.helpers import data_kind
 from pygmt.helpers.testing import skip_if_no
 
-gpd = pytest.importorskip("geopandas")
+geopandas = pytest.importorskip("geopandas")
 shapely = pytest.importorskip("shapely")
 
 
@@ -36,7 +36,7 @@ def fixture_gdf():
         }
     )
     # Multipolygon first so the OGR_GMT file has @GMULTIPOLYGON in the header
-    gdf = gpd.GeoDataFrame(
+    gdf = geopandas.GeoDataFrame(
         index=["multipolygon", "polygon", "linestring"],
         geometry=[multipolygon, polygon, linestring],
     )
@@ -54,7 +54,7 @@ def fixture_gdf_ridge():
         fname=["@RidgeTest.shp", "@RidgeTest.shx", "@RidgeTest.dbf", "@RidgeTest.prj"],
         download="c",
     )
-    gdf = gpd.read_file(shapefile[0])
+    gdf = geopandas.read_file(shapefile[0])
     # Reproject the geometry
     gdf["geometry"] = (
         gdf.to_crs(crs="EPSG:3857")
@@ -98,7 +98,7 @@ def test_geopandas_plot_default_square():
     2d.
     """
     point = shapely.geometry.Point(1, 2)
-    gdf = gpd.GeoDataFrame(geometry=[point])
+    gdf = geopandas.GeoDataFrame(geometry=[point])
     fig = Figure()
     fig.plot(data=gdf, region=[0, 2, 1, 3], projection="X2c", frame=True)
     return fig
@@ -111,7 +111,7 @@ def test_geopandas_plot3d_default_cube():
     geometry in 3d.
     """
     multipoint = shapely.geometry.MultiPoint([(0.5, 0.5, 0.5), (1.5, 1.5, 1.5)])
-    gdf = gpd.GeoDataFrame(geometry=[multipoint])
+    gdf = geopandas.GeoDataFrame(geometry=[multipoint])
     fig = Figure()
     fig.plot3d(
         data=gdf,
@@ -131,7 +131,7 @@ def test_geopandas_plot_non_default_circle():
     2d.
     """
     point = shapely.geometry.Point(1, 2)
-    gdf = gpd.GeoDataFrame(geometry=[point])
+    gdf = geopandas.GeoDataFrame(geometry=[point])
     fig = Figure()
     fig.plot(data=gdf, region=[0, 2, 1, 3], projection="X2c", frame=True, style="c0.2c")
     return fig
@@ -144,7 +144,7 @@ def test_geopandas_plot3d_non_default_circle():
     in 3d.
     """
     multipoint = shapely.geometry.MultiPoint([(0.5, 0.5, 0.5), (1.5, 1.5, 1.5)])
-    gdf = gpd.GeoDataFrame(geometry=[multipoint])
+    gdf = geopandas.GeoDataFrame(geometry=[multipoint])
     fig = Figure()
     fig.plot3d(
         data=gdf,
@@ -280,7 +280,7 @@ def test_geopandas_nonascii():
             (1, 3),
         ]
     )
-    gdf = gpd.GeoDataFrame(
+    gdf = geopandas.GeoDataFrame(
         {
             "name_ascii": ["Fiji"],
             "name_utf8": ["فيجي"],  # Arabic


### PR DESCRIPTION
ruff v0.15.3 starts to report the following error:
```
ruff check pygmt doc/conf.py examples
ICN002 `geopandas` should not be imported as `gpd`
  --> examples/gallery/lines/linestrings.py:15:1
   |
14 | # %%
15 | import geopandas as gpd
   | ^^^^^^^^^^^^^^^^^^^^^^^
16 | import pygmt
   |

ICN002 `geopandas` should not be imported as `gpd`
```
which was introduded in https://github.com/astral-sh/ruff/pull/21373.

It seems the GeoPandas site also uses `import geopandas` rather than `import geopandas as gpd` (xref: https://geopandas.org/en/stable/getting_started/introduction.html).

This PR fixes the issue.