### PR TITLE
Figure.pygmtlogo: Add a test to check the design details of the circular logo

### DIFF
--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -61,7 +61,6 @@ jobs:
     - name: Generate the image diff report
       env:
         REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         DAGSHUB_TOKEN: ${{ secrets.DAGSHUB_TOKEN }}
       run: |
@@ -73,7 +72,7 @@ jobs:
 
         # Pull image data from cloud storage
         dvc pull --remote upstream
-        dvc diff --md "${PR_BASE_REF}" HEAD >> report.md
+        dvc diff --md main HEAD >> report.md
 
         # Get just the filename of the added and modified image from the report
         awk 'NF==5 && NR>=7 && $2=="added" {print $4}' report.md > added_files.txt
@@ -82,8 +81,8 @@ jobs:
         # Backup new images in the baseline-new directory
         mkdir pygmt/tests/baseline-new
         cp pygmt/tests/baseline/*.png pygmt/tests/baseline-new/
-        # Pull images in the PR base branch from cloud storage
-        git checkout "${PR_BASE_REF}"
+        # Pull images in the main branch from cloud storage
+        git checkout main
         dvc pull --remote upstream --force
 
         # Append each image to the markdown report

--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Generate the image diff report
       env:
         REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         DAGSHUB_TOKEN: ${{ secrets.DAGSHUB_TOKEN }}
       run: |
@@ -72,7 +73,7 @@ jobs:
 
         # Pull image data from cloud storage
         dvc pull --remote upstream
-        dvc diff --md main HEAD >> report.md
+        dvc diff --md "${PR_BASE_REF}" HEAD >> report.md
 
         # Get just the filename of the added and modified image from the report
         awk 'NF==5 && NR>=7 && $2=="added" {print $4}' report.md > added_files.txt
@@ -81,8 +82,8 @@ jobs:
         # Backup new images in the baseline-new directory
         mkdir pygmt/tests/baseline-new
         cp pygmt/tests/baseline/*.png pygmt/tests/baseline-new/
-        # Pull images in the main branch from cloud storage
-        git checkout main
+        # Pull images in the PR base branch from cloud storage
+        git checkout "${PR_BASE_REF}"
         dvc pull --remote upstream --force
 
         # Append each image to the markdown report

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -17,12 +17,12 @@ from pygmt.params import Box, Position
 __doctest_skip__ = ["pygmtlogo"]
 
 
-def _create_logo(  # noqa: PLR0915
+def _create_logo(  # noqa: PLR0915, PLR0912
     shape: Literal["circle", "hexagon"] = "circle",
     theme: Literal["light", "dark"] = "light",
     wordmark: Literal["none", "horizontal", "vertical"] = "none",
     color: bool = True,
-    figname: PathLike = "pygmt_logo.eps",
+    figname: PathLike | None = None,
     debug: bool = False,
 ):
     """
@@ -236,8 +236,8 @@ def _create_logo(  # noqa: PLR0915
         from pygmt import config  # noqa: PLC0415
 
         # Gridlines
-        with config(MAP_FRAME_TYPE="inside", MAP_GRID_PEN="0.1p,gray30"):
-            fig.basemap(frame="g1")
+        with config(MAP_GRID_PEN="0.1p,gray30"):
+            fig.basemap(frame="00g1")
         # Circles for the different radii
         for r in [r0, r1, r2, r3, r4, r5]:
             fig.plot(x=0, y=0, style=f"c{2 * r}c", pen="0.3p,gray30")
@@ -247,7 +247,10 @@ def _create_logo(  # noqa: PLR0915
         fig.hlines(y=[r4, r5], xmin=-3, pen=pen, perspective=True)
         fig.vlines(x=[r4, (thick_gap + r4) / 2], ymax=3, pen=pen, perspective=True)
 
-    fig.savefig(fname=figname)
+    if figname:
+        fig.savefig(fname=figname)
+        return None
+    return fig
 
 
 @fmt_docstring

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_design.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_design.png.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 2d9fd4fdb1189514d374500d5f4add73
+  size: 149683
+  hash: md5
+  path: test_pygmtlogo_circle_design.png

--- a/pygmt/tests/test_pygmtlogo.py
+++ b/pygmt/tests/test_pygmtlogo.py
@@ -5,6 +5,20 @@ Test Figure.pygmtlogo.
 import pytest
 from pygmt import Figure
 from pygmt.params import Axis, Position
+from pygmt.src.pygmtlogo import _create_logo
+
+
+@pytest.mark.mpl_image_compare(savefig_kwargs={"dpi": 600})
+def test_pygmtlogo_circle_design():
+    """
+    Test the design details of the PyGMT circular logo.
+
+    This is a regression test to ensure that the design of the logo does not change
+    unintentionally. The debugging lines (gridlines and circles) are helpful for
+    implementing the logo, but they are not included in the final logo design.
+    """
+    fig = _create_logo(debug=True)
+    return fig
 
 
 @pytest.mark.mpl_image_compare


### PR DESCRIPTION
The existing test `test_pygmtlogo_circle_no_wordmark` works well for testing different variants of the PyGMT logos. However, the baseline image is relatively small (2-cm) and low resolution (maybe 150 dpi?), making minor logo changes difficult to detect. 

This PR adds a new test to verify the correctness of the circular logo, including all debugging gridlines and circles. The logo is 8 cm wide, and the baseline image is saved at 600 dpi, making the test more sensitive to subtle changes.
