### PR TITLE
SPEC 0: Bump minimum supported version to NumPy 2.1, pandas 2.3 and xarray 2024.7

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -76,7 +76,7 @@ jobs:
           # Python 3.12 + core packages (minimum supported versions) + optional packages (minimum supported versions if any)
           - python-version: '3.12'
             numpy-version: '2.0'
-            pandas-version: '=2.2'
+            pandas-version: '=2.3'
             xarray-version: '=2024.5'
             optional-packages: ' contextily geopandas ipython pyarrow-core rioxarray netCDF4 sphinx-gallery'
           # Python 3.14 + core packages (latest versions) + optional packages

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -77,7 +77,7 @@ jobs:
           - python-version: '3.12'
             numpy-version: '2.0'
             pandas-version: '=2.3'
-            xarray-version: '=2024.5'
+            xarray-version: '=2024.7'
             optional-packages: ' contextily geopandas ipython pyarrow-core rioxarray netCDF4 sphinx-gallery'
           # Python 3.14 + core packages (latest versions) + optional packages
           - python-version: '3.14'

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -75,7 +75,7 @@ jobs:
         include:
           # Python 3.12 + core packages (minimum supported versions) + optional packages (minimum supported versions if any)
           - python-version: '3.12'
-            numpy-version: '2.0'
+            numpy-version: '2.1'
             pandas-version: '=2.3'
             xarray-version: '=2024.7'
             optional-packages: ' contextily geopandas ipython pyarrow-core rioxarray netCDF4 sphinx-gallery'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -63,7 +63,7 @@ jobs:
             ghostscript
             numpy=2.0
             pandas=2.3
-            xarray=2024.5
+            xarray=2024.7
             packaging=24.2
             contextily=1.5
             geopandas=1.0

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -61,7 +61,7 @@ jobs:
             python=3.12
             gmt=${{ matrix.gmt_version }}
             ghostscript
-            numpy=2.0
+            numpy=2.1
             pandas=2.3
             xarray=2024.7
             packaging=24.2

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -62,7 +62,7 @@ jobs:
             gmt=${{ matrix.gmt_version }}
             ghostscript
             numpy=2.0
-            pandas=2.2
+            pandas=2.3
             xarray=2024.5
             packaging=24.2
             contextily=1.5

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
     - gmt=6.6.0
     - ghostscript=10.07.0
     - numpy>=2.0
-    - pandas>=2.2
+    - pandas>=2.3
     - xarray>=2024.5
     - packaging>=24.2
     # Optional dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     # Required dependencies
     - gmt=6.6.0
     - ghostscript=10.07.0
-    - numpy>=2.0
+    - numpy>=2.1
     - pandas>=2.3
     - xarray>=2024.7
     - packaging>=24.2

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
     - ghostscript=10.07.0
     - numpy>=2.0
     - pandas>=2.3
-    - xarray>=2024.5
+    - xarray>=2024.7
     - packaging>=24.2
     # Optional dependencies
     - contextily>=1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
     "numpy>=2.0",
     "pandas>=2.3",
-    "xarray>=2024.5",
+    "xarray>=2024.7",
     "packaging>=24.2",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "numpy>=2.0",
+    "numpy>=2.1",
     "pandas>=2.3",
     "xarray>=2024.7",
     "packaging>=24.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=2.0",
-    "pandas>=2.2",
+    "pandas>=2.3",
     "xarray>=2024.5",
     "packaging>=24.2",
 ]


### PR DESCRIPTION
Following [SPEC0](https://scientific-python.org/specs/spec-0000/) policy, we should drop NumPy 2.1, pandas 2.2 and xarray 2024.6 in 2026 quarter 2. 

Bumps the minimum supported versions in the following files:

- [x] `.github/workflows/ci_tests_legacy.yaml`
- [x] `.github/workflows/ci_tests.yaml`
- [x] `environment.yml`
- [x] `pyproject.toml`
- [x] Remove workarounds for unsupported versions

Supersedes #4090, #4092.