### PR TITLE
WIP: CI: Fix the Visual Studio path due to the upgrading of Windows runner image

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -114,7 +114,7 @@ jobs:
           mkdir build
           cd build
           if [[ "$RUNNER_OS" == "Windows" ]]; then
-            cmd.exe /c "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+            cmd.exe /c "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
             CMAKE_PREFIX_PATH="$MAMBA_ROOT_PREFIX/envs/pygmt/Library"
           else
             CMAKE_PREFIX_PATH="$MAMBA_ROOT_PREFIX/envs/pygmt"


### PR DESCRIPTION
The `windows-latest`/`windows-2025` runner image upgraded its Visual Studio to 2026 in June, 2026 (https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/#windows-2025-visual-studio-2026-image-migration).

This PR updates the Visual Studio path based on https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-VS2026-Readme.md#visual-studio-enterprise-2026. This update is necessary, otherwise the CI can't find Visual Studio and use MinGW GCC to compile the source code.


It's weird. The CI still can't find VS correctly (xref: https://github.com/GenericMappingTools/pygmt/actions/runs/32818816716/job/97712485125?pr=4860), but a similar fix in the GMT repository seems to be working (https://github.com/GenericMappingTools/gmt/actions/runs/32817632151/job/97709027710?pr=9144)