### PR TITLE
Sort the alias lists in docstrings alphabetically

### DIFF
--- a/pygmt/src/choropleth.py
+++ b/pygmt/src/choropleth.py
@@ -50,10 +50,10 @@ def choropleth(
        - C = cmap
        - I = intensity
        - J = projection
-       - R = region
        - N = no_clip
-       - W = pen
+       - R = region
        - V = verbose
+       - W = pen
        - a = column
        - c = panel
        - p = perspective

--- a/pygmt/src/grd2cpt.py
+++ b/pygmt/src/grd2cpt.py
@@ -92,8 +92,8 @@ def grd2cpt(
        - N = no_bg
        - Q = log
        - R = region
-       - Z = continuous
        - V = verbose
+       - Z = continuous
 
     Parameters
     ----------

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -51,8 +51,8 @@ def legend(
     .. hlist::
        :columns: 3
 
-       - D = position, **+w**: width/height, **+l**: line_spacing
        - B = frame
+       - D = position, **+w**: width/height, **+l**: line_spacing
        - F = box
        - J = projection
        - R = region

--- a/pygmt/src/makecpt.py
+++ b/pygmt/src/makecpt.py
@@ -79,8 +79,8 @@ def makecpt(
        - M = overrule_bg
        - N = no_bg
        - Q = log
-       - Z = continuous
        - V = verbose
+       - Z = continuous
 
     Parameters
     ----------

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -116,8 +116,8 @@ def project(
        - E = endpoint
        - L = length
        - T = pole
-       - W = width
        - V = verbose
+       - W = width
        - f = coltypes
 
     Parameters

--- a/pygmt/src/solar.py
+++ b/pygmt/src/solar.py
@@ -53,8 +53,8 @@ def solar(
        - V = verbose
        - W = pen
        - c = panel
-       - t = transparency
        - p = perspective
+       - t = transparency
 
     Parameters
     ----------

--- a/pygmt/src/sph2grd.py
+++ b/pygmt/src/sph2grd.py
@@ -42,8 +42,8 @@ def sph2grd(
        - I = spacing
        - R = region
        - V = verbose
-       - r = registration
        - i = incols
+       - r = registration
        - x = cores
 
     Parameters


### PR DESCRIPTION
The **Aliases** list in docstrings is sorted by GMT option, with uppercase options first
and lowercase ones after. Seven docstrings had entries out of order:

| Module | Out of order |
|---|---|
| `Figure.choropleth` | `R`/`N` and `W`/`V` |
| `Figure.legend` | `D`/`B` |
| `Figure.solar` | `t`/`p` |
| `pygmt.grd2cpt` | `Z`/`V` |
| `pygmt.makecpt` | `Z`/`V` |
| `pygmt.project` | `W`/`V` |
| `pygmt.sph2grd` | `r`/`i` |

This is a docstring-only change: the entries themselves are untouched, only reordered.

I checked all 65 alias lists under `pygmt/`. Three others come up as "unsorted" but are
left as they are on purpose: `Figure.basemap`, `Figure.grdview` and `Figure.plot3d` list
`Jz` before `JZ`, which matches GMT's own `-Jz|Z` documentation order and the
`zscale`/`zsize` parameter order in those signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)