### PR TITLE
Migrate frame settings in pygmt/tests/test_config.py

### DIFF
--- a/pygmt/tests/test_config.py
+++ b/pygmt/tests/test_config.py
@@ -108,9 +108,11 @@ def test_config_format_time_map():
         fig.basemap(
             region=["2020-1-24T", "2020-1-27T", 0, 1],
             projection="X6c/1c",
-            frame=["pa1K", "sa1K", "NWse"],
+            frame=Frame(axes="NWse", xaxis=Axis(annot="1K"), xaxis2=Axis(annot="1K")),
         )
-    fig.basemap(frame=["pa1K", "sa1K", "nwSE"])
+    fig.basemap(
+        frame=Frame(axes="nwSE", xaxis=Axis(annot="1K"), xaxis2=Axis(annot="1K"))
+    )
     return fig
 
 
@@ -125,9 +127,11 @@ def test_config_map_annot_offset():
         fig.basemap(
             region=["2020-1-24T", "2020-1-27T", 0, 1],
             projection="X6c/1c",
-            frame=["pa1d", "sa1d", "NWse"],
+            frame=Frame(axes="NWse", xaxis=Axis(annot="1d"), xaxis2=Axis(annot="1d")),
         )
-    fig.basemap(frame=["pa1d", "sa1d", "nwSE"])
+    fig.basemap(
+        frame=Frame(axes="nwSE", xaxis=Axis(annot="1d"), xaxis2=Axis(annot="1d"))
+    )
     return fig
 
 
@@ -142,11 +146,22 @@ def test_config_map_grid_cross_size():
         fig.basemap(
             region=["2020-1-24T21:00", "2020-1-25T00:00", 0, 1],
             projection="X6c/2c",
-            frame=["pa1Hg", "sa45mg45m", "NWse"],
+            frame=Frame(
+                axes="NWse",
+                xaxis=Axis(annot="1H", grid=True),
+                xaxis2=Axis(annot="45m", grid="45m"),
+            ),
             verbose="error",
         )
     fig.shift_origin(yshift=-3)
-    fig.basemap(frame=["pa1Hg", "sa45mg45m", "nwSE"], verbose="error")
+    fig.basemap(
+        frame=Frame(
+            axes="nwSE",
+            xaxis=Axis(annot="1H", grid=True),
+            xaxis2=Axis(annot="45m", grid="45m"),
+        ),
+        verbose="error",
+    )
     return fig
 
 
@@ -161,11 +176,22 @@ def test_config_map_grid_pen():
         fig.basemap(
             region=["2020-1-24T21:00", "2020-1-25T00:00", 0, 1],
             projection="X6c/2c",
-            frame=["pa1Hg", "sa45mg45m", "NWse"],
+            frame=Frame(
+                axes="NWse",
+                xaxis=Axis(annot="1H", grid=True),
+                xaxis2=Axis(annot="45m", grid="45m"),
+            ),
             verbose="error",
         )
     fig.shift_origin(yshift=-3)
-    fig.basemap(frame=["pa1Hg", "sa45mg45m", "nwSE"], verbose="error")
+    fig.basemap(
+        frame=Frame(
+            axes="nwSE",
+            xaxis=Axis(annot="1H", grid=True),
+            xaxis2=Axis(annot="45m", grid="45m"),
+        ),
+        verbose="error",
+    )
     return fig
 
 
@@ -180,11 +206,22 @@ def test_config_map_tick_length():
         fig.basemap(
             region=["2020-1-24T21:00", "2020-1-25T00:00", 0, 1],
             projection="X6c/2c",
-            frame=["pa1Hg", "sa45mg45m", "NWse"],
+            frame=Frame(
+                axes="NWse",
+                xaxis=Axis(annot="1H", grid=True),
+                xaxis2=Axis(annot="45m", grid="45m"),
+            ),
             verbose="error",
         )
     fig.shift_origin(yshift=-3)
-    fig.basemap(frame=["pa1Hg", "sa45mg45m", "nwSE"], verbose="error")
+    fig.basemap(
+        frame=Frame(
+            axes="nwSE",
+            xaxis=Axis(annot="1H", grid=True),
+            xaxis2=Axis(annot="45m", grid="45m"),
+        ),
+        verbose="error",
+    )
     return fig
 
 
@@ -199,11 +236,22 @@ def test_config_map_tick_pen():
         fig.basemap(
             region=["2020-1-24T21:00", "2020-1-25T00:00", 0, 1],
             projection="X6c/2c",
-            frame=["pa1Hg", "sa45mg45m", "NWse"],
+            frame=Frame(
+                axes="NWse",
+                xaxis=Axis(annot="1H", grid=True),
+                xaxis2=Axis(annot="45m", grid="45m"),
+            ),
             verbose="error",
         )
     fig.shift_origin(yshift=-3)
-    fig.basemap(frame=["pa1Hg", "sa45mg45m", "nwSE"], verbose="error")
+    fig.basemap(
+        frame=Frame(
+            axes="nwSE",
+            xaxis=Axis(annot="1H", grid=True),
+            xaxis2=Axis(annot="45m", grid="45m"),
+        ),
+        verbose="error",
+    )
     return fig
 
 

