### PR TITLE
Figure.plot/Figure.basemap/Figure.coast/Figure.text: Document the high-level wrappers in the docstrings

### DIFF
--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -124,6 +124,15 @@ def basemap(  # noqa: PLR0913
     $perspective
     $transparency
 
+    See Also
+    --------
+    pygmt.Figure.directional_rose
+        Add a map directional rose.
+    pygmt.Figure.magnetic_rose
+        Add a map magnetic rose.
+    pygmt.Figure.scalebar
+        Add a scale bar.
+
     Examples
     --------
     >>> import pygmt

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -208,6 +208,15 @@ def coast(  # noqa: PLR0913
     $perspective
     $transparency
 
+    See Also
+    --------
+    pygmt.Figure.directional_rose
+        Add a map directional rose.
+    pygmt.Figure.magnetic_rose
+        Add a map magnetic rose.
+    pygmt.Figure.scalebar
+        Add a scale bar.
+
     Example
     -------
     >>> import pygmt

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -241,12 +241,12 @@ def plot(  # noqa: PLR0912, PLR0913
     --------
     pygmt.Figure.choropleth
         Plot a choropleth map.
+    pygmt.Figure.fill_between
+        Fill the area between two curves.
     pygmt.Figure.hlines
         Plot horizontal lines.
     pygmt.Figure.vlines
         Plot vertical lines.
-    pygmt.Figure.fill_between
-        Fill the area between two curves.
     """
     # TODO(GMT>6.5.0): Remove the note for the upstream bug of the "straight_line"
     # parameter.

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -86,17 +86,6 @@ def plot(  # noqa: PLR0912, PLR0913
 
     Full GMT docs at :gmt-docs:`plot.html`.
 
-    See Also
-    --------
-    pygmt.Figure.choropleth
-        Plot a choropleth map.
-    pygmt.Figure.hlines
-        Plot horizontal lines.
-    pygmt.Figure.vlines
-        Plot vertical lines.
-    pygmt.Figure.fill_between
-        Fill the area between two curves.
-
     $aliases
        - A = straight_line
        - B = frame
@@ -107,6 +96,17 @@ def plot(  # noqa: PLR0912, PLR0913
        - i = incols
        - p = perspective
        - t = transparency
+
+    See Also
+    --------
+    pygmt.Figure.choropleth
+        Plot a choropleth map.
+    pygmt.Figure.hlines
+        Plot horizontal lines.
+    pygmt.Figure.vlines
+        Plot vertical lines.
+    pygmt.Figure.fill_between
+        Fill the area between two curves.
 
     Parameters
     ----------

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -86,6 +86,17 @@ def plot(  # noqa: PLR0912, PLR0913
 
     Full GMT docs at :gmt-docs:`plot.html`.
 
+    See Also
+    --------
+    pygmt.Figure.choropleth
+        Plot a choropleth map.
+    pygmt.Figure.hlines
+        Plot horizontal lines.
+    pygmt.Figure.vlines
+        Plot vertical lines.
+    pygmt.Figure.fill_between
+        Fill the area between two curves.
+
     $aliases
        - A = straight_line
        - B = frame

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -97,17 +97,6 @@ def plot(  # noqa: PLR0912, PLR0913
        - p = perspective
        - t = transparency
 
-    See Also
-    --------
-    pygmt.Figure.choropleth
-        Plot a choropleth map.
-    pygmt.Figure.hlines
-        Plot horizontal lines.
-    pygmt.Figure.vlines
-        Plot vertical lines.
-    pygmt.Figure.fill_between
-        Fill the area between two curves.
-
     Parameters
     ----------
     data
@@ -247,6 +236,17 @@ def plot(  # noqa: PLR0912, PLR0913
         ``transparency`` can also be a 1-D array to set varying transparency for
         symbols, but this option is only valid if using ``x``/``y``.
     $wrap
+
+    See Also
+    --------
+    pygmt.Figure.choropleth
+        Plot a choropleth map.
+    pygmt.Figure.hlines
+        Plot horizontal lines.
+    pygmt.Figure.vlines
+        Plot vertical lines.
+    pygmt.Figure.fill_between
+        Fill the area between two curves.
     """
     # TODO(GMT>6.5.0): Remove the note for the upstream bug of the "straight_line"
     # parameter.

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -190,7 +190,7 @@ def text(  # noqa: PLR0912, PLR0913, PLR0915
 
     See Also
     --------
-    pygmt.Figure.paragarph
+    pygmt.Figure.paragraph
         Typeset one or multiple paragraphs.
     """
     self._activate_figure()

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -187,6 +187,11 @@ def text(  # noqa: PLR0912, PLR0913, PLR0915
         ``transparency`` can also be a 1-D array to set varying transparency for texts,
         but this option is only valid if using ``x``/``y`` and ``text``.
     $wrap
+
+    See Also
+    --------
+    pygmt.Figure.paragarph
+        Typeset one or multiple paragraphs.
     """
     self._activate_figure()
 


### PR DESCRIPTION
**Preview**: 

- https://pygmt-dev--4686.org.readthedocs.build/en/4686/api/generated/pygmt.Figure.plot.html
- https://pygmt-dev--4686.org.readthedocs.build/en/4686/api/generated/pygmt.Figure.basemap.html#pygmt.Figure.basemap
- https://pygmt-dev--4686.org.readthedocs.build/en/4686/api/generated/pygmt.Figure.coast.html#pygmt.Figure.coast
- https://pygmt-dev--4686.org.readthedocs.build/en/4686/api/generated/pygmt.Figure.text.html#pygmt.Figure.text