### PR TITLE
Build(deps): Bump https://github.com/zizmorcore/zizmor-pre-commit from v1.26.1 to 1.30.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,6 @@ repos:
       - id: chmod
         args: ["644"]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.26.1
+    rev: v1.30.0
     hooks:
       - id: zizmor


### PR DESCRIPTION
https://github.com/zizmorcore/zizmor/releases/tag/v1.30.0

Required by changes in #4858.