### PR TITLE
Session.virtualfile_in: Remove the deprecated parameter 'required_z'/'required_data'/'extra_arrays' [Deprecated since 0.16.0]

### DIFF
--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -1756,13 +1756,12 @@ class Session:
                     seg.header = None
                     seg.text = None
 
-    # TODO(PyGMT>=0.20.0): Remove the deprecated parameter 'required_z'.
     # TODO(PyGMT>=0.20.0): Remove the deprecated parameter 'extra_arrays'.
     # TODO(PyGMT>=0.20.0): Remove the deprecated parameter 'required_data'.
     @deprecate_parameter(
         "required_data", "required", "v0.16.0", remove_version="v0.20.0"
     )
-    def virtualfile_in(  # ruff: ignore[too-many-branches]
+    def virtualfile_in(
         self,
         check_kind=None,
         data=None,
@@ -1771,7 +1770,6 @@ class Session:
         z=None,
         required=True,
         mincols=2,
-        required_z=False,
         extra_arrays=None,
     ):
         """
@@ -1802,13 +1800,6 @@ class Session:
         mincols
             Number of minimum required columns. Default is 2 (i.e. require x and y
             columns).
-        required_z : bool
-            State whether the 'z' column is required.
-
-            .. deprecated:: v0.16.0
-               The parameter 'required_z' will be removed in v0.20.0. Use parameter
-               'mincols' instead. E.g., ``required_z=True`` is equivalent to
-               ``mincols=3``.
         extra_arrays : list of 1-D arrays
             A list of numpy arrays in addition to x, y, and z. All of these arrays must
             be of the same size as the x/y/z arrays.
@@ -1844,16 +1835,6 @@ class Session:
         ...             print(fout.read().strip())
         <vector memory>: N = 3 <7/9> <4/6> <1/3>
         """
-        if required_z is True:
-            warnings.warn(
-                "The parameter 'required_z' is deprecated in v0.16.0 and will be "
-                "removed in v0.20.0. Use parameter 'mincols' instead. E.g., "
-                "``required_z=True`` is equivalent to ``mincols=3``.",
-                category=FutureWarning,
-                stacklevel=1,
-            )
-            mincols = 3
-
         kind = data_kind(data, required=required)
         _validate_data_input(
             data=data,

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -9,7 +9,6 @@ import contextlib
 import ctypes as ctp
 import io
 import sys
-import warnings
 from collections.abc import Callable, Generator, Sequence
 from typing import Literal
 
@@ -1756,7 +1755,6 @@ class Session:
                     seg.header = None
                     seg.text = None
 
-    # TODO(PyGMT>=0.20.0): Remove the deprecated parameter 'extra_arrays'.
     # TODO(PyGMT>=0.20.0): Remove the deprecated parameter 'required_data'.
     @deprecate_parameter(
         "required_data", "required", "v0.16.0", remove_version="v0.20.0"
@@ -1770,7 +1768,6 @@ class Session:
         z=None,
         required=True,
         mincols=2,
-        extra_arrays=None,
     ):
         """
         Store any data inside a virtual file.
@@ -1800,14 +1797,6 @@ class Session:
         mincols
             Number of minimum required columns. Default is 2 (i.e. require x and y
             columns).
-        extra_arrays : list of 1-D arrays
-            A list of numpy arrays in addition to x, y, and z. All of these arrays must
-            be of the same size as the x/y/z arrays.
-
-            .. deprecated:: v0.16.0
-               The parameter 'extra_arrays' will be removed in v0.20.0. Prepare and pass
-               a dictionary of arrays instead to the `data` parameter. E.g.,
-               ``data={"x": x, "y": y, "size": size}``.
 
         Returns
         -------
@@ -1889,14 +1878,6 @@ class Session:
                 _data = [x, y]
                 if z is not None:
                     _data.append(z)
-                if extra_arrays:
-                    msg = (
-                        "The parameter 'extra_arrays' will be removed in v0.20.0. "
-                        "Prepare and pass a dictionary of arrays instead to the `data` "
-                        "parameter. E.g., `data={'x': x, 'y': y, 'size': size}`"
-                    )
-                    warnings.warn(message=msg, category=FutureWarning, stacklevel=1)
-                    _data.extend(extra_arrays)
             case "vectors":
                 if hasattr(data, "items") and not hasattr(data, "to_frame"):
                     # Dictionary, pandas.DataFrame or xarray.Dataset types.

--- a/pygmt/clib/session.py
+++ b/pygmt/clib/session.py
@@ -32,7 +32,6 @@ from pygmt.exceptions import (
 from pygmt.helpers import (
     _validate_data_input,
     data_kind,
-    deprecate_parameter,
     tempfile_from_geojson,
     tempfile_from_image,
 )
@@ -1755,10 +1754,6 @@ class Session:
                     seg.header = None
                     seg.text = None
 
-    # TODO(PyGMT>=0.20.0): Remove the deprecated parameter 'required_data'.
-    @deprecate_parameter(
-        "required_data", "required", "v0.16.0", remove_version="v0.20.0"
-    )
     def virtualfile_in(
         self,
         check_kind=None,
@@ -1790,10 +1785,6 @@ class Session:
         required : bool
             Set to True when 'data' or ('x' and 'y') is required. Set to False when
             dealing with optional virtual files. Default is True.
-
-            .. versionchanged:: v0.16.0
-               The parameter 'required_data' is renamed to 'required'. The parameter
-               'required_data' is deprecated in v0.16.0 and will be removed in v0.20.0.
         mincols
             Number of minimum required columns. Default is 2 (i.e. require x and y
             columns).

--- a/pygmt/tests/test_clib_virtualfile_in.py
+++ b/pygmt/tests/test_clib_virtualfile_in.py
@@ -66,22 +66,6 @@ def test_virtualfile_in_required_z_matrix_missing():
                 pass
 
 
-# TODO(PyGMT>=0.20.0): Remove this test for the deprecated 'required_z' parameter.
-def test_virtualfile_in_required_z_deprecated():
-    """
-    Same as test_virtualfile_in_required_z_matrix_missing but using the deprecated
-    'required_z' parameter.
-    """
-    data = np.ones((5, 2))
-    with clib.Session() as lib:
-        with pytest.raises(GMTInvalidInput):  # ruff: ignore[pytest-raises-with-multiple-statements]
-            with pytest.warns(FutureWarning):
-                with lib.virtualfile_in(
-                    data=data, required_z=True, check_kind="vector"
-                ):
-                    pass
-
-
 def test_virtualfile_in_fail_non_valid_data(data):
     """
     Should raise an exception if too few or too much data is given.

--- a/pygmt/tests/test_clib_virtualfile_in.py
+++ b/pygmt/tests/test_clib_virtualfile_in.py
@@ -126,32 +126,3 @@ def test_virtualfile_in_matrix_string_dtype():
                 assert output == "347.5 348.5 -30.5 -30\n"
                 # Should check that lib.virtualfile_from_vectors is called once,
                 # not lib.virtualfile_from_matrix, but it's technically complicated.
-
-
-# TODO(PyGMT>=0.20.0): Remove the test related to deprecated parameter 'extra_arrays'.
-def test_virtualfile_in_extra_arrays(data):
-    """
-    Test that the extra_arrays parameter is deprecated.
-    """
-    with clib.Session() as lib:
-        # Call the method twice to ensure only one statement in the with block.
-        # Test that a FutureWarning is raised when extra_arrays is used.
-        with pytest.warns(FutureWarning):
-            with lib.virtualfile_in(
-                check_kind="vector",
-                x=data[:, 0],
-                y=data[:, 1],
-                extra_arrays=[data[:, 2]],
-            ) as vfile:
-                pass
-        # Test that the output is correct.
-        with GMTTempFile() as outfile:
-            with lib.virtualfile_in(
-                check_kind="vector",
-                x=data[:, 0],
-                y=data[:, 1],
-                extra_arrays=[data[:, 2]],
-            ) as vfile:
-                lib.call_module("info", [vfile, "-C", f"->{outfile.name}"])
-                output = outfile.read(keep_tabs=False)
-                assert output == "11.5309 61.7074 -2.9289 7.8648 0.1412 0.9338\n"


### PR DESCRIPTION
Part of #4824 