### PR TITLE
Figure.pygmtlogo: Parameterize existing tests

### DIFF
--- a/pygmt/tests/baseline/test_pygmtlogo_circle_design_horizontal.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_design_horizontal.png.dvc
@@ -1,5 +1,0 @@
-outs:
-- md5: de3f281a09815faff7fed339c1635bc5
-  size: 336254
-  hash: md5
-  path: test_pygmtlogo_circle_design_horizontal.png

--- a/pygmt/tests/baseline/test_pygmtlogo_circle_design_vertical.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_circle_design_vertical.png.dvc
@@ -1,5 +1,0 @@
-outs:
-- md5: dd09fa24c575eabac7659dc49f313f5f
-  size: 173671
-  hash: md5
-  path: test_pygmtlogo_circle_design_vertical.png

--- a/pygmt/tests/baseline/test_pygmtlogo_design_circle-horizontal.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_design_circle-horizontal.png.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 8924c7d80afcc92df4e77e6856b553a4
+  size: 336254
+  hash: md5
+  path: test_pygmtlogo_design_circle-horizontal.png

--- a/pygmt/tests/baseline/test_pygmtlogo_design_circle-vertical.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_design_circle-vertical.png.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 5ee82660f20bc8424f3051af4f9fb9ac
+  size: 173671
+  hash: md5
+  path: test_pygmtlogo_design_circle-vertical.png

--- a/pygmt/tests/baseline/test_pygmtlogo_no_wordmark_circle.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_no_wordmark_circle.png.dvc
@@ -2,4 +2,4 @@ outs:
 - md5: fdc90d2867bcbc096bcf5a9303d15ddf
   size: 31962
   hash: md5
-  path: test_pygmtlogo_circle_no_wordmark.png
+  path: test_pygmtlogo_no_wordmark_circle.png

--- a/pygmt/tests/baseline/test_pygmtlogo_wordmark_none_circle.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_wordmark_none_circle.png.dvc
@@ -2,4 +2,4 @@ outs:
 - md5: fdc90d2867bcbc096bcf5a9303d15ddf
   size: 31962
   hash: md5
-  path: test_pygmtlogo_no_wordmark_circle.png
+  path: test_pygmtlogo_wordmark_none_circle.png

--- a/pygmt/tests/test_pygmtlogo.py
+++ b/pygmt/tests/test_pygmtlogo.py
@@ -10,23 +10,25 @@ from pygmt.src.pygmtlogo import _create_logo
 
 @pytest.mark.mpl_image_compare(savefig_kwargs={"dpi": 600})
 @pytest.mark.parametrize("wordmark", ["horizontal", "vertical"])
-def test_pygmtlogo_circle_design(wordmark):
+@pytest.mark.parametrize("shape", ["circle"])
+def test_pygmtlogo_design(shape, wordmark):
     """
-    Test the design details of the PyGMT circular logo, with a wordmark.
+    Test the design details of the PyGMT logo with a wordmark.
 
     This is a regression test to ensure that the design of the logo does not change
     unintentionally. The debugging lines (gridlines and circles) are helpful for
     implementing the logo, but they are not included in the final logo design.
     """
-    fig = _create_logo(debug=True, wordmark=wordmark)
+    fig = _create_logo(debug=True, shape=shape, wordmark=wordmark)
     return fig
 
 
 @pytest.mark.mpl_image_compare
-def test_pygmtlogo_circle_no_wordmark():
+@pytest.mark.parametrize("shape", ["circle"])
+def test_pygmtlogo_no_wordmark(shape):
     """
-    Test the PyGMT circular logo without the wordmark, including both light/dark themes,
-    and colored/black-and-white versions.
+    Test the PyGMT logo without the wordmark, including both light/dark themes, and
+    colored/black-and-white versions.
     """
     fig = Figure()
     fig.basemap(
@@ -41,8 +43,9 @@ def test_pygmtlogo_circle_no_wordmark():
         ((3.5, 1.0), "dark", False),
     ]:
         fig.pygmtlogo(
-            position=Position((x, y), anchor="CM", cstype="mapcoords"),
+            position=Position((x, y), anchor="MC", cstype="mapcoords"),
             theme=theme,
             color=color,
+            shape=shape,
         )
     return fig

--- a/pygmt/tests/test_pygmtlogo.py
+++ b/pygmt/tests/test_pygmtlogo.py
@@ -25,7 +25,7 @@ def test_pygmtlogo_design(shape, wordmark):
 
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("shape", ["circle"])
-def test_pygmtlogo_no_wordmark(shape):
+def test_pygmtlogo_wordmark_none(shape):
     """
     Test the PyGMT logo without the wordmark, including both light/dark themes, and
     colored/black-and-white versions.


### PR DESCRIPTION
No code changes, but parameterize existing tests so tests can share similar code.

We have 24 logos for different values of `shape`/`theme`/`color`/`wordmark`. After parameterization, we will have four tests:

- `test_pygmtlogo_design`: Test the design details of circular/hexagonal logos with horizontal/vertical wordmark
- `test_pygmtlogo_no_wordmark`: Test all logos without wordmark
- `test_pygmtlogo_horizontal_wordmark`: Test all logos with horizontal wordmark [Will be added in PR #4627]
- `test_pygmtlogo_vertical_wordmark`: Test all logos with vertical wordmark [Will be added in PR #4637]