### PR TITLE
DOC/Gallery example "Histogram": Migrate frame settings to the new Frame/Axis syntax

### DIFF
--- a/examples/gallery/histograms/histogram.py
+++ b/examples/gallery/histograms/histogram.py
@@ -11,6 +11,7 @@ selected via the ``histtype`` parameter.
 # %%
 import numpy as np
 import pygmt
+from pygmt.params import Axis, Frame
 
 # Generate random elevation data from a normal distribution
 rng = np.random.default_rng(seed=100)
@@ -23,9 +24,15 @@ fig = pygmt.Figure()
 
 fig.histogram(
     data=data,
-    # Define the frame, add a title, and set the background color to
-    # "lightgray". Add labels to the x-axis and y-axis
-    frame=["WSne+tHistogram+glightgray", "x+lElevation (m)", "y+lCounts"],
+    # Define the frame, add a title, and set the background color to "lightgray".
+    # Add labels to the x-axis and y-axis
+    frame=Frame(
+        axes="WSne",
+        title="Histogram",
+        fill="lightgray",
+        xaxis=Axis(label="Elevation (m)"),
+        yaxis=Axis(label="Counts"),
+    ),
     # Generate evenly spaced bins by increments of 5
     series=5,
     # Use "red3" as color fill for the bars


### PR DESCRIPTION
**Description of proposed changes**

Update the gallery example `histograms/histogram.py‎` to use the newly implemented `Frame` and `Axis` parameter classes.
Need   to wait for #4520.

Fixes partly #4494

**Preview**: 

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
