### PR TITLE
Figure: Refactor how plotting methods are attached to the Figure class

### DIFF
--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -136,42 +136,6 @@ class Figure:
         self._preview_dir = TemporaryDirectory(prefix=f"{self._name}-preview-")
         self._activate_figure()
 
-        # Attach plotting functions implemented in pygmt/src as bound instance methods.
-        self.basemap = _basemap
-        self.choropleth = _choropleth
-        self.coast = _coast
-        self.colorbar = _colorbar
-        self.contour = _contour
-        self.directional_rose = _directional_rose
-        self.grdcontour = _grdcontour
-        self.grdimage = _grdimage
-        self.grdview = _grdview
-        self.histogram = _histogram
-        self.hlines = _hlines
-        self.image = _image
-        self.inset = _inset
-        self.legend = _legend
-        self.logo = _logo
-        self.magnetic_rose = _magnetic_rose
-        self.meca = _meca
-        self.paragraph = _paragraph
-        self.plot = _plot
-        self.plot3d = _plot3d
-        self.psconvert = _psconvert
-        self.rose = _rose
-        self.scalebar = _scalebar
-        self.set_panel = _set_panel
-        self.shift_origin = _shift_origin
-        self.solar = _solar
-        self.subplot = _subplot
-        self.ternary = _ternary
-        self.text = _text
-        self.tilemap = _tilemap
-        self.timestamp = _timestamp
-        self.velo = _velo
-        self.vlines = _vlines
-        self.wiggle = _wiggle
-
     def __del__(self) -> None:
         """
         Clean up the temporary directory that stores the previews.
@@ -477,6 +441,42 @@ class Figure:
         base64_png = base64.encodebytes(raw_png)
         html = '<img src="data:image/png;base64,{image}" width="{width}px">'
         return html.format(image=base64_png.decode("utf-8"), width=500)
+
+    # Attach plotting functions implemented in pygmt.src as Figure methods.
+    basemap = _basemap
+    choropleth = _choropleth
+    coast = _coast
+    colorbar = _colorbar
+    contour = _contour
+    directional_rose = _directional_rose
+    grdcontour = _grdcontour
+    grdimage = _grdimage
+    grdview = _grdview
+    histogram = _histogram
+    hlines = _hlines
+    image = _image
+    inset = _inset
+    legend = _legend
+    logo = _logo
+    magnetic_rose = _magnetic_rose
+    meca = _meca
+    paragraph = _paragraph
+    plot = _plot
+    plot3d = _plot3d
+    psconvert = _psconvert
+    rose = _rose
+    scalebar = _scalebar
+    set_panel = _set_panel
+    shift_origin = _shift_origin
+    solar = _solar
+    subplot = _subplot
+    ternary = _ternary
+    text = _text
+    tilemap = _tilemap
+    timestamp = _timestamp
+    velo = _velo
+    vlines = _vlines
+    wiggle = _wiggle
 
 
 def set_display(method: Literal["external", "notebook", "none", None] = None) -> None:

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -37,7 +37,7 @@ from pygmt.src.solar import solar as _solar
 from pygmt.src.subplot import set_panel as _set_panel
 from pygmt.src.subplot import subplot as _subplot
 from pygmt.src.ternary import ternary as _ternary
-from pygmt.src.text import text_ as _text
+from pygmt.src.text import text as _text
 from pygmt.src.tilemap import tilemap as _tilemap
 from pygmt.src.timestamp import timestamp as _timestamp
 from pygmt.src.velo import velo as _velo

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -9,6 +9,40 @@ from tempfile import TemporaryDirectory
 from typing import Literal, overload
 
 from pygmt._typing import PathLike
+from pygmt.src.basemap import basemap as _basemap
+from pygmt.src.choropleth import choropleth as _choropleth
+from pygmt.src.coast import coast as _coast
+from pygmt.src.colorbar import colorbar as _colorbar
+from pygmt.src.contour import contour as _contour
+from pygmt.src.directional_rose import directional_rose as _directional_rose
+from pygmt.src.grdcontour import grdcontour as _grdcontour
+from pygmt.src.grdimage import grdimage as _grdimage
+from pygmt.src.grdview import grdview as _grdview
+from pygmt.src.histogram import histogram as _histogram
+from pygmt.src.hlines import hlines as _hlines
+from pygmt.src.image import image as _image
+from pygmt.src.inset import inset as _inset
+from pygmt.src.legend import legend as _legend
+from pygmt.src.logo import logo as _logo
+from pygmt.src.magnetic_rose import magnetic_rose as _magnetic_rose
+from pygmt.src.meca import meca as _meca
+from pygmt.src.paragraph import paragraph as _paragraph
+from pygmt.src.plot import plot as _plot
+from pygmt.src.plot3d import plot3d as _plot3d
+from pygmt.src.psconvert import psconvert as _psconvert
+from pygmt.src.rose import rose as _rose
+from pygmt.src.scalebar import scalebar as _scalebar
+from pygmt.src.shift_origin import shift_origin as _shift_origin
+from pygmt.src.solar import solar as _solar
+from pygmt.src.subplot import set_panel as _set_panel
+from pygmt.src.subplot import subplot as _subplot
+from pygmt.src.ternary import ternary as _ternary
+from pygmt.src.text import text_ as _text
+from pygmt.src.tilemap import tilemap as _tilemap
+from pygmt.src.timestamp import timestamp as _timestamp
+from pygmt.src.velo import velo as _velo
+from pygmt.src.vlines import vlines as _vlines
+from pygmt.src.wiggle import wiggle as _wiggle
 
 try:
     import IPython
@@ -408,42 +442,41 @@ class Figure:
         html = '<img src="data:image/png;base64,{image}" width="{width}px">'
         return html.format(image=base64_png.decode("utf-8"), width=500)
 
-    from pygmt.src import (  # type: ignore[misc] # noqa: PLC0415
-        basemap,
-        choropleth,
-        coast,
-        colorbar,
-        contour,
-        directional_rose,
-        grdcontour,
-        grdimage,
-        grdview,
-        histogram,
-        hlines,
-        image,
-        inset,
-        legend,
-        logo,
-        magnetic_rose,
-        meca,
-        paragraph,
-        plot,
-        plot3d,
-        psconvert,
-        rose,
-        scalebar,
-        set_panel,
-        shift_origin,
-        solar,
-        subplot,
-        ternary,
-        text,
-        tilemap,
-        timestamp,
-        velo,
-        vlines,
-        wiggle,
-    )
+    # Attach plotting functions implemented in pygmt.src as Figure methods.
+    basemap = _basemap
+    choropleth = _choropleth
+    coast = _coast
+    colorbar = _colorbar
+    contour = _contour
+    directional_rose = _directional_rose
+    grdcontour = _grdcontour
+    grdimage = _grdimage
+    grdview = _grdview
+    histogram = _histogram
+    hlines = _hlines
+    image = _image
+    inset = _inset
+    legend = _legend
+    logo = _logo
+    magnetic_rose = _magnetic_rose
+    meca = _meca
+    paragraph = _paragraph
+    plot = _plot
+    plot3d = _plot3d
+    psconvert = _psconvert
+    rose = _rose
+    scalebar = _scalebar
+    set_panel = _set_panel
+    shift_origin = _shift_origin
+    solar = _solar
+    subplot = _subplot
+    ternary = _ternary
+    text = _text
+    tilemap = _tilemap
+    timestamp = _timestamp
+    velo = _velo
+    vlines = _vlines
+    wiggle = _wiggle
 
 
 def set_display(method: Literal["external", "notebook", "none", None] = None) -> None:

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -442,7 +442,7 @@ class Figure:
         html = '<img src="data:image/png;base64,{image}" width="{width}px">'
         return html.format(image=base64_png.decode("utf-8"), width=500)
 
-    # Attach plotting functions implemented in pygmt.src as Figure methods.
+    # Attach plotting functions implemented in pygmt/src as Figure methods.
     basemap = _basemap
     choropleth = _choropleth
     coast = _coast

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -136,6 +136,42 @@ class Figure:
         self._preview_dir = TemporaryDirectory(prefix=f"{self._name}-preview-")
         self._activate_figure()
 
+        # Attach plotting functions implemented in pygmt/src as bound instance methods.
+        self.basemap = _basemap
+        self.choropleth = _choropleth
+        self.coast = _coast
+        self.colorbar = _colorbar
+        self.contour = _contour
+        self.directional_rose = _directional_rose
+        self.grdcontour = _grdcontour
+        self.grdimage = _grdimage
+        self.grdview = _grdview
+        self.histogram = _histogram
+        self.hlines = _hlines
+        self.image = _image
+        self.inset = _inset
+        self.legend = _legend
+        self.logo = _logo
+        self.magnetic_rose = _magnetic_rose
+        self.meca = _meca
+        self.paragraph = _paragraph
+        self.plot = _plot
+        self.plot3d = _plot3d
+        self.psconvert = _psconvert
+        self.rose = _rose
+        self.scalebar = _scalebar
+        self.set_panel = _set_panel
+        self.shift_origin = _shift_origin
+        self.solar = _solar
+        self.subplot = _subplot
+        self.ternary = _ternary
+        self.text = _text
+        self.tilemap = _tilemap
+        self.timestamp = _timestamp
+        self.velo = _velo
+        self.vlines = _vlines
+        self.wiggle = _wiggle
+
     def __del__(self) -> None:
         """
         Clean up the temporary directory that stores the previews.
