### PR TITLE
pygmt.params.Position: Validate the values of cstype

### DIFF
--- a/pygmt/params/position.py
+++ b/pygmt/params/position.py
@@ -186,6 +186,18 @@ class Position(BaseParam):
                         description="reference point",
                         reason="Expect a valid 2-character justification code.",
                     )
+            case _:
+                raise GMTValueError(
+                    self.cstype,
+                    description="cstype",
+                    choices=[
+                        "mapcoords",
+                        "plotcoords",
+                        "boxcoords",
+                        "inside",
+                        "outside",
+                    ],
+                )
         # Validate the anchor if specified.
         if self.anchor is not None and self.anchor not in _valid_anchors:
             raise GMTValueError(

--- a/pygmt/tests/test_params_position.py
+++ b/pygmt/tests/test_params_position.py
@@ -38,6 +38,8 @@ def test_params_position_invalid_location():
     Test that invalid location inputs raise GMTValueError.
     """
     with pytest.raises(GMTValueError):
+        Position((1, 2), cstype="invalid")
+    with pytest.raises(GMTValueError):
         Position("invalid", cstype="mapcoords")
     with pytest.raises(GMTValueError):
         Position((1, 2, 3), cstype="mapcoords")


### PR DESCRIPTION
Previous behavior:
```python
In [2]: from pygmt.params import Position

In [3]: Position((1, 0), cstype="invalid")
Out[3]: Position(refpoint=(1, 0), cstype='invalid')
```

Current behavior:
```python
In [1]: from pygmt.params import Position

In [2]: Position((1, 0), cstype="invalid")
---------------------------------------------------------------------------
GMTValueError                             Traceback (most recent call last)
Cell In[2], line 1
----> 1 Position((1, 0), cstype="invalid")

File <string>:7, in __init__(self, refpoint, cstype, anchor, offset)

File ~/OSS/gmt/pygmt/pygmt/params/base.py:61, in BaseParam.__post_init__(self)
     57 def __post_init__(self):
     58     """
     59     Post-initialization method to _validate the _aliases property.
     60     """
---> 61     self._validate()

File ~/OSS/gmt/pygmt/pygmt/params/position.py:190, in Position._validate(self)
    184             raise GMTValueError(
    185                 self.refpoint,
    186                 description="reference point",
    187                 reason="Expect a valid 2-character justification code.",
    188             )
    189     case _:
--> 190         raise GMTValueError(
    191             self.cstype,
    192             description="cstype",
    193             choices=[
    194                 "mapcoords",
    195                 "plotcoords",
    196                 "boxcoords",
    197                 "inside",
    198                 "outside",
    199             ],
    200         )
    201 # Validate the anchor if specified.
    202 if self.anchor is not None and self.anchor not in _valid_anchors:

GMTValueError: Invalid cstype: 'invalid'. Expected one of: 'mapcoords', 'plotcoords', 'boxcoords', 'inside', 'outside'.
```

Related to #4212