### PR TITLE
Ruff: Enable RUF105 'noqa-comments' and bump to Ruff>=0.15.22

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,7 +26,7 @@ else:
 # Projection information.
 project = "PyGMT"
 author = "The PyGMT Developers"
-copyright = f"2017-{datetime.date.today().year}, {author}"  # noqa: A001
+copyright = f"2017-{datetime.date.today().year}, {author}"  # ruff: ignore[A001]
 version = "dev" if isdev else __version__
 release = __version__
 

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
     # Dev dependencies (style checks)
     - codespell
     - prek
-    - ruff>=0.15.5
+    - ruff>=0.15.22
     - typos
     # Dev dependencies (unit testing)
     - matplotlib-base

--- a/examples/gallery/images/cross_section.py
+++ b/examples/gallery/images/cross_section.py
@@ -20,7 +20,7 @@ from pygmt.params import Axis, Box, Frame, Position
 region_map = [122, 149, 30, 49]
 
 # Chose a survey line with start point A and end point B
-lonA, latA, lonB, latB = 126, 42, 146, 40  # noqa: N816
+lonA, latA, lonB, latB = 126, 42, 146, 40  # ruff: ignore[N816]
 
 
 fig = pygmt.Figure()

--- a/examples/gallery/images/rgb_image.py
+++ b/examples/gallery/images/rgb_image.py
@@ -13,7 +13,7 @@ The example below shows a Worldview 2 satellite image over
 Data is sourced from a Cloud-Optimized GeoTIFF (COG) file hosted on
 `OpenAerialMap <https://map.openaerialmap.org>`_ under a
 `CC BY-NC 4.0 <https://creativecommons.org/licenses/by-nc/4.0/>`_ license.
-"""  # noqa: RUF002
+"""  # ruff: ignore[RUF002]
 
 # %%
 import pygmt

--- a/examples/tutorials/advanced/non_ascii_text.py
+++ b/examples/tutorials/advanced/non_ascii_text.py
@@ -1,4 +1,4 @@
-# ruff: noqa: RUF001,RUF003
+# ruff: file-ignore[RUF001, RUF003]
 """
 Typesetting non-ASCII text
 --------------------------

--- a/pygmt/alias.py
+++ b/pygmt/alias.py
@@ -331,7 +331,7 @@ class AliasSystem(UserDict):
                 kwdict[option] = aliases._value
         super().__init__(kwdict)
 
-    def add_common(self, **kwargs):  # noqa: PLR0912
+    def add_common(self, **kwargs):  # ruff: ignore[PLR0912]
         """
         Add common parameters to the alias dictionary.
         """

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -382,7 +382,7 @@ class Session:
         self._error_log: list[str] = []
 
         @ctp.CFUNCTYPE(ctp.c_int, ctp.c_void_p, ctp.c_char_p)
-        def print_func(file_pointer, message):  # noqa: ARG001
+        def print_func(file_pointer, message):  # ruff: ignore[ARG001]
             """
             Callback function that the GMT C API will use to print log and error
             messages.
@@ -399,7 +399,7 @@ class Session:
                 return 0
             self._error_log.append(message)
             # Flush to make sure the messages are printed even if we have a crash.
-            print(message, file=sys.stderr, flush=True)  # noqa: T201
+            print(message, file=sys.stderr, flush=True)  # ruff: ignore[T201]
             return 0
 
         # Need to store a copy of the function because ctypes doesn't and it will be
@@ -1171,7 +1171,7 @@ class Session:
         ------
         GMTCLibError
             If the GMT API function fails to read the data.
