### PR TITLE
params.Axis: Add parameters hlabel/alt_label/alt_hlabel for more controls of axis labels

### DIFF
--- a/pygmt/params/frame.py
+++ b/pygmt/params/frame.py
@@ -45,12 +45,24 @@ class Axis(BaseParam):
     #: Specify the interval for gridlines. Same format as ``annot``.
     grid: float | str | bool = False
 
-    #: Label for the axis [Default is no label].
+    #: Label for the axis using GMT's default label orientation [Default is no label].
     label: str | None = None
+
+    #: Label for the axis with forced horizontal orientation for y-axes [Cartesian
+    #: plots only].
+    hlabel: str | None = None
 
     #: A leading text prefix for the axis annotations (e.g., dollar sign for plots
     #: related to money) [For Cartesian plots only].
     prefix: str | None = None
+
+    #: Alternate label for the right or upper axis using GMT's default label
+    #: orientation [Cartesian plots only].
+    alt_label: str | None = None
+
+    #: Alternate label for the right or upper axis with forced horizontal orientation
+    #: for y-axes [Cartesian plots only].
+    alt_hlabel: str | None = None
 
     #: Unit to append to the axis annotations [For Cartesian plots only].
     unit: str | None = None
@@ -65,8 +77,11 @@ class Axis(BaseParam):
             Alias(self.tick, name="tick", prefix="f"),
             Alias(self.grid, name="grid", prefix="g"),
             Alias(self.label, name="label", prefix="+l"),
+            Alias(self.hlabel, name="hlabel", prefix="+L"),
             Alias(self.angle, name="angle", prefix="+a"),
             Alias(self.prefix, name="prefix", prefix="+p"),
+            Alias(self.alt_label, name="alt_label", prefix="+s"),
+            Alias(self.alt_hlabel, name="alt_hlabel", prefix="+S"),
             Alias(self.unit, name="unit", prefix="+u"),
         ]
 

--- a/pygmt/params/frame.py
+++ b/pygmt/params/frame.py
@@ -51,7 +51,7 @@ class Axis(BaseParam):
     #: Horizontal label for y-axes, useful for very short labels.
     hlabel: str | None = None
 
-    #: Alternate label for the right or upper axis [Default is the same as ``label``].
+    #: Alternate label for the right or top axis [Default is the same as ``label``].
     alt_label: str | None = None
 
     #: Horizontal label for the right y-axis, useful for very short labels.

--- a/pygmt/params/frame.py
+++ b/pygmt/params/frame.py
@@ -45,24 +45,21 @@ class Axis(BaseParam):
     #: Specify the interval for gridlines. Same format as ``annot``.
     grid: float | str | bool = False
 
-    #: Label for the axis using GMT's default label orientation [Default is no label].
+    #: Label for the axis [Default is no label].
     label: str | None = None
 
-    #: Label for the axis with forced horizontal orientation for y-axes [Cartesian
-    #: plots only].
+    #: Horizontal label for y-axes, useful for very short labels.
     hlabel: str | None = None
+
+    #: Alternate label for the right or upper axis [Default is the same as ``label``].
+    alt_label: str | None = None
+
+    #: Horizontal label for the right y-axis, useful for very short labels.
+    alt_hlabel: str | None = None
 
     #: A leading text prefix for the axis annotations (e.g., dollar sign for plots
     #: related to money) [For Cartesian plots only].
     prefix: str | None = None
-
-    #: Alternate label for the right or upper axis using GMT's default label
-    #: orientation [Cartesian plots only].
-    alt_label: str | None = None
-
-    #: Alternate label for the right or upper axis with forced horizontal orientation
-    #: for y-axes [Cartesian plots only].
-    alt_hlabel: str | None = None
 
     #: Unit to append to the axis annotations [For Cartesian plots only].
     unit: str | None = None
@@ -78,11 +75,11 @@ class Axis(BaseParam):
             Alias(self.grid, name="grid", prefix="g"),
             Alias(self.label, name="label", prefix="+l"),
             Alias(self.hlabel, name="hlabel", prefix="+L"),
-            Alias(self.angle, name="angle", prefix="+a"),
-            Alias(self.prefix, name="prefix", prefix="+p"),
             Alias(self.alt_label, name="alt_label", prefix="+s"),
             Alias(self.alt_hlabel, name="alt_hlabel", prefix="+S"),
+            Alias(self.prefix, name="prefix", prefix="+p"),
             Alias(self.unit, name="unit", prefix="+u"),
+            Alias(self.angle, name="angle", prefix="+a"),
         ]
 
 

--- a/pygmt/params/frame.py
+++ b/pygmt/params/frame.py
@@ -48,11 +48,11 @@ class Axis(BaseParam):
     #: Label for the axis [Default is no label].
     label: str | None = None
 
