### PR TITLE
Figure.inset: Remove deprecated parameter margin [Deprecated since 0.18.0]

### DIFF
--- a/pygmt/src/inset.py
+++ b/pygmt/src/inset.py
@@ -12,7 +12,6 @@ from pygmt.clib import Session
 from pygmt.exceptions import GMTParameterError
 from pygmt.helpers import (
     build_arg_list,
-    deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
@@ -24,8 +23,6 @@ __doctest_skip__ = ["inset"]
 
 
 @fmt_docstring
-# TODO(PyGMT>=0.20.0): Remove the deprecated 'margin' parameter.
-@deprecate_parameter("margin", "clearance", "v0.18.0", remove_version="v0.20.0")
 @use_alias(C="clearance")
 @kwargs_to_strings(C="sequence")
 @contextlib.contextmanager


### PR DESCRIPTION
## Description

Remove the deprecated margin parameter alias from Figure.inset as scheduled for PyGMT v0.20.0. The replacement clearance parameter remains unchanged.

Part of #4824.

## Checks

- python3 -m compileall -q pygmt/src/inset.py
- ruff 0.16.3 format --check pygmt/src/inset.py
- ruff 0.16.3 check pygmt/src/inset.py
- git diff --check

The GMT runtime and pytest environment are not available locally, so the GMT-dependent inset tests were left to CI.