### PR TITLE
Add filtering tags for gallery examples of projections

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -162,6 +162,18 @@ html.writer-html5 .rst-content dl.field-list {
     max-width: 80%!important;
 }
 
+.sphx-glr-tag-label {
+    font-weight: bold;
+    background-color: #f2f3f5;
+    padding: 0.1rem 0.35rem;
+}
+
+.sphx-glr-tag {
+    background-color: #e6eef8;
+    margin: 0.1rem 0.2rem 0.1rem 0;
+    padding: 0.1rem 0.35rem;
+}
+
 /*
  * Styles for aligning table cells.
  * https://myst-parser.readthedocs.io/en/latest/syntax/tables.html#markdown-syntax

--- a/environment.yml
+++ b/environment.yml
@@ -41,7 +41,7 @@ dependencies:
     - sphinx-autodoc-typehints
     - sphinx-copybutton
     - sphinx-design
-    - sphinx-gallery>=0.19.0
+    - sphinx-gallery>=0.21.0
     - sphinx_rtd_theme
     # Dev dependencies (building PDF documentation)
     - cairosvg

--- a/examples/projections/azim/azim_equidistant.py
+++ b/examples/projections/azim/azim_equidistant.py
@@ -31,3 +31,5 @@ fig.coast(
     water="white",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["equidistant"]

--- a/examples/projections/azim/azim_general_stereographic.py
+++ b/examples/projections/azim/azim_general_stereographic.py
@@ -31,3 +31,5 @@ fig.coast(
     water="white",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["conformal"]

--- a/examples/projections/azim/azim_lambert.py
+++ b/examples/projections/azim/azim_lambert.py
@@ -29,3 +29,5 @@ fig.coast(
     water="white",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["equal-area"]

--- a/examples/projections/conic/conic_albers.py
+++ b/examples/projections/conic/conic_albers.py
@@ -34,3 +34,5 @@ fig.coast(
     water="gray90",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["equal-area"]

--- a/examples/projections/conic/conic_equidistant.py
+++ b/examples/projections/conic/conic_equidistant.py
@@ -28,3 +28,5 @@ fig.coast(
     water="gray90",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["equidistant"]

--- a/examples/projections/conic/conic_lambert.py
+++ b/examples/projections/conic/conic_lambert.py
@@ -30,5 +30,6 @@ fig.coast(
     land="seagreen",
     water="gray90",
 )
-
 fig.show()
+
+# sphinx_gallery_tags = ["conformal"]

--- a/examples/projections/cyl/cyl_equal_area.py
+++ b/examples/projections/cyl/cyl_equal_area.py
@@ -26,3 +26,5 @@ fig.coast(
     water="steelblue",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["equal-area"]

--- a/examples/projections/cyl/cyl_equidistant.py
+++ b/examples/projections/cyl/cyl_equidistant.py
@@ -30,3 +30,5 @@ fig.coast(
     water="steelblue",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["equidistant"]

--- a/examples/projections/cyl/cyl_mercator.py
+++ b/examples/projections/cyl/cyl_mercator.py
@@ -33,3 +33,5 @@ fig.coast(
     water="steelblue",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["conformal"]

--- a/examples/projections/cyl/cyl_oblique_mercator.py
+++ b/examples/projections/cyl/cyl_oblique_mercator.py
@@ -78,3 +78,4 @@ fig.coast(
 fig.show()
 
 # sphinx_gallery_thumbnail_number = 3
+# sphinx_gallery_tags = ["conformal"]

--- a/examples/projections/cyl/cyl_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_transverse_mercator.py
@@ -29,3 +29,5 @@ fig.coast(
     water="steelblue",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["conformal"]

--- a/examples/projections/cyl/cyl_universal_transverse_mercator.py
+++ b/examples/projections/cyl/cyl_universal_transverse_mercator.py
@@ -50,3 +50,5 @@ fig.coast(
     water="steelblue",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["conformal"]

--- a/examples/projections/misc/misc_eckertIV.py
+++ b/examples/projections/misc/misc_eckertIV.py
@@ -27,3 +27,5 @@ fig.coast(
     water="bisque4",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["equal-area"]

--- a/examples/projections/misc/misc_eckertVI.py
+++ b/examples/projections/misc/misc_eckertVI.py
@@ -28,3 +28,5 @@ fig.coast(
     water="bisque4",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["equal-area"]

--- a/examples/projections/misc/misc_hammer.py
+++ b/examples/projections/misc/misc_hammer.py
@@ -28,3 +28,5 @@ fig.coast(
     water="bisque4",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["equal-area"]

--- a/examples/projections/misc/misc_mollweide.py
+++ b/examples/projections/misc/misc_mollweide.py
@@ -29,3 +29,5 @@ fig.coast(
     water="bisque4",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["equal-area"]

--- a/examples/projections/misc/misc_sinusoidal.py
+++ b/examples/projections/misc/misc_sinusoidal.py
@@ -29,3 +29,5 @@ fig.coast(
     water="bisque4",
 )
 fig.show()
+
+# sphinx_gallery_tags = ["equal-area"]


### PR DESCRIPTION
Changes in this PR:

- [x] Bump to sphinx-gallery >= 0.21.0
- [X] Add tags for projection gallery examples [Based on the figure and table in https://docs.generic-mapping-tools.org/dev/reference/options.html#coordinate-transformations-and-map-projections-the-j-option]

**Preview**: https://pygmt-dev--4643.org.readthedocs.build/en/4643/projections/index.html

The first PR to address #4599 