### PR TITLE
CI: Add a composite action for caching Git LFS objects and saving LFS bandwidth

### DIFF
--- a/.github/actions/checkout-lfs/action.yml
+++ b/.github/actions/checkout-lfs/action.yml
@@ -1,0 +1,31 @@
+# Check out the Git LFS objects, with the objects cached by GitHub Actions
+#
+# The Git LFS objects (i.e., the baseline images for image comparison tests) are
+# restored from the GitHub Actions cache, so that they are fetched from the Git LFS
+# server only when they are missing from the cache, which saves the Git LFS bandwidth.
+#
+# This action must be used after the "actions/checkout" step, and that step must set
+# "lfs: false" (the default), otherwise the objects are fetched from the Git LFS server
+# before the cache can be restored.
+#
+name: Checkout Git LFS objects
+description: Check out the Git LFS objects, restoring them from the GitHub Actions cache
+
+runs:
+  using: composite
+  steps:
+    - name: Get the list of Git LFS objects
+      shell: bash
+      run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
+
+    - name: Cache the Git LFS objects
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning]
+      with:
+        path: .git/lfs
+        key: git-lfs-${{ hashFiles('.lfs-assets-id') }}
+        # Fall back to the most recent cache so Git LFS only fetches missing objects.
+        restore-keys: git-lfs-
+
+    - name: Checkout the Git LFS objects
+      shell: bash
+      run: git lfs pull

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       # Check for updates to GitHub Actions on Tuesdays
       interval: "weekly"

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -29,11 +29,13 @@ on:
     branches: [ main ]
     paths:
       - 'pygmt/**'
+      - '.github/actions/checkout-lfs/action.yml'
       - '.github/workflows/ci_tests.yaml'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'pygmt/**'
+      - '.github/actions/checkout-lfs/action.yml'
       - '.github/workflows/ci_tests.yaml'
   workflow_dispatch:
   release:
@@ -112,7 +114,10 @@ jobs:
           # fetch all history so that setuptools-scm works
           fetch-depth: 0
           persist-credentials: false
-          lfs: true
+          lfs: false
+
+      - name: Checkout the Git LFS (i.e., the baseline images) objects
+        uses: $/.github/actions/checkout-lfs
 
       - name: Get current week number of year
         id: date

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -116,9 +116,6 @@ jobs:
           persist-credentials: false
           lfs: false
 
-      - name: Checkout the Git LFS (i.e., the baseline images) objects
-        uses: $/.github/actions/checkout-lfs
-
       - name: Get current week number of year
         id: date
         run: echo "date=$(date +%Y-W%W)" >> $GITHUB_OUTPUT  # e.g., 2024-W19
@@ -147,6 +144,9 @@ jobs:
             pytest-doctestplus
             pytest-mpl
             pytest-rerunfailures
+
+      - name: Checkout the Git LFS (i.e., the baseline images) objects
+        uses: $/.github/actions/checkout-lfs
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -59,9 +59,6 @@ jobs:
           persist-credentials: false
           lfs: false
 
-      - name: Checkout the Git LFS (i.e., the baseline images) objects
-        uses: $/.github/actions/checkout-lfs
-
       - name: Get current week number of year
         id: date
         run: echo "date=$(date +%Y-W%W)" >> $GITHUB_OUTPUT  # e.g., 2024-W19
@@ -157,6 +154,9 @@ jobs:
       # Show installed pkg information for postmortem diagnostic
       - name: List installed packages
         run: micromamba list
+
+      - name: Checkout the Git LFS (i.e., the baseline images) objects
+        uses: $/.github/actions/checkout-lfs
 
       # Download cached remote files (artifacts) from GitHub
       - name: Download remote data from GitHub

--- a/.github/workflows/ci_tests_dev.yaml
+++ b/.github/workflows/ci_tests_dev.yaml
@@ -18,6 +18,7 @@ on:
     types: [ opened, reopened, labeled, synchronize ]
     paths:
       - 'pygmt/**'
+      - '.github/actions/checkout-lfs/action.yml'
       - '.github/workflows/ci_tests_dev.yaml'
   workflow_dispatch:
   # Schedule tests on Monday/Wednesday/Friday
@@ -56,7 +57,10 @@ jobs:
           # fetch all history so that setuptools-scm works
           fetch-depth: 0
           persist-credentials: false
-          lfs: true
+          lfs: false
+
+      - name: Checkout the Git LFS (i.e., the baseline images) objects
+        uses: $/.github/actions/checkout-lfs
 
       - name: Get current week number of year
         id: date


### PR DESCRIPTION
Address the LFS bandwidth quota issue reported in https://github.com/GenericMappingTools/pygmt/issues/4738#issuecomment-5467473657.

This PR adds a composite action to cache Git LFS objects (i.e., baseline images) as GitHub cache, so that `git lfs pull` only pulls LFS objects when missing. It should help reduce our Git LFS bandwidth.