### PR TITLE
Figure.pygmtlogo: Set the region based on wordmark for easier design

### DIFF
--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -246,7 +246,7 @@ def _create_logo(  # noqa: PLR0915
         # Lines for letter M
         fig.hlines(y=[r4, r5], xmin=-size, xmax=size, pen=pen, perspective=True)
         m_mid = (thick_gap + r4) / 2
-        fig.vlines(x=[r4, m_mid], ymin=size, ymax=size, pen=pen, perspective=True)
+        fig.vlines(x=[r4, m_mid], ymin=-size, ymax=size, pen=pen, perspective=True)
 
     if figname:
         fig.savefig(fname=figname)

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -32,8 +32,13 @@ def _create_logo(  # noqa: PLR0915
 
     # Helpful definitions
     size = 4
-    region = [-size, size] * 2
     proj = "x1c"
+    region = {
+        "horizontal": [-size, size * 8.0, -size, size],
+        "vertical": [-size, size, -size * 1.75, size],
+        "none": [-size, size, -size, size],
+    }[wordmark]
+
     # Rotation around z-axis by 30 degrees counter-clockwise placed in the center.
     perspective = "30+w0/0"
 
@@ -240,8 +245,9 @@ def _create_logo(  # noqa: PLR0915
         pen = "0.3p,gray30,2_2"
         fig.plot(x=0, y=0, style=f"c{2 * (r2 + (r3 - r4))}c", pen=pen)
         # Lines for letter M
-        fig.hlines(y=[r4, r5], xmin=-3, pen=pen, perspective=True)
-        fig.vlines(x=[r4, (thick_gap + r4) / 2], ymax=3, pen=pen, perspective=True)
+        fig.hlines(y=[r4, r5], xmin=-size, xmax=size, pen=pen, perspective=True)
+        m_mid = (thick_gap + r4) / 2
+        fig.vlines(x=[r4, m_mid], ymin=size, ymax=size, pen=pen, perspective=True)
 
     if figname:
         fig.savefig(fname=figname)

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -244,9 +244,10 @@ def _create_logo(  # noqa: PLR0915
         pen = "0.3p,gray30,2_2"
         fig.plot(x=0, y=0, style=f"c{2 * (r2 + (r3 - r4))}c", pen=pen)
         # Lines for letter M
-        fig.hlines(y=[r4, r5], xmin=-size, xmax=size, pen=pen, perspective=True)
+        size_s = size - size * 0.1
+        fig.hlines(y=[r4, r5], xmin=-size_s, xmax=size_s, pen=pen, perspective=True)
         m_mid = (thick_gap + r4) / 2
-        fig.vlines(x=[r4, m_mid], ymin=-size, ymax=size, pen=pen, perspective=True)
+        fig.vlines(x=[r4, m_mid], ymin=-size_s, ymax=size_s, pen=pen, perspective=True)
 
     if figname:
         fig.savefig(fname=figname)

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -244,7 +244,7 @@ def _create_logo(  # noqa: PLR0915
         pen = "0.3p,gray30,2_2"
         fig.plot(x=0, y=0, style=f"c{2 * (r2 + (r3 - r4))}c", pen=pen)
         # Lines for letter M
-        size_s = size - size * 0.1
+        size_s = 0.9 * size
         fig.hlines(y=[r4, r5], xmin=-size_s, xmax=size_s, pen=pen, perspective=True)
         m_mid = (thick_gap + r4) / 2
         fig.vlines(x=[r4, m_mid], ymin=-size_s, ymax=size_s, pen=pen, perspective=True)

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -82,7 +82,7 @@ def _create_logo(  # noqa: PLR0915
     font = "AvantGarde-Book"
     match wordmark:
         case "vertical":
-            args_text_wm = {"x": 0, "y": -4.5, "justify": "CT", "font": f"2.5c,{font}"}
+            args_text_wm = {"x": 0, "y": -4.5, "justify": "CT", "font": f"2.4c,{font}"}
         case "horizontal":
             args_text_wm = {"x": 4.5, "y": 0.8, "justify": "LM", "font": f"8c,{font}"}
 
@@ -229,8 +229,7 @@ def _create_logo(  # noqa: PLR0915
 
     # Add wordmark "PyGMT"
     if wordmark != "none":
-        text_wm = f"@;{color_py};Py@;;@;{color_gmt};GMT@;;"
-        fig.text(text=text_wm, no_clip=True, **args_text_wm)
+        fig.text(text=f"@;{color_py};Py@;;@;{color_gmt};GMT@;;", **args_text_wm)
 
     # Helpful for implementing the logo; not included in the logo
     if debug:

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_design.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_design.png.dvc
@@ -1,5 +1,0 @@
-outs:
-- md5: 2d9fd4fdb1189514d374500d5f4add73
-  size: 149683
-  hash: md5
-  path: test_pygmtlogo_circle_design.png

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_design_horizontal.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_design_horizontal.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: e6e13c62a596732ba3814ffbc1fa9106
-  size: 324924
+- md5: b4eccfc768721e990b08bf152116cc1e
+  size: 341246
   hash: md5
   path: test_pygmtlogo_circle_design_horizontal.png

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_design_horizontal.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_design_horizontal.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: b4eccfc768721e990b08bf152116cc1e
-  size: 341246
+- md5: de3f281a09815faff7fed339c1635bc5
+  size: 336254
   hash: md5
   path: test_pygmtlogo_circle_design_horizontal.png

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_design_horizontal.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_design_horizontal.png.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: aa81800cf61690b943b169acea92e598
+  size: 324892
+  hash: md5
+  path: test_pygmtlogo_circle_design_horizontal.png

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_design_vertical.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_design_vertical.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 5beafa63fb8c268c30f7b297ca095860
-  size: 177426
+- md5: dd09fa24c575eabac7659dc49f313f5f
+  size: 173671
   hash: md5
   path: test_pygmtlogo_circle_design_vertical.png

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_design_vertical.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_design_vertical.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: b04f10a219d1a2b92dedc721e349dc6b
-  size: 165671
+- md5: 5beafa63fb8c268c30f7b297ca095860
+  size: 177426
   hash: md5
   path: test_pygmtlogo_circle_design_vertical.png

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_design_vertical.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_design_vertical.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 9ce3200ca60b01c36fcf9270202d6556
-  size: 166673
+- md5: da5592bdda31790b6c3d136145bb4033
+  size: 165637
   hash: md5
   path: test_pygmtlogo_circle_design_vertical.png

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_design_vertical.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_design_vertical.png.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 9ce3200ca60b01c36fcf9270202d6556
+  size: 166673
+  hash: md5
+  path: test_pygmtlogo_circle_design_vertical.png

--- a/pygmt/tests/test_pygmtlogo.py
+++ b/pygmt/tests/test_pygmtlogo.py
@@ -9,15 +9,16 @@ from pygmt.src.pygmtlogo import _create_logo
 
 
 @pytest.mark.mpl_image_compare(savefig_kwargs={"dpi": 600})
-def test_pygmtlogo_circle_design():
+@pytest.mark.parametrize("wordmark", ["horizontal", "vertical"])
+def test_pygmtlogo_circle_design(wordmark):
     """
-    Test the design details of the PyGMT circular logo.
+    Test the design details of the PyGMT circular logo, with a wordmark.
 
     This is a regression test to ensure that the design of the logo does not change
     unintentionally. The debugging lines (gridlines and circles) are helpful for
     implementing the logo, but they are not included in the final logo design.
     """
-    fig = _create_logo(debug=True)
+    fig = _create_logo(debug=True, wordmark=wordmark)
     return fig
 
 


### PR DESCRIPTION
Currently, the `region` is set to `[-4, 4, -4, 4]`. The issues are:

1. We need to use `no_clip=True` when adding the wordmark
2. We can't adding debugging lines (gridlines) for wordmarks, so we can't control the size of the wordmark accurately.

This PR does three things:

- sets the `region` based on `wordmark`, i.e., larger x-range for horizontal wordmark and larger y-range for vertical wordmark
- slightly modifies the code for adding debugging lines to ensure the debugging lines are plotted inside the visual logo only
- adds two baseline images for the logo design with horizontal/vertical wordmark. The orginal baseline image for a visual logo without a wordmark is no longer needed, because  it's already covered by the two new baseline images.

~~Ideally, we should be able to remove the `no_clip=True` argument from the `Figure.text` call. But as you can see, the wordmark in the vertical version is slightly wider than the visual logo.~~

Edit: I've slightly decreased the font size for the vertical wordmark, and then remove the `no_clip` parameter from `Figure.text`.

| Old version | New version |
|---|---|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/66c903a6-3876-4a9d-becb-3fe941fb8d27" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/cefdf70e-43ac-482b-9bd7-3f143c7d4149" />|

Please note that the design of wordmarks is still ongoing in PR #4627. So, this PR focuses on adding tests to make the wordmark design easier.