### PR TITLE
Reformat the CITATION.cff file using cffinit

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,88 +1,90 @@
 # YAML 1.2
 # Metadata for citation of this software according to the CFF format (https://citation-file-format.github.io/)
 cff-version: 1.2.0
-message: If you use this software, please cite it as follows.
 title: 'PyGMT: A Python interface for the Generic Mapping Tools'
-authors:
-- given-names: Dongdong
-  family-names: Tian
-  affiliation: China University of Geosciences, China
-  orcid: https://orcid.org/0000-0001-7967-1197
-- given-names: Wei Ji
-  family-names: Leong
-  affiliation: Development Seed, USA
-  orcid: https://orcid.org/0000-0003-2354-1988
-- given-names: Yvonne
-  family-names: Fröhlich
-  affiliation: Unaffiliated
-  orcid: https://orcid.org/0000-0002-8566-0619
-- given-names: Michael
-  family-names: Grund
-  affiliation: SNP Innovation Lab GmbH, Germany
-  orcid: https://orcid.org/0000-0001-8759-2018
-- given-names: William
-  family-names: Schlitzer
-  affiliation: Unaffiliated
-  orcid: https://orcid.org/0000-0002-5843-2282
-- given-names: Max
-  family-names: Jones
-  affiliation: University of Hawaiʻi at Mānoa, USA
-  orcid: https://orcid.org/0000-0003-0180-8928
-- given-names: Liam
-  family-names: Toney
-  affiliation: University of Alaska Fairbanks, USA
-  orcid: https://orcid.org/0000-0003-0167-9433
-- given-names: Jiayuan
-  family-names: Yao
-  affiliation: Nanyang Technological University, Singapore
-  orcid: https://orcid.org/0000-0001-7036-4238
-- given-names: Jing-Hui
-  family-names: Tong
-  affiliation: National Taiwan Normal University, Taiwan
-  orcid: https://orcid.org/0009-0002-7195-3071
-- given-names: Yohai
-  family-names: Magen
-  affiliation: Tel Aviv University, Israel
-  orcid: https://orcid.org/0000-0002-4892-4013
-- given-names: Kathryn
-  family-names: Materna
-  affiliation: US Geological Survey, USA
-  orcid: https://orcid.org/0000-0002-6687-980X
-- given-names: Andre
-  family-names: Belem
-  affiliation: Fluminense Federal University, Brazil
-  orcid: https://orcid.org/0000-0002-8865-6180
-- given-names: Tyler
-  family-names: Newton
-  affiliation: University of Oregon, USA
-  orcid: https://orcid.org/0000-0002-1560-6553
-- given-names: Abhishek
-  family-names: Anant
-  affiliation: Unaffiliated
-  orcid: https://orcid.org/0000-0002-5751-2010
-- given-names: Malte
-  family-names: Ziebarth
-  affiliation: GFZ German Research Centre for Geosciences, Germany
-  orcid: https://orcid.org/0000-0002-5190-4478
-- given-names: Jamie
-  family-names: Quinn
-  affiliation: University College London, United Kingdom
-  orcid: https://orcid.org/0000-0002-0268-7032
-- given-names: Xingchen
-  family-names: He
-  affiliation: Chengdu University of Technology, China
-  orcid: https://orcid.org/0009-0004-7182-2252
-- given-names: Leonardo
-  family-names: Uieda
-  affiliation: Universidade de São Paulo, Brazil
-  orcid: https://orcid.org/0000-0001-6123-9515
-- given-names: Paul
-  family-names: Wessel
-  affiliation: University of Hawaiʻi at Mānoa, USA
-  orcid: https://orcid.org/0000-0001-5708-7336
-date-released: 2026-01-12
-doi: 10.5281/zenodo.18080259
-license: BSD-3-Clause
-repository-code: https://github.com/GenericMappingTools/pygmt
+message: 'If you use this software, please cite it as follows.'
 type: software
