### PR TITLE
Add a comment to .gitattributes explaining the Git LFS rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+# Store the baseline images for image comparison tests in Git LFS.
 pygmt/tests/baseline/test_*.png filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
`.gitattributes` contained a single rule with no explanation of what it is for. This adds
a one-line comment:

```
# Store the baseline images for image comparison tests in Git LFS.
pygmt/tests/baseline/test_*.png filter=lfs diff=lfs merge=lfs -text
```

Verified with `git check-attr` that the rule still resolves after the change
(`test_basemap.png` still gets `filter: lfs`, `diff: lfs`, `merge: lfs`, and
non-matching files are still unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)