### PR TITLE
Migrate the frame setting in the first figure tutorial

### DIFF
--- a/examples/intro/01_first_figure.py
+++ b/examples/intro/01_first_figure.py
@@ -16,7 +16,7 @@ address other PyGMT methods.
 # are accessible from the :mod:`pygmt` top level package.
 
 import pygmt
-from pygmt.params import Axis, Frame
+from pygmt.params import Frame
 
 # %%
 # Creating a figure

--- a/examples/intro/01_first_figure.py
+++ b/examples/intro/01_first_figure.py
@@ -16,6 +16,7 @@ address other PyGMT methods.
 # are accessible from the :mod:`pygmt` top level package.
 
 import pygmt
+from pygmt.params import Axis, Frame
 
 # %%
 # Creating a figure
@@ -119,7 +120,8 @@ fig.show()
 # annotate the latitude and longitude of the region.
 #
 # The ``frame`` parameter is used to add a frame to the figure. For now, it
-# will be set to ``"a"`` to **a**\ nnotate the axes automatically.
+# will be set to :class:`pygmt.params.Axis` with ``annot=True`` to annotate the
+# axes automatically.
 
 fig = pygmt.Figure()
 fig.coast(
@@ -128,7 +130,7 @@ fig.coast(
     land="lightgreen",
     water="lightblue",
     projection="M10c",
-    frame="a",
+    frame=Axis(annot=True),
 )
 fig.show()
 
@@ -137,13 +139,9 @@ fig.show()
 # Add a title
 # -----------
 #
-# The ``frame`` parameter can be used to add a title to the figure. The title
-# is set by passing ``"+t"`` followed by the title (e.g. setting the map
-# title to "Title" would be ``"+tTitle"``).
-#
-# To pass multiple arguments to ``frame``, a list can be used, as shown in the
-# example below. This format uses ``frame`` to set both the axes annotations
-# and the figure title.
+# The ``frame`` parameter can also be used to add a title to the figure. Here,
+# :class:`pygmt.params.Frame` combines the automatic axis annotations with a
+# title.
 
 fig = pygmt.Figure()
 fig.coast(
@@ -152,7 +150,7 @@ fig.coast(
     land="lightgreen",
     water="lightblue",
     projection="M10c",
-    frame=["a", "+tMaine"],
+    frame=Frame(title="Maine", axis=Axis(annot=True)),
 )
 fig.show()
 

--- a/examples/intro/01_first_figure.py
+++ b/examples/intro/01_first_figure.py
@@ -120,8 +120,7 @@ fig.show()
 # annotate the latitude and longitude of the region.
 #
 # The ``frame`` parameter is used to add a frame to the figure. For now, it
-# will be set to :class:`pygmt.params.Axis` with ``annot=True`` to annotate the
-# axes automatically.
+# will be set to ``True`` to annotate the axes automatically.
 
 fig = pygmt.Figure()
 fig.coast(
@@ -130,7 +129,7 @@ fig.coast(
     land="lightgreen",
     water="lightblue",
     projection="M10c",
-    frame=Axis(annot=True),
+    frame=True,
 )
 fig.show()
 
@@ -140,8 +139,7 @@ fig.show()
 # -----------
 #
 # The ``frame`` parameter can also be used to add a title to the figure. Here,
-# :class:`pygmt.params.Frame` combines the automatic axis annotations with a
-# title.
+# :class:`pygmt.params.Frame` sets the map title.
 
 fig = pygmt.Figure()
 fig.coast(
@@ -150,7 +148,7 @@ fig.coast(
     land="lightgreen",
     water="lightblue",
     projection="M10c",
-    frame=Frame(title="Maine", axis=Axis(annot=True)),
+    frame=Frame(title="Maine"),
 )
 fig.show()
 


### PR DESCRIPTION
## Summary
- migrate examples/intro/01_first_figure.py to use Axis and Frame for frame examples
- update the tutorial text to describe the structured frame API instead of legacy frame strings and lists

**Preview**: https://pygmt-dev--4585.org.readthedocs.build/en/4585/intro/01_first_figure.html