### PR TITLE
DOC: Add design idea of PyGMT logo to docstrings

### DIFF
--- a/examples/gallery/embellishments/pygmtlogo.py
+++ b/examples/gallery/embellishments/pygmtlogo.py
@@ -27,7 +27,7 @@ fig.show()
 
 
 # %%
-# Via the ``color``, ``theme``, ``shape`` parameters the appereance of the logo can be
+# Via the ``color``, ``theme``, ``shape`` parameters the appearance of the logo can be
 # changed.
 
 fig = pygmt.Figure()

--- a/examples/gallery/embellishments/pygmtlogo.py
+++ b/examples/gallery/embellishments/pygmtlogo.py
@@ -27,7 +27,7 @@ fig.show()
 
 
 # %%
-# Via the ``color``, ``theme``, ``shape`` parameters the appearance of the logo can be
+# Via the ``color``, ``theme``, ``shape`` parameters the appereance of the logo can be
 # changed.
 
 fig = pygmt.Figure()

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -43,7 +43,7 @@ def logo(  # noqa: PLR0913
 
     By default, the GMT logo is 2 inches wide and 1 inch high and will be positioned
     relative to the current plot origin. Besides this logo, there is a specific logo for
-    PyGMT :meth:`Figure.pygmt.pygmtlogo`.
+    PyGMT :meth:`pygmt.Figure.pygmtlogo`.
 
     Full GMT docs at :gmt-docs:`gmtlogo.html`.
 

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -42,7 +42,8 @@ def logo(  # noqa: PLR0913
        :width: 300px
 
     By default, the GMT logo is 2 inches wide and 1 inch high and will be positioned
-    relative to the current plot origin.
+    relative to the current plot origin. Besides this logo, there is a specific logo for
+    PyGMT :meth:`Figure.pygmt.pygmtlogo`.
 
     Full GMT docs at :gmt-docs:`gmtlogo.html`.
 

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -42,8 +42,7 @@ def logo(  # noqa: PLR0913
        :width: 300px
 
     By default, the GMT logo is 2 inches wide and 1 inch high and will be positioned
-    relative to the current plot origin. Besides this logo, there is a specific logo for
-    PyGMT :meth:`pygmt.Figure.pygmtlogo`.
+    relative to the current plot origin.
 
     Full GMT docs at :gmt-docs:`gmtlogo.html`.
 
@@ -97,6 +96,11 @@ def logo(  # noqa: PLR0913
     $panel
     $perspective
     $transparency
+
+    See Also
+    --------
+    pygmt.Figure.pygmtlogo
+        Plot the PyGMT logo.
 
     Examples
     --------

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -291,6 +291,11 @@ def pygmtlogo(  # noqa: PLR0913
     """
     Plot the PyGMT logo.
 
+    .. figure:: https://github.com/GenericMappingTools/pygmt/blob/main/doc/_static/pygmtlogo.png
+       :alt: PyGMT logo
+       :align: center
+       :width: 300px
+
     The design of the logo is kindly provided by `@sfrooti <https://github.com/sfrooti>`_
     and consists of a visual and the wordmark "PyGMT".
 

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -298,10 +298,10 @@ def pygmtlogo(  # noqa: PLR0913
 
     The design of the logo is kindly provided by `@sfrooti <https://github.com/sfrooti>`_
     and consists of a visual and the wordmark "PyGMT". The outer shape (in Python blue)
-	represents Earth, with compass lines (in Python yellow) surrounding the letters "GMT"
-	(in the red used for the GMT logo). The letter "T" is the needle of the compass.
-    By default, the PyGMT logo is plotted without wordmark, with a size of 2 centimeters
-	for the circular version of the icon.
+    represents Earth, with compass lines (in Python yellow) surrounding the letters
+    "GMT" (in the red used for the GMT logo). The letter "T" is the needle of the
+    compass. By default, the PyGMT logo is plotted without wordmark, with a size of 2
+    centimeters for the circular version of the icon.
 
     Parameters
     ----------

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -297,11 +297,11 @@ def pygmtlogo(  # noqa: PLR0913
        :width: 300px
 
     The design of the logo is kindly provided by `@sfrooti <https://github.com/sfrooti>`_
-    and consists of a visual and the wordmark "PyGMT".
-
-    The outer shape (in Python blue) represents the Earth, with compass lines (in Python yellow)
-    surrounding the letters "GMT" (written in the red used for the GMT logo). The letter "T"
-    is the needle of the compass.
+    and consists of a visual and the wordmark "PyGMT". The outer shape (in Python blue)
+	represents Earth, with compass lines (in Python yellow) surrounding the letters "GMT"
+	(in the red used for the GMT logo). The letter "T" is the needle of the compass.
+    By default, the PyGMT logo is plotted without wordmark, with a size of 2 centimeters
+	for the circular version of the icon.
 
     Parameters
     ----------

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -299,9 +299,9 @@ def pygmtlogo(  # noqa: PLR0913
     The design of the logo is kindly provided by `@sfrooti <https://github.com/sfrooti>`_
     and consists of a visual and the wordmark "PyGMT". The outer shape (in Python blue)
     represents Earth, with compass lines (in Python yellow) surrounding the letters
-    "GMT" (in the red used for the GMT logo :meth:`pygmt.Figure.logo`). The letter "T"
-    is the needle of the compass. By default, the PyGMT logo is plotted without
-    wordmark, with a size of 2 centimeters for the circular version of the icon.
+    "GMT" (in the red used for the GMT logo). The letter "T" aligns with the needle of
+    the compass. By default, the PyGMT logo is plotted without wordmark, with a size of
+    2 centimeters for the circular version of the icon.
 
     Parameters
     ----------
@@ -346,6 +346,11 @@ def pygmtlogo(  # noqa: PLR0913
     $panel
     $perspective
     $transparency
+
+    See Also
+    --------
+    pygmt.Figure.logo
+        Plot the GMT logo.
 
     Examples
     --------

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -299,7 +299,9 @@ def pygmtlogo(  # noqa: PLR0913
     The design of the logo is kindly provided by `@sfrooti <https://github.com/sfrooti>`_
     and consists of a visual and the wordmark "PyGMT".
 
-    The outer shape represents the Earth, with compass lines surrounding the letters "GMT".
+    The outer shape (in Python blue) represents the Earth, with compass lines (in Python yellow)
+    surrounding the letters "GMT" (written in the red used for the GMT logo). The letter "T"
+    is the needle of the compass.
 
     Parameters
     ----------

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -291,7 +291,7 @@ def pygmtlogo(  # noqa: PLR0913
     """
     Plot the PyGMT logo.
 
-    .. figure:: https://github.com/GenericMappingTools/pygmt/blob/main/doc/_static/pygmtlogo.png
+    .. figure:: https://raw.githubusercontent.com/GenericMappingTools/pygmt/main/doc/_static/pygmtlogo.png
        :alt: PyGMT logo
        :align: center
        :width: 300px

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -294,6 +294,8 @@ def pygmtlogo(  # noqa: PLR0913
     The design of the logo is kindly provided by `@sfrooti <https://github.com/sfrooti>`_
     and consists of a visual and the wordmark "PyGMT".
 
+    The outer shape represents the Earth, with compaslines surronding the letters "GMT".
+
     Parameters
     ----------
     shape

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -294,7 +294,7 @@ def pygmtlogo(  # noqa: PLR0913
     The design of the logo is kindly provided by `@sfrooti <https://github.com/sfrooti>`_
     and consists of a visual and the wordmark "PyGMT".
 
-    The outer shape represents the Earth, with compaslines surronding the letters "GMT".
+    The outer shape represents the Earth, with compass lines surrounding the letters "GMT".
 
     Parameters
     ----------

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -294,7 +294,7 @@ def pygmtlogo(  # noqa: PLR0913
     .. figure:: https://raw.githubusercontent.com/GenericMappingTools/pygmt/main/doc/_static/pygmtlogo.png
        :alt: PyGMT logo
        :align: center
-       :width: 300px
+       :width: 400px
 
     The design of the logo is kindly provided by `@sfrooti <https://github.com/sfrooti>`_
     and consists of a visual and the wordmark "PyGMT". The outer shape (in Python blue)

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -299,9 +299,9 @@ def pygmtlogo(  # noqa: PLR0913
     The design of the logo is kindly provided by `@sfrooti <https://github.com/sfrooti>`_
     and consists of a visual and the wordmark "PyGMT". The outer shape (in Python blue)
     represents Earth, with compass lines (in Python yellow) surrounding the letters
-    "GMT" (in the red used for the GMT logo). The letter "T" is the needle of the
-    compass. By default, the PyGMT logo is plotted without wordmark, with a size of 2
-    centimeters for the circular version of the icon.
+    "GMT" (in the red used for the GMT logo :meth:`pygmt.Figure.logo`). The letter "T"
+    is the needle of the compass. By default, the PyGMT logo is plotted without
+    wordmark, with a size of 2 centimeters for the circular version of the icon.
 
     Parameters
     ----------


### PR DESCRIPTION
**Description of proposed changes**

xref: https://github.com/GenericMappingTools/pygmt/pull/4715#discussion_r3525669687, https://github.com/GenericMappingTools/pygmt/pull/4715#discussion_r3525935456

based on: https://github.com/GenericMappingTools/pygmt/issues/1404#issuecomment-2574112777

**Preview**: 
* https://pygmt-dev--4719.org.readthedocs.build/en/4719/api/generated/pygmt.Figure.pygmtlogo.html
* https://pygmt-dev--4719.org.readthedocs.build/en/4719/api/generated/pygmt.Figure.logo.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
