### PR TITLE
Adds better support for plotting text in 3D at different heights

### DIFF
--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -251,6 +251,8 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
     data = None
     if kind == "empty":
         data = {"x": x, "y": y}
+        if z is not None:
+            data["z"] = z
 
         for arg, flag, name in array_args:
             if is_nonstr_iter(arg):

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -249,7 +249,10 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
     confdict = {}
     data = None
     if kind == "empty":
-        data = {"x": x, "y": y, "z": z}
+        data = {"x": x, "y": y}
+
+        if z is not None:
+            data["z"] = z
 
         for arg, flag, name in array_args:
             if is_nonstr_iter(arg):

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -100,6 +100,7 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
 
         * *x*: X coordinate or longitude
         * *y*: Y coordinate or latitude
+        * *z*: Z coordinate or altitude
         * *angle*: Angle in degrees counter-clockwise from horizontal
         * *font*: Text size, font, and color
         * *justify*:
@@ -111,8 +112,8 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
         respectively. If these parameters are set to ``True``, then the
         corresponding columns must be present in the input file(s) and the
         columns must be in the order mentioned above.
-    x/y : float or 1-D arrays
-        The x and y coordinates, or an array of x and y coordinates to plot
+    x/y/z : float or 1-D arrays
+        The x, y, and z coordinates, or an array of x, y, and z coordinates to plot
         the text.
     position
         Set reference point on the plot for the text by using x, y
@@ -188,7 +189,7 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
     $perspective
     $transparency
         ``transparency`` can also be a 1-D array to set varying transparency for texts,
-        but this option is only valid if using ``x``/``y`` and ``text``.
+        but this option is only valid if using ``x``/``y``(/``z``) and ``text``.
     $wrap
 
     See Also

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -100,7 +100,7 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
 
         * *x*: X coordinate or longitude
         * *y*: Y coordinate or latitude
-        * *z*: Z coordinate or altitude
+        * *z*: Optional Z coordinate or altitude
         * *angle*: Angle in degrees counter-clockwise from horizontal
         * *font*: Text size, font, and color
         * *justify*:
@@ -113,7 +113,7 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
         corresponding columns must be present in the input file(s) and the
         columns must be in the order mentioned above.
     x/y/z : float or 1-D arrays
-        The x, y, and z coordinates, or an array of x, y, and z coordinates to plot
+        The x, y, and optional z coordinates, or an array of x, y, and z coordinates to plot
         the text.
     position
         Set reference point on the plot for the text by using x, y
@@ -203,7 +203,7 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
         + (position is not None)
         + (x is not None or y is not None or z is not None)
     ) != 1:
-        raise GMTParameterError(at_most_one=["textfiles", "position/text", "x/y/text"])
+        raise GMTParameterError(at_most_one=["textfiles", "position/text", "x/y(/z)/text"])
 
     data_is_required = position is None
     kind = data_kind(textfiles, required=data_is_required)

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -223,7 +223,7 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
         raise GMTParameterError(at_most_one=["text", "textfiles"])
     if kind == "empty" and text is None:
         raise GMTParameterError(
-            required="text", reason="Required when 'x' and 'y' are set."
+            required="text", reason="Required when 'x', 'y', and optional 'z' are set."
         )
 
     # Arguments that can accept arrays.

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -65,6 +65,7 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
 
     - ``textfiles``
     - ``x``/``y``, and ``text``
+    - ``x``/``y``/``z``, and ``text``
     - ``position`` and ``text``
 
     The text strings passed via the ``text`` parameter can contain ASCII characters and

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -197,11 +197,11 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
     pygmt.Figure.paragraph
         Typeset one or multiple paragraphs.
     """
-    # Ensure inputs are either textfiles, x/y/text, or position/text
+    # Ensure inputs are either textfiles, x/y(/z)/text, or position/text
     if (
         (textfiles is not None)
         + (position is not None)
-        + (x is not None or y is not None)
+        + (x is not None or y is not None or z is not None)
     ) != 1:
         raise GMTParameterError(at_most_one=["textfiles", "position/text", "x/y/text"])
 

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -64,8 +64,7 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
     Must provide at least one of the following combinations as input:
 
     - ``textfiles``
-    - ``x``/``y``, and ``text``
-    - ``x``/``y``/``z``, and ``text``
+    - ``x``/``y``[/``z``], and ``text``
     - ``position`` and ``text``
 
     The text strings passed via the ``text`` parameter can contain ASCII characters and
@@ -113,8 +112,8 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
         corresponding columns must be present in the input file(s) and the
         columns must be in the order mentioned above.
     x/y/z : float or 1-D arrays
-        The x, y, and optional z coordinates, or an array of x, y, and z coordinates to plot
-        the text.
+        The x, y, and z coordinates, or arrays of x, y and z coordinates of
+        the data points.
     position
         Set reference point on the plot for the text by using x, y
         coordinates extracted from ``region`` instead of providing them
@@ -223,7 +222,7 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
         raise GMTParameterError(at_most_one=["text", "textfiles"])
     if kind == "empty" and text is None:
         raise GMTParameterError(
-            required="text", reason="Required when 'x', 'y', and optional 'z' are set."
+            required="text", reason="Required when 'x', 'y' (and optional 'z') are set."
         )
 
     # Arguments that can accept arrays.
@@ -250,9 +249,7 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
     confdict = {}
     data = None
     if kind == "empty":
-        data = {"x": x, "y": y}
-        if z is not None:
-            data["z"] = z
+        data = {"x": x, "y": y, "z": z}
 
         for arg, flag, name in array_args:
             if is_nonstr_iter(arg):

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -38,6 +38,7 @@ def text(  # ruff: ignore[too-many-branches, too-many-statements]
     textfiles: PathLike | TableLike | None = None,
     x=None,
     y=None,
+    z=None,
     position: AnchorCode | None = None,
     text: str | StringArrayTypes | None = None,
     angle: float | Sequence[float] | bool = False,

--- a/pygmt/src/text.py
+++ b/pygmt/src/text.py
@@ -25,6 +25,7 @@ from pygmt.params import Axis, Frame
 @fmt_docstring
 @use_alias(
     C="clearance",
+    Z="zvalue",
     a="aspatial",
     e="find",
     f="coltypes",


### PR DESCRIPTION
**Description of proposed changes**

Adds a `z` parameter to `Figure.text` to explicitly expose support for 3D text placement in perspective plots. Previously, users could not provide z coordinates through the PyGMT API even though the underlying GMT module supports 3D text input.
 
This PR:
 
- Adds the `z` parameter to `text.py`
- Aliases the GMT `-Z` option via `zvalue`
- Updates the docstring and parameter descriptions to document z-coordinate support
- Updates parameter validation and error messages to include `z`
Fixes #1393 

### Reviewer feedback requested
 
I would especially appreciate guidance on tests for this feature. I ran the existing tests to make sure nothing was broken with this implementation, but I'm struggling to create tests that ensure this was implemented correctly.

**Preview**:

N/A


