### PR TITLE
DOC/Tutorial "Plotting single-parameter symbols": Fix link and link to pattern class and gallery example

### DIFF
--- a/examples/tutorials/basics/symbols.py
+++ b/examples/tutorials/basics/symbols.py
@@ -47,7 +47,7 @@ fig.show()
 # Use the ``fill`` the parameter to add a fill color or pattern. Note, that no outline
 # is drawn by default when ``fill`` is used. For the available patterns and their usage
 # see :class:`pygmt.params.Pattern` and the Gallery example
-# :doc:`Line styles </gallery/symbols/patterns>`.
+# :doc:`Bit and hachure patterns </gallery/symbols/patterns>`.
 
 fig = pygmt.Figure()
 fig.basemap(region=[-5, 5, -2, 2], projection="X10c/4c", frame=True)

--- a/examples/tutorials/basics/symbols.py
+++ b/examples/tutorials/basics/symbols.py
@@ -45,8 +45,9 @@ fig.show()
 
 # %%
 # Use the ``fill`` the parameter to add a fill color or pattern. Note, that no outline
-# is drawn by default when ``fill`` is used. For the available patterns see the
-# Technical Reference :doc:`Bit and hachure patterns </techref/patterns>`.
+# is drawn by default when ``fill`` is used. For the available patterns and their usage
+# see :class:`pygmt.params.Pattern` and the Gallery example
+# :doc:`Line styles </gallery/symbols/patterns>`.
 
 fig = pygmt.Figure()
 fig.basemap(region=[-5, 5, -2, 2], projection="X10c/4c", frame=True)


### PR DESCRIPTION
**Description of proposed changes**

Fix warning in the docs: The Technical Reference page for patterns was removed after introducing the `pygmt.params.Pattern` class.

**Preview**: https://pygmt-dev--4579.org.readthedocs.build/en/4579/tutorials/basics/symbols.html#plot-single-parameter-symbols

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
