### PR TITLE
Stop recommending mamba in installation guides and error messages

### DIFF
--- a/.github/ISSUE_TEMPLATE/5-bump_gmt_checklist.md
+++ b/.github/ISSUE_TEMPLATE/5-bump_gmt_checklist.md
@@ -9,7 +9,7 @@ assignees: ''
 
 :tada: [GMT X.Y.Z](https://github.com/GenericMappingTools/gmt/releases/tag/X.Y.Z) has been released! It is installable from the [conda-forge channel](https://anaconda.org/conda-forge/gmt/files) using the following command:
 ```
-mamba install -c conda-forge gmt=X.Y.Z
+conda install -c conda-forge gmt=X.Y.Z
 ```
 
 <!-- Please add specific checklist items for the tests, xfail pytest markers, and deprecated syntax that need to be updated. -->

--- a/README.md
+++ b/README.md
@@ -51,13 +51,8 @@ program widely used across the Earth, Ocean, and Planetary sciences and beyond.
 
 ### Installation
 
-Simple installation using [mamba](https://mamba.readthedocs.org/):
-
-```bash
-mamba install --channel conda-forge pygmt
-```
-
-If you use [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/index.html):
+Simple installation using
+[conda](https://docs.conda.io/projects/conda/en/latest/user-guide/index.html):
 
 ```bash
 conda install --channel conda-forge pygmt

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -189,7 +189,7 @@ These steps for setting up your environment are necessary for
 is not needed for [editing the documentation on GitHub](contributing.md#editing-the-documentation-on-github).
 
 We highly recommend using [Miniforge](https://github.com/conda-forge/miniforge#miniforge3)
-and the `mamba` package manager to install and manage your Python packages.
+and the `conda` package manager to install and manage your Python packages.
 It will make your life a lot easier!
 
 The repository includes a virtual environment file `environment.yml` with the
@@ -210,14 +210,14 @@ Run the following on the base of the repository to create a new conda
 environment from the `environment.yml` file:
 
 ```bash
-mamba env create --file environment.yml
+conda env create --file environment.yml
 ```
 
 Before building and testing the project, you have to activate the environment
 (you'll need to do this every time you start a new terminal):
 
 ```bash
-mamba activate pygmt
+conda activate pygmt
 ```
 
 We have a [`Makefile`](https://github.com/GenericMappingTools/pygmt/blob/main/Makefile)

--- a/doc/install.md
+++ b/doc/install.md
@@ -6,44 +6,20 @@ file_format: mystnb
 
 ## Quickstart
 
-The fastest way to install PyGMT is with the [mamba](https://mamba.readthedocs.io/en/latest/)
-or [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/index.html)
-package manager which takes care of setting up a virtual environment, as well as the
+The fastest way to install PyGMT is with the
+[conda](https://docs.conda.io/projects/conda/en/latest/user-guide/index.html)
+package manager, which takes care of setting up a virtual environment, as well as the
 installation of GMT and all the dependencies PyGMT depends on:
 
-:::: {tab-set}
-::: {tab-item} mamba
-:sync: mamba
-```
-mamba create --name pygmt --channel conda-forge pygmt
-```
-:::
-
-::: {tab-item} conda
-:sync: conda
 ```
 conda create --name pygmt --channel conda-forge pygmt
 ```
-:::
-::::
 
 To activate the virtual environment, you can do:
 
-:::: {tab-set}
-::: {tab-item} mamba
-:sync: mamba
-```
-mamba activate pygmt
-```
-:::
-
-::: {tab-item} conda
-:sync: conda
 ```
 conda activate pygmt
 ```
-:::
-::::
 
 After this, check that everything works by running the following in a Python interpreter
 (e.g., in a Jupyter notebook):
@@ -71,10 +47,9 @@ development version.
 PyGMT is tested to run on Python {{ requires.python }}.
 
 We recommend using the [Miniforge](https://github.com/conda-forge/miniforge#miniforge3)
-Python distribution to ensure you have all dependencies installed and
-the [mamba](https://mamba.readthedocs.io/en/stable/user_guide/mamba.html) package manager
-in the base environment. Installing Miniforge does not require administrative rights to
-your computer and doesn't interfere with any other Python installations on your system.
+Python distribution to ensure you have all dependencies installed. Installing Miniforge
+does not require administrative rights to your computer and doesn't interfere with any
+other Python installations on your system.
 
 ## Which GMT?
 
@@ -110,8 +85,8 @@ For a complete list of the optional dependencies, refer to [](ecosystem.md).
 ## Installing GMT and other dependencies
 
 Before installing PyGMT, we must install GMT itself along with the other dependencies.
-The easiest way to do this is via the `mamba` or `conda` package manager. We recommend
-working in an isolated
+The easiest way to do this is via the `conda` package manager. We recommend working in
+an isolated
 [virtual environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)
 to avoid issues with conflicting versions of dependencies.
 
@@ -123,105 +98,45 @@ conda config --prepend channels conda-forge
 Now we can create a new virtual environment with Python and all our dependencies
 installed (we'll call it `pygmt` but feel free to change it to whatever you want):
 
-:::: {tab-set}
-::: {tab-item} mamba
-:sync: mamba
-```
-mamba create --name pygmt python=3.14 numpy pandas xarray packaging gmt
-```
-:::
-
-::: {tab-item} conda
-:sync: conda
 ```
 conda create --name pygmt python=3.14 numpy pandas xarray packaging gmt
 ```
-:::
-::::
 
 Activate the environment by running the following (**do not forget this step!**):
 
-:::: {tab-set}
-::: {tab-item} mamba
-:sync: mamba
-```
-mamba activate pygmt
-```
-:::
-
-::: {tab-item} conda
-:sync: conda
 ```
 conda activate pygmt
 ```
-:::
-::::
 
 From now on, all commands will take place inside the virtual environment called `pygmt`
 and won't affect your default `base` installation.
 
-::::: {tip}
+:::: {tip}
 You can also enable more PyGMT functionalities by installing PyGMT's optional
 dependencies in the environment.
-:::: {tab-set}
-::: {tab-item} mamba
-:sync: mamba
-```
-mamba install contextily geopandas ipython pyarrow-core rioxarray
-```
-:::
-
-::: {tab-item} conda
-:sync: conda
 ```
 conda install contextily geopandas ipython pyarrow-core rioxarray
 ```
-:::
 ::::
-:::::
 
 ## Installing PyGMT
 
 Now that you have GMT installed and your virtual environment activated, you can install
 PyGMT using any of the following methods.
 
-### Using mamba/conda (recommended)
+### Using conda (recommended)
 
 This installs the latest stable release of PyGMT from [conda-forge](https://anaconda.org/conda-forge/pygmt):
 
-:::: {tab-set}
-::: {tab-item} mamba
-:sync: mamba
-```
-mamba install pygmt
-```
-:::
-
-::: {tab-item} conda
-:sync: conda
 ```
 conda install pygmt
 ```
-:::
-::::
 
 This upgrades the installed PyGMT version to be the latest stable release:
 
-:::: {tab-set}
-::: {tab-item} mamba
-:sync: mamba
-```
-mamba update pygmt
-```
-:::
-
-::: {tab-item} conda
-:sync: conda
 ```
 conda update pygmt
 ```
-:::
-::::
 
 ### Using pip
 
@@ -244,7 +159,7 @@ python -m pip install --pre --extra-index-url https://test.pypi.org/simple/ pygm
 To upgrade the installed stable release or development version to be the latest one,
 just add `--upgrade` to the corresponding command above.
 
-Any of the above methods (mamba/conda/pip) should allow you to use the PyGMT package
+Any of the above methods (conda/pip) should allow you to use the PyGMT package
 from Python.
 
 ## Testing your install
@@ -306,7 +221,7 @@ C:\Users\USERNAME\Miniforge3\envs\pygmt\Library\bin\
 
 If you can successfully import PyGMT in a Python interpreter or IPython, but get a
 `ModuleNotFoundError` when importing PyGMT in Jupyter, you may need to activate your
-`pygmt` virtual environment (using `mamba activate pygmt` or `conda activate pygmt`)
+`pygmt` virtual environment (using `conda activate pygmt`)
 and install a `pygmt` kernel following the commands below:
 ```
 python -m ipykernel install --user --name pygmt  # install virtual environment properly

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -142,7 +142,7 @@ def load_tile_map(
         msg = (
             "Package `contextily` is required to be installed to use this function. "
             "Please use `python -m pip install contextily` or "
-            "`mamba install -c conda-forge contextily` to install the package."
+            "`conda install -c conda-forge contextily` to install the package."
         )
         raise ImportError(msg)
 
@@ -150,7 +150,7 @@ def load_tile_map(
         msg = (
             f"Package `rioxarray` is required if CRS is not {_source_crs!r}. "
             "Please use `python -m pip install rioxarray` or "
-            "`mamba install -c conda-forge rioxarray` to install the package."
+            "`conda install -c conda-forge rioxarray` to install the package."
         )
         raise ImportError(msg)
 

--- a/pygmt/helpers/tempfile.py
+++ b/pygmt/helpers/tempfile.py
@@ -194,7 +194,7 @@ def tempfile_from_image(image):
             msg = (
                 "Package `rioxarray` is required to be installed to use this function. "
                 "Please use `python -m pip install rioxarray` or "
-                "`mamba install -c conda-forge rioxarray` "
+                "`conda install -c conda-forge rioxarray` "
                 "to install the package."
             )
             raise ImportError(msg) from e


### PR DESCRIPTION
**Description of proposed changes**

- Replace Mamba commands with Conda commands in the six files identified in the issue.
- Collapse duplicated Mamba/Conda tab sets into shorter, single-path Conda instructions.
- Update optional-dependency error messages and the GMT release checklist to recommend Conda.
- Keep historical changelog references unchanged.

Conda has used the libmamba solver by default since 2023, so a separate Mamba path no longer provides enough benefit to justify duplicated instructions.

Fixes #4763

**Preview**:

**Validation**

- Repository pre-commit hooks on all six changed files
- Ruff check and format check on the modified Python modules
- Codespell on all changed files
- `git diff --check`
- Verified zero Mamba references remain in the six issue targets

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)