### PR TITLE
CI: Set GMT_DATA_SERVER to the OpenTopography mirror in CI workflows

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@9d332c4d90b43981c3e55ae8e38e68709996240f # v4.17.0
         env:
-          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
+          GMT_DATA_SERVER: https://opentopography.s3.sdsc.edu/gmtdata
         with:
           mode: "instrumentation"
           # 'bash -el -c' is needed to use the custom shell.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -85,6 +85,8 @@ jobs:
       # Run the benchmark tests
       - name: Run benchmarks
         uses: CodSpeedHQ/action@9d332c4d90b43981c3e55ae8e38e68709996240f # v4.17.0
+        env:
+          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
         with:
           mode: "instrumentation"
           # 'bash -el -c' is needed to use the custom shell.

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -70,6 +70,8 @@ jobs:
 
       # Download remote files
       - name: Download remote data
+        env:
+          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
         run: |
           python -c "from pygmt.helpers.caching import cache_data; cache_data()"
 

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -71,7 +71,7 @@ jobs:
       # Download remote files
       - name: Download remote data
         env:
-          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
+          GMT_DATA_SERVER: https://opentopography.s3.sdsc.edu/gmtdata
         run: |
           python -c "from pygmt.helpers.caching import cache_data; cache_data()"
 

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -68,9 +68,6 @@ jobs:
       run:
         shell: bash -l {0}
 
-    env:
-      GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
-
     steps:
       # Checkout current git repository
       - name: Checkout

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Build the HTML documentation
         env:
-          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
+          GMT_DATA_SERVER: https://opentopography.s3.sdsc.edu/gmtdata
         run: |
           log_file="${RUNNER_TEMP}/sphinx-html.log"
           make -C doc clean html 2>&1 | tee "${log_file}"
@@ -149,7 +149,7 @@ jobs:
 
       - name: Build the PDF documentation
         env:
-          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
+          GMT_DATA_SERVER: https://opentopography.s3.sdsc.edu/gmtdata
         run: |
           log_file="${RUNNER_TEMP}/sphinx-pdf.log"
           make -C doc pdf 2>&1 | tee "${log_file}"

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -68,6 +68,9 @@ jobs:
       run:
         shell: bash -l {0}
 
+    env:
+      GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
+
     steps:
       # Checkout current git repository
       - name: Checkout
