### PR TITLE
Figure.histogram: Let parameter 'cumulative' support Pythonic arguments

### DIFF
--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -114,8 +114,8 @@ def histogram(
         * 1 = median and L1 scale (1.4826 \* median absolute deviation; MAD);
         * 2 = LMS (least median of squares) mode and scale.
     cumulative
-        Draw a cumulative histogram. Setting it to ``"reversed"`` to compute the
-        reversed cumulative histogram instead.
+        Draw a cumulative histogram. Set it to ``"reverse"`` to compute the reverse
+        cumulative histogram instead.
     extreme : str
         **l**\|\ **h**\|\ **b**.
         The modifiers specify the handling of extreme values that fall outside
@@ -174,7 +174,7 @@ def histogram(
             Alias(bar_offset, name="bar_offset", prefix="+o"),
         ],
         G=Alias(fill, name="fill"),
-        Q=Alias(cumulative, name="cumalative", mapping={"reversed": "r"}),
+        Q=Alias(cumulative, name="cumulative", mapping={"reverse": "r"}),
         W=Alias(pen, name="pen"),
     ).add_common(
         B=frame,

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -25,7 +25,6 @@ from pygmt.params import Axis, Frame
     F="center",
     L="extreme",
     N="distribution",
-    Q="cumulative",
     S="stairs",
     T="series",
     Z="histtype",
@@ -45,6 +44,7 @@ def histogram(
     cmap: str | bool = False,
     pen: str | None = None,
     fill: str | None = None,
+    cumulative: bool | Literal["reverse"] = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
     frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
@@ -67,6 +67,7 @@ def histogram(
        - E = bar_width, **+o**: bar_offset
        - G = fill
        - J = projection
+       - Q = cumulative
        - R = region
        - V = verbose
        - W = pen
@@ -112,10 +113,9 @@ def histogram(
         * 0 = mean and standard deviation [Default];
         * 1 = median and L1 scale (1.4826 \* median absolute deviation; MAD);
         * 2 = LMS (least median of squares) mode and scale.
-    cumulative : bool or str
-        [**r**].
-        Draw a cumulative histogram by passing ``True``. Use **r** to display
-        a reverse cumulative histogram.
+    cumulative
+        Draw a cumulative histogram. Setting it to ``"reversed"`` to compute the
+        reversed cumulative histogram instead.
     extreme : str
         **l**\|\ **h**\|\ **b**.
         The modifiers specify the handling of extreme values that fall outside
@@ -174,6 +174,7 @@ def histogram(
             Alias(bar_offset, name="bar_offset", prefix="+o"),
         ],
         G=Alias(fill, name="fill"),
+        Q=Alias(cumulative, name="cumalative", mapping={"reversed": "r"}),
         W=Alias(pen, name="pen"),
     ).add_common(
         B=frame,

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -114,7 +114,7 @@ def histogram(
         * 1 = median and L1 scale (1.4826 \* median absolute deviation; MAD);
         * 2 = LMS (least median of squares) mode and scale.
     cumulative
-        Draw a cumulative histogram. Set it to ``"reverse"`` to compute the reverse
+        Draw a cumulative histogram. Set it to ``"reverse"`` to draw the reverse
         cumulative histogram instead.
     extreme : str
         **l**\|\ **h**\|\ **b**.

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -115,8 +115,8 @@ def histogram(
         * 1 = median and L1 scale (1.4826 \* median absolute deviation; MAD);
         * 2 = LMS (least median of squares) mode and scale.
     cumulative
-        Draw a cumulative histogram. Set it to ``"reverse"`` to draw the reverse
-        cumulative histogram instead.
+        Pass ``True`` to draw a cumulative histogram, or set it to ``"reverse"`` to draw
+        a reverse cumulative histogram instead.
     extreme : str
         **l**\|\ **h**\|\ **b**.
         The modifiers specify the handling of extreme values that fall outside


### PR DESCRIPTION
Migrate the parameter `cumulative` to the new alias system. 

Previously, `cumulative` can be either `True` or `"r"`. This PR lets it support more Pythonic argument, i.e., `cumulative="reverse"`.

For comparison, here is matplotlib's `hist` method (https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.hist.html):

> cumulativebool or -1, default: False
If True, then a histogram is computed where each bin gives the counts in that bin plus all bins for smaller values. The last bin gives the total number of datapoints.
> If density is also True then the histogram is normalized such that the last bin equals 1.
> If cumulative is a number less than 0 (e.g., -1), the direction of accumulation is reversed. In this case, if density is also True, then the histogram is normalized such that the first bin equals 1.

So, matplotlib uses `cumulative=-1` for reversed cumulative histogram, but I feel it's not as readable as `cumulative="reverse"`.

**Preview**: https://pygmt-dev--4881.org.readthedocs.build/en/4881/api/generated/pygmt.Figure.histogram.html#pygmt.Figure.histogram