### PR TITLE
Adjust border of searchbar to align fill color of sidebar top box

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -66,6 +66,11 @@ p {
     background: #b4c7e7;
 }
 
+/* Change border of the search bar */
+.wy-side-nav-search input[type="text"] {
+    border: solid 2px #b4c7e7;
+}
+
 /* Format parameters section similar to sphinx_rtd_theme v4.x.x (not a grid) */
 html.writer-html5 .rst-content dl.field-list {
     display: initial;


### PR DESCRIPTION
**Description of proposed changes**

Adjust the color of the border of the searchbar to be consistent with the outline of the box showing the version and to better fit to the lightblue fill of the top box; xref: https://dsw-gdscript2rst-docs.readthedocs.io/en/latest/appendix/custom_css.html.
I do not know why the box of the version appears different in the generated preview.

| currently | new |
| :---: | :---: |
| <img width="993" height="311" alt="searchbar_outline_blue" src="https://github.com/user-attachments/assets/3dfa75af-c7f9-45bb-8db8-a1cbb71c9d53" /> | <img width="993" height="312" alt="searchbar_outline_lightblue" src="https://github.com/user-attachments/assets/cbd96384-c11c-4ae9-a3c7-4ef84b5776fe" /> |

**Preview**: https://pygmt-dev--4718.org.readthedocs.build/en/4718/

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
