### PR TITLE
Figure.pygmtlogo: Force the default logo size to 2-cm and rename test_pygmtlogo to test_pygmtlogo_circle_no_wordmark

### DIFF
--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -30,6 +30,7 @@ def _create_logo(  # noqa: PLR0915
     from pygmt.figure import Figure  # noqa: PLC0415
 
     # Helpful definitions
+    # See https://github.com/GenericMappingTools/pygmt/pull/4617#issuecomment-4366140123
     size = 4.1615  # size to make the circular logo 2-cm wide when plotted with 300 dpi.
     region = [-size, size] * 2
     proj = "x1c"

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -30,7 +30,7 @@ def _create_logo(  # noqa: PLR0915
     from pygmt.figure import Figure  # noqa: PLC0415
 
     # Helpful definitions
-    size = 4
+    size = 4.1615  # size to make the circular logo 2-cm wide when plotted with 300 dpi.
     region = [-size, size] * 2
     proj = "x1c"
     # Rotation around z-axis by 30 degrees counter-clockwise placed in the center.

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -30,7 +30,7 @@ def _create_logo(  # noqa: PLR0915
     from pygmt.figure import Figure  # noqa: PLC0415
 
     # Helpful definitions
-    size = 4.1615  # size to make the circular logo 2-cm wide when plotted with 300 dpi.
+    size = 4
     region = [-size, size] * 2
     proj = "x1c"
     # Rotation around z-axis by 30 degrees counter-clockwise placed in the center.

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -30,7 +30,6 @@ def _create_logo(  # noqa: PLR0915
     from pygmt.figure import Figure  # noqa: PLC0415
 
     # Helpful definitions
-    # See https://github.com/GenericMappingTools/pygmt/pull/4617#issuecomment-4366140123
     size = 4.1615  # size to make the circular logo 2-cm wide when plotted with 300 dpi.
     region = [-size, size] * 2
     proj = "x1c"

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -10,6 +10,7 @@ from typing import Literal
 
 import numpy as np
 from pygmt._typing import AnchorCode, PathLike
+from pygmt.exceptions import GMTValueError
 from pygmt.helpers import GMTTempFile, fmt_docstring
 from pygmt.params import Box, Position
 
@@ -304,7 +305,8 @@ def pygmtlogo(  # noqa: PLR0913
     width
     height
         Width or height of the PyGMT logo. Since the aspect ratio is fixed, only one of
-        the two can be specified.
+        the two can be specified. If not specified, the default size of the visual logo
+        is set to 2 cm.
     box
         Draw a background box behind the logo. If set to ``True``, a simple rectangular
         box is drawn using :gmt-term:`MAP_FRAME_PEN`. To customize the box appearance,
@@ -333,6 +335,20 @@ def pygmtlogo(  # noqa: PLR0913
     >>> fig.pygmtlogo(wordmark="horizontal", position="BR", height="1c")
     >>> fig.show()
     """
+    # Set the default size of the visual logo to 2 cm.
+    if width is None and height is None:
+        match wordmark:
+            case "none" | "vertical":
+                width = width or "2c"
+            case "horizontal":
+                height = height or "2c"
+            case _:
+                raise GMTValueError(
+                    wordmark,
+                    description="value for wordmark",
+                    choices={"none", "horizontal", "vertical"},
+                )
+
     with GMTTempFile(suffix=".eps") as logofile:
         # Create logo file
         _create_logo(

--- a/pygmt/tests/baseline/test_pygmtlogo.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo.png.dvc
@@ -1,5 +1,0 @@
-outs:
-- md5: 35c59c31c92f13c705a24933465ff551
-  size: 14374
-  hash: md5
-  path: test_pygmtlogo.png

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_no_wordmark.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_no_wordmark.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: f71418c9c7566665086b6b250cc564c4
-  size: 18618
+- md5: b1dee02932b292335cf5f8b95676a258
+  size: 19161
   hash: md5
   path: test_pygmtlogo_circle_no_wordmark.png

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_no_wordmark.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_no_wordmark.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: f51201395f10bc1abce47b44a35b409e
-  size: 19234
+- md5: f71418c9c7566665086b6b250cc564c4
+  size: 18618
   hash: md5
   path: test_pygmtlogo_circle_no_wordmark.png

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_no_wordmark.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_no_wordmark.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: f71418c9c7566665086b6b250cc564c4
-  size: 18618
+- md5: f51201395f10bc1abce47b44a35b409e
+  size: 19234
   hash: md5
   path: test_pygmtlogo_circle_no_wordmark.png

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_no_wordmark.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_no_wordmark.png.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: f71418c9c7566665086b6b250cc564c4
+  size: 18618
+  hash: md5
+  path: test_pygmtlogo_circle_no_wordmark.png

--- a/pygmt/tests/test_pygmtlogo.py
+++ b/pygmt/tests/test_pygmtlogo.py
@@ -4,16 +4,22 @@ Test Figure.pygmtlogo.
 
 import pytest
 from pygmt import Figure
+from pygmt.params import Axis, Position
 
 
-@pytest.mark.benchmark
 @pytest.mark.mpl_image_compare
-def test_pygmtlogo():
+def test_pygmtlogo_circle_no_wordmark():
     """
     Plot the default PyGMT logo, colored, light and dark themes, without wordmark.
     """
     fig = Figure()
-    fig.pygmtlogo()
-    fig.shift_origin(xshift="+w")
-    fig.pygmtlogo(theme="dark")
+    fig.basemap(region=[-0.5, 5.0, -0.5, 5.0], projection="x1c", frame=Axis(grid=0.5))
+    fig.pygmtlogo(
+        position=Position((1, 3.5), anchor="CM", cstype="mapcoords"),
+        theme="light",
+    )
+    fig.pygmtlogo(
+        position=Position((3.5, 3.5), anchor="CM", cstype="mapcoords"),
+        theme="dark",
+    )
     return fig

--- a/pygmt/tests/test_pygmtlogo.py
+++ b/pygmt/tests/test_pygmtlogo.py
@@ -10,7 +10,8 @@ from pygmt.params import Axis, Position
 @pytest.mark.mpl_image_compare
 def test_pygmtlogo_circle_no_wordmark():
     """
-    Plot the default PyGMT logo, colored, light and dark themes, without wordmark.
+    Test the PyGMT circular logo without the wordmark, including both light/dark themes,
+    and colored/black-and-white versions.
     """
     fig = Figure()
     fig.basemap(region=[-0.5, 5.0, -0.5, 5.0], projection="x1c", frame=Axis(grid=0.5))


### PR DESCRIPTION
As shown in the table in PR https://github.com/GenericMappingTools/pygmt/pull/4616, we will likely have 24 PyGMT logo variants. Maintaining 24 separate baseline images is impractical, so we plan to group multiple variants into a single test. A reasonable approach is to define six tests based on logo shape and wordmark configuration. Each test would include four variants: colored and black-and-white logos in both light and dark themes.

This PR renames the existing test from test_pygmtlogo (which is too general) to test_pygmtlogo_circle_no_wordmark. It also adds a basemap to make the default logo size easier to inspect.

It appears that the default width/height of the logos is slightly smaller than 2 cm, although I am not sure why this value is used.