### PR TITLE
Ignore two spelling errors reported by codespell

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ local_scheme = "node-and-date"
 fallback_version = "999.999.999+unknown"
 
 [tool.codespell]
-ignore-words-list = "astroid,oints,reenable,tripel,trough,ND"
+ignore-words-list = "astroid,buda,oints,reenable,te,tripel,trough,ND"
 
 [tool.coverage.run]
 omit = ["*/tests/*", "*pygmt/__init__.py"]


### PR DESCRIPTION
`make codespell` reports 2 false positives:
- `examples/gallery/embellishments/text_formatting.py`:24 — `te` is part of GMT font escape syntax
- `doc/techref/justification_codes.md`:109 — `buda` is a colormap name `SCM/buda`

Fix  
Add `buda` and `te` to ignore-words-list in `pyproject.toml`
