### PR TITLE
CI: Cache Tectonic packages in the Docs workflow

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -155,7 +155,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning]
         with:
           path: ${{ env.TECTONIC_CACHE_DIR }}
-          # cache is persistent for one week, same as the micromamba environment cache.
+          # Cache is persistent for one week, same as the micromamba environment cache.
           key: tectonic-${{ runner.os }}-${{ steps.date.outputs.date }}
           # Fall back to the most recent cache so tectonic only downloads what's missing.
           restore-keys: tectonic-${{ runner.os }}-

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -67,6 +67,10 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
+    env:
+      # Tectonic cache directory.
+      # See https://tectonic-typesetting.github.io/book/latest/getting-started/first-document.html#cache.
+      TECTONIC_CACHE_DIR: ${{ github.workspace }}/.tectonic-cache
 
     steps:
       # Checkout current git repository
@@ -146,6 +150,15 @@ jobs:
             exit 0
           fi
           exit "${exit_code}"
+
+      - name: Cache tectonic packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning]
+        with:
+          path: ${{ env.TECTONIC_CACHE_DIR }}
+          # cache is persistent for one week, same as the micromamba environment cache.
+          key: tectonic-${{ runner.os }}-${{ steps.date.outputs.date }}
+          # Fall back to the most recent cache so tectonic only downloads what's missing.
+          restore-keys: tectonic-${{ runner.os }}-
 
       - name: Build the PDF documentation
         env:


### PR DESCRIPTION
We use Tectonic to build the PDF documentation. Tectonic downloads LaTeX packages on the fly, which occasionally fails due to network issues (e.g., [this build](https://github.com/GenericMappingTools/pygmt/actions/runs/32570864432/job/97028825483?pr=4848)).

This PR caches the downloaded LaTeX packages. It makes the PDF build more reliable and roughly halves the build time, from ~200 seconds ([before](https://github.com/GenericMappingTools/pygmt/actions/runs/32570864432/job/97029695975?pr=4848)) to ~100 seconds ([after](https://github.com/GenericMappingTools/pygmt/actions/runs/32570864432/job/97030748897?pr=4848)).