### PR TITLE
Fix typos in Contributors Guide

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -600,8 +600,8 @@ Tests also help us be confident that we won't break your code in the future.
 When writing tests, don't test everything that the GMT function already tests, such as
 every unique combination of arguments. An exception to this would be the most popular
 methods, such as <code>pygmt.Figure.plot</code> and <code>pygmt.Figure.basemap</code>.
-The highest priority for tests should be the Python-specific code, such as numpy,
-pandas, and xarray objects and the virtualfile mechanism.
+The highest priority for tests should be the Python-specific code, such as NumPy,
+pandas, and xarray objects and the virtual file mechanism.
 
 If you're **new to testing**, see existing test files for examples of things to do.
 **Don't let the tests keep you from submitting your contribution!**


### PR DESCRIPTION
**Description of proposed changes**

Just typo fixes in the Contributors Guide.

**Preview**:

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