@@ -441,42 +477,6 @@ class Figure:
         base64_png = base64.encodebytes(raw_png)
         html = '<img src="data:image/png;base64,{image}" width="{width}px">'
         return html.format(image=base64_png.decode("utf-8"), width=500)
-
-    # Attach plotting functions implemented in pygmt.src as Figure methods.
-    basemap = _basemap
-    choropleth = _choropleth
-    coast = _coast
-    colorbar = _colorbar
-    contour = _contour
-    directional_rose = _directional_rose
-    grdcontour = _grdcontour
-    grdimage = _grdimage
-    grdview = _grdview
-    histogram = _histogram
-    hlines = _hlines
-    image = _image
-    inset = _inset
-    legend = _legend
-    logo = _logo
-    magnetic_rose = _magnetic_rose
-    meca = _meca
-    paragraph = _paragraph
-    plot = _plot
-    plot3d = _plot3d
-    psconvert = _psconvert
-    rose = _rose
-    scalebar = _scalebar
-    set_panel = _set_panel
-    shift_origin = _shift_origin
-    solar = _solar
-    subplot = _subplot
-    ternary = _ternary
-    text = _text
-    tilemap = _tilemap
-    timestamp = _timestamp
-    velo = _velo
-    vlines = _vlines
-    wiggle = _wiggle
 
 
 def set_display(method: Literal["external", "notebook", "none", None] = None) -> None:

