### PR TITLE
codespell: Avoid project-level ignore words if possible

### DIFF
--- a/doc/techref/justification_codes.md
+++ b/doc/techref/justification_codes.md
@@ -106,7 +106,7 @@ fig = pygmt.Figure()
 fig.basemap(projection="X10c/2c", region=[-size, size, -size, size], frame=0)
 
 fig.colorbar(
-    cmap="SCM/buda",
+    cmap="SCM/hawaii",
     frame=0,
     position="MC",
     length=10,

--- a/pygmt/datatypes/header.py
+++ b/pygmt/datatypes/header.py
@@ -210,7 +210,7 @@ class _GMT_GRID_HEADER(ctp.Structure):  # noqa: N801
             GridFormat.NS,
             GridFormat.NI,
             GridFormat.NF,
-            GridFormat.ND,
+            GridFormat.ND,  # codespell:ignore
         }:  # Set attributes specific to CF-1.7 conventions
             attrs["Conventions"] = "CF-1.7"
             attrs["title"] = self.title.decode()

--- a/pygmt/enums.py
+++ b/pygmt/enums.py
@@ -31,7 +31,7 @@ class GridFormat(IntEnum):
     NS = 16  #: GMT netCDF format (16-bit integer)
     NI = 17  #: GMT netCDF format (32-bit integer)
     NF = 18  #: GMT netCDF format (32-bit float)
-    ND = 19  #: GMT netCDF format (64-bit float)
+    ND = 19  #: GMT netCDF format (64-bit float)  # codespell:ignore
     SD = 20  #: Golden Software Surfer format 7 (64-bit float, read-only)
     AF = 21  #: Atlantic Geoscience Center format AGC (32-bit float)
     GD = 22  #: Import through GDAL

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -126,7 +126,7 @@ COMMON_DOCSTRINGS = {
               or (m)\ **e**\ (ters), **f**\ (eet), **k**\ (ilometers),
               **M**\ (iles), or **n**\ (autical miles) [Default is (m)\ **e**\ (ters)].
             - For projected data (**X**\|\ **Y**\|\ **D**), the unit may be
-              **i**\ (nches), **c**\ (entimeters), or **p**\ (oints).
+              **i** (inches), **c** (centimeters), or **p** (points).
 
             Append modifier **+a** to specify that *all* the criteria must be
             met [default imposes breaks if any one criterion is met].

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ local_scheme = "node-and-date"
 fallback_version = "999.999.999+unknown"
 
 [tool.codespell]
-ignore-words-list = "astroid,buda,oints,reenable,te,tripel,trough,ND"
+ignore-words-list = "astroid,te,tripel,trough"
 
 [tool.coverage.run]
 omit = ["*/tests/*", "*pygmt/__init__.py"]


### PR DESCRIPTION
This PR tries to shorten the project-level ignore words list for codespell.