### PR TITLE
CI: Fix the 'Greet First-Time Contributors' workflow

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -5,7 +5,7 @@
 name: Greet First-Time Contributors
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
   issues:
@@ -21,7 +21,7 @@ permissions:
 jobs:
   greeting:
     name: Greet First-Time Contributors
-    if: github.event_name == 'issues' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
+    if: github.event_name == 'issues' || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-slim
 
     steps:


### PR DESCRIPTION
The "Greet First-Time Contributors" workflows works well for issues (https://github.com/GenericMappingTools/pygmt/issues/4815#issuecomment-5251260288), but not for pull requests (e.g., https://github.com/GenericMappingTools/pygmt/pull/4808, https://github.com/GenericMappingTools/pygmt/actions/runs/31300559514/job/93216830178?pr=4808).

This PR fixes the issue by changing the triggering event from `pull_request` to `pull_request_target`.

I didn't test it. Will know if it works or not when merging #4771.