### PR TITLE
Figure.grdview: Fix the default z-plane with GMT 6.7.0

### DIFF
--- a/pygmt/src/grdview.py
+++ b/pygmt/src/grdview.py
@@ -223,7 +223,7 @@ def grdview(
         value in the grid. However, if ``region`` was used to set *zmin/zmax* then
         *zmin* is used if it is less than the grid minimum value. Use ``facade_pen`` and
         ``facade_fill`` to control the appearance of the plane.
-        **Note**: For GMT<=6.6.0, *zmin* set in ``region`` has no effect due to a GMT
+        **Note**: For GMT<=6.7.0, *zmin* set in ``region`` has no effect due to a GMT
         bug.
     facade_fill
         Fill for the frontal facade between the plane specified by ``plane`` and the
@@ -295,7 +295,8 @@ def grdview(
     if plane is False and (facade_fill is not None or facade_pen is not None):
         plane = True
 
-    # Workaround for GMT bug https://github.com/GenericMappingTools/gmt/pull/8838
+    # Workaround for GMT bugs https://github.com/GenericMappingTools/gmt/pull/8838 and
+    # https://github.com/GenericMappingTools/gmt/pull/9123.
     # Fix the plane value to be the grid minimum if plane=True.
     # Notes:
     # 1. It's the minimum of the grid, not a subset of the grid defined by 'region'.
@@ -303,8 +304,8 @@ def grdview(
     #    it is less than the grid minimum value.". We can't add a workaround for this
     #    case since we can't parse zmin/zmax from 'region' if 'region' was set in
     #    previous plotting commands.
-    # TODO(GMT>6.6.0): Remove this workaround.
-    if Version(__gmt_version__) <= Version("6.6.0") and plane is True:
+    # TODO(GMT>6.7.0): Remove this workaround.
+    if Version(__gmt_version__) <= Version("6.7.0") and plane is True:
         plane = grdinfo(grid, per_column=True).split()[4]
 
     aliasdict = AliasSystem(


### PR DESCRIPTION
The test `test_grdview_facadepen_default_plane` fails with GMT 6.7.0, due to an upstream bug (xref: https://github.com/GenericMappingTools/gmt/pull/9123).

This PR extends the patch in #4287 to GMT 6.7.0. 