### PR TITLE
Ruff: Ignore PLR0917 (too many positional arguments) in all src files and fix a few violations

### DIFF
--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -767,7 +767,7 @@ def sequence_join(
     size: int | Sequence[int] | None = None,
     ndim: int = 1,
     name: str | None = None,
-) -> str | list[str] | None | Any:
+) -> str | list[str] | Any | None:
     """
     Join a sequence of values into a string separated by a separator.
 

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -43,7 +43,7 @@ def text(  # noqa: PLR0912, PLR0915
     font: str | StringArrayTypes | bool = False,
     fill: str | None = None,
     pen: str | None = None,
-    justify: bool | None | AnchorCode | Sequence[AnchorCode] = None,
+    justify: bool | AnchorCode | Sequence[AnchorCode] | None = None,
     offset: Sequence[float | str] | str | None = None,
     no_clip: bool = False,
     projection: str | None = None,

--- a/pygmt/xarray/backend.py
+++ b/pygmt/xarray/backend.py
@@ -154,6 +154,6 @@ class GMTBackendEntrypoint(BackendEntrypoint):
                 # Add "source" encoding
                 source: str | list = which(fname=filename_or_obj, verbose="quiet")
                 raster.encoding["source"] = (
-                    sorted(source)[0] if isinstance(source, list) else source
+                    min(source) if isinstance(source, list) else source
                 )
                 return raster.to_dataset()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,10 @@ known-third-party = ["pygmt"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Ignore `F401` (unused-import) in all `__init__.py` files
-"*/src/*.py" = ["PLR0913"]  # Ignore `PLR0913` (too many arguments) in all `src` files
+"*/src/*.py" = [
+    "PLR0913", # Ignore `PLR0913` (too many arguments) in all `src` files
+    "PLR0917", # Ignore `PLR0917` (too many positional arguments) in all `src` files
+]
 "*/tests/test_*.py" = ["S101"]  # Ignore `S101` (use of assert) in all tests files
 "examples/**/*.py" = [ # Ignore rules in examples
     "B018",  # Allow useless expressions in Jupyter Notebooks


### PR DESCRIPTION
Fix for [ruff v0.16.0](https://github.com/astral-sh/ruff/releases/tag/0.16.0).

Still works for ruff v0.15, so ruff version is not bumped in environment.yml.