### PR TITLE
Figure.histogram: Remove the deprecated parameter barwidth [Deprecated since 0.18.0]

### DIFF
--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -11,7 +11,6 @@ from pygmt.clib import Session
 from pygmt.exceptions import GMTParameterError
 from pygmt.helpers import (
     build_arg_list,
-    deprecate_parameter,
     fmt_docstring,
     kwargs_to_strings,
     use_alias,
@@ -20,8 +19,6 @@ from pygmt.params import Axis, Frame
 
 
 @fmt_docstring
-# TODO(PyGMT>=0.20.0): Remove the deprecated 'barwidth' parameter.
-@deprecate_parameter("barwidth", "bar_width", "v0.18.0", remove_version="v0.20.0")
 @use_alias(
     A="horizontal",
     D="annotate",


### PR DESCRIPTION
**Description of proposed changes**

Removes the deprecated `barwidth` compatibility parameter from `Figure.histogram`, as scheduled for PyGMT 0.20.0. The supported `bar_width` parameter is unchanged. This also removes the now-unused `deprecate_parameter` import.

Addresses the `pygmt/src/histogram.py` item in #4824.

**Validation**

- `ruff check pygmt/src/histogram.py`
- `ruff format --check pygmt/src/histogram.py`
- `python -m py_compile pygmt/src/histogram.py`
- `git diff --check`

The focused pytest module could not be collected locally because this environment does not have the GMT shared library; the repository CI will run the GMT-backed tests.

**Preview**: Not applicable (no documentation content changed).