### PR TITLE
DOC: Improve the docstring for the region parameter

### DIFF
--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -298,7 +298,8 @@ COMMON_DOCSTRINGS = {
             *projcode*\[*projparams*/]\ *width*\|\ *scale*.
             Select map :doc:`projection </projections/index>`.""",
     "region": r"""
-        region : str or list
+        region : list or str
+            [*xmin*, *xmax*, *ymin*, *ymax*] or
             *xmin/xmax/ymin/ymax*\ [**+r**][**+u**\ *unit*].
             Specify the :doc:`region </tutorials/basics/regions>` of interest.""",
     "registration": r"""
@@ -437,7 +438,8 @@ def fmt_docstring(module_func):
         :class:`xarray.Dataset` made up of 1-D :class:`xarray.DataArray`
         data variables, or a :class:`geopandas.GeoDataFrame` containing the
         tabular data.
-    region : str or list
+    region : list or str
+        [*xmin*, *xmax*, *ymin*, *ymax*] or
         *xmin/xmax/ymin/ymax*\ [**+r**][**+u**\ *unit*].
         Specify the :doc:`region </tutorials/basics/regions>` of interest.
     projection


### PR DESCRIPTION
`[xmin, xmax, ymin, ymax]` format is more commonly used.