### PR TITLE
CI: Fix the DVC Diff workflow for non-main PR base branches

### DIFF
--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Generate the image diff report
       env:
         REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         DAGSHUB_TOKEN: ${{ secrets.DAGSHUB_TOKEN }}
       run: |
@@ -72,7 +73,7 @@ jobs:
 
         # Pull image data from cloud storage
         dvc pull --remote upstream
-        dvc diff --md main HEAD >> report.md
+        dvc diff --md "${PR_BASE_REF}" HEAD >> report.md
 
         # Get just the filename of the added and modified image from the report
         awk 'NF==5 && NR>=7 && $2=="added" {print $4}' report.md > added_files.txt
@@ -81,8 +82,8 @@ jobs:
         # Backup new images in the baseline-new directory
         mkdir pygmt/tests/baseline-new
         cp pygmt/tests/baseline/*.png pygmt/tests/baseline-new/
-        # Pull images in the main branch from cloud storage
-        git checkout main
+        # Pull images in the PR base branch from cloud storage
+        git checkout "${PR_BASE_REF}"
         dvc pull --remote upstream --force
 
         # Append each image to the markdown report


### PR DESCRIPTION
The DVC Diff workflow always checks against the main branch, which doesn't work for PRs whose base branch is not the main branch, like https://github.com/GenericMappingTools/pygmt/pull/4623.

This PR fixes the issue. It works as expected as can be seen in the commit history in https://github.com/GenericMappingTools/pygmt/pull/4623.