### PR TITLE
Add git-lfs to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
     - pyarrow-core>=16
     - rioxarray
     # Development dependencies (general)
+    - git-lfs
     - jupyter
     - make
     - pip


### PR DESCRIPTION
`git-lfs` is required before running `git lfs install`.

Patches #4740.