### PR TITLE
DOC/website: Adjust order of subsections under 'Getting Help' in sidebar

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -57,7 +57,7 @@
 
     {% if menu_links %}
         <p class="caption">
-            <span class="caption-text">Getting help and contributing</span>
+            <span class="caption-text">Getting help</span>
         </p>
         <ul>
             {% for text, link in menu_links %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -222,10 +222,6 @@ html_context = {
             '<i class="fa fa-gavel fa-fw"></i> Code of Conduct',
             "https://github.com/GenericMappingTools/.github/blob/main/CODE_OF_CONDUCT.md",
         ),
-        (
-            '<i class="fa fa-book fa-fw"></i> License',
-            f"{repository_url}/blob/main/LICENSE.txt",
-        ),
     ],
     # Custom variables to enable "Improve this page"" and "Download notebook" links
     "doc_path": "doc",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -215,7 +215,7 @@ html_context = {
             "https://forum.generic-mapping-tools.org",
         ),
         (
-            '<i class="fa fa-github fa-fw"></i> Report a bug',
+            '<i class="fa fa-github fa-fw"></i> Bug Report',
             f"{repository_url}/issues",
         ),
         (

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -215,8 +215,8 @@ html_context = {
             "https://forum.generic-mapping-tools.org",
         ),
         (
-            '<i class="fa fa-github fa-fw"></i> Source Code',
-            repository_url,
+            '<i class="fa fa-github fa-fw"></i> Report a bug',
+            f"{repository_url}/issues",
         ),
         (
             '<i class="fa fa-gavel fa-fw"></i> Code of Conduct',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -211,11 +211,11 @@ html_show_sphinx = False
 html_context = {
     "menu_links": [
         (
-            '<i class="fa fa-comment fa-fw"></i> GMT Forum',
-            "https://forum.generic-mapping-tools.org",
+            '<i class="fa fa-comment fa-fw"></i> PyGMT Q&A (GMT Forum)',
+            "https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a/11",
         ),
         (
-            '<i class="fa fa-github fa-fw"></i> Bug Report',
+            '<i class="fa fa-github fa-fw"></i> Bug Report (GitHub)',
             f"{repository_url}/issues",
         ),
         (

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -211,20 +211,20 @@ html_show_sphinx = False
 html_context = {
     "menu_links": [
         (
+            '<i class="fa fa-comment fa-fw"></i> GMT Forum',
+            "https://forum.generic-mapping-tools.org",
+        ),
+        (
+            '<i class="fa fa-github fa-fw"></i> Source Code',
+            repository_url,
+        ),
+        (
             '<i class="fa fa-gavel fa-fw"></i> Code of Conduct',
             "https://github.com/GenericMappingTools/.github/blob/main/CODE_OF_CONDUCT.md",
         ),
         (
             '<i class="fa fa-book fa-fw"></i> License',
             f"{repository_url}/blob/main/LICENSE.txt",
-        ),
-        (
-            '<i class="fa fa-comment fa-fw"></i> Contact',
-            "https://forum.generic-mapping-tools.org",
-        ),
-        (
-            '<i class="fa fa-github fa-fw"></i> Source Code',
-            repository_url,
         ),
     ],
     # Custom variables to enable "Improve this page"" and "Download notebook" links

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -211,8 +211,8 @@ html_show_sphinx = False
 html_context = {
     "menu_links": [
         (
-            '<i class="fa fa-comment fa-fw"></i> PyGMT Q&A (GMT Forum)',
-            "https://forum.generic-mapping-tools.org/c/questions/pygmt-q-a/11",
+            '<i class="fa fa-comment fa-fw"></i> GMT Forum',
+            "https://forum.generic-mapping-tools.org",
         ),
         (
             '<i class="fa fa-github fa-fw"></i> Bug Report (GitHub)',


### PR DESCRIPTION
**Description of proposed changes**

Separat PR for xref: https://github.com/GenericMappingTools/pygmt/pull/4762/#discussion_r3704717771

Sofar I could not finde were the section heading can be changed from "Getting Help and Contributing" to something else. In this case to "Getting Help". (Currently the icons are not exactly the same.)

| sidebar (this PR #4799) | card (PR #4762) |
| --- | --- |
| <img width="200" alt="image" src="https://github.com/user-attachments/assets/45c4ab6b-206d-473b-9ce2-80c31db9341a" /> | <img width="200" alt="image" src="https://github.com/user-attachments/assets/af43cb12-7ec4-411b-b58a-6fda16d76d58" /> |

---
> "Code of Conduct" may be revelant to "Getting Help", but "License" isn't.

"License" does not exactly fit under this section, but I think we should list it somewhere. And at the moment I think it fits best in this section. _Edit_: Maybe we can include it into the footer ? Off Topic: Were are these "Google Analytics" data available?

<img width="500" alt="image" src="https://github.com/user-attachments/assets/565caa9a-23b6-4f31-a31c-91e685df3f9e" />

---
> Maybe "Issue Tracker" or "Bug report" linking to https://github.com/GenericMappingTools/pygmt/issues makes more sense here?

BTW we already have the "Improve this page" button in the upper right corner.

Fixes #

**Preview**:

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
