### PR TITLE
pygmt.project: Fix the bug that passing x/y/z is not allowed

### DIFF
--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -126,6 +126,8 @@ def project(
         Pass in (x, y, z) or (longitude, latitude, elevation) values by
         providing a file name to an ASCII data table, a 2-D
         $table_classes.
+    x/y/z : 1-D arrays
+        Arrays of x and y coordinates and values z of the data points.
     $output_type
     $outfile
     center
@@ -223,9 +225,9 @@ def project(
     """
     if kwargs.get("C", center) is None:
         raise GMTParameterError(required="center")
-    if kwargs.get("G") is None and data is None:
+    if kwargs.get("G") is None and data is None and x is None and y is None:
         raise GMTParameterError(
-            required="data", reason="Required unless 'generate' is set."
+            at_least_one=["data", "x/y/z"], reason="Required unless 'generate' is set."
         )
     if kwargs.get("G") is not None and kwargs.get("F") is not None:
         raise GMTParameterError(at_most_one=["convention", "generate"])
@@ -267,7 +269,7 @@ def project(
                 y=y,
                 z=z,
                 mincols=2,
-                required=False,
+                required=aliasdict.get("G") is None,
             ) as vintbl,
             lib.virtualfile_out(kind="dataset", fname=outfile) as vouttbl,
         ):

--- a/pygmt/src/project.py
+++ b/pygmt/src/project.py
@@ -127,7 +127,7 @@ def project(
         providing a file name to an ASCII data table, a 2-D
         $table_classes.
     x/y/z : 1-D arrays
-        Arrays of x and y coordinates and values z of the data points.
+        Arrays of x- and y-coordinates and z-values of the data points.
     $output_type
     $outfile
     center

--- a/pygmt/tests/test_project.py
+++ b/pygmt/tests/test_project.py
@@ -94,8 +94,8 @@ def test_project_output_filename(dataframe):
 
 def test_project_incorrect_parameters():
     """
-    Run project by providing incorrect parameters such as 1) no `center`; 2) no `data`,
-    `x`/`y` or `generate`; and 3) `generate` with `convention`.
+    Run project by providing incorrect parameters such as 1) no 'center'; 2) no 'data',
+    'x'/'y' or 'generate'; and 3) 'generate' with 'convention'.
     """
     with pytest.raises(GMTParameterError):
         # 'center' is not set

--- a/pygmt/tests/test_project.py
+++ b/pygmt/tests/test_project.py
@@ -52,6 +52,22 @@ def test_project_input_matrix(array_func, dataframe):
     )
 
 
+def test_project_input_xy(dataframe):
+    """
+    Run project by passing in x/y as input.
+    """
+    output = project(
+        x=dataframe.x, y=dataframe.y, center=[0, -1], azimuth=45, flat_earth=True
+    )
+    assert isinstance(output, pd.DataFrame)
+    assert output.shape == (1, 6)
+    npt.assert_allclose(
+        output.iloc[0],
+        [0.000000, 0.000000, 0.707107, 0.707107, 0.500000, -0.500000],
+        rtol=1e-5,
+    )
+
+
 def test_project_output_filename(dataframe):
     """
     Run project by passing in a pandas.DataFrame, and output to an ASCII txt file.
@@ -78,14 +94,14 @@ def test_project_output_filename(dataframe):
 
 def test_project_incorrect_parameters():
     """
-    Run project by providing incorrect parameters such as 1) no `center`; 2) no `data`
-    or `generate`; and 3) `generate` with `convention`.
+    Run project by providing incorrect parameters such as 1) no `center`; 2) no `data`,
+    `x`/`y` or `generate`; and 3) `generate` with `convention`.
     """
     with pytest.raises(GMTParameterError):
         # No `center`
         project(azimuth=45)
     with pytest.raises(GMTParameterError):
-        # No `data` or `generate`
+        # No `data`, `x`/`y` or `generate`
         project(center=[0, -1], azimuth=45, flat_earth=True)
     with pytest.raises(GMTParameterError):
         # Using `generate` with `convention`

--- a/pygmt/tests/test_project.py
+++ b/pygmt/tests/test_project.py
@@ -98,13 +98,13 @@ def test_project_incorrect_parameters():
     `x`/`y` or `generate`; and 3) `generate` with `convention`.
     """
     with pytest.raises(GMTParameterError):
-        # No `center`
+        # 'center' is not set
         project(azimuth=45)
     with pytest.raises(GMTParameterError):
-        # No `data`, `x`/`y` or `generate`
+        # None of 'data', 'x'/'y' or 'generate' is set
         project(center=[0, -1], azimuth=45, flat_earth=True)
     with pytest.raises(GMTParameterError):
-        # Using `generate` with `convention`
+        # Using 'generate' with 'convention'
         project(center=[0, -1], generate=0.5, convention="xypqrsz")
 
 


### PR DESCRIPTION
`project` accepts both `data` or `x/y/z` inputs, but currently passing `x/y/z` raises an exception. 

Here is the minimal example to reproduce the bug:
```python
In [1]: import pygmt

In [2]: pygmt.project(
   ...:     data=[[0, 0], [1, 1]],
   ...:     center=[0, -1], azimuth=45, flat_earth=True,
   ...: )
Out[2]:
     0    1         2         3    4             5
0  0.0  1.0  1.414214  1.414214  1.0 -1.773023e-16
1  0.0  1.0  1.414214  1.414214  1.0 -1.773023e-16

In [3]: pygmt.project(x=[0, 1], y=[0, 1], center=[0, -1], azimuth=45, flat_earth=True)
---------------------------------------------------------------------------
GMTParameterError                         Traceback (most recent call last)
Cell In[3], line 1
----> 1 pygmt.project(x=[0, 1], y=[0, 1], center=[0, -1], azimuth=45, flat_earth=True)

File ~/OSS/gmt/pygmt/pygmt/helpers/decorators.py:599, in use_alias.<locals>.alias_decorator.<locals>.new_module(*args, **kwargs)
    592 if "Y" in kwargs or "yshift" in kwargs:
    593     raise GMTParameterError(
    594         reason=(
    595             "Parameters 'Y' and 'yshift' are no longer supported since 0.12.0. "
    596             "Use Figure.shift_origin(yshift=...) instead."
    597         )
    598     )
--> 599 return module_func(*args, **kwargs)

File ~/OSS/gmt/pygmt/pygmt/src/project.py:227, in project(data, x, y, z, output_type, outfile, azimuth, center, endpoint, width, length, pole, verbose, coltypes, **kwargs)
    225     raise GMTParameterError(required="center")
    226 if kwargs.get("G") is None and data is None:
--> 227     raise GMTParameterError(
    228         required="data", reason="Required unless 'generate' is set."
    229     )
    230 if kwargs.get("G") is not None and kwargs.get("F") is not None:
    231     raise GMTParameterError(at_most_one=["convention", "generate"])

GMTParameterError: Missing required parameter: 'data'. Required unless 'generate' is set.
```
This PR fixes the issue and adds a test.