### PR TITLE
Fix test_figure_savefig_geotiff due to package updates

### DIFF
--- a/pygmt/tests/test_figure.py
+++ b/pygmt/tests/test_figure.py
@@ -160,7 +160,7 @@ def test_figure_savefig_geotiff():
         with pytest.warns(expected_warning=NotGeoreferencedWarning) as record:
             with rioxarray.open_rasterio(fname) as xds:
                 pass
-        assert len(record) == 1
+        assert len(record) > 0
         with rioxarray.open_rasterio(fname) as xds:
             assert xds.rio.crs is None
             npt.assert_allclose(


### PR DESCRIPTION
As shown in https://github.com/GenericMappingTools/pygmt/actions/runs/33465293617/job/99723779477?pr=4868, the test `test_figure_savefig_geotiff` fails with the following error messages:
```
            # TIFF
            with pytest.warns(expected_warning=NotGeoreferencedWarning) as record:
                with rioxarray.open_rasterio(fname) as xds:
                    pass
>           assert len(record) == 1
E           assert 4 == 1
E            +  where 4 = len(WarningsChecker(record=True))
```
It seems `rioxarray` raises `NotGeoreferencedWarning` four times rather than once. There are no new releases of `rioxarray` or `rasterio`, so it's unclear which package causes this failure. 

This PR fixes the issue by changing `len(record) == 1` to `len(record) > 1`. 