### PR TITLE
README: Use absolute URLs for PyGMT logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <picture align="center">
-  <source media="(prefers-color-scheme: dark)" style="width: 65%" srcset="doc/_static/pygmtlogo_dark.png">
-  <img alt="PyGMT - A Python interface for the Generic Mapping Tools" style="width: 65%" src="doc/_static/pygmtlogo.png">
+  <source media="(prefers-color-scheme: dark)" style="width: 65%" srcset="https://raw.githubusercontent.com/GenericMappingTools/pygmt/main/doc/_static/pygmtlogo_dark.png">
+  <img alt="PyGMT - A Python interface for the Generic Mapping Tools" style="width: 65%" src="https://raw.githubusercontent.com/GenericMappingTools/pygmt/main/doc/_static/pygmtlogo.png">
 </picture>
 
 # A Python interface for the [Generic Mapping Tools](https://www.generic-mapping-tools.org/)


### PR DESCRIPTION
It seems the relative URLs don't work well in PyPI, as shown in https://test.pypi.org/project/pygmt/0.20.0.dev60/

<img width="1482" height="424" alt="image" src="https://github.com/user-attachments/assets/4be329a7-de6d-4392-92b3-9a319d10337b" />

This PR uses the absolute URLs instead.