### PR TITLE
Update the frame type hints to support Axis and Frame

### DIFF
--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -20,7 +20,7 @@ def basemap(  # noqa: PLR0913
     zscale: float | str | None = None,
     zsize: float | str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     map_scale: str | None = None,

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -9,7 +9,7 @@ from typing import Literal
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, use_alias
-from pygmt.params import Box
+from pygmt.params import Axis, Box, Frame
 
 
 @fmt_docstring
@@ -20,7 +20,7 @@ def basemap(  # noqa: PLR0913
     zscale: float | str | None = None,
     zsize: float | str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     map_scale: str | None = None,

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -9,7 +9,7 @@ from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTParameterError
 from pygmt.helpers import args_in_kwargs, build_arg_list, fmt_docstring, use_alias
-from pygmt.params import Box
+from pygmt.params import Axis, Box, Frame
 
 __doctest_skip__ = ["coast"]
 
@@ -30,7 +30,7 @@ def coast(  # noqa: PLR0913
     box: Box | bool = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -30,7 +30,7 @@ def coast(  # noqa: PLR0913
     box: Box | bool = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -273,7 +273,7 @@ def colorbar(  # noqa: PLR0913
     dpi: int | None = None,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -273,7 +273,7 @@ def colorbar(  # noqa: PLR0913
     dpi: int | None = None,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -41,7 +41,7 @@ def contour(  # noqa: PLR0913
     no_clip: bool = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -14,6 +14,7 @@ from pygmt.helpers import (
     is_nonstr_iter,
     use_alias,
 )
+from pygmt.params import Axis, Frame
 
 
 @fmt_docstring
@@ -40,7 +41,7 @@ def contour(  # noqa: PLR0913
     no_clip: bool = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -17,6 +17,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
+from pygmt.params import Axis, Frame
 
 __doctest_skip__ = ["grdcontour"]
 
@@ -40,7 +41,7 @@ def grdcontour(
     grid: PathLike | xr.DataArray,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -41,7 +41,7 @@ def grdcontour(
     grid: PathLike | xr.DataArray,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -33,7 +33,7 @@ def grdimage(  # noqa: PLR0913
     no_clip: bool = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -10,6 +10,7 @@ from pygmt._typing import PathLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, use_alias
+from pygmt.params import Axis, Frame
 
 __doctest_skip__ = ["grdimage"]
 
@@ -32,7 +33,7 @@ def grdimage(  # noqa: PLR0913
     no_clip: bool = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -12,6 +12,7 @@ from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session, __gmt_version__
 from pygmt.exceptions import GMTParameterError
 from pygmt.helpers import build_arg_list, deprecate_parameter, fmt_docstring, use_alias
+from pygmt.params import Axis, Frame
 from pygmt.src.grdinfo import grdinfo
 
 __doctest_skip__ = ["grdview"]
@@ -138,7 +139,7 @@ def grdview(  # noqa: PLR0913
     zscale: float | str | None = None,
     zsize: float | str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -139,7 +139,7 @@ def grdview(  # noqa: PLR0913
     zscale: float | str | None = None,
     zsize: float | str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -16,6 +16,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
+from pygmt.params import Axis, Frame
 
 
 @fmt_docstring
@@ -49,7 +50,7 @@ def histogram(  # noqa: PLR0913
     bar_offset: float | str | None = None,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -50,7 +50,7 @@ def histogram(  # noqa: PLR0913
     bar_offset: float | str | None = None,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -9,7 +9,7 @@ from pygmt._typing import AnchorCode, PathLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, use_alias
-from pygmt.params import Box, Position
+from pygmt.params import Axis, Box, Frame, Position
 from pygmt.src._common import _parse_position
 
 
@@ -28,7 +28,7 @@ def image(  # noqa: PLR0913
     invert: bool = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -28,7 +28,7 @@ def image(  # noqa: PLR0913
     invert: bool = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -11,7 +11,7 @@ from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTTypeError
 from pygmt.helpers import build_arg_list, data_kind, fmt_docstring, is_nonstr_iter
-from pygmt.params import Box, Position
+from pygmt.params import Axis, Box, Frame, Position
 from pygmt.src._common import _parse_position
 
 
@@ -27,7 +27,7 @@ def legend(  # noqa: PLR0913
     scale: float | None = None,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -27,7 +27,7 @@ def legend(  # noqa: PLR0913
     scale: float | None = None,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -18,6 +18,7 @@ from pygmt.helpers import (
     fmt_docstring,
     use_alias,
 )
+from pygmt.params import Axis, Frame
 from pygmt.src._common import _FocalMechanismConvention
 
 
@@ -148,7 +149,7 @@ def meca(  # noqa: PLR0913
     event_name: str | Sequence[str] | None = None,
     no_clip: bool = False,
     projection: str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     region: Sequence[float | str] | str | None = None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -149,7 +149,7 @@ def meca(  # noqa: PLR0913
     event_name: str | Sequence[str] | None = None,
     no_clip: bool = False,
     projection: str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     region: Sequence[float | str] | str | None = None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -55,7 +55,7 @@ def plot(  # noqa: PLR0912, PLR0913
     straight_line: bool | Literal["x", "y"] = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -16,6 +16,7 @@ from pygmt.helpers import (
     is_nonstr_iter,
     use_alias,
 )
+from pygmt.params import Axis, Frame
 from pygmt.src._common import _data_geometry_is_point
 
 
@@ -54,7 +55,7 @@ def plot(  # noqa: PLR0912, PLR0913
     straight_line: bool | Literal["x", "y"] = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -16,6 +16,7 @@ from pygmt.helpers import (
     is_nonstr_iter,
     use_alias,
 )
+from pygmt.params import Axis, Frame
 from pygmt.src._common import _data_geometry_is_point
 
 
@@ -55,7 +56,7 @@ def plot3d(  # noqa: PLR0912, PLR0913
     zscale: float | str | None = None,
     zsize: float | str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -56,7 +56,7 @@ def plot3d(  # noqa: PLR0912, PLR0913
     zscale: float | str | None = None,
     zsize: float | str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -9,6 +9,7 @@ from pygmt._typing import PathLike, TableLike
 from pygmt.alias import AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, fmt_docstring, use_alias
+from pygmt.params import Axis, Frame
 
 
 @fmt_docstring
@@ -40,7 +41,7 @@ def rose(  # noqa: PLR0913
     length=None,
     azimuth=None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -41,7 +41,7 @@ def rose(  # noqa: PLR0913
     length=None,
     azimuth=None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -24,7 +24,7 @@ def solar(  # noqa: PLR0913
     pen: str | None = None,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -10,6 +10,7 @@ from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTValueError
 from pygmt.helpers import build_arg_list, fmt_docstring
+from pygmt.params import Axis, Frame
 
 __doctest_skip__ = ["solar"]
 
@@ -23,7 +24,7 @@ def solar(  # noqa: PLR0913
     pen: str | None = None,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -145,7 +145,7 @@ def subplot(  # noqa: PLR0913
     margins: float | str | Sequence[float | str] | None = None,
     title: str | None = None,
     projection: str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     region: Sequence[float | str] | str | None = None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -17,7 +17,7 @@ from pygmt.helpers import (
     kwargs_to_strings,
     use_alias,
 )
-from pygmt.params import Box, Position
+from pygmt.params import Axis, Box, Frame, Position
 from pygmt.src._common import _parse_position
 
 
@@ -145,7 +145,7 @@ def subplot(  # noqa: PLR0913
     margins: float | str | Sequence[float | str] | None = None,
     title: str | None = None,
     projection: str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     region: Sequence[float | str] | str | None = None,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -116,7 +116,7 @@ def ternary(  # noqa: PLR0913
     blabel: str | None = None,
     clabel: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -116,7 +116,7 @@ def ternary(  # noqa: PLR0913
     blabel: str | None = None,
     clabel: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool | Frame | Axis = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -19,6 +19,7 @@ from pygmt.helpers import (
     non_ascii_to_octal,
     use_alias,
 )
+from pygmt.params import Axis, Frame
 
 
 @fmt_docstring
@@ -47,7 +48,7 @@ def text_(  # noqa: PLR0912, PLR0913, PLR0915
     no_clip: bool = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -48,7 +48,7 @@ def text_(  # noqa: PLR0912, PLR0913, PLR0915
     no_clip: bool = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -32,7 +32,7 @@ def tilemap(  # noqa: PLR0913
     monochrome: bool = False,
     no_clip: bool = False,
     projection: str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -10,6 +10,7 @@ from pygmt.clib import Session
 from pygmt.datasets.tile_map import load_tile_map
 from pygmt.enums import GridType
 from pygmt.helpers import build_arg_list, fmt_docstring, use_alias
+from pygmt.params import Axis, Frame
 
 try:
     from xyzservices import TileProvider
@@ -31,7 +32,7 @@ def tilemap(  # noqa: PLR0913
     monochrome: bool = False,
     no_clip: bool = False,
     projection: str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -42,7 +42,7 @@ def velo(  # noqa : PLR0913
     no_clip: bool = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -12,6 +12,7 @@ from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTParameterError, GMTTypeError
 from pygmt.helpers import build_arg_list, deprecate_parameter, fmt_docstring, use_alias
+from pygmt.params import Axis, Frame
 
 
 @fmt_docstring
@@ -41,7 +42,7 @@ def velo(  # noqa : PLR0913
     no_clip: bool = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -47,7 +47,7 @@ def wiggle(  # noqa: PLR0913
     negative_fill: str | None = None,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: Frame | Axis | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -9,7 +9,7 @@ from pygmt._typing import AnchorCode, PathLike, TableLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.helpers import build_arg_list, deprecate_parameter, fmt_docstring, use_alias
-from pygmt.params import Position
+from pygmt.params import Axis, Frame, Position
 from pygmt.src._common import _parse_position
 
 
@@ -47,7 +47,7 @@ def wiggle(  # noqa: PLR0913
     negative_fill: str | None = None,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
-    frame: str | Sequence[str] | Literal["none"] | bool = False,
+    frame: Frame | Axis | Literal["none"] | bool = False,
     verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
     | bool = False,
     panel: int | Sequence[int] | bool = False,


### PR DESCRIPTION
Old type hint: `frame: str | Sequence[str] | Literal["none"] | bool = False,`

New type hint: `frame: Frame | Axis | Literal["none"] | bool = False`


`ste | Sequence[str]` is still supported, but not type hinted.