### PR TITLE
Fix the baseline image for test_text_position_offset_with_line.png

### DIFF
--- a/pygmt/tests/baseline/test_text_position_offset_with_line.png
+++ b/pygmt/tests/baseline/test_text_position_offset_with_line.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f187b24ac6326a22d0904186de4d5eaaa59e80277a035ac5aa33d840b3f1c189
-size 7220
+oid sha256:61f21101a057b8c6d4196a76a36053e195f00943752eed8bc3958d92fc2a218e
+size 7215

--- a/pygmt/tests/baseline/test_text_position_offset_with_line_legacy.png
+++ b/pygmt/tests/baseline/test_text_position_offset_with_line_legacy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f187b24ac6326a22d0904186de4d5eaaa59e80277a035ac5aa33d840b3f1c189
+size 7220

--- a/pygmt/tests/test_text.py
+++ b/pygmt/tests/test_text.py
@@ -6,7 +6,9 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from packaging.version import Version
 from pygmt import Figure, config
+from pygmt.clib.session import __gmt_version__
 from pygmt.exceptions import GMTCLibError, GMTParameterError, GMTTypeError
 from pygmt.helpers import GMTTempFile
 from pygmt.helpers.testing import skip_if_no
@@ -169,7 +171,12 @@ def test_text_invalid_inputs(region):
         fig.text(region=region, projection="x1c", textfiles="file.txt", x=1.2, y=2.4)
 
 
-@pytest.mark.mpl_image_compare
+# TODO(GMT>=6.7.0): Remove the conditional filename when the minimum version is reached.
+@pytest.mark.mpl_image_compare(
+    filename="test_text_position_offset_with_line.png"
+    if Version(__gmt_version__) >= Version("6.7.0")
+    else "test_text_position_offset_with_line_legacy.png"
+)
 def test_text_position_offset_with_line(region):
     """
     Print text at centre middle (CM) and eight other positions (Top/Middle/Bottom x


### PR DESCRIPTION
Related to https://github.com/GenericMappingTools/pygmt/issues/4801.

The baseline change is caused by an upstream GMT change, but I can't find the upstream PR (likely https://github.com/GenericMappingTools/gmt/pull/8965).