### PR TITLE
CI: Temporarily pin tectonic=0.15

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -116,7 +116,7 @@ jobs:
             sphinx_rtd_theme
             cairosvg
             sphinxcontrib-svg2pdfconverter
-            tectonic
+            tectonic=0.15
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub

--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
     # Dev dependencies (building PDF documentation)
     - cairosvg
     - sphinxcontrib-svg2pdfconverter
-    - tectonic
+    - tectonic=0.15
     # Dev dependencies (type hints)
     - mypy
     - pandas-stubs


### PR DESCRIPTION
Building the PDF documentation started to fail recently with tectonic=0.16 (released two weeks ago), and has been working well with tectonic=0.15 (released in 2024). 

xref: 

- https://github.com/GenericMappingTools/pygmt/actions/runs/25033436618/job/73319833940
- https://github.com/GenericMappingTools/pygmt/actions/runs/24624382851/job/72000657169

It's likely related to the upstream issue https://github.com/tectonic-typesetting/tectonic/issues/1342. 

This PR pins tectonic to 0.15, so that we can have docs updated in CI. I'll open a separate PR to unpin it to track if any future releases fix the issue.