### PR TITLE
DOC: Fix typos before the release of v0.19.0

### DIFF
--- a/examples/gallery/embellishments/pygmtlogo.py
+++ b/examples/gallery/embellishments/pygmtlogo.py
@@ -27,7 +27,7 @@ fig.show()
 
 
 # %%
-# Via the ``color``, ``theme``, ``shape`` parameters the appereance of the logo can be
+# Via the ``color``, ``theme``, ``shape`` parameters the appearance of the logo can be
 # changed.
 
 fig = pygmt.Figure()


### PR DESCRIPTION
**Description of proposed changes**

PR to fix any typos beforethe release of v0.19.0.
Feel free to push to this branch, in case you find any typo.
Regarding the capizalization of `the earth` and `Earth` see PR #4720.

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
