### PR TITLE
Figure: Defer figure activation until plotting arguments are prepared

### DIFF
--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -140,8 +140,6 @@ def basemap(
     >>> fig.basemap(region="g", projection="H15c", frame=True)
     >>> fig.show()
     """
-    self._activate_figure()
-
     for name, value, recommendation in (
         ("map_scale", map_scale, "Figure.scalebar"),
         ("compass", compass, "Figure.magnetic_rose"),
@@ -172,5 +170,6 @@ def basemap(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         lib.call_module(module="basemap", args=build_arg_list(aliasdict))

--- a/pygmt/src/choropleth.py
+++ b/pygmt/src/choropleth.py
@@ -101,8 +101,6 @@ def choropleth(
     >>> fig.colorbar(frame=True)
     >>> fig.show()
     """
-    self._activate_figure()
-
     aliasdict = AliasSystem(
         C=Alias(cmap, name="cmap"),
         I=Alias(intensity, name="intensity"),
@@ -121,6 +119,7 @@ def choropleth(
     # Force -G+z and -L to be set for choropleth
     aliasdict.update({"G": "+z", "L": True})
 
+    self._activate_figure()
     with Session() as lib:
         with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
             lib.call_module(

--- a/pygmt/src/coast.py
+++ b/pygmt/src/coast.py
@@ -241,8 +241,6 @@ def coast(
     >>> # Show the plot
     >>> fig.show()
     """
-    self._activate_figure()
-
     if (
         kwargs.get("G", land) is None
         and kwargs.get("S", water) is None
@@ -295,5 +293,6 @@ def coast(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         lib.call_module(module="coast", args=build_arg_list(aliasdict))

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -480,8 +480,6 @@ def colorbar(
     >>> # Show the plot
     >>> fig.show()
     """
-    self._activate_figure()
-
     position = _parse_position(
         position,
         default=None,  # Use GMT's default behavior if position is not provided.
@@ -543,5 +541,6 @@ def colorbar(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         lib.call_module(module="colorbar", args=build_arg_list(aliasdict))

--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -151,8 +151,6 @@ def contour(
     $perspective
     $transparency
     """
-    self._activate_figure()
-
     # Specify levels for contours or annotations.
     # One level is converted to a string with a trailing comma to separate it from
     # specifying an interval.
@@ -178,6 +176,7 @@ def contour(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with lib.virtualfile_in(
             check_kind="vector", data=data, x=x, y=y, z=z, mincols=3

--- a/pygmt/src/directional_rose.py
+++ b/pygmt/src/directional_rose.py
@@ -82,8 +82,6 @@ def directional_rose(
     >>> fig.directional_rose()
     >>> fig.show()
     """
-    self._activate_figure()
-
     # The default position is set to "TR" since GMT 6.7.0, which has no default value
     # in GMT 6.6.0 and earlier versions.
     # TODO(GMT>6.6.0): Set 'default=None' after GMT 6.7.0.
@@ -109,5 +107,6 @@ def directional_rose(
         t=transparency,
     )
 
+    self._activate_figure()
     with Session() as lib:
         lib.call_module(module="basemap", args=build_arg_list(aliasdict))

--- a/pygmt/src/fill_between.py
+++ b/pygmt/src/fill_between.py
@@ -113,7 +113,6 @@ def fill_between(
     ... )
     >>> fig.show()
     """
-    self._activate_figure()
     _x = np.atleast_1d(x)
     _y = np.atleast_1d(y)
     _y2 = np.atleast_1d(y2)
@@ -177,6 +176,7 @@ def fill_between(
         t=transparency,
     )
 
+    self._activate_figure()
     with Session() as lib:
         if _x2 is not None:
             with (

--- a/pygmt/src/grdcontour.py
+++ b/pygmt/src/grdcontour.py
@@ -156,8 +156,6 @@ def grdcontour(
     >>> # Show the plot
     >>> fig.show()
     """
-    self._activate_figure()
-
     # Specify levels for the annotation and levels parameters.
     # One level is converted to a string with a trailing comma to separate it from
     # specifying an interval.
@@ -180,6 +178,7 @@ def grdcontour(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with lib.virtualfile_in(check_kind="raster", data=grid) as vingrd:
             lib.call_module(

--- a/pygmt/src/grdimage.py
+++ b/pygmt/src/grdimage.py
@@ -175,8 +175,6 @@ def grdimage(
     >>> # show the plot
     >>> fig.show()
     """
-    self._activate_figure()
-
     # Do not support -A option
     if any(kwargs.get(arg) is not None for arg in ["A", "img_out"]):
         msg = (
@@ -200,6 +198,7 @@ def grdimage(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with (
             lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -291,8 +291,6 @@ def grdview(
     >>> # Show the plot
     >>> fig.show()
     """
-    self._activate_figure()
-
     # Enable 'plane' if 'facade_fill' or 'facade_pen' are set
     if plane is False and (facade_fill is not None or facade_pen is not None):
         plane = True
@@ -339,6 +337,7 @@ def grdview(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with (
             lib.virtualfile_in(check_kind="raster", data=grid) as vingrd,

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -161,8 +161,6 @@ def histogram(
     $transparency
     $wrap
     """
-    self._activate_figure()
-
     if bar_offset is not None and bar_width is None:
         raise GMTParameterError(
             required="bar_width", reason="Required when 'bar_offset' is set."
@@ -185,6 +183,7 @@ def histogram(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
             lib.call_module(

--- a/pygmt/src/image.py
+++ b/pygmt/src/image.py
@@ -132,8 +132,6 @@ def image(
     $perspective
     $transparency
     """
-    self._activate_figure()
-
     position = _parse_position(
         position,
         default=Position((0, 0), cstype="plotcoords"),  # Default to (0,0) in plotcoords
@@ -166,6 +164,7 @@ def image(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         lib.call_module(
             module="image", args=build_arg_list(aliasdict, infile=imagefile)

--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -125,8 +125,6 @@ def inset(
     >>> fig.logo(position=Position("BR", offset=0.2), width="3c")
     >>> fig.show()
     """
-    self._activate_figure()
-
     position = _parse_position(
         position,
         default=Position((0, 0), cstype="plotcoords"),  # Default to (0,0) in plotcoords
@@ -159,6 +157,7 @@ def inset(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         try:
             lib.call_module(module="inset", args=["begin", *build_arg_list(aliasdict)])

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -116,8 +116,6 @@ def legend(
     $perspective
     $transparency
     """
-    self._activate_figure()
-
     # Set default box if both position and box are not given.
     # The default position will be set later in _parse_position().
     if kwargs.get("D", position) is None and kwargs.get("F", box) is False:
@@ -161,6 +159,7 @@ def legend(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with lib.virtualfile_in(data=spec, required=False) as vintbl:
             lib.call_module(

--- a/pygmt/src/logo.py
+++ b/pygmt/src/logo.py
@@ -120,8 +120,6 @@ def logo(
     >>> fig.logo(position="TR", width="3c")
     >>> fig.show()
     """
-    self._activate_figure()
-
     position = _parse_position(
         position,
         default=Position((0, 0), cstype="plotcoords"),  # Default to (0,0) in plotcoords
@@ -151,5 +149,6 @@ def logo(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         lib.call_module(module="logo", args=build_arg_list(aliasdict))

--- a/pygmt/src/magnetic_rose.py
+++ b/pygmt/src/magnetic_rose.py
@@ -107,8 +107,6 @@ def magnetic_rose(
     ... )
     >>> fig.show()
     """
-    self._activate_figure()
-
     # The default position is set to "TR" since GMT 6.7.0, which has no default value
     # in GMT 6.6.0 and earlier versions.
     # TODO(GMT>6.6.0): Set 'default=None' after GMT 6.7.0.
@@ -148,5 +146,6 @@ def magnetic_rose(
         t=transparency,
     )
 
+    self._activate_figure()
     with Session() as lib:
         lib.call_module(module="basemap", args=build_arg_list(aliasdict))

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -359,7 +359,6 @@ def meca(
     $perspective
     $transparency
     """
-    self._activate_figure()
     # Determine the focal mechanism convention from the input data or parameters.
     _convention = _get_focal_convention(spec, convention, component)
     # Preprocess the input data.
@@ -394,6 +393,7 @@ def meca(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with lib.virtualfile_in(check_kind="vector", data=spec) as vintbl:
             lib.call_module(

--- a/pygmt/src/paragraph.py
+++ b/pygmt/src/paragraph.py
@@ -114,8 +114,6 @@ def paragraph(
     ... )
     >>> fig.show()
     """
-    self._activate_figure()
-
     _valid_alignments = ("left", "center", "right", "justified")
     if alignment not in _valid_alignments:
         raise GMTValueError(
@@ -175,6 +173,7 @@ def paragraph(
         _textstr = non_ascii_to_octal(_textstr, encoding=encoding)
         confdict["PS_CHAR_ENCODING"] = encoding
 
+    self._activate_figure()
     with Session() as lib:
         with io.StringIO() as buffer:  # Prepare the StringIO input.
             buffer.write(f"> {x} {y} {linespacing} {parwidth} {alignment[0]}\n")

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -250,8 +250,6 @@ def plot(  # noqa: PLR0912
     """
     # TODO(GMT>6.5.0): Remove the note for the upstream bug of the "straight_line"
     # parameter.
-    self._activate_figure()
-
     kind = data_kind(data)
     if kind == "empty":  # Data is given via a series of vectors.
         data = {"x": x, "y": y}
@@ -317,6 +315,7 @@ def plot(  # noqa: PLR0912
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
             lib.call_module(

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -220,8 +220,6 @@ def plot3d(  # noqa: PLR0912
     """
     # TODO(GMT>6.5.0): Remove the note for the upstream bug of the "straight_line"
     # parameter.
-    self._activate_figure()
-
     kind = data_kind(data)
     if kind == "empty":  # Data is given via a series of vectors.
         data = {"x": x, "y": y, "z": z}
@@ -290,6 +288,7 @@ def plot3d(  # noqa: PLR0912
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with lib.virtualfile_in(check_kind="vector", data=data, mincols=3) as vintbl:
             lib.call_module(

--- a/pygmt/src/psconvert.py
+++ b/pygmt/src/psconvert.py
@@ -114,7 +114,6 @@ def psconvert(
         ``prefix`` parameter.
     $verbose
     """
-    self._activate_figure()
     # Default cropping the figure to True
     if kwargs.get("A") is None:
         kwargs["A"] = ""
@@ -142,5 +141,6 @@ def psconvert(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         lib.call_module(module="psconvert", args=build_arg_list(aliasdict))

--- a/pygmt/src/rose.py
+++ b/pygmt/src/rose.py
@@ -209,8 +209,6 @@ def rose(
     $transparency
     $wrap
     """
-    self._activate_figure()
-
     aliasdict = AliasSystem().add_common(
         B=frame,
         R=region,
@@ -222,6 +220,7 @@ def rose(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with lib.virtualfile_in(
             check_kind="vector", data=data, x=length, y=azimuth

--- a/pygmt/src/scalebar.py
+++ b/pygmt/src/scalebar.py
@@ -109,7 +109,6 @@ def scalebar(
     ... )
     >>> fig.show()
     """
-    self._activate_figure()
     position = _parse_position(position, default=Position("BL", offset=(0.2, 0.4)))
 
     aliasdict = AliasSystem(
@@ -140,6 +139,7 @@ def scalebar(
     if height is not None:
         confdict["MAP_SCALE_HEIGHT"] = height
 
+    self._activate_figure()
     with Session() as lib:
         lib.call_module(
             module="basemap", args=build_arg_list(aliasdict, confdict=confdict)

--- a/pygmt/src/shift_origin.py
+++ b/pygmt/src/shift_origin.py
@@ -100,9 +100,9 @@ def shift_origin(
     ...     fig.basemap(region=[0, 5, 0, 5], projection="X5c/5c", frame=True)
     >>> fig.show()
     """
-    self._activate_figure()
     kwdict = {"T": True, "X": xshift, "Y": yshift}
 
+    self._activate_figure()
     with Session() as lib:
         lib.call_module(module="plot", args=build_arg_list(kwdict))
         _xshift = lib.get_common("X")  # False or xshift in inches

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -113,8 +113,6 @@ def solar(
     >>> # show the plot
     >>> fig.show()
     """
-    self._activate_figure()
-
     datetime_string, datetime_timezone = None, None
     if terminator_datetime:
         try:
@@ -156,5 +154,6 @@ def solar(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         lib.call_module(module="solar", args=build_arg_list(aliasdict))

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -298,8 +298,6 @@ def subplot(
     $frame
     $verbose
     """
-    self._activate_figure()
-
     if nrows < 1 or ncols < 1:
         _value = f"{nrows=}, {ncols=}"
         raise GMTValueError(
@@ -337,6 +335,8 @@ def subplot(
     # Otherwise, "subplot end" will use the last session, which may cause
     # strange positioning issues for later plotting calls.
     # See https://github.com/GenericMappingTools/pygmt/issues/2426.
+    self._activate_figure()
+
     try:
         with Session() as lib:
             lib.call_module(
@@ -414,8 +414,6 @@ def set_panel(
 
     $verbose
     """
-    self._activate_figure()
-
     aliasdict = AliasSystem(A=Alias(tag, name="tag")).add_common(V=verbose)
     aliasdict.merge(kwargs)
 
@@ -424,6 +422,7 @@ def set_panel(
         args.append(Alias(panel, name="panel", sep=",", size=2)._value)  # type: ignore[arg-type]
     args.extend(build_arg_list(aliasdict))
 
+    self._activate_figure()
     with Session() as lib:
         lib.call_module(module="subplot", args=args)
         yield

--- a/pygmt/src/ternary.py
+++ b/pygmt/src/ternary.py
@@ -194,7 +194,6 @@ def ternary(
     $perspective
     $transparency
     """
-    self._activate_figure()
     # -Lalabel/blabel/clabel. '-' means skipping the label.
     _labels = [v if v is not None else "-" for v in (alabel, blabel, clabel)]
     labels = _labels if any(v != "-" for v in _labels) else None
@@ -215,6 +214,7 @@ def ternary(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
             lib.call_module(

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -193,8 +193,6 @@ def text(  # noqa: PLR0912, PLR0915
     pygmt.Figure.paragraph
         Typeset one or multiple paragraphs.
     """
-    self._activate_figure()
-
     # Ensure inputs are either textfiles, x/y/text, or position/text
     if (
         (textfiles is not None)
@@ -300,6 +298,7 @@ def text(  # noqa: PLR0912, PLR0915
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with lib.virtualfile_in(
             check_kind="vector", data=textfiles or data, required=data_is_required

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -111,8 +111,6 @@ def tilemap(
     kwargs : dict
         Extra keyword arguments to pass to :meth:`pygmt.Figure.grdimage`.
     """
-    self._activate_figure()
-
     raster = load_tile_map(
         region=region,
         zoom=zoom,
@@ -145,6 +143,7 @@ def tilemap(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with lib.virtualfile_in(check_kind="raster", data=raster) as vingrd:
             lib.call_module(

--- a/pygmt/src/timestamp.py
+++ b/pygmt/src/timestamp.py
@@ -74,8 +74,6 @@ def timestamp(
     >>> fig.timestamp(label="Powered by PyGMT")
     >>> fig.show()
     """
-    self._activate_figure()
-
     if text is not None and len(str(text)) > 64:
         msg = (
             "Parameter 'text' expects a string no longer than 64 characters. "
@@ -94,6 +92,7 @@ def timestamp(
     )
     aliasdict["T"] = ""  # Add '-T' to the "plot" module.
 
+    self._activate_figure()
     with Session() as lib:
         lib.call_module(
             module="plot",

--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -255,8 +255,6 @@ def velo(
     $perspective
     $transparency
     """
-    self._activate_figure()
-
     if kwargs.get("S") is None:
         raise GMTParameterError(required="spec")
     if not isinstance(kwargs["S"], str):
@@ -288,6 +286,7 @@ def velo(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with lib.virtualfile_in(check_kind="vector", data=data) as vintbl:
             lib.call_module(

--- a/pygmt/src/wiggle.py
+++ b/pygmt/src/wiggle.py
@@ -138,8 +138,6 @@ def wiggle(
     $transparency
     $wrap
     """
-    self._activate_figure()
-
     position = _parse_position(
         position,
         default=Position("BL", offset=0.2),  # Default to BL with 0.2-cm offset.
@@ -174,6 +172,7 @@ def wiggle(
     )
     aliasdict.merge(kwargs)
 
+    self._activate_figure()
     with Session() as lib:
         with lib.virtualfile_in(
             check_kind="vector", data=data, x=x, y=y, z=z, mincols=3


### PR DESCRIPTION
Move `self._activate_figure()` later in plotting wrappers, immediately before the first GMT session call.

This lets PyGMT perform pure-Python operations and validations before activating a figure or changing GMT state. Invalid input now fails earlier without creating or modifying the figure state.

`Figure.hlines` and `Figure.vlines` retain earlier activation because they may need to retrieve the current plot region before delegating to `Figure.plot`.