### PR TITLE
CI: Use setup-msvc-dev action instead of hardcoding the VS install path on Windows

### DIFF
--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -105,8 +105,14 @@ jobs:
           path: 'gmt'
           persist-credentials: false
 
-      # Build GMT from source on Linux/macOS, script is adapted from
-      # https://github.com/GenericMappingTools/gmt/blob/6.5.0/ci/build-gmt.sh
+      - name: Set up MSVC environment (Windows)
+        if: runner.os == 'Windows'
+        uses: TheMrMilchmann/setup-msvc-dev@368ef7d1ee4d1171b31d4a7f67f4d954f903f5a9 # v4.1.0
+        with:
+          arch: x64
+
+      # Build GMT from source.
+      # Script is adapted from https://github.com/GenericMappingTools/gmt/blob/6.5.0/ci/build-gmt.sh
       - name: Build GMT from source
         shell: bash
         run: |
@@ -114,7 +120,6 @@ jobs:
           mkdir build
           cd build
           if [[ "$RUNNER_OS" == "Windows" ]]; then
-            cmd.exe /c "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
             CMAKE_PREFIX_PATH="$MAMBA_ROOT_PREFIX/envs/pygmt/Library"
           else
             CMAKE_PREFIX_PATH="$MAMBA_ROOT_PREFIX/envs/pygmt"


### PR DESCRIPTION
The Windows runner image upgrade moved Visual Studio from "...\2022\Enterprise\..." to "...\18\Enterprise\...", breaking the hardcoded vcvars64.bat path (see PR #4860). 

This PR uses the [`TheMrMilchmann/setup-msvc-dev`](https://github.com/TheMrMilchmann/setup-msvc-dev) action, which locates the VS installation dynamically via `vswhere` and exports the environment to later steps, so future runner image upgrades don't require another hardcoded-path fix.

Supersedes #4860.