### PR TITLE
Figure.scalebar: Remove the note that height only works for fancy scalebar

### DIFF
--- a/pygmt/src/scalebar.py
+++ b/pygmt/src/scalebar.py
@@ -44,7 +44,7 @@ def scalebar(  # noqa: PLR0913
         Valid units are: **e**: meters; **f**: feet; **k**: kilometers; **M**: statute
         miles; **n**: nautical miles; **u**: US survey feet.
     height
-        Height of the scale bar [Default is ``"5p"``]. Only works when ``fancy=True``.
+        Height of the scale bar [Default is ``"5p"``].
     position
         Position of the scale bar on the plot. It can be specified in multiple ways:
 


### PR DESCRIPTION
`MAP_SCALE_HEIGHT` works for both plain and fancy scalebars, which can be verified below:
```
gmt begin map
gmt basemap -R0/20/0/10 -JM10c -Baf
gmt basemap -Lx1/1+w300k
gmt basemap -Lx3/1+w300k+f
gmt basemap -Lx5/1+w300k --MAP_SCALE_HEIGHT=1c
gmt basemap -Lx7/1+w300k+f --MAP_SCALE_HEIGHT=1c
gmt end show
```

<img width="1324" height="664" alt="map" src="https://github.com/user-attachments/assets/9f4897ea-682c-450e-ae83-140200187aa9" />
