### PR TITLE
Figure.solar: Fix the baseline image for test_solar_terminators

### DIFF
--- a/pygmt/tests/baseline/test_solar_terminators.png.dvc
+++ b/pygmt/tests/baseline/test_solar_terminators.png.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 8325728360e1d302bb9abbb681b41cc6
-  size: 42122
+- md5: a426e3b83eb29dbc273a480d9c3019e1
+  size: 43708
   path: test_solar_terminators.png
+  hash: md5

--- a/pygmt/tests/test_solar.py
+++ b/pygmt/tests/test_solar.py
@@ -5,39 +5,31 @@ Test Figure.solar.
 import datetime
 
 import pytest
+from packaging.version import Version
 from pygmt import Figure
+from pygmt.clib import __gmt_version__
 from pygmt.exceptions import GMTParameterError, GMTValueError
 from pygmt.params import Axis
 
 
+# TODO(GMT>6.6.0): Remove the xfail marker.
+@pytest.mark.xfail(
+    condition=Version(__gmt_version__) <= Version("6.6.0"),
+    reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/8938",
+)
 @pytest.mark.mpl_image_compare
 def test_solar_terminators():
     """
     Test passing the solar argument with a time string and no terminator type to confirm
     the default terminator type.
     """
+    dt = "1990-02-17 04:25:00"
     fig = Figure()
     fig.basemap(region="d", projection="W0/15c", frame=Axis(annot=True))
-    fig.solar(
-        terminator="d",
-        pen="1p,blue",
-        terminator_datetime="1990-02-17 04:25:00",
-    )
-    fig.solar(
-        terminator="a",
-        pen="1p,red",
-        terminator_datetime="1990-02-17 04:25:00",
-    )
-    fig.solar(
-        terminator="c",
-        pen="1p,green",
-        terminator_datetime="1990-02-17 04:25:00",
-    )
-    fig.solar(
-        terminator="n",
-        pen="1p,yellow",
-        terminator_datetime="1990-02-17 04:25:00",
-    )
+    fig.solar(terminator="day_night", pen="1p,blue", terminator_datetime=dt)
+    fig.solar(terminator="astronomical", pen="1p,red", terminator_datetime=dt)
+    fig.solar(terminator="civil", pen="1p,green", terminator_datetime=dt)
+    fig.solar(terminator="nautical", pen="1p,yellow", terminator_datetime=dt)
     return fig
 
 


### PR DESCRIPTION
`test_solar_terminators` is failing in the GMT Dev Tests workflow. It turns out the current baseline image is correct.

This PR updates the baseline image and marks the test as xfail for GMT<=6.6.0. This PR also simplifies the test a little bit.

The correctness of the new baseline image can be confirmed by comparing with 
https://www.timeanddate.com/worldclock/sunearth.html?day=17&month=2&year=1990&hour=4&min=25&sec=00&n=%3A&ntxt=&earth=0