### PR TITLE
SPEC 0: Bump minimum supported version to NumPy 2.2 and xarray 2024.10

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -77,9 +77,9 @@ jobs:
         include:
           # Python 3.12 + core packages (minimum supported versions) + optional packages (minimum supported versions if any)
           - python-version: '3.12'
-            numpy-version: '2.1'
+            numpy-version: '2.2'
             pandas-version: '=2.3'
-            xarray-version: '=2024.7'
+            xarray-version: '=2024.10'
             optional-packages: ' contextily geopandas ipython pyarrow-core rioxarray netCDF4 sphinx-gallery'
           # Python 3.14 + core packages (latest versions) + optional packages
           - python-version: '3.14'

--- a/.github/workflows/ci_tests_legacy.yaml
+++ b/.github/workflows/ci_tests_legacy.yaml
@@ -61,9 +61,9 @@ jobs:
             python=3.12
             gmt=${{ matrix.gmt_version }}
             ghostscript
-            numpy=2.1
+            numpy=2.2
             pandas=2.3
-            xarray=2024.7
+            xarray=2024.10
             packaging=24.2
             contextily=1.5
             geopandas=1.0

--- a/environment.yml
+++ b/environment.yml
@@ -7,9 +7,9 @@ dependencies:
     # Required dependencies
     - gmt=6.7.0
     - ghostscript=10.07.1
-    - numpy>=2.1
+    - numpy>=2.2
     - pandas>=2.3
-    - xarray>=2024.7
+    - xarray>=2024.10
     - packaging>=24.2
     # Optional dependencies
     - contextily>=1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,9 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "numpy>=2.1",
+    "numpy>=2.2",
     "pandas>=2.3",
-    "xarray>=2024.7",
+    "xarray>=2024.10",
     "packaging>=24.2",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Following [SPEC0](https://scientific-python.org/specs/spec-0000/) policy, we should drop NumPy 2.2 and xarray 2024.9 in 2026 quarter 3. 

Bumps the minimum supported versions in the following files:

- [x] `.github/workflows/ci_tests_legacy.yaml`
- [x] `.github/workflows/ci_tests.yaml`
- [x] `environment.yml`
- [x] `pyproject.toml`
- [x] Remove workarounds for unsupported versions

Previous PR at #4650.