### PR TITLE
Add the Spilhaus projection to the supported GMT projections

### DIFF
--- a/doc/techref/projections.md
+++ b/doc/techref/projections.md
@@ -47,4 +47,4 @@ The table below shows the projection codes for the 32 GMT map projections:
 | **W**[{{ lon0 }}/]*width*                                   | [](/projections/misc/misc_mollweide.rst) |
 | **X***width*[**l**\|**p***exp*\|**T**\|**t**][/*height*[**l**\|**p***exp*\|**T**\|**t**]][**d**] | Cartesian [linear](/projections/nongeo/cartesian_linear.rst), [logarithmic](/projections/nongeo/cartesian_logarithmic.rst), [power](/projections/nongeo/cartesian_power.rst), and time |
 | **Y**{{ lon0 }}/{{ lat0 }}/*width*                          | [](/projections/cyl/cyl_equal_area.rst) |
-| **+proj=spilhaus+width=**_width_                             | [](/projections/misc/misc_spilhaus.rst) |
+| **+proj=spilhaus+width=**_width_                            | [](/projections/misc/misc_spilhaus.rst) |

--- a/doc/techref/projections.md
+++ b/doc/techref/projections.md
@@ -47,4 +47,4 @@ The table below shows the projection codes for the 32 GMT map projections:
 | **W**[{{ lon0 }}/]*width*                                   | [](/projections/misc/misc_mollweide.rst) |
 | **X***width*[**l**\|**p***exp*\|**T**\|**t**][/*height*[**l**\|**p***exp*\|**T**\|**t**]][**d**] | Cartesian [linear](/projections/nongeo/cartesian_linear.rst), [logarithmic](/projections/nongeo/cartesian_logarithmic.rst), [power](/projections/nongeo/cartesian_power.rst), and time |
 | **Y**{{ lon0 }}/{{ lat0 }}/*width*                          | [](/projections/cyl/cyl_equal_area.rst) |
-| **+proj=spilhaus+width=**\ *width*                           | [](/projections/misc/misc_spilhaus.rst) |
+| **+proj=spilhaus+width=**_width_                             | [](/projections/misc/misc_spilhaus.rst) |

--- a/doc/techref/projections.md
+++ b/doc/techref/projections.md
@@ -12,7 +12,7 @@ myst:
 
 # GMT Map Projections
 
-The table below shows the projection codes for the 31 GMT map projections:
+The table below shows the projection codes for the 32 GMT map projections:
 
 | PyGMT Projection Argument | Projection Name |
 | --- | --- |
@@ -47,3 +47,4 @@ The table below shows the projection codes for the 31 GMT map projections:
 | **W**[{{ lon0 }}/]*width*                                   | [](/projections/misc/misc_mollweide.rst) |
 | **X***width*[**l**\|**p***exp*\|**T**\|**t**][/*height*[**l**\|**p***exp*\|**T**\|**t**]][**d**] | Cartesian [linear](/projections/nongeo/cartesian_linear.rst), [logarithmic](/projections/nongeo/cartesian_logarithmic.rst), [power](/projections/nongeo/cartesian_power.rst), and time |
 | **Y**{{ lon0 }}/{{ lat0 }}/*width*                          | [](/projections/cyl/cyl_equal_area.rst) |
+| **+proj=spilhaus+width=**\ *width*                           | [](/projections/misc/misc_spilhaus.rst) |

--- a/examples/projections/misc/misc_spilhaus.py
+++ b/examples/projections/misc/misc_spilhaus.py
@@ -22,7 +22,6 @@ fig.coast(
     region="d",
     projection="+proj=spilhaus+width=12c",
     frame=Axis(annot=True, tick=True, grid=True),
-    land="ivory",
-    water="bisque4",
+    shorelines=True,
 )
 fig.show()

--- a/examples/projections/misc/misc_spilhaus.py
+++ b/examples/projections/misc/misc_spilhaus.py
@@ -10,6 +10,11 @@ developed by Athelstan Spilhaus and is useful for oceanographic studies.
 
 The projection is set as a PROJ string with ``+proj=spilhaus`` and the figure
 size is set with *width*.
+
+.. note::
+
+    This projection works well for coastlines but currently has issues for filling
+    land and water masses.
 """
 
 # %%

--- a/examples/projections/misc/misc_spilhaus.py
+++ b/examples/projections/misc/misc_spilhaus.py
@@ -1,0 +1,27 @@
+r"""
+Spilhaus projection
+===================
+
+The Spilhaus projection is a world map projection that presents the world's
+oceans as one contiguous body of water, with Antarctica at the top. It was
+developed by Athelstan Spilhaus and is useful for oceanographic studies.
+
+**+proj=spilhaus+width=**\ *width*
+
+The projection is set as a PROJ string with ``+proj=spilhaus`` and the figure
+size is set with *width*.
+"""
+
+# %%
+import pygmt
+
+fig = pygmt.Figure()
+# Use the PROJ string to set the Spilhaus projection
+fig.basemap(projection="+proj=spilhaus+width=15c", region="d", frame="none")
+# Plot Earth relief with shading for better visual effect
+fig.grdimage(grid="@earth_relief_01d", shading=True)
+fig.coast(shorelines=True)
+fig.basemap(frame="a30f30g")
+fig.show()
+
+# sphinx_gallery_tags = ["misc"]

--- a/examples/projections/misc/misc_spilhaus.py
+++ b/examples/projections/misc/misc_spilhaus.py
@@ -26,5 +26,3 @@ fig.coast(
     water="bisque4",
 )
 fig.show()
-
-# sphinx_gallery_tags = ["misc"]

--- a/examples/projections/misc/misc_spilhaus.py
+++ b/examples/projections/misc/misc_spilhaus.py
@@ -14,14 +14,17 @@ size is set with *width*.
 
 # %%
 import pygmt
+from pygmt.params import Axis
 
 fig = pygmt.Figure()
 # Use the PROJ string to set the Spilhaus projection
-fig.basemap(projection="+proj=spilhaus+width=15c", region="d", frame="none")
-# Plot Earth relief with shading for better visual effect
-fig.grdimage(grid="@earth_relief_01d", shading=True)
-fig.coast(shorelines=True)
-fig.basemap(frame="a30f30g")
+fig.coast(
+    region="d",
+    projection="+proj=spilhaus+width=12c",
+    frame=Axis(annot=True, tick=True, grid=True),
+    land="ivory",
+    water="bisque4",
+)
 fig.show()
 
 # sphinx_gallery_tags = ["misc"]


### PR DESCRIPTION
Add the Spilhaus projection to the supported GMT projections.

**Preview:**
- https://pygmt-dev--4657.org.readthedocs.build/en/4657/projections/misc/misc_spilhaus.html
- https://pygmt-dev--4657.org.readthedocs.build/en/4657/projections/index.html#miscellaneous-projections
- https://pygmt-dev--4657.org.readthedocs.build/en/4657/techref/projections.html

Fix: #4656