--- a/pygmt/tests/test_config.py
+++ b/pygmt/tests/test_config.py
@@ -108,11 +108,9 @@ def test_config_format_time_map():
         fig.basemap(
             region=["2020-1-24T", "2020-1-27T", 0, 1],
             projection="X6c/1c",
-            frame=Frame(axes="NWse", xaxis=Axis(annot="1K"), xaxis2=Axis(annot="1K")),
+            frame=Frame(axes="NWse", axis=Axis(annot="1K"), axis2=Axis(annot="1K")),
         )
-    fig.basemap(
-        frame=Frame(axes="nwSE", xaxis=Axis(annot="1K"), xaxis2=Axis(annot="1K"))
-    )
+    fig.basemap(frame=Frame(axes="nwSE", axis=Axis(annot="1K"), axis2=Axis(annot="1K")))
     return fig
 
 
@@ -127,11 +125,9 @@ def test_config_map_annot_offset():
         fig.basemap(
             region=["2020-1-24T", "2020-1-27T", 0, 1],
             projection="X6c/1c",
-            frame=Frame(axes="NWse", xaxis=Axis(annot="1d"), xaxis2=Axis(annot="1d")),
+            frame=Frame(axes="NWse", axis=Axis(annot="1d"), axis2=Axis(annot="1d")),
         )
-    fig.basemap(
-        frame=Frame(axes="nwSE", xaxis=Axis(annot="1d"), xaxis2=Axis(annot="1d"))
-    )
+    fig.basemap(frame=Frame(axes="nwSE", axis=Axis(annot="1d"), axis2=Axis(annot="1d")))
     return fig
 
 
@@ -148,8 +144,8 @@ def test_config_map_grid_cross_size():
             projection="X6c/2c",
             frame=Frame(
                 axes="NWse",
-                xaxis=Axis(annot="1H", grid=True),
-                xaxis2=Axis(annot="45m", grid="45m"),
+                axis=Axis(annot="1H", grid=True),
+                axis2=Axis(annot="45m", grid="45m"),
             ),
             verbose="error",
         )
@@ -157,8 +153,8 @@ def test_config_map_grid_cross_size():
     fig.basemap(
         frame=Frame(
             axes="nwSE",
-            xaxis=Axis(annot="1H", grid=True),
-            xaxis2=Axis(annot="45m", grid="45m"),
+            axis=Axis(annot="1H", grid=True),
+            axis2=Axis(annot="45m", grid="45m"),
         ),
         verbose="error",
     )
@@ -178,8 +174,8 @@ def test_config_map_grid_pen():
             projection="X6c/2c",
             frame=Frame(
                 axes="NWse",
-                xaxis=Axis(annot="1H", grid=True),
-                xaxis2=Axis(annot="45m", grid="45m"),
+                axis=Axis(annot="1H", grid=True),
+                axis2=Axis(annot="45m", grid="45m"),
             ),
             verbose="error",
         )
@@ -187,8 +183,8 @@ def test_config_map_grid_pen():
     fig.basemap(
         frame=Frame(
             axes="nwSE",
-            xaxis=Axis(annot="1H", grid=True),
-            xaxis2=Axis(annot="45m", grid="45m"),
+            axis=Axis(annot="1H", grid=True),
+            axis2=Axis(annot="45m", grid="45m"),
         ),
         verbose="error",
     )
@@ -208,8 +204,8 @@ def test_config_map_tick_length():
             projection="X6c/2c",
             frame=Frame(
                 axes="NWse",
-                xaxis=Axis(annot="1H", grid=True),
-                xaxis2=Axis(annot="45m", grid="45m"),
+                axis=Axis(annot="1H", grid=True),
+                axis2=Axis(annot="45m", grid="45m"),
             ),
             verbose="error",
         )
@@ -217,8 +213,8 @@ def test_config_map_tick_length():
     fig.basemap(
         frame=Frame(
             axes="nwSE",
-            xaxis=Axis(annot="1H", grid=True),
-            xaxis2=Axis(annot="45m", grid="45m"),
+            axis=Axis(annot="1H", grid=True),
+            axis2=Axis(annot="45m", grid="45m"),
         ),
         verbose="error",
     )
@@ -238,8 +234,8 @@ def test_config_map_tick_pen():
             projection="X6c/2c",
             frame=Frame(
                 axes="NWse",
-                xaxis=Axis(annot="1H", grid=True),
-                xaxis2=Axis(annot="45m", grid="45m"),
+                axis=Axis(annot="1H", grid=True),
+                axis2=Axis(annot="45m", grid="45m"),
             ),
             verbose="error",
         )
@@ -247,8 +243,8 @@ def test_config_map_tick_pen():
     fig.basemap(
         frame=Frame(
             axes="nwSE",
-            xaxis=Axis(annot="1H", grid=True),
-            xaxis2=Axis(annot="45m", grid="45m"),
+            axis=Axis(annot="1H", grid=True),
+            axis2=Axis(annot="45m", grid="45m"),
         ),
         verbose="error",
     )


### PR DESCRIPTION
## Summary
- migrate list-style frame settings in pygmt/tests/test_config.py to Frame/Axis
- preserve the mixed-case axis coverage and primary/secondary time-axis settings in the config tests