### PR TITLE
Exclude .gitattributes from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ prune ci
 prune doc*
 prune examples*
 prune pygmt/tests*
+exclude .gitattributes
 exclude .gitignore
 exclude .pre-commit-config.yaml
 exclude .readthedocs.yaml


### PR DESCRIPTION
`.gitattributes` should not be added to the source package. Patches #4740.