### PR TITLE
Figure.tilemap/pygmt.datasets.tile_map: Set User-Agent to avoid blocked access to OSM tile server

### DIFF
--- a/examples/gallery/maps/tilemaps.py
+++ b/examples/gallery/maps/tilemaps.py
@@ -2,8 +2,8 @@
 Tile maps
 =========
 
-The :meth:`pygmt.Figure.tilemap` method allows to plot
-tiles from a tile server or local file as a basemap or overlay.
+The :meth:`pygmt.Figure.tilemap` method allows to plot tiles from a tile server or
+local file as a basemap or overlay.
 """
 
 # %%
@@ -15,14 +15,13 @@ fig = pygmt.Figure()
 fig.tilemap(
     region=[-157.84, -157.8, 21.255, 21.285],
     projection="M12c",
-    # Set level of details (0-22)
-    # Higher levels mean a zoom level closer to the Earth's
-    # surface with more tiles covering a smaller
-    # geographic area and thus more details and vice versa
-    # Please note, not all zoom levels are always available
+    # Set level of details (0-22).
+    # Higher levels mean a zoom level closer to the Earth's surface with more tiles
+    # covering a smaller geographic area and thus more details and vice versa.
+    # Please note, not all zoom levels are always available.
     zoom=14,
     # Use tiles from OpenStreetMap tile server
-    source="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    source="https://tile.openstreetmap.org/{z}/{x}/{y}.png",
     frame=Axis(annot=True, tick=True, grid=True),
 )
 
@@ -30,9 +29,9 @@ fig.show()
 
 # %%
 # It's also possible to use tiles provided via the
-# `contextily <https://github.com/geopandas/contextily>`__
-# library. See :doc:`Contextily providers <contextily:providers_deepdive>`
-# for a list of possible tilemap options.
+# `contextily <https://github.com/geopandas/contextily>`__ library. See
+# :doc:`Contextily providers <contextily:providers_deepdive>` for a list of possible
+# tilemap options.
 
 fig = pygmt.Figure()
 fig.tilemap(

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -107,7 +107,7 @@ def load_tile_map(
         HTTP headers to include with requests to the tile server. This can be useful
         for authentication or to set a custom User-Agent. When supported by
         ``contextily`` (>=1.7.0), PyGMT sets a default ``User-Agent`` header like
-        ``PyGMT/v0.19.0 (+https://www.pygmt.org)``.
+        ``PyGMT/vX.Y.Z (+https://www.pygmt.org)``.
 
         .. note::
            Requires ``contextily>=1.7.0``.

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -6,7 +6,9 @@ Function to load raster tile maps from XYZ tile providers, and load as
 from collections.abc import Sequence
 from typing import Literal
 
+from packaging.version import Version
 from pygmt._show_versions import __version__ as _pygmt_version
+from pygmt.exceptions import GMTParameterError
 
 try:
     import contextily
@@ -161,10 +163,6 @@ def load_tile_map(
         )
         raise ImportError(msg)
 
-    # Set default HTTP headers.
-    if headers is None:
-        headers = {"User-Agent": f"PyGMT/{_pygmt_version} (+https://www.pygmt.org)"}
-
     # Keyword arguments for contextily.bounds2img
     contextily_kwargs = {
         "zoom": zoom,
@@ -173,8 +171,20 @@ def load_tile_map(
         "wait": wait,
         "max_retries": max_retries,
         "zoom_adjust": zoom_adjust,
-        "headers": headers,
     }
+
+    # TODO(contextily>=1.7.0): Remove once contextily>=1.7.0 is required.
+    # The 'headers' parameter was added in contextily v1.7.0
+    if Version(contextily.__version__) < Version("1.7.0"):
+        if headers is not None:
+            raise GMTParameterError(
+                reason="The 'headers' parameter requires contextily>=1.7.0."
+            )
+    else:
+        # Set default HTTP headers.
+        if headers is None:
+            headers = {"User-Agent": f"PyGMT/{_pygmt_version} (+https://www.pygmt.org)"}
+        contextily_kwargs["headers"] = headers
 
     west, east, south, north = region
     image, extent = contextily.bounds2img(

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -108,6 +108,9 @@ def load_tile_map(
         for authentication or to set a custom User-Agent. By default, only passing
         PyGMT (with the version string and URL) as the User-Agent.
 
+        .. note::
+           The ``headers`` parameter requires ``contextily>=1.7.0``.
+
     Returns
     -------
     raster

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -6,6 +6,8 @@ Function to load raster tile maps from XYZ tile providers, and load as
 from collections.abc import Sequence
 from typing import Literal
 
+from pygmt._show_versions import __version__ as _pygmt_version
+
 try:
     import contextily
     from rasterio.crs import CRS
@@ -40,6 +42,7 @@ def load_tile_map(
     wait: int = 0,
     max_retries: int = 2,
     zoom_adjust: int | None = None,
+    headers: dict[str, str] | None = None,
 ) -> xr.DataArray:
     """
     Load a georeferenced raster tile map from XYZ tile providers.
