### PR TITLE
[BREAKING] Raise GMTTypeError exception for unsupported image dtypes

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1895,13 +1895,15 @@ class Session:
         _data = data
         match kind:
             case "image" if data.dtype != "uint8":
-                msg = (
-                    f"Input image has dtype: {data.dtype} which is unsupported, and "
-                    "may result in an incorrect output. Please recast image to a uint8 "
-                    "dtype and/or scale to 0-255 range, e.g. using a histogram "
-                    "equalization function like skimage.exposure.equalize_hist."
+                raise GMTTypeError(
+                    data.dtype,
+                    reason=(
+                        "Only uint8 images are supported. Please recast image to a "
+                        "uint8 dtype and/or scale to 0-255 range, e.g. using a "
+                        "histogram equalization function like "
+                        "skimage.exposure.equalize_hist."
+                    ),
                 )
-                warnings.warn(message=msg, category=RuntimeWarning, stacklevel=2)
             case "empty":  # data is None, so data must be given via x/y/z.
                 _data = [x, y]
                 if z is not None:

--- a/pygmt/tests/test_grdimage_image.py
+++ b/pygmt/tests/test_grdimage_image.py
@@ -7,6 +7,7 @@ import pytest
 from pygmt import Figure
 from pygmt.clib.session import DTYPES_NUMERIC
 from pygmt.datasets import load_blue_marble
+from pygmt.exceptions import GMTTypeError
 
 rioxarray = pytest.importorskip("rioxarray")
 
@@ -53,6 +54,5 @@ def test_grdimage_image_dataarray_unsupported_dtype(dtype, xr_image):
     """
     fig = Figure()
     image = xr_image.copy().astype(dtype=dtype)
-    with pytest.warns(expected_warning=RuntimeWarning) as record:
+    with pytest.raises(GMTTypeError, match="Only uint8 images are supported"):
         fig.grdimage(grid=image)
-    assert len(record) == 1


### PR DESCRIPTION
GMT only supports images with the `uint8` data type. Previously, GMT would emit the following errors for unsupported image data types but would not stop execution:
```
Error: e [ERROR]: Using this data type (Int8) is not implemented
grdimage (gmtapi_import_image): Bad measurement unit.  Choose among c|i|p [/tmp/pygmt-6rst4f_m.tif]
[Session pygmt-session (1729)]: Error returned from GMT API: GMT_IMAGE_READ_ERROR (22)
[Session pygmt-session (1729)]: Error returned from GMT API: GMT_IMAGE_READ_ERROR (22)
```
As a result, unsupported images were still read and plotted, although the output was likely incorrect. PyGMT would then issue a warning about the unsupported data type.

It is unclear when this behavior changed, but the GMT dev version now produces the following error instead (xref: https://github.com/GenericMappingTools/pygmt/actions/runs/27249793607/job/80471539938):
```
Error: e [ERROR]: Using this data type (Int8) is not implemented
pygmt-session (gmtapi_import_image): Bad measurement unit.  Choose among c|i|p [/tmp/pygmt-87amr_xv.tif]
[Session pygmt-session (1729)]: Error returned from GMT API: GMT_IMAGE_READ_ERROR (22)
[Session pygmt-session (1729)]: Error returned from GMT API: GMT_IMAGE_READ_ERROR (22)
Error: e [ERROR]: Option -R parsing failure. Correct syntax:
...
Error: e [ERROR]: Offending option -R0/0/0/0
```
Apparently, GMT now fails to read images with unsupported data types altogether, causing our tests to fail. I can't find the exact changes that lead to the behavior changes, but I feel it's likely some changes in GDAL.

This PR addresses the issue by raising a GMTTypeError whenever an unsupported image data type is encountered.