### PR TITLE
CI: Bump the GMT version in CI to 6.7.0

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -55,7 +55,7 @@ jobs:
           # environment cache is persistent for one week.
           cache-environment-key: micromamba-environment-${{ steps.date.outputs.date }}
           create-args: >-
-            gmt=6.6.0
+            gmt=6.7.0
             python=3.14
             numpy
             pandas

--- a/.github/workflows/cache_data.yaml
+++ b/.github/workflows/cache_data.yaml
@@ -55,7 +55,7 @@ jobs:
           environment-name: pygmt
           create-args: >-
             python=3.14
-            gmt=6.6.0
+            gmt=6.7.0
             numpy
             pandas
             xarray

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -91,7 +91,7 @@ jobs:
           cache-environment-key: micromamba-environment-${{ steps.date.outputs.date }}
           create-args: >-
             python=3.14
-            gmt=6.6.0
+            gmt=6.7.0
             ghostscript=10.07.1
             numpy
             pandas

--- a/.github/workflows/ci_doctests.yaml
+++ b/.github/workflows/ci_doctests.yaml
@@ -50,7 +50,7 @@ jobs:
           environment-name: pygmt
           create-args: >-
             python=3.14
-            gmt=6.6.0
+            gmt=6.7.0
             numpy
             pandas
             xarray

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -128,7 +128,7 @@ jobs:
           cache-environment-key: micromamba-environment-${{ steps.date.outputs.date }}
           create-args: >-
             python=${{ matrix.python-version }}${{ matrix.optional-packages }}
-            gmt=6.6.0
+            gmt=6.7.0
             ghostscript=10.07.1
             numpy=${{ matrix.numpy-version }}
             pandas${{ matrix.pandas-version }}

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14, windows-2022]
-        gmt_version: ['6.5']
+        gmt_version: ['6.5', '6.6']
     timeout-minutes: 30
     defaults:
       run:

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
     # Required dependencies
     - python=3.14
-    - gmt=6.6.0
+    - gmt=6.7.0
     - ghostscript=10.07.1
     - numpy
     - pandas

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -88,8 +88,8 @@ autosummary_generate = []
 
 # Options for extlinks.
 extlinks = {
-    "gmt-docs": ("https://docs.generic-mapping-tools.org/6.6/%s", None),
-    "gmt-term": ("https://docs.generic-mapping-tools.org/6.6/gmt.conf#term-%s", "%s"),
+    "gmt-docs": ("https://docs.generic-mapping-tools.org/6.7/%s", None),
+    "gmt-term": ("https://docs.generic-mapping-tools.org/6.7/gmt.conf#term-%s", "%s"),
     "gmt-datasets": ("https://www.generic-mapping-tools.org/remote-datasets/%s", None),
 }
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -240,4 +240,4 @@ please check your GMT and Ghostscript versions (you can run `pygmt.show_versions
 We recommend:
 
 - Ghostscript 9.53-9.56 for GMT 6.4.0 (or below)
-- Ghostscript 10.03-10.07 for GMT 6.5.0-6.6.0
+- Ghostscript 10.03-10.07 for GMT 6.5.0-6.7.0

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
     - python>=3.12
     # Required dependencies
-    - gmt=6.6.0
+    - gmt=6.7.0
     - ghostscript=10.07.1
     - numpy>=2.1
     - pandas>=2.3


### PR DESCRIPTION
See checklist at https://github.com/GenericMappingTools/pygmt/issues/4801

Previous PR at #4018