### PR TITLE
DOC: Add ecosystem figure from the PyGMT paper to the ecosystem documentation page

### DIFF
--- a/doc/ecosystem.md
+++ b/doc/ecosystem.md
@@ -5,10 +5,8 @@ line program that provides a wide range of tools for manipulating geospatial dat
 making publication-quality maps and figures. PyGMT integrates well with the
 [scientific Python ecosystem](https://scientific-python.org/), with [NumPy][] for its
 fundamental array data structure, [pandas][] for tabular data I/O and [xarray][] for
-raster grids/images/cubes I/O.
-
-In addition to these core dependencies, PyGMT also relies on several optional packages to
-provide additional functionality for users.
+raster grids/images/cubes I/O. In addition to these core dependencies, PyGMT also
+relies on several optional packages to provide additional functionality for users.
 
 ![](https://github.com/user-attachments/assets/2e36bd3e-d8ae-4399-b7c0-af614cb414fb)
 

--- a/doc/ecosystem.md
+++ b/doc/ecosystem.md
@@ -108,7 +108,7 @@ more details, see
 ## Packages depending on PyGMT
 
 Various packages rely on PyGMT for geospatial data processing, analysis, and visualization.
-Below is an incomplete list (in no particular order) of this tools.
+Below is an incomplete list (in no particular order) of these tools.
 
 ```{note}
 If your package relies on PyGMT, please

--- a/doc/ecosystem.md
+++ b/doc/ecosystem.md
@@ -2,10 +2,10 @@
 
 PyGMT provides a Python interface to the Generic Mapping Tools (GMT), which is a command
 line program that provides a wide range of tools for manipulating geospatial data and
-making publication-quality maps and figures. PyGMT integrates well with the
+making publication-quality maps and figures. It integrates well with the
 [scientific Python ecosystem](https://scientific-python.org/), with [NumPy][] for its
 fundamental array data structure, [pandas][] for tabular data I/O and [xarray][] for
-raster grids/images/cubes I/O. In addition to these core dependencies, PyGMT also
+raster grids/images/cubes I/O. In addition to these core dependencies, it also
 relies on several optional packages to provide additional functionality for users.
 
 ![](https://github.com/user-attachments/assets/2e36bd3e-d8ae-4399-b7c0-af614cb414fb)

--- a/doc/ecosystem.md
+++ b/doc/ecosystem.md
@@ -5,8 +5,8 @@ line program that provides a wide range of tools for manipulating geospatial dat
 making publication-quality maps and figures. It integrates well with the
 [scientific Python ecosystem](https://scientific-python.org/), with [NumPy][] for its
 fundamental array data structure, [pandas][] for tabular data I/O and [xarray][] for
-raster grids/images/cubes I/O. In addition to these core dependencies, it also
-relies on several optional packages to provide additional functionality for users.
+raster grids/images/cubes I/O. In addition to these core dependencies, it also relies on
+several optional packages to provide additional functionality for users.
 
 ![](https://github.com/user-attachments/assets/2e36bd3e-d8ae-4399-b7c0-af614cb414fb)
 

--- a/doc/ecosystem.md
+++ b/doc/ecosystem.md
@@ -10,6 +10,10 @@ relies on several optional packages to provide additional functionality for user
 
 ![](https://github.com/user-attachments/assets/2e36bd3e-d8ae-4399-b7c0-af614cb414fb)
 
+_The PyGMT ecosystem. This figure was originally published in the
+[PyGMT paper](https://doi.org/10.1029/2026GC013105) in G-Cubed. The full publication is
+released under CC BY-NC 4.0. No modifications were made._
+
 
 ## PyGMT dependencies
 

--- a/doc/ecosystem.md
+++ b/doc/ecosystem.md
@@ -12,7 +12,6 @@ provide additional functionality for users.
 
 ![](https://github.com/user-attachments/assets/2e36bd3e-d8ae-4399-b7c0-af614cb414fb)
 
-*This page was adapted from [GeoPandas's Ecosystem](https://geopandas.org/en/latest/community/ecosystem.html) page.*
 
 ## PyGMT dependencies
 
@@ -115,6 +114,9 @@ If your package relies on PyGMT, please
 [let us know](https://github.com/GenericMappingTools/pygmt/issues/new) or
 [add it by yourself](contributing.md).
 ```
+
+*This page was adapted from [GeoPandas's Ecosystem](https://geopandas.org/en/latest/community/ecosystem.html) page.*
+
 
 [apache arrow]: https://arrow.apache.org/
 [contextily]: https://contextily.readthedocs.io/

--- a/doc/ecosystem.md
+++ b/doc/ecosystem.md
@@ -105,7 +105,7 @@ more details, see
 [issue #2800](https://github.com/GenericMappingTools/pygmt/issues/2800).
 ```
 
-## PyGMT ecosystem
+## PyGMT-related ecosystem
 
 Various packages rely on PyGMT for geospatial data processing, analysis, and visualization.
 Below is an incomplete list (in no particular order) of tools which form the PyGMT-related

--- a/doc/ecosystem.md
+++ b/doc/ecosystem.md
@@ -1,4 +1,4 @@
-# Ecosystem
+# PyGMT Ecosystem
 
 PyGMT provides a Python interface to the Generic Mapping Tools (GMT), which is a command
 line program that provides a wide range of tools for manipulating geospatial data and
@@ -105,11 +105,10 @@ more details, see
 [issue #2800](https://github.com/GenericMappingTools/pygmt/issues/2800).
 ```
 
-## PyGMT-related ecosystem
+## Packages depending on PyGMT
 
 Various packages rely on PyGMT for geospatial data processing, analysis, and visualization.
-Below is an incomplete list (in no particular order) of tools which form the PyGMT-related
-ecosystem.
+Below is an incomplete list (in no particular order) of this tools.
 
 ```{note}
 If your package relies on PyGMT, please

--- a/doc/ecosystem.md
+++ b/doc/ecosystem.md
@@ -10,6 +10,8 @@ raster grids/images/cubes I/O.
 In addition to these core dependencies, PyGMT also relies on several optional packages to
 provide additional functionality for users.
 
+![](https://github.com/user-attachments/assets/2e36bd3e-d8ae-4399-b7c0-af614cb414fb)
+
 *This page was adapted from [GeoPandas's Ecosystem](https://geopandas.org/en/latest/community/ecosystem.html) page.*
 
 ## PyGMT dependencies


### PR DESCRIPTION
**Description of proposed changes**

Add ecosystem figure from the PyGMT paper to the ecosystem documentation page.

Fixes #4728 

**Preview**: https://pygmt-dev--4731.org.readthedocs.build/en/4731/ecosystem.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
