### PR TITLE
CI: Allow Doctests workflow to pass for segment fault on Windows

### DIFF
--- a/.github/workflows/ci_doctests.yaml
+++ b/.github/workflows/ci_doctests.yaml
@@ -84,4 +84,12 @@ jobs:
 
       # Run the doctests
       - name: Run doctests
-        run: make doctest PYTEST_EXTRA="-r P"
+        run: |
+          log_file="${RUNNER_TEMP}/pytest.log"
+          make doctest PYTEST_EXTRA="-r P" 2>&1 | tee "${log_file}"
+          exit_code=${PIPESTATUS[0]}
+          if [[ "${RUNNER_OS}" == "Windows" && "${exit_code}" -eq 2 ]] && grep -q "make: .* Error 2816" "${log_file}"; then
+            echo "Doctests exited with make error 2816 (segmentation fault) on Windows; allowing workflow to continue."
+            exit 0
+          fi
+          exit "${exit_code}"


### PR DESCRIPTION
Simliar to https://github.com/GenericMappingTools/pygmt/pull/4664 but for the Doctests workflow.

Changes will be reverted in https://github.com/GenericMappingTools/pygmt/pull/4156.

Triggered CI runs at https://github.com/GenericMappingTools/pygmt/actions/runs/27415631685.