### PR TITLE
Figure.set_panel: Fix the bug when panel is not set

### DIFF
--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -419,13 +419,11 @@ def set_panel(
     aliasdict = AliasSystem(A=Alias(tag, name="tag")).add_common(V=verbose)
     aliasdict.merge(kwargs)
 
+    args = ["set"]
+    if panel is not None:
+        args.append(Alias(panel, name="panel", sep=",", size=2)._value)  # type: ignore[arg-type]
+    args.extend(build_arg_list(aliasdict))
+
     with Session() as lib:
-        lib.call_module(
-            module="subplot",
-            args=[
-                "set",
-                Alias(panel, name="panel", sep=",", size=2)._value,
-                *build_arg_list(aliasdict),
-            ],
-        )
+        lib.call_module(module="subplot", args=args)
         yield

--- a/pygmt/tests/test_subplot.py
+++ b/pygmt/tests/test_subplot.py
@@ -132,6 +132,25 @@ def test_subplot_outside_plotting_positioning():
     return fig
 
 
+@pytest.mark.mpl_image_compare(filename="test_subplot_basic_frame.png")
+def test_subplot_set_panel_without_panel():
+    """
+    Ensure Figure.set_panel works when panel is omitted.
+
+    Omitting ``panel`` should let GMT advance to the next panel according to the subplot
+    order instead of passing an invalid ``None`` argument to the C API.
+
+    Use the baseline image from test_subplot_basic_frame.
+    """
+    fig = Figure()
+    with fig.subplot(nrows=1, ncols=2, figsize=("6c", "3c"), frame=Frame(axes="WSne")):
+        with fig.set_panel():
+            fig.basemap(region=[0, 3, 0, 3], frame=Frame(title="plot0"))
+        with fig.set_panel():
+            fig.basemap(region=[0, 3, 0, 3], frame=Frame(title="plot1"))
+    return fig
+
+
 def test_subplot_deprecated_autolabel():
     """
     Test that using the deprecated autolabel parameter raises a warning when conflicted


### PR DESCRIPTION
In the GMT CLI, using `gmt subplot set` without specifying the panel activates the next panel. For example:
```
gmt begin map
	gmt subplot begin 1x2 -Fs6c/3c
	gmt subplot set
	gmt basemap -R0/3/0/3 -B
	gmt subplot set 
	gmt basemap -R0/3/0/3 -B
	gmt subplot end
gmt end show

```


 The equivalent PyGMT script is:
```python
import pygmt

fig = pygmt.Figure()
with fig.subplot(nrows=1, ncols=2, figsize=("6c", "3c")):
     with fig.set_panel():
         fig.basemap(region=[0, 3, 0, 3], frame=True)
     with fig.set_panel():
         fig.basemap(region=[0, 3, 0, 3], frame=True)
fig.show()
```
But it doesn't work as expected:
```
subplot [ERROR]: No subplot information file!
...
```
The bug is because we always pass `panel` to `gmt subplot set` even if it's `None`. The bug can be traced back to the initial implementation in PR #822.

This PR fixes the long-term bug and add a test for it.