### PR TITLE
Figure.pygmtlogo: Add tests for the circular, black/white PyGMT logo

### DIFF
--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -221,7 +221,7 @@ def _create_logo(  # noqa: PLR0915, PLR0912
             x=0,
             y=0,
             style=f"{symbol}{size_shape + thick_shape}c",
-            pen=f"1p,{color_dark}",
+            pen=f"{thick_comp / 2.0}c,{color_bg}",
             perspective=True,
             no_clip=True,
         )

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_no_wordmark.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_no_wordmark.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: b1dee02932b292335cf5f8b95676a258
-  size: 19161
+- md5: dcb54b2c28e02c4fc83d38278b2700c6
+  size: 31454
   hash: md5
   path: test_pygmtlogo_circle_no_wordmark.png

--- a/pygmt/tests/test_pygmtlogo.py
+++ b/pygmt/tests/test_pygmtlogo.py
@@ -37,4 +37,14 @@ def test_pygmtlogo_circle_no_wordmark():
         position=Position((3.5, 3.5), anchor="CM", cstype="mapcoords"),
         theme="dark",
     )
+    fig.pygmtlogo(
+        position=Position((1, 1), anchor="CM", cstype="mapcoords"),
+        theme="light",
+        color=False,
+    )
+    fig.pygmtlogo(
+        position=Position((3.5, 1), anchor="CM", cstype="mapcoords"),
+        theme="dark",
+        color=False,
+    )
     return fig


### PR DESCRIPTION
Finalize the circular, black/white PyGMT logo for both light/dark themes.