### PR TITLE
DOC: Remove "move_text" parameter in gallery example colorbars

### DIFF
--- a/examples/gallery/embellishments/colorbar.py
+++ b/examples/gallery/embellishments/colorbar.py
@@ -47,13 +47,11 @@ fig.colorbar(
     # Colorbar placed at Middle Right (MR) outside the plot bounding box, offset by 1 cm
     # horizontally and 0 cm vertically from anchor point, with a length of 7 cm and
     # width of 0.5 cm, and a rectangle for NaN values.
-    # Note that the label 'Elevation' is moved to the opposite side and plotted
-    # vertically as a column of characters.
+    # Note that the label 'Elevation' is plotted vertically as a column of characters.
     position=Position("MR", cstype="outside", offset=(1, 0)),
     length=7,
     width=0.5,
     nan=True,
-    move_text="label",
     label_as_column=True,
     frame=["x+lElevation", "y+lm"],
     scale=10,


### PR DESCRIPTION
**Description of proposed changes**

Different version based on the usage of the `move_text` parameter:

| (I) move both <br> [current version] | (II) move `label` | (III) move `annotations` | (IV) move none <br> [old version] |
| :---: | :---: | :---: | :---: |
| <img width="1288" height="1236" alt="colorbars_move_both" src="https://github.com/user-attachments/assets/b562eb82-4f8e-441f-914b-065b6be6da1e" /> | <img width="1345" height="1236" alt="colorbars_move_l" src="https://github.com/user-attachments/assets/3bde3bbb-1c9c-47d0-a01c-33cd424db71e" /> | <img width="1328" height="1236" alt="colorbars_move_a" src="https://github.com/user-attachments/assets/4885ad03-413a-4b03-a684-ddc659659dd8" /> | <img width="1392" height="1236" alt="colorbars_move_none" src="https://github.com/user-attachments/assets/f805175a-9186-4744-afb9-419f2e78eab4" /> | 

Overall I am fine with all versions expect version (I). Happy to adjust the change in this PR according to the version which is prefered by most of us 🙂.

Fixes #4450


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**: https://pygmt-dev--4452.org.readthedocs.build/en/4452/gallery/embellishments/colorbar.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