+authors:
+  - given-names: Dongdong
+    family-names: Tian
+    affiliation: 'China University of Geosciences, China'
+    orcid: 'https://orcid.org/0000-0001-7967-1197'
+  - given-names: Wei Ji
+    family-names: Leong
+    affiliation: 'Development Seed, USA'
+    orcid: 'https://orcid.org/0000-0003-2354-1988'
+  - given-names: Yvonne
+    family-names: Fröhlich
+    affiliation: Unaffiliated
+    orcid: 'https://orcid.org/0000-0002-8566-0619'
+  - given-names: Michael
+    family-names: Grund
+    affiliation: 'SNP Innovation Lab GmbH, Germany'
+    orcid: 'https://orcid.org/0000-0001-8759-2018'
+  - given-names: William
+    family-names: Schlitzer
+    affiliation: Unaffiliated
+    orcid: 'https://orcid.org/0000-0002-5843-2282'
+  - given-names: Max
+    family-names: Jones
+    affiliation: 'University of Hawaiʻi at Mānoa, USA'
+    orcid: 'https://orcid.org/0000-0003-0180-8928'
+  - given-names: Liam
+    family-names: Toney
+    affiliation: 'University of Alaska Fairbanks, USA'
+    orcid: 'https://orcid.org/0000-0003-0167-9433'
+  - given-names: Jiayuan
+    family-names: Yao
+    affiliation: 'Nanyang Technological University, Singapore'
+    orcid: 'https://orcid.org/0000-0001-7036-4238'
+  - given-names: Jing-Hui
+    family-names: Tong
+    affiliation: 'National Taiwan Normal University, Taiwan'
+    orcid: 'https://orcid.org/0009-0002-7195-3071'
+  - given-names: Yohai
+    family-names: Magen
+    affiliation: 'Tel Aviv University, Israel'
+    orcid: 'https://orcid.org/0000-0002-4892-4013'
+  - given-names: Kathryn
+    family-names: Materna
+    affiliation: 'US Geological Survey, USA'
+    orcid: 'https://orcid.org/0000-0002-6687-980X'
+  - given-names: Andre
+    family-names: Belem
+    affiliation: 'Fluminense Federal University, Brazil'
+    orcid: 'https://orcid.org/0000-0002-8865-6180'
+  - given-names: Tyler
+    family-names: Newton
+    affiliation: 'University of Oregon, USA'
+    orcid: 'https://orcid.org/0000-0002-1560-6553'
+  - given-names: Abhishek
+    family-names: Anant
+    affiliation: Unaffiliated
+    orcid: 'https://orcid.org/0000-0002-5751-2010'
+  - given-names: Malte
+    family-names: Ziebarth
+    affiliation: 'GFZ German Research Centre for Geosciences, Germany'
+    orcid: 'https://orcid.org/0000-0002-5190-4478'
+  - given-names: Jamie
+    family-names: Quinn
+    affiliation: 'University College London, United Kingdom'
+    orcid: 'https://orcid.org/0000-0002-0268-7032'
+  - given-names: Xingchen
+    family-names: He
+    affiliation: 'Chengdu University of Technology, China'
+    orcid: 'https://orcid.org/0009-0004-7182-2252'
+  - given-names: Leonardo
+    family-names: Uieda
+    affiliation: 'Universidade de São Paulo, Brazil'
+    orcid: 'https://orcid.org/0000-0001-6123-9515'
+  - given-names: Paul
+    family-names: Wessel
+    affiliation: 'University of Hawaiʻi at Mānoa, USA'
+    orcid: 'https://orcid.org/0000-0001-5708-7336'
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.18080259
+repository-code: 'https://github.com/GenericMappingTools/pygmt'
+license: BSD-3-Clause
 version: 0.18.0
+date-released: '2026-01-12'


### PR DESCRIPTION
This PR regenerates the `CITATION.cff` file using [cffinit](https://citation-file-format.github.io/cff-initializer-javascript/)⁠￼.

Main changes include:

* The author list is indented by two spaces
* Some fields are now enclosed in single quotes
* The `doi` field is not a standard top-level field in CFF; although GitHub’s citation tool can still recognize it, this PR updates the entry to use the `identifiers` field instead