### PR TITLE
Add check in contour for data and xyz

### DIFF
--- a/pygmt/src/contour.py
+++ b/pygmt/src/contour.py
@@ -8,6 +8,7 @@ from typing import Literal
 from pygmt._typing import PathLike, TableLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
+from pygmt.exceptions import GMTParameterError
 from pygmt.helpers import (
     build_arg_list,
     fmt_docstring,
@@ -151,6 +152,9 @@ def contour(
     $perspective
     $transparency
     """
+    # Validate that 'data' and 'x,y,z' aren't both passed to contour
+    if data is not None and any(triplet is not None for triplet in (x, y, z)):
+        raise GMTParameterError(at_most_one=["data", "x/y/z"])
     # Specify levels for contours or annotations.
     # One level is converted to a string with a trailing comma to separate it from
     # specifying an interval.

--- a/pygmt/tests/test_contour.py
+++ b/pygmt/tests/test_contour.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 from pygmt import Figure
+from pygmt.exceptions import GMTParameterError
 from pygmt.params import Axis
 
 POINTS_DATA = Path(__file__).parent / "data" / "points.txt"
@@ -198,3 +199,22 @@ def test_contour_incols_transposed_data(region):
         incols=[1, 0, 2],
     )
     return fig
+
+
+def test_contour_fail_too_much_data(data, region):
+    """
+    Check that contour raises an exception if both data and x/y/z are given.
+    """
+    fig = Figure()
+    with pytest.raises(GMTParameterError):
+        fig.contour(
+            data=data,
+            # Transpose x and y values
+            x=data[1],
+            y=data[0],
+            z=data[2],
+            region=region,
+            projection="X10c",
+            frame=Axis(annot=True),
+            pen=True,
+        )


### PR DESCRIPTION
The documentation states that either `data` or `x/y/z` can be passed to `contour`, but there is no check that both are not passed. This adds a check for it, and an associated test.

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
