### PR TITLE
Ruff: Ignore PLR0913 violations (too-many-arguments) in the src directory

### DIFF
--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -14,7 +14,7 @@ from pygmt.params import Axis, Box, Frame
 
 @fmt_docstring
 @use_alias(f="coltypes")
-def basemap(  # noqa: PLR0913
+def basemap(
     self,
     projection: str | None = None,
     zscale: float | str | None = None,

--- a/pygmt/src/blockm.py
+++ b/pygmt/src/blockm.py
@@ -81,7 +81,7 @@ def _blockm(
     h="header",
     w="wrap",
 )
-def blockmean(  # noqa: PLR0913
+def blockmean(
     data: PathLike | TableLike | None = None,
     x=None,
     y=None,
@@ -196,7 +196,7 @@ def blockmean(  # noqa: PLR0913
 @use_alias(
     a="aspatial", b="binary", d="nodata", e="find", f="coltypes", h="header", w="wrap"
 )
-def blockmedian(  # noqa: PLR0913
+def blockmedian(
     data: PathLike | TableLike | None = None,
     x=None,
     y=None,
@@ -311,7 +311,7 @@ def blockmedian(  # noqa: PLR0913
     h="header",
     w="wrap",
 )
-def blockmode(  # noqa: PLR0913
+def blockmode(
     data: PathLike | TableLike | None = None,
     x=None,
     y=None,

--- a/pygmt/src/choropleth.py
+++ b/pygmt/src/choropleth.py
@@ -15,7 +15,7 @@ __doctest_skip__ = ["choropleth"]
 
 
 @fmt_docstring
-def choropleth(  # noqa: PLR0913
+def choropleth(
     self,
     data: GeoLike | PathLike,
     column: str,

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -16,7 +16,7 @@ __doctest_skip__ = ["coast"]
 
 @fmt_docstring
 @use_alias(A="area_thresh", C="lakes", E="dcw")
-def coast(  # noqa: PLR0913
+def coast(
     self,
     resolution: Literal[
         "auto", "full", "high", "intermediate", "low", "crude", None

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -92,7 +92,7 @@ def _build_frame(
     return Frame(xaxis=xaxis, yaxis=yaxis)
 
 
-def _alias_option_D(  # noqa: N802, PLR0913
+def _alias_option_D(  # noqa: N802
     position=None,
     length=None,
     width=None,
@@ -242,7 +242,7 @@ def _alias_option_N(dpi=None):  # noqa: N802
 
 @fmt_docstring
 @use_alias(C="cmap", L="equalsize", Z="zfile")
-def colorbar(  # noqa: PLR0913
+def colorbar(
     self,
     position: Position | Sequence[float | str] | AnchorCode | None = None,
     length: float | str | None = None,

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -32,7 +32,7 @@ from pygmt.params import Axis, Frame
     h="header",
     l="label",
 )
-def contour(  # noqa: PLR0913
+def contour(
     self,
     data: PathLike | TableLike | None = None,
     x=None,

--- a/pygmt/src/fill_between.py
+++ b/pygmt/src/fill_between.py
@@ -16,7 +16,7 @@ __doctest_skip__ = ["fill_between"]
 
 
 @fmt_docstring
-def fill_between(  # noqa: PLR0913
+def fill_between(
     self,
     x: Sequence[float],
     y: Sequence[float],

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -67,7 +67,7 @@ def _alias_option_F(  # noqa: N802
 
 @fmt_docstring
 @use_alias(f="coltypes")
-def grdfilter(  # noqa: PLR0913
+def grdfilter(
     grid: PathLike | xr.DataArray,
     outgrid: PathLike | None = None,
     filter: Literal[  # noqa: A002

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -71,7 +71,7 @@ def _alias_option_N(  # noqa: N802
 
 @fmt_docstring
 @use_alias(D="direction", Q="tiles", S="slope_file", f="coltypes", n="interpolation")
-def grdgradient(  # noqa: PLR0913
+def grdgradient(
     grid: PathLike | xr.DataArray,
     outgrid: PathLike | None = None,
     azimuth: float | Sequence[float] | None = None,

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -26,7 +26,7 @@ __doctest_skip__ = ["grdimage"]
     n="interpolation",
     f="coltypes",
 )
-def grdimage(  # noqa: PLR0913
+def grdimage(
     self,
     grid: PathLike | xr.DataArray,
     monochrome: bool = False,

--- a/pygmt/src/grdproject.py
+++ b/pygmt/src/grdproject.py
@@ -17,7 +17,7 @@ __doctest_skip__ = ["grdproject"]
 
 @fmt_docstring
 @use_alias(n="interpolation")
-def grdproject(  # noqa: PLR0913
+def grdproject(
     grid: PathLike | xr.DataArray,
     outgrid: PathLike | None = None,
     center: Sequence[float | str] | bool = False,

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -121,7 +121,7 @@ def _alias_option_Q(  # noqa: N802
 @deprecate_parameter("meshpen", "mesh_pen", "v0.18.0", remove_version="v0.20.0")
 @deprecate_parameter("drapegrid", "drape_grid", "v0.18.0", remove_version="v0.20.0")
 @use_alias(I="shading", f="coltypes", n="interpolation")
-def grdview(  # noqa: PLR0913
+def grdview(
     self,
     grid: PathLike | xr.DataArray,
     cmap: str | None = None,

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -43,7 +43,7 @@ from pygmt.params import Axis, Frame
     w="wrap",
 )
 @kwargs_to_strings(T="sequence")
-def histogram(  # noqa: PLR0913
+def histogram(
     self,
     data: PathLike | TableLike,
     bar_width: float | str | None = None,

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -15,7 +15,7 @@ from pygmt.src._common import _parse_position
 
 @fmt_docstring
 @use_alias(G="bitcolor")
-def image(  # noqa: PLR0913
+def image(
     self,
     imagefile: PathLike,
     position: Position | Sequence[float | str] | AnchorCode | None = None,

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -16,7 +16,7 @@ from pygmt.src._common import _parse_position
 
 
 @fmt_docstring
-def legend(  # noqa: PLR0913
+def legend(
     self,
     spec: PathLike | io.StringIO | None = None,
     position: Position | Sequence[float | str] | AnchorCode | None = None,

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -17,7 +17,7 @@ __doctest_skip__ = ["logo"]
 
 
 @fmt_docstring
-def logo(  # noqa: PLR0913
+def logo(
     self,
     position: Position | Sequence[float | str] | AnchorCode | None = None,
     width: float | str | None = None,

--- a/pygmt/src/magnetic_rose.py
+++ b/pygmt/src/magnetic_rose.py
@@ -18,7 +18,7 @@ __doctest_skip__ = ["magnetic_rose"]
 
 
 @fmt_docstring
-def magnetic_rose(  # noqa: PLR0913
+def magnetic_rose(
     self,
     position: Position | Sequence[float | str] | AnchorCode | None = None,
     width: float | str | None = None,

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -135,7 +135,7 @@ def _auto_offset(spec) -> bool:
     T="nodal",
     W="pen",
 )
-def meca(  # noqa: PLR0913
+def meca(
     self,
     spec: PathLike | TableLike,
     scale,

--- a/pygmt/src/paragraph.py
+++ b/pygmt/src/paragraph.py
@@ -23,7 +23,7 @@ __doctest_skip__ = ["paragraph"]
 
 
 @fmt_docstring
-def paragraph(  # noqa: PLR0913
+def paragraph(
     self,
     x: float | str,
     y: float | str,

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -43,7 +43,7 @@ from pygmt.src._common import _data_geometry_is_point
     l="label",
     w="wrap",
 )
-def plot(  # noqa: PLR0912, PLR0913
+def plot(  # noqa: PLR0912
     self,
     data: PathLike | TableLike | None = None,
     x=None,

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -42,7 +42,7 @@ from pygmt.src._common import _data_geometry_is_point
     l="label",
     w="wrap",
 )
-def plot3d(  # noqa: PLR0912, PLR0913
+def plot3d(  # noqa: PLR0912
     self,
     data: PathLike | TableLike | None = None,
     x=None,

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -29,7 +29,7 @@ from pygmt.helpers import (
     Z="ellipse",
     f="coltypes",
 )
-def project(  # noqa: PLR0913
+def project(
     data: PathLike | TableLike | None = None,
     x=None,
     y=None,

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -272,7 +272,7 @@ def _create_logo(  # noqa: PLR0915
 
 
 @fmt_docstring
-def pygmtlogo(  # noqa: PLR0913
+def pygmtlogo(
     self,
     shape: Literal["circle", "hexagon"] = "circle",
     theme: Literal["light", "dark"] = "light",

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -35,7 +35,7 @@ from pygmt.params import Axis, Frame
     h="header",
     w="wrap",
 )
-def rose(  # noqa: PLR0913
+def rose(
     self,
     data: PathLike | TableLike | None = None,
     length=None,

--- a/pygmt/src/scalebar.py
+++ b/pygmt/src/scalebar.py
@@ -16,7 +16,7 @@ __doctest_skip__ = ["scalebar"]
 
 
 @fmt_docstring
-def scalebar(  # noqa: PLR0913
+def scalebar(
     self,
     length: float | str,
     height: float | str | None = None,

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -16,7 +16,7 @@ __doctest_skip__ = ["solar"]
 
 
 @fmt_docstring
-def solar(  # noqa: PLR0913
+def solar(
     self,
     terminator: Literal["astronomical", "civil", "day_night", "nautical"] = "day_night",
     terminator_datetime=None,

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -131,7 +131,7 @@ def _alias_option_A(  # noqa: N802
 @contextlib.contextmanager
 @use_alias(Ff="figsize", Fs="subsize", C="clearance", SC="sharex", SR="sharey")
 @kwargs_to_strings(Ff="sequence", Fs="sequence")
-def subplot(  # noqa: PLR0913
+def subplot(
     self,
     nrows: int = 1,
     ncols: int = 1,

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -109,7 +109,7 @@ def _ternary_frame(frame):
 
 @fmt_docstring
 @use_alias(C="cmap", S="style")
-def ternary(  # noqa: PLR0913
+def ternary(
     self,
     data: PathLike | TableLike,
     fill: str | None = None,

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -32,7 +32,7 @@ from pygmt.params import Axis, Frame
     it="use_word",
     w="wrap",
 )
-def text(  # noqa: PLR0912, PLR0913, PLR0915
+def text(  # noqa: PLR0912, PLR0915
     self,
     textfiles: PathLike | TableLike | None = None,
     x=None,

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -20,7 +20,7 @@ except ImportError:
 
 @fmt_docstring
 @use_alias(E="dpi", I="shading", Q="nan_transparent")
-def tilemap(  # noqa: PLR0913
+def tilemap(
     self,
     region: Sequence[float],
     zoom: int | Literal["auto"] = "auto",

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -59,7 +59,7 @@ class triangulate:  # noqa: N801
         s="skiprows",
         w="wrap",
     )
-    def regular_grid(  # noqa: PLR0913
+    def regular_grid(
         data: PathLike | TableLike | None = None,
         x=None,
         y=None,
@@ -186,7 +186,7 @@ class triangulate:  # noqa: N801
         s="skiprows",
         w="wrap",
     )
-    def delaunay_triples(  # noqa: PLR0913
+    def delaunay_triples(
         data: PathLike | TableLike | None = None,
         x=None,
         y=None,

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -36,7 +36,7 @@ from pygmt.params import Axis, Frame
     e="find",
     h="header",
 )
-def velo(  # noqa : PLR0913
+def velo(
     self,
     data: PathLike | TableLike | None = None,
     no_clip: bool = False,

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -34,7 +34,7 @@ from pygmt.src._common import _parse_position
     h="header",
     w="wrap",
 )
-def wiggle(  # noqa: PLR0913
+def wiggle(
     self,
     data: PathLike | TableLike | None = None,
     x=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,7 @@ known-third-party = ["pygmt"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Ignore `F401` (unused-import) in all `__init__.py` files
+"*/src/*.py" = ["PLR0913"]  # Ignore `PLR0913` (too many arguments) in all `src` files
 "*/tests/test_*.py" = ["S101"]  # Ignore `S101` (use of assert) in all tests files
 "examples/**/*.py" = [ # Ignore rules in examples
     "B018",  # Allow useless expressions in Jupyter Notebooks


### PR DESCRIPTION
Currently, the maximum allowed number of arguments for functions and methods is set to `10`:
https://github.com/GenericMappingTools/pygmt/blob/63353f389bda44240346577b45ef32af64a1124a/pyproject.toml#L197

This limit is insufficient for PyGMT functions and methods that wrap GMT modules. At present, we add `noqa: PLR0913` to suppress this lint violation in nearly every file within `pygmt/src/`.

We could set `max-args` to a larger value like 20, but this would permit longer argument lists for non-wrapper functions and methods, which is undesirable.

Instead, this PR suppresses the PLR0913 violations selectively for all files under the `src` directory.