### PR TITLE
DOC: Use the needle.jpg image hosted on GitHub for stability

### DIFF
--- a/examples/gallery/images/image.py
+++ b/examples/gallery/images/image.py
@@ -22,7 +22,7 @@ fig.basemap(region=[0, 2, 0, 2], projection="X10c", frame=True)
 # the current plot, scale it to a width of 8 centimeters and draw a rectangular border
 # around it.
 fig.image(
-    imagefile="https://oceania.generic-mapping-tools.org/cache/needle.jpg",
+    imagefile="https://github.com/GenericMappingTools/gmtserver-admin/raw/master/cache/needle.jpg",
     position=Position((1, 1), cstype="mapcoords", anchor="MC"),
     width="8c",
     box=True,


### PR DESCRIPTION
The Docs workflow is frequently failing recently because it fails to download the image file from https://oceania.generic-mapping-tools.org/cache/needle.jpg (https://github.com/GenericMappingTools/pygmt/actions/runs/27239405212/job/80439236899).


This PR addresses the issue by use the image hosted by GitHub, which hopefully is more stable.