### PR TITLE
POC: Add a LegendSpec class for building legend specifications

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -216,6 +216,7 @@ Class-style Parameters
     Axis
     Box
     Frame
+    LegendSpec
     Pattern
     Position
 

--- a/pygmt/params/__init__.py
+++ b/pygmt/params/__init__.py
@@ -4,5 +4,6 @@ Classes for common parameters in PyGMT.
 
 from pygmt.params.box import Box
 from pygmt.params.frame import Axis, Frame
+from pygmt.params.legendspec import LegendSpec
 from pygmt.params.pattern import Pattern
 from pygmt.params.position import Position

--- a/pygmt/params/legendspec.py
+++ b/pygmt/params/legendspec.py
@@ -1,0 +1,104 @@
+"""
+legendspec - Build a legend specification for Figure.legend.
+"""
+
+import io
+
+
+def _fmt(value: float | str | None) -> str:
+    """
+    Format a value for a legend record.
+
+    >>> _fmt(1.0)
+    '1.0'
+    >>> _fmt("1.0c")
+    '1.0c'
+    >>> _fmt(None)
+    '-'
+    """
+    return "-" if value is None else str(value)
+
+
+class LegendSpec:
+    """
+    A legend specification for :meth:`pygmt.Figure.legend`.
+    """
+
+    def __init__(self) -> None:
+        self.records: list[str] = []
+
+    def _append(self, record: str):
+        """
+        Append one record.
+        """
+        self.records.append(record)
+
+    def add_header(self, text: str, font: str | None = None):
+        """
+        Add a centered header (``H``) [Default font is :gmt-term:`FONT_TITLE`].
+        """
+        return self._append(f"H {_fmt(font)} {text}")
+
+    def add_symbol(
+        self,
+        symbol: str,
+        size: float | str,
+        fill: str | None = None,
+        pen: str | None = None,
+        label: str | None = None,
+        dx1: float | str | None = None,
+        dx2: float | str | None = None,
+    ):
+        """
+        Add a symbol, with an optional explanatory ``label``.
+
+        ``dx1`` is the offset of the symbol from the left margin of the column and
+        ``dx2`` the offset of the label; both are computed by GMT if not given.
+        """
+        args = ["S", _fmt(dx1), symbol, f"{size}", _fmt(fill), _fmt(pen)]
+        if label is not None:
+            args += [_fmt(dx2), f"{label}"]
+        self._append(" ".join(args))
+
+    def add_line(
+        self,
+        pen: str | None = None,
+        length: float | str | None = None,
+        label: str | None = None,
+        dx1: float | str | None = None,
+        dx2: float | str | None = None,
+    ):
+        """
+        Add a line segment (``S``), with an optional explanatory ``label``.
+
+        A line segment is a symbol record using GMT's horizontal dash symbol, so
+        ``length`` is the length of the segment and ``pen`` its attributes.
+
+        ``dx1`` is the offset of the segment from the left margin of the column and
+        ``dx2`` the offset of the label; both are computed by GMT if not given.
+        """
+        self.add_symbol(symbol="-", size=length, pen=pen, label=label, dx1=dx1, dx2=dx2)
+
+    def to_stringio(self) -> io.StringIO:
+        """
+        Return the specification as a :class:`io.StringIO` object.
+        """
+        return io.StringIO(str(self))
+
+    def __str__(self) -> str:
+        """
+        The legend specification, one record per line.
+        """
+        return "\n".join(self.records)
+
+    def __repr__(self) -> str:
+        """
+        A representation listing the records.
+        """
+        return f"{self.__class__.__name__}({self.records!r})"
+
+    def __len__(self) -> int:
+        """
+        The number of records.
+        """
+        return len(self.records)

--- a/pygmt/src/legend.py
+++ b/pygmt/src/legend.py
@@ -11,14 +11,14 @@ from pygmt.alias import Alias, AliasSystem
 from pygmt.clib import Session
 from pygmt.exceptions import GMTTypeError
 from pygmt.helpers import build_arg_list, data_kind, fmt_docstring, is_nonstr_iter
-from pygmt.params import Axis, Box, Frame, Position
+from pygmt.params import Axis, Box, Frame, LegendSpec, Position
 from pygmt.src._common import _parse_position
 
 
 @fmt_docstring
 def legend(
     self,
-    spec: PathLike | io.StringIO | None = None,
+    spec: PathLike | io.StringIO | LegendSpec | None = None,
     position: Position | Sequence[float | str] | AnchorCode | None = None,
     width: float | str | None = None,
     height: float | str | None = None,
@@ -71,6 +71,7 @@ def legend(
           file
         - Path to the legend specification file
         - A :class:`io.StringIO` object containing the legend specification
+        - A :class:`pygmt.params.LegendSpec` object built up record by record
 
         See :gmt-docs:`legend.html` for the definition of the legend specification.
     position
@@ -130,6 +131,10 @@ def legend(
     # Set width to 0 (auto calculated) if height is given but width is not.
     if height is not None and width is None:
         width = 0
+
+    # A LegendSpec is passed to GMT as its rendered specification.
+    if isinstance(spec, LegendSpec):
+        spec = spec.to_stringio()
 
     kind = data_kind(spec)
     if kind not in {"empty", "file", "stringio"}:


### PR DESCRIPTION
Implement a `LegendSpec` class to create a legend specification file in a more readable way (initial idea from https://github.com/GenericMappingTools/pygmt/issues/1513#issuecomment-3637736978).

## List of legend codes

Documentation: https://docs.generic-mapping-tools.org/6.7/legend.html#legend-codes

- [ ] `#`
- [ ] `A`
- [ ] `B`
- [ ] `C`
- [ ] `D`
- [ ] `F`
- [ ] `G`
- [ ] `H`: `add_header`
- [ ] `I`
- [ ] `L`
- [ ] `M`
- [ ] `N`
- [ ] `P`
- [ ] `S`
- [ ] `T`
- [ ] `V`

**Preview**: https://pygmt-dev--4870.org.readthedocs.build/en/4870/api/generated/pygmt.params.LegendSpec.html#pygmt.params.LegendSpec

## Example

```python
import pygmt
from pygmt.params import LegendSpec

# Build a legend specification 
spec = LegendSpec()
spec.add_header("My Legend")
spec.add_symbol(symbol="c", size=0.2, label="Circle", pen="1p,black")
spec.add_symbol(symbol="s", size=0.3, label="Square", fill="blue", pen="2p,red", dx1=0.5, dx2=2.0)
spec.add_line(length=1.0, pen="1p,blue", label="Line 1")
spec.add_line(length=1.0, pen="1p,red,-", label="Line 2", dx1=0.5, dx2=2.0)

print(spec)

fig = pygmt.Figure()
fig.basemap(region=[0, 10, 0, 10], projection="X10c/10c", frame=True)
fig.legend(spec=spec)
fig.show()
```
The output is:
```
H - My Legend
S - c 0.2 - 1p,black - Circle
S 0.5 s 0.3 blue 2p,red 2.0 Square
S - - 1.0 - 1p,blue - Line 1
S 0.5 - 1.0 - 1p,red,- 2.0 Line 2
```
<img width="1265" height="1249" alt="legend" src="https://github.com/user-attachments/assets/f9b0a68e-3081-4d4c-96cb-40504953ca0d" />


