### PR TITLE
Fix two static type errors reported by mypy 2.0.0

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -110,7 +110,7 @@ DTYPES_TEXT = {
 DTYPES = DTYPES_NUMERIC | DTYPES_TEXT
 
 # Dictionary for storing the values of GMT constants.
-GMT_CONSTANTS = {}
+GMT_CONSTANTS: dict[str, int] = {}
 
 # Load the GMT library outside the Session class to avoid repeated loading.
 _libgmt = load_libgmt()

--- a/pygmt/figure.py
+++ b/pygmt/figure.py
@@ -93,7 +93,7 @@ def _get_default_display_method() -> Literal["external", "notebook", "none"]:
 
 # A registry of all figures that have had "show" called in this session.
 # This is needed for the sphinx-gallery scraper in pygmt/sphinx_gallery.py
-SHOWED_FIGURES = []
+SHOWED_FIGURES: list["Figure"] = []
 # Configurations for figure display.
 SHOW_CONFIG = {
     "method": _get_default_display_method(),  # The image preview display method.


### PR DESCRIPTION
The new mypy v2.0.0 reports two new errors:

```
mypy pygmt
pygmt/clib/session.py:113: error: Need type annotation for "GMT_CONSTANTS" (hint: "GMT_CONSTANTS: dict[<type>, <type>] = ...")  [var-annotated]
pygmt/figure.py:96: error: Need type annotation for "SHOWED_FIGURES" (hint: "SHOWED_FIGURES: list[<type>] = ...")  [var-annotated]
Found 2 errors in 2 files (checked 128 source files)
make: *** [Makefile:74: typecheck] Error 1
```

xref: https://github.com/GenericMappingTools/pygmt/actions/runs/25474333778/job/74744492600

