### PR TITLE
DOC: Correct and update BibTex entry for PyGMT Paper in README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -126,6 +126,7 @@ preferred-citation:
   title: 'PyGMT: Bridging Python and the Generic Mapping Tools for Geospatial Visualization and Analysis'
   journal: 'Geochemistry, Geophysics, Geosystems'
   volume: 27
+  issue: 7
   article-number: e2026GC013105
   year: 2026
   doi: 10.1029/2026GC013105

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ PyGMT is a community developed project. See the
 [AUTHORS.md](https://github.com/GenericMappingTools/pygmt/blob/main/AUTHORS.md) file
 on GitHub for a list of the people involved and a definition of the term "PyGMT Developers".
 
-Feel free to cite our work in your research. You can either cite the PyGMT paper published
-in *Geochemistry, Geophysics, Geosystems* or the Zenodo archive of the PyGMT software.
+Feel free to cite our work in your research. You can either cite the [PyGMT paper](https://doi.org/10.1029/2026GC013105)
+published in *Geochemistry, Geophysics, Geosystems* or the Zenodo archive of the PyGMT software.
 
 The BibTeX entry for the PyGMT paper is:
 ```
@@ -152,8 +152,10 @@ The BibTeX entry for the PyGMT paper is:
   journal      = {Geochemistry, Geophysics, Geosystems},
   year         = 2026,
   volume       = {27},
-  pages        = {e2019GC008515},
-  doi          = {10.1029/2019GC008515},
+  number       = {7},
+  pages        = {e2026GC013105},
+  doi          = {10.1029/2026GC013105},
+  url          = {https://doi.org/10.1029/2026GC013105},
 }
 ```
 The BibTeX entry for the latest Zenodo archive of the PyGMT software is:


### PR DESCRIPTION
**Description of proposed changes**

Correct BibTex entry for PyGMT Paper in README, not the DOI from the GMT 6 paper. The changelog is correct.
Pathes #4713 

**Preview**: https://github.com/GenericMappingTools/pygmt/tree/add-paper-issue-to-citiation#citing-pygmt

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
