### PR TITLE
Bump ruff to 0.15.5 and ignore a violation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
     # Dev dependencies (style checks)
     - codespell
     - prek
-    - ruff>=0.12.0
+    - ruff>=0.15.5
     # Dev dependencies (unit testing)
     - matplotlib-base
     - pytest>=6.0

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1918,7 +1918,7 @@ class Session:
                 if hasattr(data, "items") and not hasattr(data, "to_frame"):
                     # Dictionary, pandas.DataFrame or xarray.Dataset types.
                     # pandas.Series will be handled below like a 1-D numpy.ndarray.
-                    _data = [array for _, array in data.items()]
+                    _data = [array for _, array in data.items()]  # noqa: PERF102
                 else:
                     # Python list, tuple, numpy.ndarray, and pandas.Series types
                     _data = np.atleast_2d(np.asanyarray(data).T)


### PR DESCRIPTION
ruff v0.15.0 finds a new violation:
```
ruff check pygmt doc/conf.py examples
PERF102 When using only the values of a dict use the `values()` method
    --> pygmt/clib/session.py:1921:52
     |
1919 |                     # Dictionary, pandas.DataFrame or xarray.Dataset types.
1920 |                     # pandas.Series will be handled below like a 1-D numpy.ndarray.
1921 |                     _data = [array for _, array in data.items()]
     |                                                    ^^^^^^^^^^
1922 |                 else:
1923 |                     # Python list, tuple, numpy.ndarray, and pandas.Series types
     |
help: Replace `.items()` with `.values()`
```
but here, `data` can be a dict, panda.DataFrame or xarray.Dataset, so we can't change it to `data.values()`.

This PR ignores the violation and bumps ruff to v0.15.0