### PR TITLE
DOC: Remove the reference to a broken link

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -1407,7 +1407,7 @@
 * [@daroari](https://github.com/daroari)
 * [@obaney](https://github.com/obaney)
 * [@srijac](https://github.com/srijac)
-* [Andrés Ignacio Torres](https://github.com/aitorres)
+* Andrés Ignacio Torres
 * [Becky Salvage](https://github.com/BeckySalvage)
 * [Claudio Satriano](https://github.com/claudiodsf)
 * [Jamie J Quinn](https://github.com/JamieJQuinn)


### PR DESCRIPTION
Closes https://github.com/GenericMappingTools/pygmt/issues/4736.