### PR TITLE
Figure.velo: Remove deprecated parameter 'uncertaintyfill' [Deprecated since 0.18.0]

### DIFF
--- a/pygmt/src/velo.py
+++ b/pygmt/src/velo.py
@@ -11,15 +11,11 @@ from pygmt._typing import PathLike, TableLike
 from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTParameterError, GMTTypeError
-from pygmt.helpers import build_arg_list, deprecate_parameter, fmt_docstring, use_alias
+from pygmt.helpers import build_arg_list, fmt_docstring, use_alias
 from pygmt.params import Axis, Frame
 
 
 @fmt_docstring
-# TODO(PyGMT>=0.20.0): Remove the deprecated 'uncertaintyfill' parameter.
-@deprecate_parameter(
-    "uncertaintyfill", "uncertainty_fill", "v0.18.0", remove_version="v0.20.0"
-)
 @use_alias(
     A="vector",
     D="rescale",


### PR DESCRIPTION
## Description of proposed changes

- Remove the deprecated `uncertaintyfill` parameter wrapper from `Figure.velo` as planned for PyGMT v0.20.0.
- Keep the current `uncertainty_fill` parameter and its alias unchanged.

This addresses the `pygmt/src/velo.py` checklist item in #4824. It intentionally does not close the aggregate issue because other deprecation removals remain.

## Testing

- `ruff check pygmt/src/velo.py`
- `pytest pygmt/tests/test_velo.py -q` — 4 passed on Linux with Python 3.12.13 and GMT 6.7.0

## Preview

No visual change is intended; the existing `velo` image tests passed unchanged.
