### PR TITLE
DOC/Gallery example "Ternary diagram": Migrate frame settings to the new Frame/Axis syntax

### DIFF
--- a/examples/gallery/basemaps/ternary.py
+++ b/examples/gallery/basemaps/ternary.py
@@ -35,11 +35,11 @@ fig.ternary(
     clabel="Air",
     cmap=True,
     frame=Frame(
-        axis=Axis(
+        aaxis=Axis(
             annot=True, tick=True, grid=True, label="Limestone component", unit="%"
         ),
-        bxis=Axis(annot=True, tick=True, grid=True, label="Water component", unit="%"),
-        cxis=Axis(annot=True, tick=True, grid=True, label="Air component", unit="%"),
+        baxis=Axis(annot=True, tick=True, grid=True, label="Water component", unit="%"),
+        caxis=Axis(annot=True, tick=True, grid=True, label="Air component", unit="%"),
     ),
 )
 

--- a/examples/gallery/basemaps/ternary.py
+++ b/examples/gallery/basemaps/ternary.py
@@ -35,11 +35,11 @@ fig.ternary(
     clabel="Air",
     cmap=True,
     frame=Frame(
-        aaxis=Axis(
+        xaxis=Axis(
             annot=True, tick=True, grid=True, label="Limestone component", unit="%"
         ),
-        baxis=Axis(annot=True, tick=True, grid=True, label="Water component", unit="%"),
-        caxis=Axis(annot=True, tick=True, grid=True, label="Air component", unit="%"),
+        yaxis=Axis(annot=True, tick=True, grid=True, label="Water component", unit="%"),
+        zaxis=Axis(annot=True, tick=True, grid=True, label="Air component", unit="%"),
     ),
 )
 

--- a/examples/gallery/basemaps/ternary.py
+++ b/examples/gallery/basemaps/ternary.py
@@ -14,7 +14,7 @@ sample dataset via ``cmap=True``.
 
 # %%
 import pygmt
-from pygmt.params import Position
+from pygmt.params import Axis, Frame, Position
 
 fig = pygmt.Figure()
 
@@ -34,11 +34,13 @@ fig.ternary(
     blabel="Water",
     clabel="Air",
     cmap=True,
-    frame=[
-        "aafg+lLimestone component+u %",
-        "bafg+lWater component+u %",
-        "cafg+lAir component+u %",
-    ],
+    frame=Frame(
+        axis=Axis(
+            annot=True, tick=True, grid=True, label="Limestone component", unit="%"
+        ),
+        bxis=Axis(annot=True, tick=True, grid=True, label="Water component", unit="%"),
+        cxis=Axis(annot=True, tick=True, grid=True, label="Air component", unit="%"),
+    ),
 )
 
 # Add a colorbar indicating the values given in the fourth column of the input dataset


### PR DESCRIPTION
**Description of proposed changes**

Update the gallery example `basemaps/ternary.py` to use the newly implemented `Frame` and `Axis` parameter classes.
Need ``aaxis``, ``baxis``, ``caxis`` similar to ``xaxis``, ``yaxis``, ``zaxis``.

Fixes partly #4494

**Preview**: 

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