-        """  # noqa: W505
+        """  # ruff: ignore[W505]
         c_read_data = self.get_libgmt_func(
             "GMT_Read_Data",
             argtypes=[
@@ -1762,7 +1762,7 @@ class Session:
     @deprecate_parameter(
         "required_data", "required", "v0.16.0", remove_version="v0.20.0"
     )
-    def virtualfile_in(  # noqa: PLR0912
+    def virtualfile_in(  # ruff: ignore[PLR0912]
         self,
         check_kind=None,
         data=None,
@@ -1920,7 +1920,7 @@ class Session:
                 if hasattr(data, "items") and not hasattr(data, "to_frame"):
                     # Dictionary, pandas.DataFrame or xarray.Dataset types.
                     # pandas.Series will be handled below like a 1-D numpy.ndarray.
-                    _data = [array for _, array in data.items()]  # noqa: PERF102
+                    _data = [array for _, array in data.items()]  # ruff: ignore[PERF102]
                 else:
                     # Python list, tuple, numpy.ndarray, and pandas.Series types
                     _data = np.atleast_2d(np.asanyarray(data).T)
@@ -2354,7 +2354,7 @@ class Session:
         ...     region = lib.extract_region()
         >>> print(", ".join([f"{x:.2f}" for x in region]))
         -165.00, -150.00, 15.00, 25.00
-        """  # noqa: RUF002
+        """  # ruff: ignore[RUF002]
         c_extract_region = self.get_libgmt_func(
             "GMT_Extract_Region",
             argtypes=[ctp.c_void_p, ctp.c_char_p, ctp.POINTER(ctp.c_double)],

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -11,7 +11,7 @@ from pygmt.exceptions import GMTParameterError, GMTValueError
 
 with contextlib.suppress(ImportError):
     # rioxarray is needed to register the rio accessor
-    import rioxarray  # noqa: F401
+    pass
 
 
 class Resolution(NamedTuple):

--- a/pygmt/datasets/load_remote_dataset.py
+++ b/pygmt/datasets/load_remote_dataset.py
@@ -11,7 +11,7 @@ from pygmt.exceptions import GMTParameterError, GMTValueError
 
 with contextlib.suppress(ImportError):
     # rioxarray is needed to register the rio accessor
-    pass
+    import rioxarray  # ruff: ignore[F401]
 
 
 class Resolution(NamedTuple):

--- a/pygmt/datasets/samples.py
+++ b/pygmt/datasets/samples.py
@@ -339,7 +339,7 @@ def load_sample_data(
      'usgs_quakes': 'Table of earthquakes from the USGS'}
     >>> # Load the sample bathymetry dataset
     >>> data = load_sample_data("bathymetry")
-    """  # noqa: W505
+    """  # ruff: ignore[W505]
     if name not in datasets:
         raise GMTValueError(name, choices=datasets.keys(), description="dataset name")
     return datasets[name].func()

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -18,7 +18,7 @@ except ImportError:
     _HAS_CONTEXTILY = False
 
 try:
-    import rioxarray  # noqa: F401
+    import rioxarray  # ruff: ignore[F401]
 
     _HAS_RIOXARRAY = True
 except ImportError:

--- a/pygmt/datatypes/dataset.py
+++ b/pygmt/datatypes/dataset.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 
 
-class _GMT_DATASEGMENT(ctp.Structure):  # noqa: N801
+class _GMT_DATASEGMENT(ctp.Structure):  # ruff: ignore[N801]
     """
     GMT datasegment structure for holding a segment with multiple columns.
     """
@@ -38,7 +38,7 @@ class _GMT_DATASEGMENT(ctp.Structure):  # noqa: N801
     ]
 
 
-class _GMT_DATATABLE(ctp.Structure):  # noqa: N801
+class _GMT_DATATABLE(ctp.Structure):  # ruff: ignore[N801]
     """
     GMT datatable structure for holding a table with multiple segments.
     """
@@ -65,7 +65,7 @@ class _GMT_DATATABLE(ctp.Structure):  # noqa: N801
     ]
 
 
-class _GMT_DATASET(ctp.Structure):  # noqa: N801
+class _GMT_DATASET(ctp.Structure):  # ruff: ignore[N801]
     """
     GMT dataset structure for holding multiple tables (files).
 

--- a/pygmt/datatypes/grid.py
+++ b/pygmt/datatypes/grid.py
@@ -10,7 +10,7 @@ import xarray as xr
 from pygmt.datatypes.header import _GMT_GRID_HEADER, gmt_grdfloat
 
 
-class _GMT_GRID(ctp.Structure):  # noqa: N801
+class _GMT_GRID(ctp.Structure):  # ruff: ignore[N801]
     """
     GMT grid structure for holding a grid and its header.
 

--- a/pygmt/datatypes/header.py
+++ b/pygmt/datatypes/header.py
@@ -66,7 +66,7 @@ def _parse_nameunits(nameunits: str) -> tuple[str, str | None]:
     return long_name, units
 
 
-class _GMT_GRID_HEADER(ctp.Structure):  # noqa: N801
+class _GMT_GRID_HEADER(ctp.Structure):  # ruff: ignore[N801]
     """
     GMT grid header structure for metadata about the grid.
 

--- a/pygmt/datatypes/image.py
+++ b/pygmt/datatypes/image.py
@@ -16,7 +16,7 @@ __doctest_skip__ = (
 )
 
 
-class _GMT_IMAGE(ctp.Structure):  # noqa: N801
+class _GMT_IMAGE(ctp.Structure):  # ruff: ignore[N801]
     """
     GMT image data structure.
 

--- a/pygmt/exceptions.py
+++ b/pygmt/exceptions.py
@@ -38,7 +38,7 @@ class GMTCLibNoSessionError(GMTCLibError):
     """
 
 
-class GMTInvalidInput(GMTError):  # noqa: N818
+class GMTInvalidInput(GMTError):  # ruff: ignore[N818]
     """
     Raised when the input of a function/method is invalid.
     """
@@ -50,7 +50,7 @@ class GMTVersionError(GMTError):
     """
 
 
-class GMTImageComparisonFailure(AssertionError):  # noqa: N818
+class GMTImageComparisonFailure(AssertionError):  # ruff: ignore[N818]
     """
     Raised when a comparison between two images fails.
     """
@@ -99,7 +99,7 @@ class GMTValueError(GMTError, ValueError):
     Traceback (most recent call last):
         ...
     pygmt.exceptions.GMTValueError: Invalid value: 'invalid'. Explain why it's invalid.
-    """  # noqa: W505
+    """  # ruff: ignore[W505]
 
     def __init__(
         self,

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -430,6 +430,7 @@ def fmt_docstring(module_func):
     <BLANKLINE>
     My nice module.
     <BLANKLINE>
+
     Parameters
     ----------
     data
@@ -454,7 +455,7 @@ def fmt_docstring(module_func):
        - J = projection
        - R = region
     <BLANKLINE>
-    """  # noqa: D410,D411
+    """
     filler_text = {}
 
     if hasattr(module_func, "aliases"):

--- a/pygmt/helpers/decorators.py
+++ b/pygmt/helpers/decorators.py
@@ -430,7 +430,6 @@ def fmt_docstring(module_func):
     <BLANKLINE>
     My nice module.
     <BLANKLINE>
-
     Parameters
     ----------
     data
@@ -455,7 +454,7 @@ def fmt_docstring(module_func):
        - J = projection
        - R = region
     <BLANKLINE>
-    """
+    """  # ruff: ignore[D410, D411]
     filler_text = {}
 
     if hasattr(module_func, "aliases"):

--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -132,7 +132,7 @@ def tempfile_from_geojson(geojson):
         E.g. '1a2b3c4d5e6.gmt'.
     """
     with GMTTempFile(suffix=".gmt") as tmpfile:
-        import geopandas  # noqa: PLC0415
+        import geopandas  # ruff: ignore[PLC0415]
 
         Path(tmpfile.name).unlink()  # Ensure file is deleted first
         ogrgmt_kwargs = {
@@ -162,7 +162,7 @@ def tempfile_from_geojson(geojson):
             geojson.to_file(**ogrgmt_kwargs)
         except AttributeError:
             # Other 'geo' formats which implement __geo_interface__
-            import json  # noqa: PLC0415
+            import json  # ruff: ignore[PLC0415]
 
             jsontext = json.dumps(geojson.__geo_interface__)
             geopandas.read_file(filename=io.StringIO(jsontext)).to_file(**ogrgmt_kwargs)

--- a/pygmt/helpers/testing.py
+++ b/pygmt/helpers/testing.py
@@ -75,8 +75,8 @@ def check_figures_equal(*, extensions=("png",), tol=0.0, result_dir="result_imag
     keyword_only = inspect.Parameter.KEYWORD_ONLY
 
     def decorator(func):
-        import pytest  #  noqa: PLC0415
-        from matplotlib.testing.compare import compare_images  # noqa: PLC0415
+        import pytest  # ruff: ignore[PLC0415]
+        from matplotlib.testing.compare import compare_images  # ruff: ignore[PLC0415]
 
         Path(result_dir).mkdir(parents=True, exist_ok=True)
         old_sig = inspect.signature(func)
@@ -191,7 +191,7 @@ def skip_if_no(package):
         A pytest.mark.skipif to use as either a test decorator or a
         parametrization mark.
     """
-    import pytest  # noqa: PLC0415
+    import pytest  # ruff: ignore[PLC0415]
 
     try:
         _ = importlib.import_module(name=package)

--- a/pygmt/helpers/utils.py
+++ b/pygmt/helpers/utils.py
@@ -43,7 +43,7 @@ Encoding = Literal[
 ]
 
 
-def _validate_data_input(  # noqa: PLR0912
+def _validate_data_input(  # ruff: ignore[PLR0912]
     data=None, x=None, y=None, z=None, required=True, mincols=2, kind=None
 ) -> None:
     """
@@ -217,7 +217,7 @@ def _contains_apostrophe_or_backtick(argstr: str) -> bool:
     True
     >>> _contains_apostrophe_or_backtick("12AB'`")
     True
-    """  # noqa: RUF002
+    """  # ruff: ignore[RUF002]
     return "'" in argstr or "`" in argstr
 
 
@@ -452,7 +452,7 @@ def non_ascii_to_octal(argstr: str, encoding: Encoding = "ISOLatin1+") -> str:
     '12AB\\340\\341\\342\\343\\344\\345@~\\142@~@%34%\\254@%%@%34%\\255@%%'
     >>> non_ascii_to_octal("'‘’\"“”")
     '\\234\\140\\047"\\216\\217'
-    """  # noqa: RUF002
+    """  # ruff: ignore[RUF002]
     # Return the input string if it only contains printable ASCII characters, excluding
     # apostrophe (') and backtick (`).
     if encoding == "ascii" or (
@@ -481,7 +481,7 @@ def non_ascii_to_octal(argstr: str, encoding: Encoding = "ISOLatin1+") -> str:
     return argstr.translate(str.maketrans(mapping))
 
 
-def build_arg_list(  # noqa: PLR0912
+def build_arg_list(  # ruff: ignore[PLR0912]
     kwdict: Mapping[str, Any],
     confdict: Mapping[str, Any] | None = None,
     infile: PathLike | Sequence[PathLike] | None = None,
@@ -712,7 +712,7 @@ def launch_external_viewer(fname: PathLike, waiting: float = 0) -> None:
         case "darwin":  # macOS
             subprocess.run([shutil.which("open"), fname], check=False, **run_args)  # type:ignore[call-overload]
         case "win32":  # Windows
-            os.startfile(fname)  # type:ignore[attr-defined] # noqa: S606
+            os.startfile(fname)  # type:ignore[attr-defined] # ruff: ignore[S606]
         case _:  # Fall back to the browser if can't recognize the operating system.
             webbrowser.open_new_tab(f"file://{Path(fname).resolve()}")
     if waiting > 0:

--- a/pygmt/params/base.py
+++ b/pygmt/params/base.py
@@ -62,7 +62,7 @@ class BaseParam(ABC):
         """
         self._validate()
 
-    def _validate(self):  # noqa: B027
+    def _validate(self):  # ruff: ignore[B027]
         """
         Validate the parameters of the object.
 

--- a/pygmt/sphinx_gallery.py
+++ b/pygmt/sphinx_gallery.py
@@ -19,7 +19,7 @@ class PyGMTScraper:
     ``conf.py`` as the ``"image_scrapers"`` argument.
     """
 
-    def __call__(self, block, block_vars, gallery_conf):  # noqa: ARG002
+    def __call__(self, block, block_vars, gallery_conf):  # ruff: ignore[ARG002]
         """
         Called by sphinx-gallery to save the figures generated after running code.
         """

--- a/pygmt/src/colorbar.py
+++ b/pygmt/src/colorbar.py
@@ -92,7 +92,7 @@ def _build_frame(
     return Frame(xaxis=xaxis, yaxis=yaxis)
 
 
-def _alias_option_D(  # noqa: N802
+def _alias_option_D(  # ruff: ignore[N802]
     position=None,
     length=None,
     width=None,
@@ -220,7 +220,7 @@ def _alias_option_D(  # noqa: N802
     ]
 
 
-def _alias_option_N(dpi=None):  # noqa: N802
+def _alias_option_N(dpi=None):  # ruff: ignore[N802]
     """
     Return an Alias object for the colorbar encoding setting.
 

--- a/pygmt/src/config.py
+++ b/pygmt/src/config.py
@@ -9,7 +9,7 @@ from typing import ClassVar
 from pygmt.clib import Session
 
 
-class config:  # noqa: N801
+class config:  # ruff: ignore[N801]
     """
     Change GMT default settings globally or locally.
 

--- a/pygmt/src/grdfilter.py
+++ b/pygmt/src/grdfilter.py
@@ -15,8 +15,8 @@ from pygmt.helpers import build_arg_list, fmt_docstring, is_given, use_alias
 __doctest_skip__ = ["grdfilter"]
 
 
-def _alias_option_F(  # noqa: N802
-    filter=None,  # noqa: A002
+def _alias_option_F(  # ruff: ignore[N802]
+    filter=None,  # ruff: ignore[A002]
     width=None,
     highpass=False,
 ):
@@ -70,7 +70,7 @@ def _alias_option_F(  # noqa: N802
 def grdfilter(
     grid: PathLike | xr.DataArray,
     outgrid: PathLike | None = None,
-    filter: Literal[  # noqa: A002
+    filter: Literal[  # ruff: ignore[A002]
         "boxcar", "cosarch", "gaussian", "minall", "minpos", "maxall", "maxneg"
     ]
     | str

--- a/pygmt/src/grdgradient.py
+++ b/pygmt/src/grdgradient.py
@@ -15,7 +15,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring, is_given, use_alias
 __doctest_skip__ = ["grdgradient"]
 
 
-def _alias_option_N(  # noqa: N802
+def _alias_option_N(  # ruff: ignore[N802]
     normalize=False,
     norm_amp=None,
     norm_ambient=None,

--- a/pygmt/src/grdhisteq.py
+++ b/pygmt/src/grdhisteq.py
@@ -22,7 +22,7 @@ from pygmt.helpers import (
 __doctest_skip__ = ["grdhisteq.*"]
 
 
-class grdhisteq:  # noqa: N801
+class grdhisteq:  # ruff: ignore[N801]
     r"""
     Perform histogram equalization for a grid.
 

--- a/pygmt/src/grdmask.py
+++ b/pygmt/src/grdmask.py
@@ -15,7 +15,7 @@ from pygmt.helpers import build_arg_list, fmt_docstring
 __doctest_skip__ = ["grdmask"]
 
 
-def _alias_option_N(  # noqa: N802
+def _alias_option_N(  # ruff: ignore[N802]
     outside: float | None = None,
     edge: float | Literal["z", "id"] | None = None,
     inside: float | Literal["z", "id"] | None = None,

--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -24,7 +24,7 @@ from pygmt.src.grdinfo import grdinfo
 __doctest_skip__ = ["grdview"]
 
 
-def _alias_option_Q(  # noqa: N802
+def _alias_option_Q(  # ruff: ignore[N802]
     surftype=None, dpi=None, mesh_fill=None, monochrome=False, nan_transparent=False
 ):
     """

--- a/pygmt/src/plot.py
+++ b/pygmt/src/plot.py
@@ -43,7 +43,7 @@ from pygmt.src._common import _data_geometry_is_point
     l="label",
     w="wrap",
 )
-def plot(  # noqa: PLR0912
+def plot(  # ruff: ignore[PLR0912]
     self,
     data: PathLike | TableLike | None = None,
     x=None,

--- a/pygmt/src/plot3d.py
+++ b/pygmt/src/plot3d.py
@@ -42,7 +42,7 @@ from pygmt.src._common import _data_geometry_is_point
     l="label",
     w="wrap",
 )
-def plot3d(  # noqa: PLR0912
+def plot3d(  # ruff: ignore[PLR0912]
     self,
     data: PathLike | TableLike | None = None,
     x=None,

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -17,7 +17,7 @@ from pygmt.params import Box, Position
 __doctest_skip__ = ["pygmtlogo"]
 
 
-def _create_logo(  # noqa: PLR0915
+def _create_logo(  # ruff: ignore[PLR0915]
     shape: Literal["circle", "hexagon"] = "circle",
     theme: Literal["light", "dark"] = "light",
     wordmark: Literal["none", "horizontal", "vertical"] = "none",
@@ -28,7 +28,7 @@ def _create_logo(  # noqa: PLR0915
     """
     Create the PyGMT logo using PyGMT.
     """
-    from pygmt.figure import Figure  # noqa: PLC0415
+    from pygmt.figure import Figure  # ruff: ignore[PLC0415]
 
     # Helpful definitions
     size = 4
@@ -242,7 +242,7 @@ def _create_logo(  # noqa: PLR0915
 
     # Helpful for implementing the logo; not included in the logo
     if debug:
-        from pygmt import config  # noqa: PLC0415
+        from pygmt import config  # ruff: ignore[PLC0415]
 
         # Gridlines
         with config(MAP_GRID_PEN="0.1p,gray30"):

--- a/pygmt/src/subplot.py
+++ b/pygmt/src/subplot.py
@@ -22,7 +22,7 @@ from pygmt.params import Axis, Box, Frame, Position
 from pygmt.src._common import _parse_position
 
 
-def _alias_option_A(  # noqa: N802
+def _alias_option_A(  # ruff: ignore[N802]
     tag: str | bool = False,
     tag_position: AnchorCode | Position | None = None,
     tag_box: Box | None = None,

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -32,7 +32,7 @@ from pygmt.params import Axis, Frame
     it="use_word",
     w="wrap",
 )
-def text(  # noqa: PLR0912, PLR0915
+def text(  # ruff: ignore[PLR0912, PLR0915]
     self,
     textfiles: PathLike | TableLike | None = None,
     x=None,

--- a/pygmt/src/triangulate.py
+++ b/pygmt/src/triangulate.py
@@ -20,7 +20,7 @@ from pygmt.helpers import (
 )
 
 
-class triangulate:  # noqa: N801
+class triangulate:  # ruff: ignore[N801]
     """
     Delaunay triangulation or Voronoi partitioning and gridding of Cartesian data.
 

--- a/pygmt/tests/test_clib.py
+++ b/pygmt/tests/test_clib.py
@@ -32,7 +32,7 @@ def mock(session, func, returns=None, mock_func=None):
     """
     if mock_func is None:
 
-        def mock_api_function(*args):  # noqa: ARG001
+        def mock_api_function(*args):  # ruff: ignore[ARG001]
             """
             A mock GMT API function that always returns a given value.
             """
@@ -215,7 +215,7 @@ def test_info_dict():
         assert lib.info
 
     # Mock GMT_Get_Default to return always the same string
-    def mock_defaults(api, name, value):  # noqa: ARG001
+    def mock_defaults(api, name, value):  # ruff: ignore[ARG001]
         """
         Put 'bla' in the value buffer.
         """
@@ -247,7 +247,7 @@ def test_fails_for_wrong_version(monkeypatch):
         assert clib.__gmt_version__.split(".")[0] == "6"
 
         # Monkeypatch the version string returned by pygmt.clib.loading.get_gmt_version.
-        mpatch.setattr(clib.loading, "get_gmt_version", lambda libgmt: "5.4.3")  # noqa: ARG005
+        mpatch.setattr(clib.loading, "get_gmt_version", lambda libgmt: "5.4.3")  # ruff: ignore[ARG005]
 
         # Reload clib.session and check the __gmt_version__ string.
         importlib.reload(clib.session)

--- a/pygmt/tests/test_clib_to_numpy.py
+++ b/pygmt/tests/test_clib_to_numpy.py
@@ -18,7 +18,7 @@ try:
     _HAS_PYARROW = True
 except ImportError:
 
-    class pa:  # noqa: N801
+    class pa:  # ruff: ignore[N801]
         """
         A dummy class to mimic pyarrow.
         """

--- a/pygmt/tests/test_clib_virtualfile_in.py
+++ b/pygmt/tests/test_clib_virtualfile_in.py
@@ -74,7 +74,7 @@ def test_virtualfile_in_required_z_deprecated():
     """
     data = np.ones((5, 2))
     with clib.Session() as lib:
-        with pytest.raises(GMTInvalidInput):  # noqa: PT012
+        with pytest.raises(GMTInvalidInput):  # ruff: ignore[PT012]
             with pytest.warns(FutureWarning):
                 with lib.virtualfile_in(
                     data=data, required_z=True, check_kind="vector"

--- a/pygmt/tests/test_datasets_samples.py
+++ b/pygmt/tests/test_datasets_samples.py
@@ -191,7 +191,7 @@ def test_earth_relief_holes():
     npt.assert_allclose(grid.max(), 1601)
     npt.assert_allclose(grid.min(), -4929.5)
     # Test for the NaN values in the remote file
-    assert grid[2, 21].isnull()  # noqa: PD003  # Ruff's bug
+    assert grid[2, 21].isnull()  # ruff: ignore[PD003]  # Ruff's bug
 
 
 def test_maunaloa_co2():

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -129,9 +129,9 @@ def test_figure_savefig_geotiff():
 
     # Check if a TIFF is georeferenced or not
     if _HAS_RIOXARRAY:
-        import rioxarray  # noqa: PLC0415
-        from rasterio.errors import NotGeoreferencedWarning  # noqa: PLC0415
-        from rasterio.transform import Affine  # noqa: PLC0415
+        import rioxarray  # ruff: ignore[PLC0415]
+        from rasterio.errors import NotGeoreferencedWarning  # ruff: ignore[PLC0415]
+        from rasterio.transform import Affine  # ruff: ignore[PLC0415]
 
         # GeoTIFF
         with rioxarray.open_rasterio(geofname) as xds:

--- a/pygmt/tests/test_session_management.py
+++ b/pygmt/tests/test_session_management.py
@@ -69,7 +69,7 @@ def _gmt_func_wrapper(figname):
     Currently, we have to import pygmt and reload it in each process. Workaround from
     https://github.com/GenericMappingTools/pygmt/issues/217#issuecomment-754774875.
     """
-    import pygmt  # noqa: PLC0415
+    import pygmt  # ruff: ignore[PLC0415]
 
     reload(pygmt)
     fig = pygmt.Figure()

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -470,8 +470,8 @@ def test_text_nonascii(encoding):
     if encoding == "Standard+":  # Temporarily set the PS_CHAR_ENCODING to "Standard+".
         config(PS_CHAR_ENCODING="Standard+")
     fig.basemap(region=[0, 10, 0, 10], projection="X10c", frame=True)
-    fig.text(position="TL", text="position-text:°α")  # noqa: RUF001
-    fig.text(x=1, y=1, text="xytext:°α")  # noqa: RUF001
+    fig.text(position="TL", text="position-text:°α")  # ruff: ignore[RUF001]
+    fig.text(x=1, y=1, text="xytext:°α")  # ruff: ignore[RUF001]
     fig.text(x=[5, 5], y=[3, 5], text=["xytext1:αζ∆❡", "xytext2:∑π∇✉"])
     return fig
 
@@ -484,7 +484,7 @@ def test_text_quotation_marks():
     See https://github.com/GenericMappingTools/pygmt/issues/3104 and
     https://github.com/GenericMappingTools/pygmt/issues/3476.
     """
-    quotations = "` ' ‘ ’ \" “ ”"  # noqa: RUF001
+    quotations = "` ' ‘ ’ \" “ ”"  # ruff: ignore[RUF001]
     fig = Figure()
     fig.basemap(
         projection="X4c/2c",

--- a/pygmt/xarray/backend.py
+++ b/pygmt/xarray/backend.py
@@ -114,7 +114,7 @@ class GMTBackendEntrypoint(BackendEntrypoint):
         self,
         filename_or_obj: PathLike,
         *,
-        drop_variables=None,  # noqa: ARG002
+        drop_variables=None,  # ruff: ignore[ARG002]
         raster_kind: Literal["grid", "image"],
         region: Sequence[float] | str | None = None,
         # other backend specific keyword arguments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ extend-select = [
     "D410",     # A blank line after section headings.
     "PLR6201",  # Use a set literal when testing for membership
     "PLW1514",  # {function_name} in text mode without explicit encoding argument
+    "RUF105",   # Use `# ruff: ignore` rather than `# noqa`
     "RUF027",   # Possible f-string without an f prefix
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,8 +152,8 @@ extend-select = [
     "D410",     # A blank line after section headings.
     "PLR6201",  # Use a set literal when testing for membership
     "PLW1514",  # {function_name} in text mode without explicit encoding argument
-    "RUF105",   # Use `# ruff: ignore` rather than `# noqa`
     "RUF027",   # Possible f-string without an f prefix
+    "RUF105",   # Use `# ruff: ignore` rather than `# noqa`
 ]
 ignore = [
     "COM812",   # Do not always add the trailing commas


### PR DESCRIPTION
Ruff supports two types of comments for suppressing linting errors: `# noqa` and `# ruff: ignore` (xref: https://docs.astral.sh/ruff/linter/#error-suppression). The `# noqa` syntax originates from `flake8`, whereas `# ruff: ignore` is Ruff-specific and provides greater flexibility. For example:

> In [preview](https://docs.astral.sh/ruff/preview/), rule names (e.g., `unused-import`) can be used in `ruff: ignore`, `ruff: file-ignore`, `ruff: disable`, and `ruff: enable` comments instead of rule codes (e.g., `F401`).

This means we can write `# ruff: ignore[unused-import]`, which is more readable than either `# ruff: ignore[F401]` or `# noqa: F401`.

This PR enables the [`RUF105`](https://docs.astral.sh/ruff/rules/noqa-comments/) rule, which automatically detects `# noqa` comments that can be expressed as `# ruff: ignore` and performs the conversion. 

Note that `RUF105` is still a preview rule and requires Ruff 0.15.22 (released on 2026-07-16). I'm happy to postpone this PR if you think adopting a preview feature at this stage is too aggressive.

Will explore [`RUF106`](https://docs.astral.sh/ruff/rules/rule-codes-in-suppression-comments/) and [`RUF201`](https://docs.astral.sh/ruff/rules/rule-codes-in-selectors/) in futher PRs.

Related to https://github.com/GenericMappingTools/pygmt/issues/2741.