-    #: Horizontal label for y-axes, useful for very short labels.
-    hlabel: str | None = None
-
     #: Alternate label for the right or top axis [Default is the same as ``label``].
     alt_label: str | None = None
+
+    #: Horizontal label for y-axes, useful for very short labels.
+    hlabel: str | None = None
 
     #: Horizontal label for the right y-axis, useful for very short labels.
     alt_hlabel: str | None = None
@@ -74,8 +74,8 @@ class Axis(BaseParam):
             Alias(self.tick, name="tick", prefix="f"),
             Alias(self.grid, name="grid", prefix="g"),
             Alias(self.label, name="label", prefix="+l"),
-            Alias(self.hlabel, name="hlabel", prefix="+L"),
             Alias(self.alt_label, name="alt_label", prefix="+s"),
+            Alias(self.hlabel, name="hlabel", prefix="+L"),
             Alias(self.alt_hlabel, name="alt_hlabel", prefix="+S"),
             Alias(self.prefix, name="prefix", prefix="+p"),
             Alias(self.unit, name="unit", prefix="+u"),

--- a/pygmt/tests/test_params_frame.py
+++ b/pygmt/tests/test_params_frame.py
@@ -15,7 +15,7 @@ def test_params_axis():
     assert str(Axis(annot=True, tick=True, grid=True)) == "afg"
     assert str(Axis(annot=30, tick=15, grid=5)) == "a30f15g5"
     assert str(Axis(annot=30, label="LABEL")) == "a30+lLABEL"
-    assert str(Axis(annot=30, hlabel="LABEL")) == "a30+LLABEL"
+    assert str(Axis(annot=30, hlabel="HLABEL")) == "a30+LHLABEL"
     assert str(Axis(annot=30, prefix="$", unit="m")) == "a30+p$+um"
     assert str(Axis(annot=30, alt_label="LABEL2")) == "a30+sLABEL2"
     assert (

--- a/pygmt/tests/test_params_frame.py
+++ b/pygmt/tests/test_params_frame.py
@@ -14,22 +14,16 @@ def test_params_axis():
     assert str(Axis(annot=True)) == "a"
     assert str(Axis(annot=True, tick=True, grid=True)) == "afg"
     assert str(Axis(annot=30, tick=15, grid=5)) == "a30f15g5"
-    assert str(Axis(annot=30, label="LABEL")) == "a30+lLABEL"
-    assert str(Axis(annot=30, hlabel="HLABEL")) == "a30+LHLABEL"
     assert str(Axis(annot=30, prefix="$", unit="m")) == "a30+p$+um"
+    assert str(Axis(annot=30, label="LABEL")) == "a30+lLABEL"
     assert str(Axis(annot=30, alt_label="LABEL2")) == "a30+sLABEL2"
-    assert (
-        str(
-            Axis(
-                annot=30,
-                label="LABEL",
-                hlabel="HLABEL",
-                alt_label="LABEL2",
-                alt_hlabel="HLABEL2",
-            )
-        )
-        == "a30+lLABEL+LHLABEL+sLABEL2+SHLABEL2"
-    )
+    assert str(Axis(annot=30, hlabel="HLABEL")) == "a30+LHLABEL"
+    assert str(Axis(annot=30, alt_hlabel="HLABEL2")) == "a30+SHLABEL2"
+
+    xaxis = Axis(annot=30, label="LABEL", alt_label="LABEL2")
+    assert str(xaxis) == "a30+lLABEL+sLABEL2"
+    yaxis = Axis(annot=30, hlabel="HLABEL", alt_hlabel="HLABEL2")
+    assert str(yaxis) == "a30+LHLABEL+SHLABEL2"
 
 
 def test_params_frame_only():

--- a/pygmt/tests/test_params_frame.py
+++ b/pygmt/tests/test_params_frame.py
@@ -15,7 +15,21 @@ def test_params_axis():
     assert str(Axis(annot=True, tick=True, grid=True)) == "afg"
     assert str(Axis(annot=30, tick=15, grid=5)) == "a30f15g5"
     assert str(Axis(annot=30, label="LABEL")) == "a30+lLABEL"
+    assert str(Axis(annot=30, hlabel="LABEL")) == "a30+LLABEL"
     assert str(Axis(annot=30, prefix="$", unit="m")) == "a30+p$+um"
+    assert str(Axis(annot=30, alt_label="LABEL2")) == "a30+sLABEL2"
+    assert (
+        str(
+            Axis(
+                annot=30,
+                label="LABEL",
+                hlabel="HLABEL",
+                alt_label="LABEL2",
+                alt_hlabel="HLABEL2",
+            )
+        )
+        == "a30+lLABEL+LHLABEL+sLABEL2+SHLABEL2"
+    )
 
 
 def test_params_frame_only():


### PR DESCRIPTION
Implements the `+L`/`+s`/`+S` modifiers for the `-B` option.

Address #4588 