### PR TITLE
Fix typo in intro documentation comment

### DIFF
--- a/examples/intro/04_table_inputs.py
+++ b/examples/intro/04_table_inputs.py
@@ -68,7 +68,7 @@ Path("input_data.dat").unlink()
 # The ``data`` parameter also accepts a 2-D array, e.g.,
 #
 # - A 2-D :class:`list` (i.e., a list of lists)
-# - A :class:`numpy.ndarray` object with with a dimension of 2
+# - A :class:`numpy.ndarray` object with a dimension of 2
 # - A :class:`pandas.DataFrame` object
 #
 # This is useful when you want to plot data that is already in memory.


### PR DESCRIPTION
Remove duplicate "with"


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
