### PR TITLE
Fix Xarray to xarray in source code and documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/4-release_checklist.md
@@ -20,7 +20,7 @@ assignees: ''
 
 **Before release**:
 
-- [ ] Check [SPEC 0](https://scientific-python.org/specs/spec-0000/) to see if we need to bump the minimum supported versions of GMT, Python and core package dependencies (NumPy, pandas, Xarray)
+- [ ] Check [SPEC 0](https://scientific-python.org/specs/spec-0000/) to see if we need to bump the minimum supported versions of GMT, Python and core package dependencies (NumPy, pandas, xarray)
 - [ ] Review the ["PyGMT Team" page](https://www.pygmt.org/dev/team.html)
 - [ ] README looks good on TestPyPI. Visit [TestPyPI](https://test.pypi.org/project/pygmt/#history), click the latest pre-release, and check the homepage.
 - [ ] Review new parameter names added/changed for clarity and consistency across the API

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -199,7 +199,7 @@ Getting metadata from tabular or grid data:
     info
     grdinfo
 
-Xarray Integration
+xarray Integration
 ------------------
 
 .. autosummary::

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -63,7 +63,7 @@
 ### Maintenance
 
 * Add support for Python 3.14 ([#4150](https://github.com/GenericMappingTools/pygmt/pull/4150))
-* SPEC 0: Bump minimum supported version to Python 3.12, NumPy 2.0, and Xarray 2024.5 ([#4248](https://github.com/GenericMappingTools/pygmt/pull/4248), [#4090](https://github.com/GenericMappingTools/pygmt/pull/4090))
+* SPEC 0: Bump minimum supported version to Python 3.12, NumPy 2.0, and xarray 2024.5 ([#4248](https://github.com/GenericMappingTools/pygmt/pull/4248), [#4090](https://github.com/GenericMappingTools/pygmt/pull/4090))
 * DOC: Update naming convention in contributors guide: Separate words in parameter names by underscores ([#4284](https://github.com/GenericMappingTools/pygmt/pull/4284))
 * fmt_docstrings: Use string template syntax for docstring placeholders and support curly braces in docstrings ([#4210](https://github.com/GenericMappingTools/pygmt/pull/4210))
 * Remove dev dependency on "geodatasets" ([#4230](https://github.com/GenericMappingTools/pygmt/pull/4230))
@@ -136,7 +136,7 @@
 
 * **BREAKING** Figure.text: Raise GMTTypeError if text is a sequence when position is given ([#4065](https://github.com/GenericMappingTools/pygmt/pull/4065))
 * Switch from pre-commit to prek ([#4082](https://github.com/GenericMappingTools/pygmt/pull/4082))
-* SPEC 0: Bump minimum supported version to pandas 2.2 and Xarray 2023.10 ([#4092](https://github.com/GenericMappingTools/pygmt/pull/4092), [#4091](https://github.com/GenericMappingTools/pygmt/pull/4091))
+* SPEC 0: Bump minimum supported version to pandas 2.2 and xarray 2023.10 ([#4092](https://github.com/GenericMappingTools/pygmt/pull/4092), [#4091](https://github.com/GenericMappingTools/pygmt/pull/4091))
 * Remove the support of non-aliased aliases in use_alias/fmt_docstrings ([#4042](https://github.com/GenericMappingTools/pygmt/pull/4042))
 * CI: Bump to macOS 26 in the GMT Dev Tests workflow ([#4084](https://github.com/GenericMappingTools/pygmt/pull/4084))
 * CI: Bump to macOS 14 in the GMT Legacy Tests workflow ([#3996](https://github.com/GenericMappingTools/pygmt/pull/3996))

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -601,7 +601,7 @@ When writing tests, don't test everything that the GMT function already tests, s
 every unique combination of arguments. An exception to this would be the most popular
 methods, such as <code>pygmt.Figure.plot</code> and <code>pygmt.Figure.basemap</code>.
 The highest priority for tests should be the Python-specific code, such as numpy,
-pandas, and Xarray objects and the virtualfile mechanism.
+pandas, and xarray objects and the virtualfile mechanism.
 
 If you're **new to testing**, see existing test files for examples of things to do.
 **Don't let the tests keep you from submitting your contribution!**

--- a/doc/ecosystem.md
+++ b/doc/ecosystem.md
@@ -4,7 +4,7 @@ PyGMT provides a Python interface to the Generic Mapping Tools (GMT), which is a
 line program that provides a wide range of tools for manipulating geospatial data and
 making publication-quality maps and figures. PyGMT integrates well with the
 [scientific Python ecosystem](https://scientific-python.org/), with [NumPy][] for its
-fundamental array data structure, [pandas][] for tabular data I/O and [Xarray][] for
+fundamental array data structure, [pandas][] for tabular data I/O and [xarray][] for
 raster grids/images/cubes I/O.
 
 In addition to these core dependencies, PyGMT also relies on several optional packages to
@@ -32,9 +32,9 @@ designed to make working with "relational" or "labeled" data both easy and intui
 It aims to be the fundamental high-level building block for doing practical, real-world
 data analysis in Python.
 
-### Xarray*
+### xarray*
 
-[Xarray][] is an open source project and Python package that introduces labels in the
+[xarray][] is an open source project and Python package that introduces labels in the
 form of dimensions, coordinates, and attributes on top of raw NumPy-like arrays, which
 allows for more intuitive, more concise, and less error-prone user experience.
 
@@ -67,7 +67,7 @@ In PyGMT, {func}`pygmt.datasets.load_tile_map` and {meth}`pygmt.Figure.tilemap` 
 
 ### rioxarray
 
-[rioxarray][] is a geospatial [Xarray][] extension powered by [rasterio][]. Built on top
+[rioxarray][] is a geospatial [xarray][] extension powered by [rasterio][]. Built on top
 of rasterio, it enables seamless reading, writing, and manipulation of multi-dimensional
 arrays with geospatial attributes such as coordinate reference systems (CRS) and spatial
 extent (bounds).

--- a/doc/install.md
+++ b/doc/install.md
@@ -94,7 +94,7 @@ PyGMT requires the following packages to be installed:
 
 - [NumPy](https://numpy.org)
 - [pandas](https://pandas.pydata.org)
-- [Xarray](https://xarray.dev/)
+- [xarray](https://xarray.dev/)
 - [packaging](https://packaging.pypa.io)
 
 :::{note}

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -261,7 +261,7 @@ publishing the actual release notes at [](changes.md).
    `git shortlog vX.Y.Z..HEAD -sne --group=author --group=trailer:co-authored-by`).
 8. Update `doc/minversions.md` with new information on the new release version,
    including a vX.Y.Z documentation link, and minimum required versions of GMT, Python
-   and core package dependencies (NumPy, pandas, Xarray). Follow
+   and core package dependencies (NumPy, pandas, xarray). Follow
    [SPEC 0](https://scientific-python.org/specs/spec-0000/) for updates.
 9. Refresh citation information. Specifically, the BibTeX in `README.md` and
    `CITATION.cff` needs to be updated with any metadata changes, including the

--- a/doc/minversions.md
+++ b/doc/minversions.md
@@ -27,7 +27,7 @@ PyGMT has adopted [SPEC 0](https://scientific-python.org/specs/spec-0000/) along
 rest of the scientific Python ecosystem, and will therefore:
 
 - Drop support for Python versions 3 years after their initial release.
-- Drop support for core package dependencies (NumPy, pandas, Xarray) 2 years after their
+- Drop support for core package dependencies (NumPy, pandas, xarray) 2 years after their
   initial release.
 
 In addition to the above, the PyGMT team has also decided to:
@@ -44,7 +44,7 @@ drop support for core (and optional) package dependencies earlier than recommend
 compatibility reasons.
 :::
 
-| PyGMT Version | Documentation | GMT | Python | NumPy | pandas | Xarray |
+| PyGMT Version | Documentation | GMT | Python | NumPy | pandas | xarray |
 |---|---|---|---|---|---|---|
 | [Dev][]* | <doc:dev>, [HTML+ZIP](doc:dev/pygmt-docs.zip), [PDF](doc:dev/pygmt-docs.pdf) | {{ requires.gmt }} | {{ requires.python }} | {{ requires.numpy }} | {{ requires.pandas }} | {{ requires.xarray }} |
 | <tag:v0.18.0> | <doc:v0.18.0>, <html:v0.18.0>, <pdf:v0.18.0> | >=6.5.0 | >=3.12 | >=2.0 | >=2.2 | >=2024.5 |

--- a/pygmt/_show_versions.py
+++ b/pygmt/_show_versions.py
@@ -145,7 +145,7 @@ def show_versions(file: TextIO | None = sys.stdout) -> None:
 
     - PyGMT itself
     - System information (Python version, Operating System)
-    - Core dependency versions (NumPy, pandas, Xarray, etc)
+    - Core dependency versions (NumPy, pandas, xarray, etc)
     - GDAL and Ghostscript versions
     - GMT library information
 

--- a/pygmt/xarray/__init__.py
+++ b/pygmt/xarray/__init__.py
@@ -1,5 +1,5 @@
 """
-PyGMT integration with Xarray accessors and backends.
+PyGMT integration with xarray accessors and backends.
 """
 
 from pygmt.xarray.accessor import GMTDataArrayAccessor

--- a/pygmt/xarray/backend.py
+++ b/pygmt/xarray/backend.py
@@ -22,7 +22,7 @@ __doctest_skip__ = (
 
 class GMTBackendEntrypoint(BackendEntrypoint):
     """
-    Xarray backend to read raster grid/image files using 'gmt' engine.
+    xarray backend to read raster grid/image files using 'gmt' engine.
 
     Internally, GMT uses the netCDF C library to read netCDF files, and GDAL for GeoTIFF
     and other raster formats. See :gmt-docs:`reference/features.html#grid-file-format`
@@ -105,7 +105,7 @@ class GMTBackendEntrypoint(BackendEntrypoint):
         units:         m
     """
 
-    description = "Open raster (.grd, .nc or .tif) files in Xarray via GMT."
+    description = "Open raster (.grd, .nc or .tif) files in xarray via GMT."
     open_dataset_parameters = ("filename_or_obj", "raster_kind", "region")
     url = "https://pygmt.org/dev/api/generated/pygmt.GMTBackendEntrypoint.html"
 
@@ -121,7 +121,7 @@ class GMTBackendEntrypoint(BackendEntrypoint):
         # `chunks` and `cache` DO NOT go here, they are handled by xarray
     ) -> xr.Dataset:
         """
-        Backend open_dataset method used by Xarray in :py:func:`~xarray.open_dataset`.
+        Backend open_dataset method used by xarray in :py:func:`~xarray.open_dataset`.
 
         Parameters
         ----------


### PR DESCRIPTION
## Summary

Update all occurrences of "Xarray" (capitalized) to "xarray" (lowercase) across source code and documentation, since the formal name of the package is "xarray" (ref: [JORS paper](https://doi.org/10.5334/jors.148), [xarray contributing guide](https://docs.xarray.dev/en/stable/contribute/contributing.html)).

## Changed files (11)

- `.github/ISSUE_TEMPLATE/4-release_checklist.md`
- `doc/api/index.rst`
- `doc/changes.md`
- `doc/contributing.md`
- `doc/ecosystem.md`
- `doc/install.md`
- `doc/maintenance.md`
- `doc/minversions.md`
- `pygmt/_show_versions.py`
- `pygmt/xarray/__init__.py`
- `pygmt/xarray/backend.py`

Fixes #4460