### PR TITLE
Migrate intro figure element example frame

### DIFF
--- a/examples/intro/03_figure_element.py
+++ b/examples/intro/03_figure_element.py
@@ -23,6 +23,7 @@ The figure below shows the naming of figure elements in PyGMT.
 
 # %%
 import pygmt
+from pygmt.params import Axis, Frame
 
 fig = pygmt.Figure()
 
@@ -33,7 +34,12 @@ y_2 = [4, 5, 6, 3, 5, 5]
 fig.basemap(
     region=[0, 10, 0, 20],
     projection="X10c/8c",
-    frame=["WStr+tTitle", "xa2f1g2+lxlabel", "ya5f1g5+lylabel"],
+    frame=Frame(
+        axes="WStr",
+        title="Title",
+        xaxis=Axis(annot=2, tick=1, grid=2, label="xlabel"),
+        yaxis=Axis(annot=5, tick=1, grid=5, label="ylabel"),
+    ),
 )
 fig.plot(x=x, y=y_1, style="t0.3c", label="fig.plot (style)")
 fig.plot(x=x, y=y_2, pen="1.5p,red", label="fig.plot (pen)")
@@ -44,34 +50,45 @@ minorexplain = {"font": "10p,8", "justify": "TC", "no_clip": True}
 fig.text(x=12, y=22, text="Figure", **mainexplain)
 fig.text(x=12, y=20.8, text="pygmt.Figure()", **minorexplain)
 # ============ Title
-fig.text(x=7.5, y=22, text='frame="+tTitle"', **minorexplain)
+fig.text(x=7.5, y=22, text='frame=Frame(title="Title")', **minorexplain)
 # ============ xlabel
-fig.text(x=5, y=-3, text='frame="x+lxlabel"', **minorexplain)
+fig.text(x=5, y=-3, text='frame=Frame(xaxis=Axis(label="xlabel"))', **minorexplain)
 # ============ ylabel
-fig.text(x=-1.7, y=10, text='frame="y+lylabel"', angle=90, **minorexplain)
+fig.text(
+    x=-1.7,
+    y=10,
+    text='frame=Frame(yaxis=Axis(label="ylabel"))',
+    angle=90,
+    **minorexplain,
+)
 # ============ x-majorticks
 fig.plot(x=10, y=-0.2, style="c1c", pen="2p,darkblue", no_clip=True)
 fig.text(x=10, y=-1.6, text="Annotation", **mainexplain)
-fig.text(x=10, y=-2.8, text='frame="xa2"', **minorexplain)
+fig.text(x=10, y=-2.8, text='frame=Frame(xaxis=Axis(annot=2))', **minorexplain)
 # ============ y-majorticks
 fig.plot(x=-0.2, y=20, style="c1c", pen="2p,darkblue", no_clip=True)
 fig.text(x=0, y=23.4, text="Annotation", **mainexplain)
-fig.text(x=0, y=22.2, text='frame="ya5"', **minorexplain)
+fig.text(x=0, y=22.2, text='frame=Frame(yaxis=Axis(annot=5))', **minorexplain)
 # ============ x-minorticks
 fig.plot(x=1, y=-0.2, style="c0.7c", pen="2p,darkblue", no_clip=True)
 fig.text(x=1, y=-1.4, text="Frame", **mainexplain)
-fig.text(x=1, y=-2.6, text='frame="xf1"', **minorexplain)
+fig.text(x=1, y=-2.6, text='frame=Frame(xaxis=Axis(tick=1))', **minorexplain)
 # ============ y-minorticks
 fig.plot(x=0, y=2, style="c0.7c", pen="2p,darkblue", no_clip=True)
-fig.text(x=-1.5, y=1, text='frame="yf1"', **minorexplain)
+fig.text(x=-1.5, y=1, text='frame=Frame(yaxis=Axis(tick=1))', **minorexplain)
 # ============ Grid
 fig.plot(x=2, y=15, style="c0.5c", pen="2p,darkblue")
 fig.text(x=2, y=17, text="Grid", **mainexplain)
-fig.text(x=2.4, y=18, text='frame=["xg2", "yg5"]', **minorexplain)
+fig.text(
+    x=2.4,
+    y=18,
+    text='frame=Frame(xaxis=Axis(grid=2), yaxis=Axis(grid=5))',
+    **minorexplain,
+)
 # ============ Plot Boundaries
 fig.plot(x=10, y=9, style="c0.5c", pen="2p,darkblue", no_clip=True)
 fig.text(x=11.5, y=8, text="Plot Boundary", **mainexplain)
-fig.text(x=11.5, y=6.8, text='frame="WStr"', **minorexplain)
+fig.text(x=11.5, y=6.8, text='frame=Frame(axes="WStr")', **minorexplain)
 # ============ fig.plot (style)
 fig.plot(x=6, y=8, style="c0.7c", pen="2p,darkblue")
 fig.text(x=7, y=6.5, text="fig.plot(style)", **minorexplain)

