### PR TITLE
CI: Use windows-2025-vs2026 in the GMT Dev Tests workflow

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025-vs2026]
         gmt_git_ref: [master]
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
**Description of proposed changes**

Xref https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/#windows-2025-visual-studio-2026-image-migration

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

:warning: the blogpost mentions:

> The windows-latest and windows-2025 labels in GitHub Actions will be migrated to use Visual Studio 2026 by default. This change will be rolled out over a week beginning June 8, 2026 and will complete by June 15, 2026.
>
> If you want to test the new image, update the runs-on: target in your YAML workflow file to the new label windows-2025-vs2026.
>
> Note: This label is meant for testing only. After the migration, this label will point to the windows-2025 image.

So treat this PR as testing the change in advance only, otherwise we need to change it back to `windows-2025` after mid-June.

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Supersedes #3701