### PR TITLE
Figure.logo: Add an inline example to plot the GMT logo without any arguments

### DIFF
--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -100,6 +100,16 @@ def logo(  # noqa: PLR0913
     Examples
     --------
     >>> import pygmt
+
+    The simplest way to plot the GMT logo is to just call the method without any
+    parameters.
+
+    >>> fig = pygmt.Figure()
+    >>> fig.logo()
+    >>> fig.show()
+
+    To plot the GMT logo at the Top Right corner on a existing basemap:
+
     >>> fig = pygmt.Figure()
     >>> fig.basemap(region=[-90, -70, 0, 20], projection="M10c", frame=True)
     >>> fig.logo(position="TR", width="3c")

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -102,13 +102,13 @@ def logo(  # noqa: PLR0913
     >>> import pygmt
 
     The simplest way to plot the GMT logo is to just call the method without any
-    parameters.
+    arguments.
 
     >>> fig = pygmt.Figure()
     >>> fig.logo()
     >>> fig.show()
 
-    To plot the GMT logo at the Top Right corner on a existing basemap:
+    To plot the GMT logo at the Top Right corner on an existing basemap:
 
     >>> fig = pygmt.Figure()
     >>> fig.basemap(region=[-90, -70, 0, 20], projection="M10c", frame=True)


### PR DESCRIPTION


Address comment https://github.com/GenericMappingTools/pygmt/pull/3849#discussion_r3151732765.


**Preview**: https://pygmt-dev--4607.org.readthedocs.build/en/4607/api/generated/pygmt.Figure.logo.html