### PR TITLE
CI: Exclude URL to OSM tiles in docs

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -69,6 +69,7 @@ jobs:
           --exclude "^https://www.pygmt.org/%7B%7Bpath%7D%7D"
           --exclude "^https://www.researchgate.net/"
           --exclude "^https://stackoverflow.com/a/69170441"
+          --exclude "^https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png"
           "repository/*.md"
           "repository/**/*.py"
           "documentation/dev/**/*.html"


### PR DESCRIPTION
**Description of proposed changes**

Fixes #4840

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
