### PR TITLE
Figure.directional_rose/Figure.magnetic_rose: Set the default position to the top right

### DIFF
--- a/examples/gallery/embellishments/directional_roses.py
+++ b/examples/gallery/embellishments/directional_roses.py
@@ -3,7 +3,7 @@ Directional map rose
 ====================
 
 The :meth:`pygmt.Figure.directional_rose` method allows to add directional roses on
-maps. Using the method without any arguments will plot a rose at the bottom left corner,
+maps. Using the method without any arguments will plot a rose at the Top Right corner,
 but this example will focus on customizing its position and appearance.
 
 Colors of the map roses can be adjusted using :gmt-term:`MAP_DEFAULT_PEN` and

--- a/examples/gallery/embellishments/magnetic_rose.py
+++ b/examples/gallery/embellishments/magnetic_rose.py
@@ -13,7 +13,7 @@ fig = pygmt.Figure()
 fig.basemap(region=[-8, 8, -7, 7], projection="M10c", frame=True)
 
 # Add a magnetic rose
-# By default, it's placed in the lower left corner
+# By default, it's placed in the Top Right corner
 fig.magnetic_rose()
 
 # Add a magnetic rose with several adjustments

--- a/pygmt/src/directional_rose.py
+++ b/pygmt/src/directional_rose.py
@@ -5,9 +5,10 @@ directional_rose - Add a map directional rose.
 from collections.abc import Sequence
 from typing import Literal
 
+from packaging.version import Version
 from pygmt._typing import AnchorCode
 from pygmt.alias import Alias, AliasSystem
-from pygmt.clib import Session
+from pygmt.clib import Session, __gmt_version__
 from pygmt.helpers import build_arg_list, fmt_docstring
 from pygmt.params import Box, Position
 from pygmt.src._common import _parse_position
@@ -45,7 +46,7 @@ def directional_rose(
         - A :doc:`2-character justification code </techref/justification_codes>` for a
           position inside the plot, e.g., ``"TL"`` for Top Left corner inside the plot.
 
-        If not specified, defaults to the Bottom Left corner of the plot.
+        If not specified, defaults to the Top Right corner of the plot.
     width
         Width of the rose in plot coordinates, or append unit ``%`` for a size in
         percentage of plot width [Default is 10%].
@@ -83,7 +84,15 @@ def directional_rose(
     """
     self._activate_figure()
 
-    position = _parse_position(position, default=Position("BL", cstype="inside"))
+    # The default position is set to "TR" since GMT 6.7.0, which has no default value
+    # in GMT 6.6.0 and earlier versions.
+    # TODO(GMT>6.6.0): Set 'default=None' after GMT 6.7.0.
+    position = _parse_position(
+        position,
+        default=None
+        if Version(__gmt_version__) > Version("6.6.0")
+        else Position("TR", cstype="inside"),
+    )
 
     aliasdict = AliasSystem(
         F=Alias(box, name="box"),

--- a/pygmt/src/magnetic_rose.py
+++ b/pygmt/src/magnetic_rose.py
@@ -5,9 +5,10 @@ magnetic_rose - Add a map magnetic rose.
 from collections.abc import Sequence
 from typing import Literal
 
+from packaging.version import Version
 from pygmt._typing import AnchorCode
 from pygmt.alias import Alias, AliasSystem
-from pygmt.clib import Session
+from pygmt.clib import Session, __gmt_version__
 from pygmt.exceptions import GMTParameterError
 from pygmt.helpers import build_arg_list, fmt_docstring
 from pygmt.params import Box, Position
@@ -49,8 +50,7 @@ def magnetic_rose(  # noqa: PLR0913
         - A :doc:`2-character justification code </techref/justification_codes>` for a
           position inside the plot, e.g., ``"TL"`` for Top Left corner inside the plot.
 
-        If not specified, defaults to the Bottom Left corner of the plot (position
-        ``(0, 0)`` with anchor ``"BL"``).
+        If not specified, defaults to the Top Right corner of the plot.
     width
         Width of the rose in plot coordinates, or append unit ``%`` for a size in
         percentage of plot width [Default is 15%].
@@ -109,7 +109,15 @@ def magnetic_rose(  # noqa: PLR0913
     """
     self._activate_figure()
 
-    position = _parse_position(position, default=Position("BL", cstype="inside"))
+    # The default position is set to "TR" since GMT 6.7.0, which has no default value
+    # in GMT 6.6.0 and earlier versions.
+    # TODO(GMT>6.6.0): Set 'default=None' after GMT 6.7.0.
+    position = _parse_position(
+        position,
+        default=None
+        if Version(__gmt_version__) > Version("6.6.0")
+        else Position("TR", cstype="inside"),
+    )
 
     if declination_label is not None:
         if declination is None:

--- a/pygmt/tests/baseline/test_directional_rose.png.dvc
+++ b/pygmt/tests/baseline/test_directional_rose.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: c1c167a826132bcdabc3b032438db01e
-  size: 8319
+- md5: 10663a14391589a1854a0ea0285d1ac3
+  size: 8372
   hash: md5
   path: test_directional_rose.png

--- a/pygmt/tests/baseline/test_directional_rose_fancy.png.dvc
+++ b/pygmt/tests/baseline/test_directional_rose_fancy.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 7498ed12efd8b956a0fe13d18e0e3ea9
-  size: 8648
+- md5: 1846c3d58d0d10361040c5c846852036
+  size: 8593
   hash: md5
   path: test_directional_rose_fancy.png

--- a/pygmt/tests/baseline/test_magnetic_rose.png.dvc
+++ b/pygmt/tests/baseline/test_magnetic_rose.png.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 5af8ffee19917b1fbc3371cd3aed53cd
-  size: 27013
+- md5: 2438ead5b21314a50e5485b0aa715d88
+  size: 27016
   hash: md5
   path: test_magnetic_rose.png


### PR DESCRIPTION
**Description of proposed changes**

For GMT<=6.6.0, the position argument is required when plotting directional or magnetic roses. When implementing `Figure.directional_rose` and `Figure.magnetic_rose` in PyGMT, we decided to set the default position to the "bottom left" corner.

In a recent PR https://github.com/GenericMappingTools/gmt/pull/9074, the default position was changed to "Top Right." As a result, the default positions will be inconsistent between GMT and PyGMT.

Fortunately, `Figure.directional_rose` and `Figure.magnetic_rose` were added recently and have not yet been released. This gives us the opportunity to change the default behavior without breaking backward compatibility.

This PR updates the default position.