--- a/examples/intro/03_figure_element.py
+++ b/examples/intro/03_figure_element.py
@@ -4,21 +4,19 @@
 
 The figure below shows the naming of figure elements in PyGMT.
 
-- :meth:`pygmt.Figure()`: having a number of plotting methods. Every new
-  figure must start with the creation of a :meth:`pygmt.Figure()` instance
-- ``frame``: setting plot boundaries (a combination of the single
-  letters of **WSNE**, **wsne**, or **lbtr**), adding annotations, ticks,
-  gridlines (**afg**), axis labels (**+l**), and title (**+t**), e.g.,
-  in :meth:`pygmt.Figure.basemap`. Detailed examples can be found at
+- :meth:`pygmt.Figure()`: having a number of plotting methods. Every new figure must
+  start with the creation of a :meth:`pygmt.Figure()` instance
+- ``frame``: setting plot boundaries (a combination of the single letters of **WSNE**,
+  **wsne**, or **lbtr**), adding annotations, ticks, gridlines, axis labels, and title,
+  e.g., in :meth:`pygmt.Figure.basemap`. Detailed examples can be found at
   :doc:`frame and axes attributes </tutorials/basics/frames>`
-- :meth:`pygmt.Figure.plot`: plotting lines or symbols based on ``pen``
-  or ``style`` parameters, respectively
-- :meth:`pygmt.Figure.text`: plotting text strings whereby the ``font``
-  parameter adjusts fontsize, fontstyle, and color
-- :meth:`pygmt.Figure.legend`: showing the naming of lines or symbols while
-  the ``label`` is given in :meth:`pygmt.Figure.plot`
-- :meth:`pygmt.Figure.show`: previewing the content added to the current
-  figure instance
+- :meth:`pygmt.Figure.plot`: plotting lines or symbols based on ``pen`` or ``style``
+  parameters, respectively
+- :meth:`pygmt.Figure.text`: plotting text strings whereby the ``font`` parameter
+  adjusts fontsize, fontstyle, and color
+- :meth:`pygmt.Figure.legend`: showing the naming of lines or symbols while the
+  ``label`` is given in :meth:`pygmt.Figure.plot`
+- :meth:`pygmt.Figure.show`: previewing the content added to the current figure instance
 """
 
 # %%
@@ -64,25 +62,25 @@ fig.text(
 # ============ x-majorticks
 fig.plot(x=10, y=-0.2, style="c1c", pen="2p,darkblue", no_clip=True)
 fig.text(x=10, y=-1.6, text="Annotation", **mainexplain)
-fig.text(x=10, y=-2.8, text='frame=Frame(xaxis=Axis(annot=2))', **minorexplain)
+fig.text(x=10, y=-2.8, text="frame=Frame(xaxis=Axis(annot=2))", **minorexplain)
 # ============ y-majorticks
 fig.plot(x=-0.2, y=20, style="c1c", pen="2p,darkblue", no_clip=True)
 fig.text(x=0, y=23.4, text="Annotation", **mainexplain)
-fig.text(x=0, y=22.2, text='frame=Frame(yaxis=Axis(annot=5))', **minorexplain)
+fig.text(x=0, y=22.2, text="frame=Frame(yaxis=Axis(annot=5))", **minorexplain)
 # ============ x-minorticks
 fig.plot(x=1, y=-0.2, style="c0.7c", pen="2p,darkblue", no_clip=True)
 fig.text(x=1, y=-1.4, text="Frame", **mainexplain)
-fig.text(x=1, y=-2.6, text='frame=Frame(xaxis=Axis(tick=1))', **minorexplain)
+fig.text(x=1, y=-2.6, text="frame=Frame(xaxis=Axis(tick=1))", **minorexplain)
 # ============ y-minorticks
 fig.plot(x=0, y=2, style="c0.7c", pen="2p,darkblue", no_clip=True)
-fig.text(x=-1.5, y=1, text='frame=Frame(yaxis=Axis(tick=1))', **minorexplain)
+fig.text(x=-1.5, y=1, text="frame=Frame(yaxis=Axis(tick=1))", **minorexplain)
 # ============ Grid
 fig.plot(x=2, y=15, style="c0.5c", pen="2p,darkblue")
 fig.text(x=2, y=17, text="Grid", **mainexplain)
 fig.text(
     x=2.4,
     y=18,
-    text='frame=Frame(xaxis=Axis(grid=2), yaxis=Axis(grid=5))',
+    text="frame=Frame(xaxis=Axis(grid=2), yaxis=Axis(grid=5))",
     **minorexplain,
 )
 # ============ Plot Boundaries


### PR DESCRIPTION
**Preview**: https://pygmt-dev--4584.org.readthedocs.build/en/4584/intro/03_figure_element.html

<img width="1473" height="853" alt="image" src="https://github.com/user-attachments/assets/d0692d57-f1a5-464e-92f9-4e3dbf383546" />

The result image looks bad. This tutorial should focus on introducing the plotting elements (e.g., `annot`/`tick`/`grid`/`title`/`subtitle` in GMT, rather than showing details about plotting commands.