--- a/pygmt/src/__init__.py
+++ b/pygmt/src/__init__.py
@@ -3,7 +3,7 @@ Source code for PyGMT methods.
 """
 
 # Re-export standalone functions that can be used directly.
-# Figure plotting methods are attached in pygmt.figure and are not exported here.
+# Figure plotting methods are attached in pygmt/figure.py and are not exported here.
 from pygmt.src.binstats import binstats
 from pygmt.src.blockm import blockmean, blockmedian, blockmode
 from pygmt.src.config import config

--- a/pygmt/src/__init__.py
+++ b/pygmt/src/__init__.py
@@ -2,27 +2,21 @@
 Source code for PyGMT methods.
 """
 
-from pygmt.src.basemap import basemap
+# Re-export standalone functions that can be used directly.
+# Figure plotting methods are attached in pygmt.figure and are not exported here.
 from pygmt.src.binstats import binstats
 from pygmt.src.blockm import blockmean, blockmedian, blockmode
-from pygmt.src.choropleth import choropleth
-from pygmt.src.coast import coast
-from pygmt.src.colorbar import colorbar
 from pygmt.src.config import config
-from pygmt.src.contour import contour
 from pygmt.src.dimfilter import dimfilter
-from pygmt.src.directional_rose import directional_rose
 from pygmt.src.filter1d import filter1d
 from pygmt.src.grd2cpt import grd2cpt
 from pygmt.src.grd2xyz import grd2xyz
 from pygmt.src.grdclip import grdclip
-from pygmt.src.grdcontour import grdcontour
 from pygmt.src.grdcut import grdcut
 from pygmt.src.grdfill import grdfill
 from pygmt.src.grdfilter import grdfilter
 from pygmt.src.grdgradient import grdgradient
 from pygmt.src.grdhisteq import grdhisteq
-from pygmt.src.grdimage import grdimage
 from pygmt.src.grdinfo import grdinfo
 from pygmt.src.grdlandmask import grdlandmask
 from pygmt.src.grdmask import grdmask
@@ -30,43 +24,18 @@ from pygmt.src.grdpaste import grdpaste
 from pygmt.src.grdproject import grdproject
 from pygmt.src.grdsample import grdsample
 from pygmt.src.grdtrack import grdtrack
-from pygmt.src.grdview import grdview
 from pygmt.src.grdvolume import grdvolume
