### PR TITLE
CI: Fix the "DVC Diff" workflow

### DIFF
--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -37,6 +37,8 @@ jobs:
 
     - name: Setup continuous machine learning (CML)
       uses: iterative/setup-cml@1b5ab8766e715e8f1aab96bbb1f4f2e3e1e8af45 # v3
+      with:
+        vega: false
 
     # Produce the markdown diff report, which should look like:
     # ## Summary of changed images


### PR DESCRIPTION
Explanations from ChatGPT:

* Your runner has Node 24.14.1.
* canvas@2.11.2 has no prebuilt binary for Node ABI node-v137, so it falls back to building from source.
* Source build then fails because system dependency pixman-1 is missing: