### PR TITLE
params.Frame: Add parameters for 3-D plots

### DIFF
--- a/pygmt/params/frame.py
+++ b/pygmt/params/frame.py
@@ -216,7 +216,7 @@ class Frame(BaseParam):
     subtitle: str | None = None
 
     #: Fill for the interior of the frame with a color or a pattern [Default is no
-    #: fill]. For 3-D plots, it sets the fill for the xy-, yz-, and xz-planes, but can 
+    #: fill]. For 3-D plots, it sets the fill for the xy-, yz-, and xz-planes, but can
     #: be overridden by ``xyfill``, ``yzfill``, and ``xzfill``.
     fill: str | None = None
 

--- a/pygmt/params/frame.py
+++ b/pygmt/params/frame.py
@@ -102,10 +102,10 @@ class _Axes(BaseParam):
     """
 
     axes: str | None = None
-    box: bool = False
     title: str | None = None
     subtitle: str | None = None
     fill: str | None = None
+    box: bool = False
     wall_pen: str | bool = False
     yzfill: str | None = None
     xzfill: str | None = None

--- a/pygmt/params/frame.py
+++ b/pygmt/params/frame.py
@@ -102,17 +102,27 @@ class _Axes(BaseParam):
     """
 
     axes: str | None = None
+    box: bool = False
     title: str | None = None
     subtitle: str | None = None
     fill: str | None = None
+    wall_pen: str | bool = False
+    yzfill: str | None = None
+    xzfill: str | None = None
+    xyfill: str | None = None
 
     @property
     def _aliases(self):
         return [
             Alias(self.axes, name="axes"),
+            Alias(self.box, name="box", prefix="+b"),
             Alias(self.fill, name="fill", prefix="+g"),
             Alias(self.title, name="title", prefix="+t"),
             Alias(self.subtitle, name="subtitle", prefix="+s"),
+            Alias(self.wall_pen, name="wall_pen", prefix="+w"),
+            Alias(self.yzfill, name="yzfill", prefix="+x"),
+            Alias(self.xzfill, name="xzfill", prefix="+y"),
+            Alias(self.xyfill, name="xyfill", prefix="+z"),
         ]
 
 
@@ -209,6 +219,21 @@ class Frame(BaseParam):
     #: fill].
     fill: str | None = None
 
+    #: Draw the foreground lines of a 3-D box.
+    box: bool = False
+
+    #: Pen for the outlines of the side walls in a 3-D plot.
+    wall_pen: str | bool = False
+
+    #: Fill for the yz-plane (the plane normal to the x-axis) in a 3-D plot.
+    yzfill: str | None = None
+
+    #: Fill for the xz-plane (the plane normal to the y-axis) in a 3-D plot.
+    xzfill: str | None = None
+
+    #: Fill for the xy-plane (the plane normal to the z-axis) in a 3-D plot.
+    xyfill: str | None = None
+
     #: Specify the attributes for axes by an :class:`Axis` object.
     #:
     #: The attributes for x and y axes can be specified in two ways: (1) specifying the
