### PR TITLE
DOC/Test "test_basemap": Migrate frame settings to the new Frame/Axis syntax 

### DIFF
--- a/pygmt/tests/test_basemap.py
+++ b/pygmt/tests/test_basemap.py
@@ -180,7 +180,11 @@ def test_basemap_frame_sequence_true():
     Test for https://github.com/GenericMappingTools/pygmt/issues/3981.
     """
     fig = Figure()
-    fig.basemap(region=[0, 10, 0, 10], projection="X10c", frame=[True, "WSen"])
+    fig.basemap(
+        region=[0, 10, 0, 10],
+        projection="X10c",
+        frame=Frame(axes="WSen", axis=Axis(annot=True, tick=True)),
+    )
     return fig
 
 


### PR DESCRIPTION
Update the test pygmt/tests/test_basemap.py to use the new implemented Frame and Axis parameter classes.

Fixes partly https://github.com/GenericMappingTools/pygmt/issues/4494