### PR TITLE
Ruff: Enable PT023 (pytest-incorrect-mark-parentheses-style)

### DIFF
--- a/pygmt/tests/test_grdimage.py
+++ b/pygmt/tests/test_grdimage.py
@@ -265,7 +265,7 @@ def test_grdimage_imgout_fails(grid):
     condition=Version(__gmt_version__) <= Version("6.5.0"),
     reason="Upstream bug fixed in https://github.com/GenericMappingTools/gmt/pull/8554",
 )
-@pytest.mark.mpl_image_compare()
+@pytest.mark.mpl_image_compare
 def test_grdimage_grid_no_redundant_360():
     """
     Test that global grids with and without redundant 360/0 longitude values work.

--- a/pygmt/tests/test_subplot.py
+++ b/pygmt/tests/test_subplot.py
@@ -110,7 +110,7 @@ def test_subplot_nrows_ncols_less_than_one_error():
             pass
 
 
-@pytest.mark.mpl_image_compare()
+@pytest.mark.mpl_image_compare
 def test_subplot_outside_plotting_positioning():
     """
     Plotting calls are correctly positioned after exiting subplot.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,6 @@ ignore = [
     "D412",     # No blank lines allowed between a section header and its content
     "E501",     # Avoid enforcing line-length violations
     "ISC001",   # Single-line-implicit-string-concatenation, conflict with formatter
-    "PT023",    # Allow using pytest marker without parentheses
     "PLR2004",  # Allow any magic values
     "RET504",   # Allow variable assignment and return immediately for readability
     "S603",     # Allow method calls that initiate a subprocess without a shell


### PR DESCRIPTION
Do not ignore [PT023 rule](https://docs.astral.sh/ruff/rules/pytest-incorrect-mark-parentheses-style/), and fix violations.

Patches https://github.com/GenericMappingTools/pygmt/pull/2899.