### PR TITLE
pygmt.grdfill: Remove the deprecated '*fill' parameters [Deprecated since 0.18.0]

### DIFF
--- a/pygmt/src/grdfill.py
+++ b/pygmt/src/grdfill.py
@@ -13,7 +13,6 @@ from pygmt.clib import Session
 from pygmt.exceptions import GMTParameterError
 from pygmt.helpers import (
     build_arg_list,
-    deprecate_parameter,
     fmt_docstring,
     is_given,
     use_alias,
@@ -23,15 +22,6 @@ __doctest_skip__ = ["grdfill"]
 
 
 @fmt_docstring
-# TODO(PyGMT>=0.20.0): Remove the deprecated '*fill' parameters.
-@deprecate_parameter(
-    "constantfill", "constant_fill", "v0.18.0", remove_version="v0.20.0"
-)
-@deprecate_parameter("gridfill", "grid_fill", "v0.18.0", remove_version="v0.20.0")
-@deprecate_parameter(
-    "neighborfill", "neighbor_fill", "v0.18.0", remove_version="v0.20.0"
-)
-@deprecate_parameter("splinefill", "spline_fill", "v0.18.0", remove_version="v0.20.0")
 @use_alias(f="coltypes")
 def grdfill(
     grid: PathLike | xr.DataArray,


### PR DESCRIPTION
**Description of proposed changes**

Remove the deprecated `constantfill`, `gridfill`, `neighborfill`, and `splinefill` parameter aliases from `pygmt.grdfill` as scheduled for PyGMT v0.20.0. The replacement `constant_fill`, `grid_fill`, `neighbor_fill`, and `spline_fill` parameters remain unchanged.

Part of #4824.

**Checks**

- `python3 -m compileall -q pygmt/src/grdfill.py`
- `uvx --from ruff==0.16.3 ruff format --check pygmt/src/grdfill.py`
- `uvx --from ruff==0.16.3 ruff check pygmt/src/grdfill.py`
- `git diff --check`

The GMT runtime and pytest environment are not available locally, so the GMT-dependent grdfill tests are left to CI.
