### PR TITLE
DOC: Fix filename in link to PyGMT logo image file

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -2,7 +2,7 @@
 ```
 
 <div class="banner">
-    <img src="_static/pygmtlogo.png" alt="PyGMT Logo" style="width: 65%;">
+    <img src="_static/pygmtlogo_light.png" alt="PyGMT Logo" style="width: 65%;">
     <h2>
         A Python interface for the
         <a href="https://www.generic-mapping-tools.org/">Generic Mapping Tools</a>

--- a/pygmt/src/pygmtlogo.py
+++ b/pygmt/src/pygmtlogo.py
@@ -291,7 +291,7 @@ def pygmtlogo(
     """
     Plot the PyGMT logo.
 
-    .. figure:: https://raw.githubusercontent.com/GenericMappingTools/pygmt/main/doc/_static/pygmtlogo.png
+    .. figure:: https://raw.githubusercontent.com/GenericMappingTools/pygmt/main/doc/_static/pygmtlogo_light.png
        :alt: PyGMT logo
        :align: center
        :width: 400px


### PR DESCRIPTION
**Description of proposed changes**

Forgot to update the link to the PyGMT logo file on the landing page and the api page for `Figure.pygmtlogo` after changing the filename in PR #4778.

Fixes: #4791

**Preview**:

- https://pygmt-dev--4792.org.readthedocs.build/en/4792/
- https://pygmt-dev--4792.org.readthedocs.build/en/4792/api/generated/pygmt.Figure.pygmtlogo.html

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
