### PR TITLE
Simplify AUTHORS.md and add authorship links

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,10 +1,5 @@
 # Project Contributors
 
-This project was started in 2017 by [Leonardo Uieda](https://www.leouieda.com)
-during [an NSF funded postdoc](https://www.leouieda.com/blog/hawaii-gmt-postdoc)
-with [Paul Wessel](https://en.wikipedia.org/wiki/Pål_Wessel) at the University of
-Hawaiʻi at Mānoa.
-
 The following people have contributed code and/or documentation to the project
 (alphabetically by name) and are considered to be "PyGMT Developers":
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,6 +23,3 @@ The following people have contributed code and/or documentation to the project
 | [Xingchen He](https://github.com/Chuan1937) | [0009-0004-7182-2252](https://orcid.org/0009-0004-7182-2252) | Chengdu University of Technology, China |
 | [Yohai Magen](https://github.com/yohaimagen) | [0000-0002-4892-4013](https://orcid.org/0000-0002-4892-4013) | Tel Aviv University, Israel |
 | [Yvonne Fröhlich](https://github.com/yvonnefroehlich) | [0000-0002-8566-0619](https://orcid.org/0000-0002-8566-0619) | Unaffiliated |
-
-Individuals who have made significant contributions to PyGMT are recognized on the
-[PyGMT Team](https://www.pygmt.org/dev/team.html) page.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,6 @@
 # PyGMT Developers
 
-The following people have contributed code and/or documentation to the project
+The following people have contributed code and/or documentation to the PyGMT project
 (alphabetically by name) and are considered to be "PyGMT Developers":
 
 | Name | ORCID | Affiliation |

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,4 +1,4 @@
-# Project Contributors
+# PyGMT Developers
 
 The following people have contributed code and/or documentation to the project
 (alphabetically by name) and are considered to be "PyGMT Developers":

--- a/AUTHORSHIP.md
+++ b/AUTHORSHIP.md
@@ -30,7 +30,7 @@ repository and is packaged with distributions. This is an optional process.
 a group of individuals who maintain the PyGMT project, make decisions about the
 direction of the project, and manage release cycles. The team also includes
 distinguished contributors who have made significant contributions to the project in
-many ways and who are selected by a vote of the active maintainers before each release.
+many ways in the project's history.
 
 ## Changelog for each release
 

--- a/AUTHORSHIP.md
+++ b/AUTHORSHIP.md
@@ -20,9 +20,9 @@ The following are the ways in which individuals who have contributed will be rec
 
 ## The `AUTHORS.md` file
 
-Anyone who has contributed a pull request to the project is welcome to add themselves to
-the `AUTHORS.md` file. This file lives in the repository and is packaged with
-distributions. This is an optional process.
+The `AUTHORS.md` file lists PyGMT Developers. Anyone who has contributed a pull request
+to the project is welcome to add themselves to the file. This file lives in the
+repository and is packaged with distributions. This is an optional process.
 
 ## Changelog for each release
 

--- a/AUTHORSHIP.md
+++ b/AUTHORSHIP.md
@@ -24,6 +24,14 @@ The `AUTHORS.md` file lists PyGMT Developers. Anyone who has contributed a pull 
 to the project is welcome to add themselves to the file. This file lives in the
 repository and is packaged with distributions. This is an optional process.
 
+## The PyGMT Team
+
+[The PyGMT Team](https://github.com/GenericMappingTools/pygmt/blob/main/doc/team.md) is
+a group of individuals who maintain the PyGMT project, make decisions about the
+direction of the project, and manage release cycles. The team also includes
+distinguished contributors who have made significant contributions to the project in
+many ways and who are selected by a vote of the active maintainers before each release.
+
 ## Changelog for each release
 
 Every time we make a release, everyone who has made a contribution (commits or PR

--- a/README.md
+++ b/README.md
@@ -185,14 +185,6 @@ The development of PyGMT has been supported by NSF grants
 [OCE-1558403](https://www.nsf.gov/awardsearch/show-award/?AWD_ID=1558403) and
 [EAR-1948602](https://www.nsf.gov/awardsearch/show-award/?AWD_ID=1948602).
 
-## About Us
-
-PyGMT is maintained and governed by the [PyGMT Team](https://www.pygmt.org/dev/team.html).
-For a list of PyGMT Developers, see
-[AUTHORS.md](https://github.com/GenericMappingTools/pygmt/blob/main/AUTHORS.md).
-For authorship and contributor recognition guidelines, see
-[AUTHORSHIP.md](https://github.com/GenericMappingTools/pygmt/blob/main/AUTHORSHIP.md).
-
 ## Related projects
 
 Other official wrappers for GMT:

--- a/README.md
+++ b/README.md
@@ -185,6 +185,14 @@ The development of PyGMT has been supported by NSF grants
 [OCE-1558403](https://www.nsf.gov/awardsearch/show-award/?AWD_ID=1558403) and
 [EAR-1948602](https://www.nsf.gov/awardsearch/show-award/?AWD_ID=1948602).
 
+## About Us
+
+PyGMT is maintained and governed by the [PyGMT Team](https://www.pygmt.org/dev/team.html).
+For a list of PyGMT Developers, see
+[AUTHORS.md](https://github.com/GenericMappingTools/pygmt/blob/main/AUTHORS.md).
+For authorship and contributor recognition guidelines, see
+[AUTHORSHIP.md](https://github.com/GenericMappingTools/pygmt/blob/main/AUTHORSHIP.md).
+
 ## Related projects
 
 Other official wrappers for GMT:


### PR DESCRIPTION
This PR removes unrelated text from AUTHORS.md so that the file only lists PyGMT Developers. It also clarifies that AUTHORS.md contains the list of PyGMT Developers, and that the PyGMT Team is a separate group.

Changes in this PR:

- Simplify `AUTHORS.md` into a list of PyGMT Developers
- Clarify the role of `AUTHORS.md` in `AUTHORSHIP.md`
- Add a section for the PyGMT team in `AUTHORSHIP.md`

Closes https://github.com/GenericMappingTools/pygmt/issues/4622.