### PR TITLE
Figure.histogram: Add parameter 'out_range' to handle extreme values and deprecate parameter 'extreme'

### DIFF
--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -44,7 +44,7 @@ def histogram(
     pen: str | None = None,
     fill: str | None = None,
     horizontal: bool = False,
-    extreme: Literal["low", "high", "both"] | None = None,
+    extreme: Literal["first", "last", "both"] | None = None,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
     frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -22,7 +22,6 @@ from pygmt.params import Axis, Frame
 @use_alias(
     D="annotate",
     F="center",
-    L="extreme",
     N="distribution",
     Q="cumulative",
     S="stairs",
@@ -45,6 +44,7 @@ def histogram(
     pen: str | None = None,
     fill: str | None = None,
     horizontal: bool = False,
+    extreme: Literal["low", "high", "both"] | None = None,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
     frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
@@ -68,6 +68,7 @@ def histogram(
        - E = bar_width, **+o**: bar_offset
        - G = fill
        - J = projection
+       - L = extreme
        - R = region
        - V = verbose
        - W = pen
@@ -117,14 +118,13 @@ def histogram(
         [**r**].
         Draw a cumulative histogram by passing ``True``. Use **r** to display
         a reverse cumulative histogram.
-    extreme : str
-        **l**\|\ **h**\|\ **b**.
-        The modifiers specify the handling of extreme values that fall outside
-        the range set by ``series``. By default, these values are ignored.
-        Append **b** to let these values be included in the first or last
-        bins. To only include extreme values below first bin into the first
-        bin, use **l**, and to only include extreme values above the last bin
-        into that last bin, use **h**.
+    extreme
+        Handle extreme values that fall outside the range set by ``series``. By default,
+        these values are ignored. Valid values are:
+
+        - ``"first"``: only include extreme values below first bin into the first bin
+        - ``"last"``: only include extreme values above the last bin into that last bin
+        - ``"both"``:  include extreme values into the first or last bins
     stairs : bool
         Draw a stairs-step diagram which does not include the internal bars
         of the default histogram.
@@ -176,6 +176,9 @@ def histogram(
             Alias(bar_offset, name="bar_offset", prefix="+o"),
         ],
         G=Alias(fill, name="fill"),
+        L=Alias(
+            extreme, name="extreme", mapping={"first": "l", "last": "h", "both": "b"}
+        ),
         W=Alias(pen, name="pen"),
     ).add_common(
         B=frame,


### PR DESCRIPTION
This PR migrates `histogram`'s `-L` option to the new alias system and add support for Pythonic arguments. 

The GMT CLI syntax is `-Ll|h|b` (https://docs.generic-mapping-tools.org/6.7/histogram.html#l), in which `l|h|b` are shorthands for `low`/`high`/`both` respectively. The table below summarize the current choices of parameter/argument names in GMT/PyGMT/GMT.jl:

| | Parameter Name | Arguments |
|---|---|---|
| GMT option | -L | `l`/`h`/`b`|
| GMT long-option | `extreme` or `out_range` | `low`/`first`, `high`/`last`, `both`|
| PyGMT | `extreme` | `first`, `last`, `both`|
| GMT.jl | `out_range` | `first`, `last`, `both`| 

- GMT.jl: https://www.generic-mapping-tools.org/GMTjl_doc/documentation/modules/histogram.html). 
- GMT: https://github.com/GenericMappingTools/gmt/blob/3604ba84e15e11e6977c4042a4af277506c9c51d/src/longopt/pshistogram_inc.h#L51

Personablly, I feel `first`/`last` are more readable and intuitive than `low`/`high`. So, this PR uses `first`/`last`, which is also consistent with GMT.jl.

~~**One thing that still differs** between GMT.jl and PyGMT is the parameter name. GMT.jl uses `out_range`, while `PyGMT` uses `extreme`. I feel `out_range` is more understandable. If we decide to use `out_range`, then we need to deprecate `extreme` to `out_range` in a few releases.~~ Edit: I've renamed the parameter to `out_range`