### PR TITLE
Figure.basemap: Improve the docstring for coltypes

### DIFF
--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -20,12 +20,12 @@ def basemap(
     zsize: float | str | None = None,
     region: Sequence[float | str] | str | None = None,
     frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
-    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
-    | bool = False,
     map_scale: str | None = None,
     compass: str | None = None,
     rose: str | None = None,
     box: Box | str | bool = False,
+    verbose: Literal["quiet", "error", "warning", "timing", "info", "compat", "debug"]
+    | bool = False,
     panel: int | Sequence[int] | bool = False,
     coltypes: str | None = None,
     perspective: float | Sequence[float] | str | bool = False,
@@ -35,9 +35,9 @@ def basemap(
     """
     Plot base maps and frames.
 
-    Creates a basic or fancy basemap with axes, fill, and titles. Several map
-    projections are available, and separate tick-mark intervals for axis annotation,
-    ticking, and gridlines can be specified.
+    Creates a basic or fancy basemap with axes, fill, and title. Several map projections
+    are available, and separate tick-mark intervals for axis annotation, ticks, and
+    gridlines can be specified.
 
     If not in subplot mode (see :meth:`pygmt.Figure.subplot`), at least one of the
     parameters ``frame``, ``map_scale``, ``rose``, or ``compass`` must be specified.
@@ -125,7 +125,9 @@ def basemap(
             parameters.
     $verbose
     $panel
-    $coltypes
+    coltypes
+        Specify the types of the coordinates given via ``region``. See
+        :gmt-docs:`basemap.html#f` for details.
     $perspective
     $transparency
 

--- a/pygmt/src/basemap.py
+++ b/pygmt/src/basemap.py
@@ -127,7 +127,7 @@ def basemap(
     $panel
     coltypes
         Specify the types of the coordinates given via ``region``. See
-        :gmt-docs:`basemap.html#f` for details.
+        :gmt-docs:`gmt.html#f-full` for details.
     $perspective
     $transparency
 


### PR DESCRIPTION
Usually, the `-f` option sets the data types of input/output columns. But in `basemap`, it only sets the coordinate types specified in the `-R` option (xref: https://docs.generic-mapping-tools.org/dev/basemap.html). So the common description for `coltypes` makes no sense in `Figure.basemap`.

This PR fixes the docstring for `coltypes` in `Figure.basemap` to clarify it.

**Preview**: https://pygmt-dev--4856.org.readthedocs.build/en/4856/api/generated/pygmt.Figure.basemap.html#pygmt.Figure.basemap