### PR TITLE
Add docstring example to Figure.logo

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -51,6 +51,9 @@ jobs:
   test:
     name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    environment:
+      name: pr-tests
+      deployment: false
     permissions:
       id-token: write  # This is required for requesting OIDC token for codecov
     strategy:


### PR DESCRIPTION
### Description of proposed changes
Added a `doctest` example to the `Figure.logo` docstring to demonstrate its practical usage. 

Fixes #4456
