### PR TITLE
Figure.pygmtlogo: Remove the additional black outline for the black-and-white dark-theme logo

### DIFF
--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -216,17 +216,6 @@ def _create_logo(  # noqa: PLR0915
     # Upper vertical line
     fig.plot(data=_vline_coords(), fill=red, perspective=True)
 
-    # Outline around the shape for black and white color with dark theme
-    if not color and theme == "dark":
-        fig.plot(
-            x=0,
-            y=0,
-            style=f"{symbol}{size_shape + thick_shape}c",
-            pen=f"{thick_comp / 2.0}c,{color_bg}",
-            perspective=True,
-            no_clip=True,
-        )
-
     # Add wordmark "PyGMT"
     if wordmark != "none":
         fig.text(text=f"@;{color_py};Py@;;@;{color_gmt};GMT@;;", **args_text_wm)

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_no_wordmark.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_no_wordmark.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 781ac55a32194d2818a1d96ab2d32727
-  size: 31485
+- md5: fdc90d2867bcbc096bcf5a9303d15ddf
+  size: 31962
   hash: md5
   path: test_pygmtlogo_circle_no_wordmark.png

--- a/pygmt/tests/test_pygmtlogo.py
+++ b/pygmt/tests/test_pygmtlogo.py
@@ -4,7 +4,7 @@ Test Figure.pygmtlogo.
 
 import pytest
 from pygmt import Figure
-from pygmt.params import Axis, Position
+from pygmt.params import Axis, Frame, Position
 from pygmt.src.pygmtlogo import _create_logo
 
 
@@ -29,23 +29,20 @@ def test_pygmtlogo_circle_no_wordmark():
     and colored/black-and-white versions.
     """
     fig = Figure()
-    fig.basemap(region=[-0.5, 5.0, -0.5, 5.0], projection="x1c", frame=Axis(grid=0.5))
-    fig.pygmtlogo(
-        position=Position((1, 3.5), anchor="CM", cstype="mapcoords"),
-        theme="light",
+    fig.basemap(
+        region=[-0.5, 5.0, -0.5, 5.0],
+        projection="x1c",
+        frame=Frame(fill="gray", axis=Axis(grid=0.5)),
     )
-    fig.pygmtlogo(
-        position=Position((3.5, 3.5), anchor="CM", cstype="mapcoords"),
-        theme="dark",
-    )
-    fig.pygmtlogo(
-        position=Position((1, 1), anchor="CM", cstype="mapcoords"),
-        theme="light",
-        color=False,
-    )
-    fig.pygmtlogo(
-        position=Position((3.5, 1), anchor="CM", cstype="mapcoords"),
-        theme="dark",
-        color=False,
-    )
+    for (x, y), theme, color in [
+        ((1.0, 3.5), "light", True),
+        ((3.5, 3.5), "dark", True),
+        ((1.0, 1.0), "light", False),
+        ((3.5, 1.0), "dark", False),
+    ]:
+        fig.pygmtlogo(
+            position=Position((x, y), anchor="CM", cstype="mapcoords"),
+            theme=theme,
+            color=color,
+        )
     return fig


### PR DESCRIPTION
Currently, we add an additional black outline to the black-and-white logo in dark theme. But is it really necessary? Dark mode usually implies a dark (black) background, and the white shape outline is already visually distinct from the background (see below).
```python
import pygmt
from pygmt.params import Frame

fig = pygmt.Figure()
fig.basemap(region=[-2, 2, -2, 2], projection="X4c", frame=Frame(fill="darkgray"))
fig.pygmtlogo(color=False, theme="dark", width="3c")
fig.show()
```
| With black outline | Without black outline |
|---|---|
| <img width="473" height="473" alt="logo-dark" src="https://github.com/user-attachments/assets/e59b0e1c-c147-4f41-8c26-ed115fe1a273" /> | <img width="473" height="473" alt="logo-dark" src="https://github.com/user-attachments/assets/eb2a7930-5d9d-4de4-8159-b1c14f5a79a1" />|
