### PR TITLE
Fix the required sphinx-gallery version in doc/conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -50,7 +50,7 @@ extensions = [
     "sphinxcontrib.cairosvgconverter",
 ]
 needs_extensions = {
-    "sphinx_gallery.gen_gallery": "0.19",
+    "sphinx_gallery.gen_gallery": "0.21",
 }
 # Options for highlighting.
 pygments_style = "default"


### PR DESCRIPTION
Requires sphinx-gallery>=0.21 in PR https://github.com/GenericMappingTools/pygmt/pull/4643.

Patches https://github.com/GenericMappingTools/pygmt/pull/4643.