### PR TITLE
DOC: Fix typos in the text tutorial

### DIFF
--- a/examples/tutorials/basics/text.py
+++ b/examples/tutorials/basics/text.py
@@ -153,7 +153,7 @@ fig.show()
 # ----------------------------
 #
 # It is also possible to add text labels via an external input file containing ``x``,
-# ``y``, and ``text`` columns. Addionaly, columns to set the ``angle``, ``front``,
+# ``y``, and ``text`` columns. Additionally, columns to set the ``angle``, ``font``,
 # and ``justify`` parameters can be provided. Here, we give a complete example.
 
 fig = pygmt.Figure()
@@ -162,7 +162,7 @@ fig.coast(land="darkgray", water="steelblue", shorelines="1/0.1p,gray30")
 
 # Create space-delimited file with region / sea names:
 # - longitude (x) and latitude (y) coordinates are in the first two columns
-# - angle, font, and justify muss be present in this order in the next three columns
+# - angle, font, and justify must be present in this order in the next three columns
 # - the text to be printed is given in the last column
 with Path.open("examples.txt", "w") as f:
     f.write("114.00  0.50   0 15p,Helvetica-Bold,white CM BORNEO\n")


### PR DESCRIPTION
Fix minor typos in the docs in text.py.


<!-- If significant changes to the documentation are made, please insert the link to the documentation page after it has been built. -->
**Preview**:

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
