### PR TITLE
docs: update project description to reflect geospatial visualization and analysis focus

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -10,7 +10,7 @@
 ::::
 <!-- Add short text what PyGMT is and does -->
 :::{div} sd-text-center sd-fs-3 sd-pt-3 sd-pb-3
-A Python interface for the [Generic Mapping Tools](https://www.generic-mapping-tools.org/)
+A Python interface to the [Generic Mapping Tools](https://www.generic-mapping-tools.org/) for geospatial visualization and analysis
 :::
 
 :::{div} sd-text-center sd-fs-5 sd-pb-3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygmt"
-description = "A Python interface for the Generic Mapping Tools"
+description = "A Python interface to the Generic Mapping Tools for geospatial visualization and analysis"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [{name = "The PyGMT Developers", email = "pygmt.team@gmail.com"}]


### PR DESCRIPTION
Updates the project description from "A Python interface for the Generic Mapping Tools" to "A Python interface to the Generic Mapping Tools for geospatial visualization and analysis" in:

- `pyproject.toml` (project metadata shown on PyPI/GitHub)
- `doc/index.md` (homepage tagline)

As proposed in the issue, this helps users unfamiliar with GMT understand PyGMT's purpose. The PyGMT paper title is "PyGMT: Bridging Python and the Generic Mapping Tools for Geospatial Visualization and Analysis"; the new description stays close to it without being identical.

Closes #4744

**Preview**:

- https://pygmt-dev--4808.org.readthedocs.build/en/4808/