### PR TITLE
Add typos for source code spelling check

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/4-release_checklist.md
@@ -33,7 +33,7 @@ assignees: ''
 - [ ] Update warnings in `pygmt/_show_versions.py` as well as notes in [Not working transparency](https://www.pygmt.org/dev/install.html#not-working-transparency) regarding GMT-Ghostscript incompatibility
 - [ ] Reserve a DOI on [Zenodo](https://zenodo.org) by clicking on "New Version"
 - [ ] Finish up the "Changelog entry for v0.x.x" Pull Request (Use the previous changelog PR as a reference)
-- [ ] Run `make codespell` to check common misspellings. If there are any, either fix them or add them to `ignore-words-list` in `pyproject.toml`
+- [ ] Run `make spellcheck` to check common misspellings. If there are any, either fix them or add them to the relevant spelling configuration in `pyproject.toml`
 - [ ] Draft the announcement on https://hackmd.io/@pygmt
 
 **Release**:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help:
 	@echo "  test_no_images run the test suite (including all doctests) but skip image comparisons"
 	@echo "  format         run Ruff to automatically format the code"
 	@echo "  check          run Ruff to check code style and quality"
-	@echo "  codespell      run codespell to check common misspellings"
+	@echo "  spellcheck     run codespell and typos to check common misspellings"
 	@echo "  typecheck      run mypy for static type check"
 	@echo "  clean          clean up build and generated files"
 	@echo "  distclean      clean up build and generated files, including project metadata files"
@@ -67,8 +67,11 @@ check:
 	ruff check $(FORMAT_FILES)
 	ruff format --check $(FORMAT_FILES)
 
-codespell:
-	@codespell
+spellcheck:
+	@status=0; \
+	codespell || status=1; \
+	typos || status=1; \
+	exit $$status
 
 typecheck:
 	mypy ${PROJECT}

--- a/doc/techref/justification_codes.md
+++ b/doc/techref/justification_codes.md
@@ -10,8 +10,8 @@ figure (**reference point**) and a point on the feature (**anchor point**). For 
 users can use a two-character code, a combination of a vertical code and a horizontal
 code (order-independent):
 
-- Vertical: **T**(op), **M**(iddle), **B**(ottom)
-- Horizontal: **L**(eft), **C**(entre), **R**(ight)
+- Vertical: **T** (Top), **M** (Middle), **B** (Bottom)
+- Horizontal: **L** (Left), **C** (Centre), **R** (Right)
 
 For example, `"TL"` means **T**op **L**eft.
 

--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,7 @@ dependencies:
     - codespell
     - prek
     - ruff>=0.15.5
+    - typos
     # Dev dependencies (unit testing)
     - matplotlib-base
     - pytest>=6.0

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -239,7 +239,7 @@ def velo(  # noqa : PLR0913
         Select the quantity that will be used with the CPT given via ``cmap``
         to set the fill color.  Choose from **m**\ agnitude (vector magnitude
         or rotation magnitude), **e**\ ast-west velocity, **n**\ orth-south
-        velocity, or **u**\ ser-supplied data column (supplied after the
+        velocity, or **u** (User-supplied data column after the
         required columns). To instead use the corresponding error estimates
         (i.e., vector or rotation uncertainty) to lookup the color and paint
         the error ellipse or wedge instead, append **+e**.

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -239,7 +239,7 @@ def velo(  # noqa : PLR0913
         Select the quantity that will be used with the CPT given via ``cmap``
         to set the fill color.  Choose from **m**\ agnitude (vector magnitude
         or rotation magnitude), **e**\ ast-west velocity, **n**\ orth-south
-        velocity, or **u** (User-supplied data column after the
+        velocity, or **u** (user-supplied data column after the
         required columns). To instead use the corresponding error estimates
         (i.e., vector or rotation uncertainty) to lookup the color and paint
         the error ellipse or wedge instead, append **+e**.

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -21,7 +21,7 @@ def test_begin_end():
     end()  # Kill the global session
     begin()
     with Session() as lib:
-        lib.call_module("basemap", ["-R10/70/-3/8", "-JX4i/3i", "-Ba"])
+        lib.call_module("basemap", ["-R10/70/-3/8", "-JX4i/3i", "-Bafg"])
     end()
     begin()  # Restart the global session
     assert Path("pygmt-session.pdf").exists()
@@ -42,7 +42,7 @@ def test_gmt_compat_6_is_applied(capsys):
             lib.call_module("gmtset", ["GMT_COMPATIBILITY=5"])
         begin()
         with Session() as lib:
-            lib.call_module("basemap", ["-R10/70/-3/8", "-JX4i/3i", "-Ba"])
+            lib.call_module("basemap", ["-R10/70/-3/8", "-JX4i/3i", "-Bafg"])
             out, err = capsys.readouterr()  # capture stdout and stderr
             assert out == ""
             assert err != (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,22 @@ fallback_version = "999.999.999+unknown"
 [tool.codespell]
 ignore-words-list = "astroid,te,tripel,trough"
 
+[tool.typos.default]
+extend-ignore-re = [
+    # Ignore lines that end with `# codespell:ignore`
+    # TODO: Refactor the re if codespell support is dropped in the future.
+    "(?Rm)^.*(#|//)\\s*codespell:ignore$",
+]
+extend-ignore-words-re = [
+    "astroid",
+    "fo",  # codespell:ignore
+    "OCE", # codespell:ignore
+    "[tT]ripel",
+]
+extend-ignore-identifiers-re = [
+    "pn",
+]
+
 [tool.coverage.run]
 omit = ["*/tests/*", "*pygmt/__init__.py"]
 


### PR DESCRIPTION
Closes #4689.

Changes in this PR:

- Add support for `typos`
- Ignore some words for `typos`
- Rename the `codespell` make target to the more general target `spellcheck`
- Update the instruction in the release checklist

After excluding some false detections, `typos` still reports one typo: 
```
error: `pricipal` should be `principal`
    ╭▸ ./doc/changes.md:643:25
    │
643 │ * Figure.meca: Fix typo pricipal_axis -> principal_axis ([#2940](https://github.com/GenericMa…
    ╰╴                        ━━━━━━━━
make: *** [Makefile:71: spellcheck] Error 1
```
I guess we need to either remove the entry from the changelog or just ignore it.

**Preview**:

- https://pygmt-dev--4690.org.readthedocs.build/en/4690/techref/justification_codes.html