### PR TITLE
Figure.basemap: Add a doctest example

### DIFF
--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -123,6 +123,13 @@ def basemap(  # noqa: PLR0913
     $coltypes
     $perspective
     $transparency
+
+    Examples
+    --------
+    >>> import pygmt
+    >>> fig = pygmt.Figure()
+    >>> fig.basemap(region="g", projection="H15c", frame=True)
+    >>> fig.show()
     """
     self._activate_figure()
 


### PR DESCRIPTION
## Summary

- add a simple doctest example to Figure.basemap
- demonstrate a minimal basemap call with region, projection, and frame

Related to #4239
