### PR TITLE
DOC/ gallery example "Vector heads and tails": Add note on GMT 4 vector syntax

### DIFF
--- a/examples/gallery/lines/vector_heads_tails.py
+++ b/examples/gallery/lines/vector_heads_tails.py
@@ -2,29 +2,28 @@ r"""
 Vector heads and tails
 ======================
 
-Many methods in PyGMT allow plotting vectors with individual
-heads and tails. For this purpose, several modifiers may be appended to
-the corresponding vector-producing parameters for specifying the placement
-of vector heads and tails, their shapes, and the justification of the vector.
+Many methods in PyGMT allow plotting vectors with individual heads and tails.
+For this purpose, several modifiers may be appended to the corresponding
+vector-producing parameters for specifying the placement of vector heads and
+tails, their shapes, and the justification of the vector.
 
-To place a vector head at the beginning of the vector path
-simply append **+b** to the vector-producing option (use **+e** to place
-one at the end). Optionally, append **t** for a terminal line, **c** for a
-circle, **a** for arrow (default), **i** for tail, **A** for plain open
-arrow, and **I** for plain open tail. Further append **l** or **r** (e.g.
-``"+bar"``) to only draw the left or right half-sides of the selected head/tail
-(default is both sides) or use **+l** or **+r** to apply simultaneously to both
-beginning and end. In this context, left and right refer to the side of the
-vector line when viewed from the beginning point to the end point of a line
-segment. The angle of the vector head apex can be set using **+a**\ *angle*
-(default is 30). The shape of the vector head can be adjusted using
-**+h**\ *shape* (e.g. ``"+h0.5"``).
+To place a vector head at the beginning of the vector path simply append **+b**
+to the vector-producing option (use **+e** to place one at the end). Optionally,
+append **t** for a terminal line, **c** for a circle, **a** for arrow (default),
+**i** for tail, **A** for plain open arrow, and **I** for plain open tail.
+Further append **l** or **r** (e.g. ``"+bar"``) to only draw the left or right
+half-sides of the selected head/tail (default is both sides) or use **+l** or
+**+r** to apply simultaneously to both beginning and end. In this context, left
+and right refer to the side of the vector line when viewed from the beginning
+point to the end point of a line segment. The angle of the vector head apex can
+be set using **+a**\ *angle* (default is 30). The shape of the vector head can
+be adjusted using **+h**\ *shape* (e.g. ``"+h0.5"``).
 
 In the following, we use the :meth:`pygmt.Figure.plot` method to plot vectors
 with individual heads and tails. We must specify the modifiers (together with
 the vector type, here ``"v"`` for Cartesian vector, see also the
-:doc:`Vector types example </gallery/lines/vector_styles>`)
-by passing the corresponding shortcuts to the ``style`` parameter.
+:doc:`Vector types example </gallery/lines/vector_styles>`) by passing the
+corresponding shortcuts to the ``style`` parameter.
 
 For further modifiers see :gmt-docs:`plot.html#vector-attributes`. Please note
 that vectors were completely redesigned for GMT 5 which separated the vector

--- a/examples/gallery/lines/vector_heads_tails.py
+++ b/examples/gallery/lines/vector_heads_tails.py
@@ -30,8 +30,8 @@ by passing the corresponding shortcuts to the ``style`` parameter.
 
 Note: Vectors were completely redesigned for GMT 5 which separated the vector
 head (a polygon) from the vector stem (a line). In GMT 4, the entire vector was
-a polygon. Thus, for plotting an arrow with a fill for both head and stem users
-have to follow the GMT 4 synthax explained at :gmt-docs:`plot.html#id13`.
+a polygon. Thus, to fill the entire vector with a color users have to follow the
+GMT 4 synthax explained at :gmt-docs:`plot.html#id13`.
 """
 
 # %%

--- a/examples/gallery/lines/vector_heads_tails.py
+++ b/examples/gallery/lines/vector_heads_tails.py
@@ -20,15 +20,14 @@ segment. The angle of the vector head apex can be set using **+a**\ *angle*
 (default is 30). The shape of the vector head can be adjusted using
 **+h**\ *shape* (e.g. ``"+h0.5"``).
 
-For further modifiers see :gmt-docs:`plot.html#vector-attributes`.
-
 In the following, we use the :meth:`pygmt.Figure.plot` method to plot vectors
 with individual heads and tails. We must specify the modifiers (together with
 the vector type, here ``"v"`` for Cartesian vector, see also the
 :doc:`Vector types example </gallery/lines/vector_styles>`)
 by passing the corresponding shortcuts to the ``style`` parameter.
 
-Note: Vectors were completely redesigned for GMT 5 which separated the vector
+For further modifiers see :gmt-docs:`plot.html#vector-attributes`. Please note
+that vectors were completely redesigned for GMT 5 which separated the vector
 head (a polygon) from the vector stem (a line). In GMT 4, the entire vector was
 a polygon. Thus, to fill the entire vector with a color users have to follow the
 GMT 4 synthax explained at :gmt-docs:`plot.html#id13`.

--- a/examples/gallery/lines/vector_heads_tails.py
+++ b/examples/gallery/lines/vector_heads_tails.py
@@ -27,6 +27,11 @@ with individual heads and tails. We must specify the modifiers (together with
 the vector type, here ``"v"`` for Cartesian vector, see also the
 :doc:`Vector types example </gallery/lines/vector_styles>`)
 by passing the corresponding shortcuts to the ``style`` parameter.
+
+Note: Vectors were completely redesigned for GMT 5 which separated the vector
+head (a polygon) from the vector stem (a line). In GMT 4, the entire vector was
+a polygon. Thus, for plotting an arrow with a fill for both head and stem users
+have to follow the GMT 4 synthax explained at :gmt-docs:`plot.html#id13`.
 """
 
 # %%

--- a/examples/gallery/lines/vector_heads_tails.py
+++ b/examples/gallery/lines/vector_heads_tails.py
@@ -29,7 +29,7 @@ For further modifiers see :gmt-docs:`plot.html#vector-attributes`. Please note
 that vectors were completely redesigned for GMT 5 which separated the vector
 head (a polygon) from the vector stem (a line). In GMT 4, the entire vector was
 a polygon. Thus, to fill the entire vector with a color users have to follow the
-GMT 4 synthax explained at :gmt-docs:`plot.html#id13`.
+GMT 4 synthax, which can be found on the webpage mentioned above.
 """
 
 # %%


### PR DESCRIPTION
**Description of proposed changes**

The definition of vectors has changed between GMT 4 and 5. The GMT 4 syntax is still supported. Having an entirely filled vector can be useful. I think (at least) adding a note to the gallery example "Vector heads and tails" that this can be achieved with the GMT 4 syntax can be helpful for users. 

**Preview**:

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
