### PR TITLE
CI: Set concurrency for Cache Data workflow and fix runner typo

### DIFF
--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -27,6 +27,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gmt_cache:
     name: Cache GMT artifacts

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -30,7 +30,7 @@ permissions: {}
 jobs:
   gmt_cache:
     name: Cache GMT artifacts
-    runs-on: macos-slim
+    runs-on: ubuntu-slim
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
**Description of proposed changes**

Fix a typo in the runner machine used (macos-slim -> ubuntu-slim) which meant Cache Data workflow hasn't been running for the entire April 2026 (see https://github.com/GenericMappingTools/pygmt/actions/workflows/cache_data.yaml?query=branch%3Amain). Also set a concurrency limit in the `cache_data.yaml` workflow - https://docs.zizmor.sh/audits/#concurrency-limits

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Patches #4488


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