@@ -75,7 +78,7 @@ def load_tile_map(
           OpenStreetMap Humanitarian web tiles.
         - A web tile provider in the form of a URL. The placeholders for the XYZ in the
           URL need to be {x}, {y}, {z}, respectively. E.g.
-          ``https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png``.
+          ``https://tile.openstreetmap.org/{z}/{x}/{y}.png``.
         - A local file path. The file is read with :doc:`rasterio <rasterio:index>` and
           all bands are loaded into the basemap. See
           :doc:`contextily:working_with_local_files`.
@@ -98,6 +101,10 @@ def load_tile_map(
     zoom_adjust
         The amount to adjust a chosen zoom level if it is chosen automatically. Values
         outside of -1 to 1 are not recommended as they can lead to slow execution.
+    headers
+        HTTP headers to includes with requests to the tile server. This can be useful
+        for authentication or to set a custom User-Agent. By default, only passing
+        PyGMT (with the version string and URL) as the User-Agent.
 
     Returns
     -------
@@ -154,6 +161,10 @@ def load_tile_map(
         )
         raise ImportError(msg)
 
+    # Set default HTTP headers.
+    if headers is None:
+        headers = {"User-Agent": f"PyGMT/{_pygmt_version} (+https://www.pygmt.org)"}
+
     # Keyword arguments for contextily.bounds2img
     contextily_kwargs = {
         "zoom": zoom,
@@ -162,6 +173,7 @@ def load_tile_map(
         "wait": wait,
         "max_retries": max_retries,
         "zoom_adjust": zoom_adjust,
+        "headers": headers,
     }
 
     west, east, south, north = region

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -87,9 +87,6 @@ def load_tile_map(
 
         .. important::
            Tiles are assumed to be in the Spherical Mercator projection (EPSG:3857).
-
-        .. note::
-           OpenStreetMap tile providers require ``contextily>=1.7.0``.
     lonlat
         If ``False``, coordinates in ``region`` are assumed to be Spherical Mercator as
         opposed to longitude/latitude.

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -108,8 +108,9 @@ def load_tile_map(
         for authentication or to set a custom User-Agent. When supported by
         ``contextily`` (>=1.7.0), PyGMT sets a default ``User-Agent`` header like
         ``PyGMT/v0.19.0 (+https://www.pygmt.org)``.
+
         .. note::
-           The ``headers`` parameter requires ``contextily>=1.7.0``.
+           Requires ``contextily>=1.7.0``.
 
     Returns
     -------

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -87,6 +87,9 @@ def load_tile_map(
 
         .. important::
            Tiles are assumed to be in the Spherical Mercator projection (EPSG:3857).
+
+        .. note::
+           OpenStreetMap tile providers require ``contextily>=1.7.0``.
     lonlat
         If ``False``, coordinates in ``region`` are assumed to be Spherical Mercator as
         opposed to longitude/latitude.

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -185,8 +185,11 @@ def load_tile_map(
             )
     else:
         # Set default HTTP headers.
+        default_ua = f"PyGMT/{_pygmt_version} (+https://www.pygmt.org)"
         if headers is None:
-            headers = {"User-Agent": f"PyGMT/{_pygmt_version} (+https://www.pygmt.org)"}
+            headers = {"User-Agent": default_ua}
+        elif not any(key.lower() == "user-agent" for key in headers):
+            headers = {**headers, "User-Agent": default_ua}
         contextily_kwargs["headers"] = headers
 
     west, east, south, north = region

--- a/pygmt/datasets/tile_map.py
+++ b/pygmt/datasets/tile_map.py
@@ -104,10 +104,10 @@ def load_tile_map(
         The amount to adjust a chosen zoom level if it is chosen automatically. Values
         outside of -1 to 1 are not recommended as they can lead to slow execution.
     headers
-        HTTP headers to includes with requests to the tile server. This can be useful
-        for authentication or to set a custom User-Agent. By default, only passing
-        PyGMT (with the version string and URL) as the User-Agent.
-
+        HTTP headers to include with requests to the tile server. This can be useful
+        for authentication or to set a custom User-Agent. When supported by
+        ``contextily`` (>=1.7.0), PyGMT sets a default ``User-Agent`` header like
+        ``PyGMT/v0.19.0 (+https://www.pygmt.org)``.
         .. note::
            The ``headers`` parameter requires ``contextily>=1.7.0``.
 

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -116,7 +116,7 @@ def tilemap(
         ``PyGMT/v0.19.0 (+https://www.pygmt.org)``.
 
         .. note::
-           The ``headers`` parameter requires ``contextily>=1.7.0``.
+           Requires ``contextily>=1.7.0``.
     kwargs : dict
         Extra keyword arguments to pass to :meth:`pygmt.Figure.grdimage`.
     """

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -29,6 +29,7 @@ def tilemap(
     wait: int = 0,
     max_retries: int = 2,
     zoom_adjust: int | None = None,
+    headers: dict[str, str] | None = None,
     monochrome: bool = False,
     no_clip: bool = False,
     projection: str | None = None,
@@ -89,7 +90,7 @@ def tilemap(
           OpenStreetMap Humanitarian web tiles.
         - A web tile provider in the form of a URL. The placeholders for the XYZ in the
           URL need to be ``{x}``, ``{y}``, ``{z}``, respectively. E.g.
-          ``https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png``.
+          ``https://tile.openstreetmap.org/{z}/{x}/{y}.png``.
         - A local file path. The file is read with :doc:`rasterio <rasterio:index>` and
           all bands are loaded into the basemap. See
           :doc:`contextily:working_with_local_files`.
@@ -108,6 +109,10 @@ def tilemap(
     zoom_adjust
         The amount to adjust a chosen zoom level if it is chosen automatically. Values
         outside of -1 to 1 are not recommended as they can lead to slow execution.
+    headers
+        HTTP headers to includes with requests to the tile server. This can be useful
+        for authentication or to set a custom User-Agent. By default, only passing
+        PyGMT (with the version string and URL) as the User-Agent.
     kwargs : dict
         Extra keyword arguments to pass to :meth:`pygmt.Figure.grdimage`.
     """
@@ -120,6 +125,7 @@ def tilemap(
         wait=wait,
         max_retries=max_retries,
         zoom_adjust=zoom_adjust,
+        headers=headers,
     )
     if lonlat:
         raster.gmt.gtype = GridType.GEOGRAPHIC

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -110,9 +110,10 @@ def tilemap(
         The amount to adjust a chosen zoom level if it is chosen automatically. Values
         outside of -1 to 1 are not recommended as they can lead to slow execution.
     headers
-        HTTP headers to includes with requests to the tile server. This can be useful
-        for authentication or to set a custom User-Agent. By default, only passing
-        PyGMT (with the version string and URL) as the User-Agent.
+        HTTP headers to include with requests to the tile server. This can be useful
+        for authentication or to set a custom User-Agent. When supported by
+        ``contextily`` (>=1.7.0), PyGMT sets a default ``User-Agent`` header like
+        ``PyGMT/v0.19.0 (+https://www.pygmt.org)``.
 
         .. note::
            The ``headers`` parameter requires ``contextily>=1.7.0``.

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -113,7 +113,7 @@ def tilemap(
         HTTP headers to include with requests to the tile server. This can be useful
         for authentication or to set a custom User-Agent. When supported by
         ``contextily`` (>=1.7.0), PyGMT sets a default ``User-Agent`` header like
-        ``PyGMT/v0.19.0 (+https://www.pygmt.org)``.
+        ``PyGMT/vX.Y.Z (+https://www.pygmt.org)``.
 
         .. note::
            Requires ``contextily>=1.7.0``.

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -97,9 +97,6 @@ def tilemap(
 
         .. important::
            Tiles are assumed to be in the Spherical Mercator projection (EPSG:3857).
-
-        .. note::
-           OpenStreetMap tile providers require ``contextily>=1.7.0``.
     lonlat
         If ``False``, coordinates in ``region`` are assumed to be Spherical Mercator as
         opposed to longitude/latitude.

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -113,6 +113,9 @@ def tilemap(
         HTTP headers to includes with requests to the tile server. This can be useful
         for authentication or to set a custom User-Agent. By default, only passing
         PyGMT (with the version string and URL) as the User-Agent.
+
+        .. note::
+           The ``headers`` parameter requires ``contextily>=1.7.0``.
     kwargs : dict
         Extra keyword arguments to pass to :meth:`pygmt.Figure.grdimage`.
     """

--- a/pygmt/src/tilemap.py
+++ b/pygmt/src/tilemap.py
@@ -97,6 +97,9 @@ def tilemap(
 
         .. important::
            Tiles are assumed to be in the Spherical Mercator projection (EPSG:3857).
+
+        .. note::
+           OpenStreetMap tile providers require ``contextily>=1.7.0``.
     lonlat
         If ``False``, coordinates in ``region`` are assumed to be Spherical Mercator as
         opposed to longitude/latitude.


### PR DESCRIPTION
Not sure why it worked before, but it turns out that now we need to set "User-Agent" when requesting tiles from the OSM tile server.

This PR sets the default User-Agent to something like `PyGMT/v0.19.0 (+https://www.pygmt.org)` and allows custom headers. 

Reference:

- https://wiki.openstreetmap.org/wiki/Blocked_tiles
- https://operations.osmfoundation.org/policies/tiles/

Closes https://github.com/GenericMappingTools/pygmt/issues/4815.

**Preview**: 

- Current main: https://www.pygmt.org/dev/gallery/maps/tilemaps.html
- This PR: https://pygmt-dev--4816.org.readthedocs.build/en/4816/gallery/maps/tilemaps.html
- https://pygmt-dev--4816.org.readthedocs.build/en/4816/api/generated/pygmt.Figure.tilemap.html
- https://pygmt-dev--4816.org.readthedocs.build/en/4816/api/generated/pygmt.datasets.load_tile_map.html