### PR TITLE
DOC: Add import of Axis and Frame parameter classes to inline examples

### DIFF
--- a/pygmt/params/frame.py
+++ b/pygmt/params/frame.py
@@ -23,6 +23,7 @@ class Axis(BaseParam):
     annotations, 2 for ticks, and 1 for gridlines:
 
     >>> import pygmt
+    >>> from pygmt.params import Axis
     >>> fig = pygmt.Figure()
     >>> fig.basemap(
     ...     region=[0, 10, 0, 20],
@@ -127,6 +128,7 @@ class Frame(BaseParam):
     and north axes with ticks but without annotations:
 
     >>> import pygmt
+    >>> from pygmt.params import Axis, Frame
     >>> fig = pygmt.Figure()
     >>> fig.basemap(
     ...     region=[0, 10, 0, 20], projection="X10c/10c", frame=Frame(axes="WSen")


### PR DESCRIPTION
**Description of proposed changes**

Add import of the `Axis` and `Frame` parameter classes to make inline examples directly executable.

**Preview**:

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
