### PR TITLE
Figure.pygmtlogo: Increase the gap around the vertical red line and arrow

### DIFF
--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -139,14 +139,21 @@ def _create_logo(  # noqa: PLR0915
         mask = np.abs(t_x) <= (thick_gap + r4) / 2
         return {"x": t_x[mask], "y": t_y[mask]}
 
+    def _vline_coords():
+        """
+        Coordinates for the vertical line at the top.
+        """
+        x0 = thick_gt / 2
+        return {"x": [-x0, -x0, x0, x0], "y": [r0, r3, r3, r0]}
+
     def _bg_arrow_coords():
         """Coordinates for the background arrow."""
         # x0, y0 is the same as in _letter_t_coords().
         x0 = thick_gt / 2
         y0 = 1.8 * x0 * np.sqrt(3)
-        # The background arrow is thick_comp wider than the letter T.
-        x1 = x0 + thick_comp / 2.0  # Half-width of the arrow tail
-        x2 = 2 * x0 + thick_comp / np.sqrt(3)  # Half-width of the arrow head
+        # The background arrow 2*thick_gap wider than the letter T.
+        x1 = x0 + thick_gap  # Half-width of the arrow tail
+        x2 = 2 * (x0 + thick_gap / np.sqrt(3))  # Half-width of the arrow head
 
         arrow_x = [-x1, -x1, -x2, -(x2 - 2 * x0), (x2 - 2 * x0), x2, x1, x1]
         arrow_y = [r0, -r0 + y0, -r0 + y0, -r0, -r0, -r0 + y0, -r0 + y0, r0]
@@ -168,13 +175,6 @@ def _create_logo(  # noqa: PLR0915
             (x1, y1, x3, y3),  # upper right
             (x1, -y1, x2, -y2),  # lower right
         ]
-
-    def _vline_coords():
-        """
-        Coordinates for the vertical line at the top.
-        """
-        x0 = thick_gt / 2
-        return {"x": [-x0, -x0, x0, x0], "y": [r0, r3, r3, r0]}
 
     fig = Figure()
     fig.basemap(region=region, projection=proj, perspective=perspective, frame="none")

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_design.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_design.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 2d9fd4fdb1189514d374500d5f4add73
-  size: 149683
+- md5: 459b74dee35adcb7f3519269ad49668d
+  size: 149831
   hash: md5
   path: test_pygmtlogo_circle_design.png

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_no_wordmark.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_no_wordmark.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: dcb54b2c28e02c4fc83d38278b2700c6
-  size: 31454
+- md5: 781ac55a32194d2818a1d96ab2d32727
+  size: 31485
   hash: md5
   path: test_pygmtlogo_circle_no_wordmark.png


### PR DESCRIPTION
Currently, the gap between the vertical red line and the outline shape is set to `thick_comp / 2`, i.e., half the thickness of the compass line. This value was chosen arbitrarily.

This PR changes the gap from `thick_comp / 2` to `thick_gap`, making it consistent with the gap between the letters G and M. The new gap is slightly larger, making it more visible when logos are small.

After this change, the variable `thick_comp` is used only for the compass lines.

| Old | New |
|---|---|
| <img width="1892" height="1892" alt="image" src="https://github.com/user-attachments/assets/28214018-0d48-4b86-82f9-0afdc7198cea" /> | <img width="1892" height="1892" alt="image" src="https://github.com/user-attachments/assets/3951e9bc-c12f-4a20-be02-8c0a4359febe" />|