@@ -260,7 +285,15 @@ class Frame(BaseParam):
         # _Axes() maps to an empty string, which becomes '-B' without arguments and is
         # invalid when combined with individual axis settings (e.g., '-B -Bxaf -Byaf').
         frame_settings = _Axes(
-            axes=self.axes, title=self.title, subtitle=self.subtitle, fill=self.fill
+            axes=self.axes,
+            box=self.box,
+            title=self.title,
+            subtitle=self.subtitle,
+            fill=self.fill,
+            wall_pen=self.wall_pen,
+            yzfill=self.yzfill,
+            xzfill=self.xzfill,
+            xyfill=self.xyfill,
         )
         has_secondary_xy_axis = any([self.axis2, self.xaxis2, self.yaxis2])
         return [

--- a/pygmt/params/frame.py
+++ b/pygmt/params/frame.py
@@ -287,10 +287,10 @@ class Frame(BaseParam):
         # invalid when combined with individual axis settings (e.g., '-B -Bxaf -Byaf').
         frame_settings = _Axes(
             axes=self.axes,
-            box=self.box,
             title=self.title,
             subtitle=self.subtitle,
             fill=self.fill,
+            box=self.box,
             wall_pen=self.wall_pen,
             yzfill=self.yzfill,
             xzfill=self.xzfill,

--- a/pygmt/params/frame.py
+++ b/pygmt/params/frame.py
@@ -216,7 +216,8 @@ class Frame(BaseParam):
     subtitle: str | None = None
 
     #: Fill for the interior of the frame with a color or a pattern [Default is no
-    #: fill].
+    #: fill]. For 3-D plots, it sets the fill for the xy-, yz-, and xz-planes, but can 
+    #: be overridden by ``xyfill``, ``yzfill``, and ``xzfill``.
     fill: str | None = None
 
     #: Draw the foreground lines of a 3-D box. [For 3-D plots only]

--- a/pygmt/params/frame.py
+++ b/pygmt/params/frame.py
@@ -115,10 +115,10 @@ class _Axes(BaseParam):
     def _aliases(self):
         return [
             Alias(self.axes, name="axes"),
-            Alias(self.box, name="box", prefix="+b"),
             Alias(self.fill, name="fill", prefix="+g"),
             Alias(self.title, name="title", prefix="+t"),
             Alias(self.subtitle, name="subtitle", prefix="+s"),
+            Alias(self.box, name="box", prefix="+b"),
             Alias(self.wall_pen, name="wall_pen", prefix="+w"),
             Alias(self.yzfill, name="yzfill", prefix="+x"),
             Alias(self.xzfill, name="xzfill", prefix="+y"),
@@ -219,19 +219,20 @@ class Frame(BaseParam):
     #: fill].
     fill: str | None = None
 
-    #: Draw the foreground lines of a 3-D box.
+    #: Draw the foreground lines of a 3-D box. [For 3-D plots only]
     box: bool = False
 
-    #: Pen for the outlines of the side walls in a 3-D plot.
+    #: Draw the outlines of the x-z and y-z planes by the specified pen attributes.
+    #: If ``True``, use the default pen. [For 3-D plots only]
     wall_pen: str | bool = False
 
-    #: Fill for the yz-plane (the plane normal to the x-axis) in a 3-D plot.
+    #: Fill for the yz-plane (the plane normal to the x-axis). [For 3-D plots only]
     yzfill: str | None = None
 
-    #: Fill for the xz-plane (the plane normal to the y-axis) in a 3-D plot.
+    #: Fill for the xz-plane (the plane normal to the y-axis). [For 3-D plots only]
     xzfill: str | None = None
 
-    #: Fill for the xy-plane (the plane normal to the z-axis) in a 3-D plot.
+    #: Fill for the xy-plane (the plane normal to the z-axis). [For 3-D plots only]
     xyfill: str | None = None
 
     #: Specify the attributes for axes by an :class:`Axis` object.

--- a/pygmt/tests/test_params_frame.py
+++ b/pygmt/tests/test_params_frame.py
@@ -58,7 +58,7 @@ def test_params_frame_only():
         xzfill="green",
         xyfill="blue",
     )
-    assert str(frame) == "WSrtZ+b+ggray+tMy Title+w0.5p,black+xred+ygreen+zblue"
+    assert str(frame) == "WSrtZ+ggray+tMy Title+b+w0.5p,black+xred+ygreen+zblue"
 
 
 def test_params_frame_axis():

--- a/pygmt/tests/test_params_frame.py
+++ b/pygmt/tests/test_params_frame.py
@@ -52,17 +52,13 @@ def test_params_frame_only():
         axes="WSrtZ",
         box=True,
         title="My Title",
-        subtitle="My Subtitle",
         fill="gray",
         wall_pen="0.5p,black",
         yzfill="red",
         xzfill="green",
         xyfill="blue",
     )
-    assert (
-        str(frame)
-        == "WSrtZ+b+ggray+tMy Title+sMy Subtitle+w0.5p,black+xred+ygreen+zblue"
-    )
+    assert str(frame) == "WSrtZ+b+ggray+tMy Title+w0.5p,black+xred+ygreen+zblue"
 
 
 def test_params_frame_axis():

--- a/pygmt/tests/test_params_frame.py
+++ b/pygmt/tests/test_params_frame.py
@@ -42,6 +42,28 @@ def test_params_frame_only():
     frame = Frame(axes="WSEN", title="My Title", subtitle="My Subtitle", fill="red")
     assert str(frame) == "WSEN+gred+tMy Title+sMy Subtitle"
 
+    frame = Frame(axes="WSrtZ", box=True, wall_pen="1p,red")
+    assert str(frame) == "WSrtZ+b+w1p,red"
+
+    frame = Frame(axes="WSrtZ", yzfill="red", xzfill="green", xyfill="blue")
+    assert str(frame) == "WSrtZ+xred+ygreen+zblue"
+
+    frame = Frame(
+        axes="WSrtZ",
+        box=True,
+        title="My Title",
+        subtitle="My Subtitle",
+        fill="gray",
+        wall_pen="0.5p,black",
+        yzfill="red",
+        xzfill="green",
+        xyfill="blue",
+    )
+    assert (
+        str(frame)
+        == "WSrtZ+b+ggray+tMy Title+sMy Subtitle+w0.5p,black+xred+ygreen+zblue"
+    )
+
 
 def test_params_frame_axis():
     """


### PR DESCRIPTION
This PR adds parameters for -B modifiers related to 3-D plots:

- `+b`: `box`
- `+w`: `wall_pen`
- `+x`: `yzfill`
- `+y`: `xzfill`
- `+z`: `xyfill`

GMT uses `pen` for `+b` (xref: https://github.com/GenericMappingTools/gmt/blob/ac580b28da697232ae21cfa2ec102610572af2d8/src/gmt_common_longoptions.h#L72), but I feel `pen` is too general, and it's also a little misleading because it only sets pen for x-z and y-z planes, not the frame pen for the x-y plane.

Example
```
import pygmt
from pygmt.params import Axis, Frame

fig = pygmt.Figure()
fig.basemap(
    region=(0, 1, 0, 2, 0, 3),
    projection="X10c/10c",
    zsize="5c",
    perspective=(120, 30),
    frame=Frame(
        axes="WSENZ",
        axis=True,
        zaxis=True,
        box=True,
        wall_pen="1p,red",
        xzfill="lightgreen",
        xyfill="lightblue",
        yzfill="lightyellow",
    )
)
fig.show()
```
<img width="1725" height="1356" alt="map" src="https://github.com/user-attachments/assets/ad4e0369-453d-45f5-bcc7-615742d92b8f" />

Related to #4588