### PR TITLE
CI: Check DVC isexec metadata in "Style Checks" workflow

### DIFF
--- a/.github/workflows/style_checks.yaml
+++ b/.github/workflows/style_checks.yaml
@@ -66,3 +66,14 @@ jobs:
             rm output.txt
             exit $nfiles
           fi
+
+      - name: Ensure baseline PNG DVC metadata does not mark files executable
+        run: |
+          grep -l '^[[:space:]]*isexec:[[:space:]]*true$' pygmt/tests/baseline/*.png.dvc > output.txt || true
+          nfiles=$(wc --lines output.txt | awk '{print $1}')
+          if [[ $nfiles > 0 ]]; then
+            echo "The following baseline PNG DVC files mark images as executable:"
+            cat output.txt
+            rm output.txt
+            exit $nfiles
+          fi

--- a/pygmt/tests/baseline/test_grdcontour_multiple_levels.png.dvc
+++ b/pygmt/tests/baseline/test_grdcontour_multiple_levels.png.dvc
@@ -1,6 +1,5 @@
 outs:
 - md5: 4d20cdb71af2e6568f64f0246ec860ea
   size: 64008
-  isexec: true
   hash: md5
   path: test_grdcontour_multiple_levels.png

--- a/pygmt/tests/baseline/test_grdcontour_one_level.png.dvc
+++ b/pygmt/tests/baseline/test_grdcontour_one_level.png.dvc
@@ -1,6 +1,5 @@
 outs:
 - md5: fc624766f0b8eac8206735a05c7c9662
   size: 45023
-  isexec: true
   hash: md5
   path: test_grdcontour_one_level.png


### PR DESCRIPTION
## Summary
- add a style-check workflow step that scans baseline .png.dvc files for isexec: true
- fail the workflow if any baseline DVC metadata marks a PNG as executable
- avoid pulling baseline images from DVC because the metadata check is sufficient
- Fix permission issue in two baseline images