-from pygmt.src.histogram import histogram
-from pygmt.src.hlines import hlines
-from pygmt.src.image import image
 from pygmt.src.info import info
-from pygmt.src.inset import inset
-from pygmt.src.legend import legend
-from pygmt.src.logo import logo
-from pygmt.src.magnetic_rose import magnetic_rose
 from pygmt.src.makecpt import makecpt
-from pygmt.src.meca import meca
 from pygmt.src.nearneighbor import nearneighbor
-from pygmt.src.paragraph import paragraph
-from pygmt.src.plot import plot
-from pygmt.src.plot3d import plot3d
 from pygmt.src.project import project
-from pygmt.src.psconvert import psconvert
-from pygmt.src.rose import rose
-from pygmt.src.scalebar import scalebar
 from pygmt.src.select import select
-from pygmt.src.shift_origin import shift_origin
-from pygmt.src.solar import solar
 from pygmt.src.sph2grd import sph2grd
 from pygmt.src.sphdistance import sphdistance
 from pygmt.src.sphinterpolate import sphinterpolate
-from pygmt.src.subplot import set_panel, subplot
 from pygmt.src.surface import surface
-from pygmt.src.ternary import ternary
-from pygmt.src.text import text_ as text  # "text" is an argument within "text_"
-from pygmt.src.tilemap import tilemap
-from pygmt.src.timestamp import timestamp
 from pygmt.src.triangulate import triangulate
-from pygmt.src.velo import velo
-from pygmt.src.vlines import vlines
 from pygmt.src.which import which
-from pygmt.src.wiggle import wiggle
 from pygmt.src.x2sys_cross import x2sys_cross
 from pygmt.src.x2sys_init import x2sys_init
 from pygmt.src.xyz2grd import xyz2grd

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -33,7 +33,7 @@ from pygmt.params import Axis, Frame
     it="use_word",
     w="wrap",
 )
-def text_(  # noqa: PLR0912, PLR0913, PLR0915
+def text(  # noqa: PLR0912, PLR0913, PLR0915
     self,
     textfiles: PathLike | TableLike | None = None,
     x=None,


### PR DESCRIPTION
## Motivation

In PR #3849, we're seeing many static type check errors (https://github.com/GenericMappingTools/pygmt/actions/runs/25118862756/job/73613589767?pr=3849), mainly because in `pygmtlogo`, we're trying to re-import the `Figure` class, which causes some circular imports. 

Codex recommends a different way to attach the plotting wrappers to the `Figure` class, which can solve the static type error found in PR #3849. Changes in this PR are made by Codex.

## Summary
This PR refactors how plotting methods are attached to `pygmt.Figure` and clarifies the role of `pygmt.src`.

## Why
Previously, `Figure` methods were attached through a class-scoped `from pygmt.src import (...)` block in `pygmt/figure.py`. That worked at runtime, but it had a few drawbacks:

- It depended on package-level re-exports from `pygmt/src/__init__.py` just to populate `Figure`.
- Static analysis could misinterpret some imported names as modules instead of callables. (see the mypy errors in found https://github.com/GenericMappingTools/pygmt/actions/runs/25118862756/job/73613589767?pr=3849)
- The class-scoped import block was harder to read and maintain than explicit assignments.
- It blurred two separate concepts:
  - standalone functions that are part of the functional API
  - plotting functions that are intended to be used as methods of `Figure`

## What changed
### `pygmt/figure.py`
- Import each plotting callable directly from its concrete `pygmt.src.*` module.
- Attach these callables explicitly on the `Figure` class body, e.g. `plot = _plot`.
- Add a short comment above the attachment block to clarify the pattern.

### `pygmt/src/__init__.py`
- Keep only standalone functions that are intended to be called directly.
- Stop re-exporting `Figure`-bound plotting methods from `pygmt.src`.
- Add a short comment explaining the distinction between standalone functions and `Figure` methods.

## Why this is better
This makes the API structure clearer:

- `pygmt.src` becomes a cleaner namespace for standalone operations.
- `Figure` is the clear home for plotting methods.

It also improves maintainability:

- Each attached `Figure` method points to one explicit source module.
- The attachment logic is easier to scan and modify.
- `Figure` no longer depends on package-level re-export behavior for method attachment.
- The structure is friendlier to static analysis and code review.

## Behavioral intent
This is intended as an internal API-structure cleanup, not a plotting behavior change. The plotting implementations themselves are unchanged; only the way they are attached/exported has been reorganized.