### PR TITLE
Figure.magnetic_rose/Figure.directional_rose: Add missing docstring for 'panel' and fix type hints for 'perspective'

### DIFF
--- a/pygmt/src/directional_rose.py
+++ b/pygmt/src/directional_rose.py
@@ -26,7 +26,7 @@ def directional_rose(
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,
-    perspective: str | bool = False,
+    perspective: float | Sequence[float] | str | bool = False,
     transparency: float | None = None,
 ):
     """

--- a/pygmt/src/magnetic_rose.py
+++ b/pygmt/src/magnetic_rose.py
@@ -31,7 +31,7 @@ def magnetic_rose(  # noqa: PLR0913
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,
-    perspective: str | bool = False,
+    perspective: float | Sequence[float] | str | bool = False,
     transparency: float | None = None,
 ):
     """
@@ -84,8 +84,9 @@ def magnetic_rose(  # noqa: PLR0913
         rectangular box is drawn using :gmt-term:`MAP_FRAME_PEN`. To customize the box
         appearance, pass a :class:`pygmt.params.Box` object to control style, fill, pen,
         and other box properties.
-    $perspective
     $verbose
+    $panel
+    $perspective
     $transparency
 
     Examples


### PR DESCRIPTION
Just fix typos. Detected by copilot.