### PR TITLE
Figure.pygmtlogo: Extend the region to get rid of the 'no_clip' parameter

### DIFF
--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -33,10 +33,11 @@ def _create_logo(  # noqa: PLR0915
     # Helpful definitions
     size = 4
     proj = "x1c"
+    factor = 1.2  # Extension factor for the region
     region = {
-        "horizontal": [-size, size * 7.0, -size, size],
-        "vertical": [-size, size, -size * 1.75, size],
-        "none": [-size, size, -size, size],
+        "horizontal": [-size * factor, size * 7.0, -size * factor, size * factor],
+        "vertical": [-size * factor, size * factor, -size * 2.0, size * factor],
+        "none": [-size * factor, size * factor, -size * factor, size * factor],
     }[wordmark]
 
     # Rotation around z-axis by 30 degrees counter-clockwise placed in the center.
@@ -96,7 +97,6 @@ def _create_logo(  # noqa: PLR0915
                 "y": -size * (1.375 if shape == "circle" else 1.5),
                 "justify": "ML",
                 "font": f"{fontsize}c,{font}",
-                "no_clip": True,  # Needed because x<xmin.
             }
         case "horizontal":
             # The stroke width matches the outline thickness.
@@ -210,11 +210,7 @@ def _create_logo(  # noqa: PLR0915
     fig.basemap(region=region, projection=proj, perspective=perspective, frame="none")
 
     # Earth - circle / hexagon
-    args_shape = {
-        "style": f"{symbol}{size_shape}c",
-        "perspective": True,
-        "no_clip": True,  # Needed for corners of hexagon shape
-    }
+    args_shape = {"style": f"{symbol}{size_shape}c", "perspective": True}
     # Shape fill
     fig.plot(x=0, y=0, fill=color_bg, **args_shape)
 
@@ -224,7 +220,6 @@ def _create_logo(  # noqa: PLR0915
         pen=f"{thick_comp}c,{yellow}",
         style="v0c+s",
         perspective=True,
-        no_clip=True,
     )
 
     # Shape outline (over ends of compass lines for hexagon shape)

--- a/pygmt/tests/baseline/test_pygmtlogo_design_circle-horizontal.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_design_circle-horizontal.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: c7f505e806eb73810f5763a80ad64429
-  size: 320079
+- md5: 831a6698935382f61d8bcc6fc370d274
+  size: 335810
   hash: md5
   path: test_pygmtlogo_design_circle-horizontal.png

--- a/pygmt/tests/baseline/test_pygmtlogo_design_circle-vertical.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_design_circle-vertical.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 3c5ee0bd73272bf1cbce54ef17a9e144
-  size: 174742
+- md5: 0c38f25ed07da7d75af993c12cdad179
+  size: 193354
   hash: md5
   path: test_pygmtlogo_design_circle-vertical.png

--- a/pygmt/tests/baseline/test_pygmtlogo_design_hexagon-horizontal.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_design_hexagon-horizontal.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 039c82f3d7857e0519612f89b55881d3
-  size: 357201
+- md5: f72973f5962322f332bdea84779cef99
+  size: 366555
   hash: md5
   path: test_pygmtlogo_design_hexagon-horizontal.png

--- a/pygmt/tests/baseline/test_pygmtlogo_design_hexagon-vertical.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_design_hexagon-vertical.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 1e3b6735330f85bd03c339bd28157ded
-  size: 195818
+- md5: c1dc51f566e278f969f5cd8d07c3d4f4
+  size: 212032
   hash: md5
   path: test_pygmtlogo_design_hexagon-vertical.png

--- a/pygmt/tests/baseline/test_pygmtlogo_wordmark_vertical_circle.png.dvc
+++ b/pygmt/tests/baseline/test_pygmtlogo_wordmark_vertical_circle.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 4556fca734c6101f6fbc895192ee48f3
-  size: 41793
+- md5: 18030a7c5fa9dcab169ef3c34c298b83
+  size: 41886
   hash: md5
   path: test_pygmtlogo_wordmark_vertical_circle.png


### PR DESCRIPTION
Extending the `region` parameter by 20% so that we no longer need the `no_clip` parameter when plotting hexagonal logos and wordmarks.

Changes this PR don't affect the logo appearance, but affect the debugging basemap in the tests for logo designs.