### PR TITLE
DOC/Gallery example "Rose diagram": Migrate frame settings to the new Frame/Axis syntax

### DIFF
--- a/examples/gallery/histograms/rose.py
+++ b/examples/gallery/histograms/rose.py
@@ -8,6 +8,7 @@ histograms.
 
 # %%
 import pygmt
+from pygmt.params import Axis, Frame
 
 # Load sample compilation of fracture lengths and azimuth as
 # hypothetically digitized from geological maps
@@ -34,11 +35,9 @@ fig.rose(
     norm=True,
     # use red3 as color fill for the sectors
     fill="red3",
-    # define the frame with ticks and gridlines every 0.2
-    # length unit in radial direction and every 30 degrees
-    # in azimuthal direction, set background color to
-    # lightgray
-    frame=["x0.2g0.2", "y30g30", "+glightgray"],
+    # define the frame with gridlines every 0.2 length unit in radial direction
+    # and every 30 degrees in azimuthal direction, set background color to lightgray
+    frame=Frame(xaxis=Axis(grid=0.2), yaxis=Axis(grid=30), fill="lightgray"),
     # use a pen size of 1p to draw the outlines
     pen="1p",
 )


### PR DESCRIPTION
**Description of proposed changes**

Update the gallery example `histograms/rose.py‎` to use the newly implemented `Frame` and `Axis` parameter classes.
Need to wait for #4520.

Fixes partly #4494

**Preview**: 

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
