### PR TITLE
CI: Fix release-drafter version resolution and credit new contributors

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,9 +9,11 @@ categories:
     when:
       label: 'feature'
   - title: 'Enhancements'
+    semver-increment: 'minor'
     when:
       label: 'enhancement'
   - title: 'Deprecations'
+    semver-increment: 'minor'
     when:
       label: 'deprecation'
   - title: 'Bug Fixes'
@@ -36,6 +38,8 @@ sort-direction: 'ascending'
 replacers:
   - search: '/@(\w+)?/g'
     replace: '[@$1](https://github.com/$1)'
+  - search: '@Chuan1937'
+    replace: 'Xingchen He'
   - search: '@maxrjones'
     replace: 'Max Jones'
   - search: '@michaelgrund'
@@ -64,3 +68,7 @@ template: |
   ### Contributors
 
   $CONTRIBUTORS
+
+  ### New Contributors
+
+  $NEW_CONTRIBUTORS


### PR DESCRIPTION
Changes to the release-drafter template:

1. Bump the *minor* version when a release contains new features, enhancements, or deprecations. Previously only the `feature` label triggered a minor increment, so the current draft resolved to `v0.19.1`; with this fix we should see `v0.20.0` on the [Releases page](https://github.com/GenericMappingTools/pygmt/releases).
2. Add a replacer mapping `@Chuan1937` to `Xingchen He`, since he has been active over the past few months.
3. Add a "New Contributors" section to the release template, using the `$NEW_CONTRIBUTORS` variable added in [release-drafter v7.6.0](https://github.com/release-drafter/release-drafter/releases/tag/v7.6.0). See [the changelog of release-drafter v7.6.0](https://github.com/release-drafter/release-drafter/releases/tag/v7.6.0) for a preview of the new section.

I don't think we want to keep the "New Contributors" section in the final changelog, but it's a good reminder to check whether the upcoming release has any new contributors, and whether they have been added to `AUTHORS.md` (see also #4839).