### PR TITLE
DOC/Intro "2. Create a contour map": Fix highlighting syntax

### DIFF
--- a/examples/intro/02_contour_map.py
+++ b/examples/intro/02_contour_map.py
@@ -57,7 +57,7 @@ fig.show()
 #
 # To control the annotation and labels on the colorbar, use the ``annot`` parameter to
 # set the annotation interval (in this case every 1,000 meters), the ``label`` and
-# ``unit``parameters to set the labels along the long and short dimensions of the
+# ``unit`` parameters to set the labels along the long and short dimensions of the
 # colorbar, respectively.
 #
 # By default, the CPT for the colorbar is the same as the one set in


### PR DESCRIPTION
**Description of proposed changes**

Add white space to fix the higlighting and warning in the Intro "2. Create a contour map".

**Preview**: https://pygmt-dev--4580.org.readthedocs.build/en/4580/intro/02_contour_map.html#adding-a-colorbar

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
