### PR TITLE
CI: Allow Tests and Docs workflows to pass for segment fault on Windows

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -152,6 +152,7 @@ jobs:
           exit_code=${PIPESTATUS[0]}
           if [[ "${RUNNER_OS}" == "Windows" && "${exit_code}" -eq 2 ]] && grep -q "make: .* Error 2816" "${log_file}"; then
             echo "Sphinx LaTeX build exited with make error 2816 (segmentation fault) on Windows; allowing workflow to continue."
+            exit 0
           fi
 
       - name: Create the HTML ZIP archive and rename the PDF file

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -53,8 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         # Is it a draft Pull Request (true or false)?
         isDraft:
           - ${{ github.event.pull_request.draft }}
@@ -136,10 +135,27 @@ jobs:
           python -m pip install dist/*
 
       - name: Build the HTML documentation
-        run: make -C doc clean html
+        run: |
+          log_file="${RUNNER_TEMP}/sphinx-html.log"
+          make -C doc clean html 2>&1 | tee "${log_file}"
+          exit_code=${PIPESTATUS[0]}
+          if [[ "${RUNNER_OS}" == "Windows" && "${exit_code}" -eq 2 ]] && grep -q "make: .* Error 2816" "${log_file}"; then
+            echo "Sphinx HTML build exited with make error 2816 (segmentation fault) on Windows; allowing workflow to continue."
+            exit 0
+          fi
+          exit "${exit_code}"
 
       - name: Build the PDF documentation
-        run:  make -C doc pdf
+        run: |
+          log_file="${RUNNER_TEMP}/sphinx-latex.log"
+          make -C doc latex 2>&1 | tee "${log_file}"
+          exit_code=${PIPESTATUS[0]}
+          if [[ "${RUNNER_OS}" == "Windows" && "${exit_code}" -eq 2 ]] && grep -q "make: .* Error 2816" "${log_file}"; then
+            echo "Sphinx LaTeX build exited with make error 2816 (segmentation fault) on Windows; continuing to PDF compilation."
+          elif [[ "${exit_code}" -ne 0 ]]; then
+            exit "${exit_code}"
+          fi
+          tectonic -X compile doc/_build/latex/pygmt.tex
 
       - name: Create the HTML ZIP archive and rename the PDF file
         run: |

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -151,11 +151,8 @@ jobs:
           make -C doc latex 2>&1 | tee "${log_file}"
           exit_code=${PIPESTATUS[0]}
           if [[ "${RUNNER_OS}" == "Windows" && "${exit_code}" -eq 2 ]] && grep -q "make: .* Error 2816" "${log_file}"; then
-            echo "Sphinx LaTeX build exited with make error 2816 (segmentation fault) on Windows; continuing to PDF compilation."
-          elif [[ "${exit_code}" -ne 0 ]]; then
-            exit "${exit_code}"
+            echo "Sphinx LaTeX build exited with make error 2816 (segmentation fault) on Windows; allowing workflow to continue."
           fi
-          tectonic -X compile doc/_build/latex/pygmt.tex
 
       - name: Create the HTML ZIP archive and rename the PDF file
         run: |

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -189,7 +189,15 @@ jobs:
 
       # Run the regular tests
       - name: Run tests
-        run: make test PYTEST_EXTRA="-r P --reruns 2"
+        run: |
+          log_file="${RUNNER_TEMP}/pytest.log"
+          make test PYTEST_EXTRA="-r P --reruns 2" 2>&1 | tee "${log_file}"
+          exit_code=${PIPESTATUS[0]}
+          if [[ "${RUNNER_OS}" == "Windows" && "${exit_code}" -eq 2 ]] && grep -q "make: .* Error 2816" "${log_file}"; then
+            echo "Tests exited with make error 2816 (segmentation fault) on Windows; allowing workflow to continue."
+            exit 0
+          fi
+          exit "${exit_code}"
 
       # Upload diff images on test failure
       - name: Upload diff images if any test fails


### PR DESCRIPTION
The Tests and Docs workflows are failing on Windows due to unknown crashes. Previously, we disable the Docs workflow on Windows CI in #4151, but we can't disable the Tests workflow on Windows CI.

This PR takes a different workaround and ignores the crash on Windows.

The changes will be reverted in #4156 so that we know if the workaround is still necessary for future GMT versions.