### PR TITLE
Figure.pygmtlogo: Validate the shape, theme, and wordmark parameters

### DIFF
--- a/examples/gallery/embellishments/pygmtlogo.py
+++ b/examples/gallery/embellishments/pygmtlogo.py
@@ -45,7 +45,7 @@ fig.show()
 
 
 # %%
-# Via the ``wordamrk`` parameter the text "PyGMT" can be added on the right side or at
+# Via the ``wordmark`` parameter the text "PyGMT" can be added on the right side or at
 # the bottom of the visual. Use the ``width`` and ``height`` parameters to adjust the
 # size of the logo.
 

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -321,7 +321,7 @@ def pygmtlogo(
     color
         ``True`` for a color logo, and ``False`` for a black and white logo.
     position
-        Position of the GMT logo on the plot. It can be specified in multiple ways:
+        Position of the PyGMT logo on the plot. It can be specified in multiple ways:
 
         - A :class:`pygmt.params.Position` object to fully control the reference point,
           anchor point, and offset.
@@ -370,6 +370,15 @@ def pygmtlogo(
     >>> fig.pygmtlogo(wordmark="horizontal", position="BR", height="1c")
     >>> fig.show()
     """
+    # Validate shape, theme, and wordmark values
+    for value, description, choices in [
+        (shape, "value for shape", ("circle", "hexagon")),
+        (theme, "value for theme", ("light", "dark")),
+        (wordmark, "value for wordmark", ("none", "horizontal", "vertical")),
+    ]:
+        if value not in choices:
+            raise GMTValueError(value, description=description, choices=choices)
+
     # Set the default size of the visual logo to 2 cm.
     if width is None and height is None:
         match wordmark:
@@ -377,12 +386,6 @@ def pygmtlogo(
                 width = width or "2c"
             case "horizontal":
                 height = height or "2c"
-            case _:
-                raise GMTValueError(
-                    wordmark,
-                    description="value for wordmark",
-                    choices={"none", "horizontal", "vertical"},
-                )
 
     with GMTTempFile(suffix=".eps") as logofile:
         # Create logo file

--- a/pygmt/tests/test_pygmtlogo.py
+++ b/pygmt/tests/test_pygmtlogo.py
@@ -116,7 +116,7 @@ def test_pygmtlogo_wordmark_vertical(shape):
 )
 def test_pygmtlogo_invalid_options(parameter, value):
     """
-    Test that invalid shape, theme, and wordmark options raise an error.
+    Test that invalid arguments passed to shape, theme, and wordmark raise an error.
     """
     fig = Figure()
     with pytest.raises(GMTValueError):

--- a/pygmt/tests/test_pygmtlogo.py
+++ b/pygmt/tests/test_pygmtlogo.py
@@ -4,6 +4,7 @@ Test Figure.pygmtlogo.
 
 import pytest
 from pygmt import Figure
+from pygmt.exceptions import GMTValueError
 from pygmt.params import Axis, Frame, Position
 from pygmt.src.pygmtlogo import _create_logo
 
@@ -107,3 +108,16 @@ def test_pygmtlogo_wordmark_vertical(shape):
             wordmark="vertical",
         )
     return fig
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [("shape", "square"), ("theme", "blue"), ("wordmark", "diagonal")],
+)
+def test_pygmtlogo_invalid_options(parameter, value):
+    """
+    Test that invalid shape, theme, and wordmark options raise an error.
+    """
+    fig = Figure()
+    with pytest.raises(GMTValueError):
+        fig.pygmtlogo(**{parameter: value})


### PR DESCRIPTION
Need to validate `shape`/`theme`/`wordmark`. Also fix a few typos.