### PR TITLE
Figure.solar: Consolidate tests for invalid values using parametrize marker

### DIFF
--- a/pygmt/tests/test_solar.py
+++ b/pygmt/tests/test_solar.py
@@ -64,45 +64,22 @@ def test_solar_set_terminator_datetime(terminator_datetime):
     return fig
 
 
-def test_invalid_terminator_type():
+@pytest.mark.parametrize(
+    ("kwargs", "expected_exception"),
+    [
+        ({"terminator": "invalid"}, GMTValueError),
+        ({"T": "d+d1990-02-17T04:25:00"}, GMTParameterError),
+        ({"terminator_datetime": "199A-02-17 04:25:00"}, GMTValueError),
+    ],
+)
+def test_solar_invalid_inputs(kwargs, expected_exception):
     """
-    Test if solar fails when it receives an invalid terminator type.
-    """
-    fig = Figure()
-    with pytest.raises(GMTValueError):
-        fig.solar(
-            region="d",
-            projection="W0/15c",
-            frame="a",
-            terminator="invalid",
-        )
-
-
-def test_invalid_parameter():
-    """
-    Test if solar fails when it receives a GMT argument for 'T' instead of the PyGMT
-    arguments for 'terminator' and 'terminator_datetime'.
+    Test if the appropriate error is raised when an invalid
+    value is passed.
     """
     fig = Figure()
-    with pytest.raises(GMTParameterError):
-        # Use single-letter parameter 'T' for testing
-        fig.solar(
-            region="d", projection="W0/15c", frame="a", T="d+d1990-02-17T04:25:00"
-        )
-
-
-def test_invalid_datetime():
-    """
-    Test if solar fails when it receives an invalid datetime string.
-    """
-    fig = Figure()
-    with pytest.raises(GMTValueError):
-        fig.solar(
-            region="d",
-            projection="W0/15c",
-            frame="a",
-            terminator_datetime="199A-02-17 04:25:00",
-        )
+    with pytest.raises(expected_exception):
+        fig.solar(region="d", projection="W0/15c", frame="a", **kwargs)
 
 
 @pytest.mark.mpl_image_compare(filename="test_solar_set_terminator_datetime.png")


### PR DESCRIPTION
Parametrize test_invalid_terminator_type, test_invalid_parameter, and test_invalid_datetime.