@@ -135,6 +138,8 @@ jobs:
           python -m pip install dist/*
 
       - name: Build the HTML documentation
+        env:
+          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
         run: |
           log_file="${RUNNER_TEMP}/sphinx-html.log"
           make -C doc clean html 2>&1 | tee "${log_file}"
@@ -146,6 +151,8 @@ jobs:
           exit "${exit_code}"
 
       - name: Build the PDF documentation
+        env:
+          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
         run: |
           log_file="${RUNNER_TEMP}/sphinx-pdf.log"
           make -C doc pdf 2>&1 | tee "${log_file}"

--- a/.github/workflows/ci_doctests.yaml
+++ b/.github/workflows/ci_doctests.yaml
@@ -85,7 +85,7 @@ jobs:
       # Run the doctests
       - name: Run doctests
         env:
-          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
+          GMT_DATA_SERVER: https://opentopography.s3.sdsc.edu/gmtdata
         run: |
           log_file="${RUNNER_TEMP}/pytest.log"
           make doctest PYTEST_EXTRA="-r P" 2>&1 | tee "${log_file}"

--- a/.github/workflows/ci_doctests.yaml
+++ b/.github/workflows/ci_doctests.yaml
@@ -84,6 +84,8 @@ jobs:
 
       # Run the doctests
       - name: Run doctests
+        env:
+          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
         run: |
           log_file="${RUNNER_TEMP}/pytest.log"
           make doctest PYTEST_EXTRA="-r P" 2>&1 | tee "${log_file}"

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -100,7 +100,6 @@ jobs:
 
     # Environment variables used by codecov
     env:
-      GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
       NUMPY: ${{ matrix.numpy-version }}

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -144,15 +144,15 @@ jobs:
             pytest-rerunfailures
 
       # Download cached remote files (artifacts) from GitHub
-      #- name: Download remote data from GitHub
-      #  run: |
-      #    # Download files to ~/.gmt directory and list them
-      #    gh run download --name gmt-cache --dir ~/.gmt/
-      #    # Change modification times of the two files, so GMT won't refresh it
-      #    touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
-      #    ls -lhR ~/.gmt
-      #  env:
-      #    GH_TOKEN: ${{ github.token }}
+      - name: Download remote data from GitHub
+        run: |
+          # Download files to ~/.gmt directory and list them
+          gh run download --name gmt-cache --dir ~/.gmt/
+          # Change modification times of the two files, so GMT won't refresh it
+          touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
+          ls -lhR ~/.gmt
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -190,7 +190,7 @@ jobs:
       # Run the regular tests
       - name: Run tests
         env:
-          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
+          GMT_DATA_SERVER: https://opentopography.s3.sdsc.edu/gmtdata
         run: |
           log_file="${RUNNER_TEMP}/pytest.log"
           make test PYTEST_EXTRA="-r P --reruns 2" 2>&1 | tee "${log_file}"

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -144,15 +144,15 @@ jobs:
             pytest-rerunfailures
 
       # Download cached remote files (artifacts) from GitHub
-      - name: Download remote data from GitHub
-        run: |
-          # Download files to ~/.gmt directory and list them
-          gh run download --name gmt-cache --dir ~/.gmt/
-          # Change modification times of the two files, so GMT won't refresh it
-          touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
-          ls -lhR ~/.gmt
-        env:
-          GH_TOKEN: ${{ github.token }}
+      #- name: Download remote data from GitHub
+      #  run: |
+      #    # Download files to ~/.gmt directory and list them
+      #    gh run download --name gmt-cache --dir ~/.gmt/
+      #    # Change modification times of the two files, so GMT won't refresh it
+      #    touch ~/.gmt/gmt_data_server.txt ~/.gmt/gmt_hash_server.txt
+      #    ls -lhR ~/.gmt
+      #  env:
+      #    GH_TOKEN: ${{ github.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -100,6 +100,7 @@ jobs:
 
     # Environment variables used by codecov
     env:
+      GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
       NUMPY: ${{ matrix.numpy-version }}
@@ -189,6 +190,8 @@ jobs:
 
       # Run the regular tests
       - name: Run tests
+        env:
+          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
         run: |
           log_file="${RUNNER_TEMP}/pytest.log"
           make test PYTEST_EXTRA="-r P --reruns 2" 2>&1 | tee "${log_file}"

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -184,7 +184,7 @@ jobs:
       - name: Test with pytest
         run: make test PYTEST_EXTRA="-r P --reruns 2"
         env:
-          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
+          GMT_DATA_SERVER: https://opentopography.s3.sdsc.edu/gmtdata
           GMT_LIBRARY_PATH: ${{ runner.temp }}/gmt-install-dir/lib
 
       # Upload diff images on test failure

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -184,6 +184,7 @@ jobs:
       - name: Test with pytest
         run: make test PYTEST_EXTRA="-r P --reruns 2"
         env:
+          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
           GMT_LIBRARY_PATH: ${{ runner.temp }}/gmt-install-dir/lib
 
       # Upload diff images on test failure

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -95,4 +95,6 @@ jobs:
 
       # Run the tests but skip images
       - name: Run tests
+        env:
+          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
         run: make test_no_images PYTEST_EXTRA="-r P"

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -96,5 +96,5 @@ jobs:
       # Run the tests but skip images
       - name: Run tests
         env:
-          GMT_DATA_SERVER: https://mirrors.ustc.edu.cn/gmtdata/
+          GMT_DATA_SERVER: https://opentopography.s3.sdsc.edu/gmtdata
         run: make test_no_images PYTEST_EXTRA="-r P"

--- a/examples/tutorials/advanced/draping_on_3d_surface.py
+++ b/examples/tutorials/advanced/draping_on_3d_surface.py
@@ -99,7 +99,9 @@ region_3d = [*region_2d, grd_relief.min().to_numpy(), grd_relief.max().to_numpy(
 # The original image is available on Wikimedia Commons at
 # https://commons.wikimedia.org/wiki/File:Flag_of_Europe.svg
 # but we use a cached version on the GMT data server.
-url_to_image = "https://oceania.generic-mapping-tools.org/cache/euflag.png"
+url_to_image = (
+    "https://github.com/GenericMappingTools/gmtserver-admin/raw/master/cache/euflag.png"
+)
 with rasterio.open(url_to_image) as dataset:
     data = dataset.read()
     drape_grid = xr.DataArray(data, dims=("band", "y", "x"))

--- a/pygmt/tests/test_datatypes_dataset.py
+++ b/pygmt/tests/test_datatypes_dataset.py
@@ -156,25 +156,17 @@ def test_dataset_to_strings_with_none_values():
 
     See the bug report at https://github.com/GenericMappingTools/pygmt/issues/3170.
     """
-    # Sometimes, the test may fail in CI due to intermittent internet connection issue.
-    # Catch the FileNotFoundError exception so that we can focus on the bug.
     tiles = ["@N30E060.earth_age_01m_g.nc", "@N30E090.earth_age_01m_g.nc"]
-    try:
-        paths = which(fname=tiles, download="auto")
-        assert len(paths) == 2
 
-        # 'paths' may contain an empty string or not, depending on if tiles are cached.
-        if "" not in paths:  # Contains two valid paths.
-            # Delete the cached tiles and try again.
-            for path in paths:
-                Path(path).unlink()
-            with pytest.warns(expected_warning=RuntimeWarning) as record:  # noqa: PT031
-                try:
-                    paths = which(fname=tiles, download="auto")
-                    assert len(record) == 1
-                    assert len(paths) == 2
-                    assert "" in paths
-                except FileNotFoundError:
-                    pass
-    except FileNotFoundError:
-        pass
+    paths = which(fname=tiles, download="auto")
+    assert len(paths) == 2
+    # 'paths' may contain an empty string or not, depending on if the tiles are cached.
+    if "" not in paths:  # Contains two valid paths.
+        # Delete the cached tiles and try again.
+        for path in paths:
+            Path(path).unlink()
+        with pytest.warns(expected_warning=RuntimeWarning) as record:
+            paths = which(fname=tiles, download="auto")
+        assert len(record) == 1
+        assert len(paths) == 2
+        assert "" in paths

--- a/pygmt/tests/test_which.py
+++ b/pygmt/tests/test_which.py
@@ -68,10 +68,7 @@ def test_which_nonascii_path(monkeypatch):
             # Start a new session
             begin()
             # GMT should download the remote file under the new home directory.
-            try:
-                fname = which(fname="@static_earth_relief.nc", download="cache")
-            except FileNotFoundError:
-                pytest.skip("Failed to download the file, skipping the test.")
+            fname = which(fname="@static_earth_relief.nc", download="cache")
             assert fname.startswith(fakehome)
             assert fname.endswith("static_earth_relief.nc")
             end()


### PR DESCRIPTION
As inspired by https://github.com/conda-forge/gmt-feedstock/pull/343#issuecomment-4716296777, using direct URLs to the GMT data server is more stable.

This PR updates the CI workflows to use the OpenTopograhy mirror. It also reverts some workarounds for data download failures.