### PR TITLE
Change 'import importlib' to 'import importlib.util' in test files.

### DIFF
--- a/pygmt/tests/test_clib_vectors_to_arrays.py
+++ b/pygmt/tests/test_clib_vectors_to_arrays.py
@@ -3,7 +3,7 @@ Test the vectors_to_arrays function in the clib.conversion module.
 """
 
 import datetime
-import importlib
+import importlib.util
 
 import numpy as np
 import numpy.testing as npt

--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -4,7 +4,7 @@ Test the behavior of the Figure class.
 Doesn't include the plotting commands which have their own test files.
 """
 
-import importlib
+import importlib.util
 from pathlib import Path
 from unittest.mock import Mock, patch
 

--- a/pygmt/tests/test_tilemap.py
+++ b/pygmt/tests/test_tilemap.py
@@ -2,7 +2,7 @@
 Test Figure.tilemap.
 """
 
-import importlib
+import importlib.util
 from unittest.mock import patch
 
 import pytest

--- a/pygmt/tests/test_xarray_accessor.py
+++ b/pygmt/tests/test_xarray_accessor.py
@@ -2,7 +2,7 @@
 Test the behaviour of the GMTDataArrayAccessor class.
 """
 
-import importlib
+import importlib.util
 from pathlib import Path
 
 import pytest

--- a/pygmt/tests/test_xarray_backend.py
+++ b/pygmt/tests/test_xarray_backend.py
@@ -2,7 +2,7 @@
 Tests for xarray 'gmt' backend engine.
 """
 
-import importlib
+import importlib.util
 
 import numpy as np
 import numpy.testing as npt


### PR DESCRIPTION
I ran the ty typechecker and it raised `warning[possibly-missing-submodule]: Submodule `util` might not have been imported` for `import importlib`. This adds util to the import statement in several test files.

I was surprised since there wasn't an error when running the tests, and I figured util is a sub-module for importlib. Digging into this, it sounds like util needs its own import since Python 3.10, and this may have gone unnoticed because it was imported elsewhere when tests were running (I don't understand why that would have worked). Python's [documentation](https://docs.python.org/3/library/importlib.html#importlib.util.find_spec) includes an example of explicitly importing importlib.util



<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
