### PR TITLE
CI: Run Tests workflow in pr-tests environment without deployment

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -51,6 +51,9 @@ jobs:
   test:
     name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    environment:
+      name: pr-tests
+      deployment: false
     permissions:
       id-token: write  # This is required for requesting OIDC token for codecov
     strategy:


### PR DESCRIPTION
**Description of proposed changes**

~Enable forked repositories to access DagsHub token, by granting them access within a GitHub environment.~ Edit: doesn't for forks either, see #4462.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Same as #4148, but now with a `deployment: false` condition to make things less noisy.

References:
- https://github.blog/changelog/2026-03-19-github-actions-late-march-2026-updates/#github-actions-now-allows-developers-to-use-environments-without-auto-deployment


<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Reverts #4160, addresses Option 2 in #4147


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
