### PR TITLE
Figure.histogram: Migrate parameter 'stairs' to the new alias system

### DIFF
--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -25,7 +25,6 @@ from pygmt.params import Axis, Frame
     L="extreme",
     N="distribution",
     Q="cumulative",
-    S="stairs",
     T="series",
     Z="histtype",
     b="binary",
@@ -45,6 +44,7 @@ def histogram(
     pen: str | None = None,
     fill: str | None = None,
     horizontal: bool = False,
+    stairs: bool = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
     frame: Frame | Axis | Literal["none"] | str | Sequence[str] | bool = False,
@@ -69,6 +69,7 @@ def histogram(
        - G = fill
        - J = projection
        - R = region
+       - S = stairs
        - V = verbose
        - W = pen
        - c = panel
@@ -125,9 +126,9 @@ def histogram(
         bins. To only include extreme values below first bin into the first
         bin, use **l**, and to only include extreme values above the last bin
         into that last bin, use **h**.
-    stairs : bool
-        Draw a stairs-step diagram which does not include the internal bars
-        of the default histogram.
+    stairs
+        Draw a stairs-step diagram which does not include the internal bars of the
+        default histogram.
     horizontal
         Plot the histogram horizontally from x = 0 [Default is vertically from y = 0].
         The plot dimensions remain the same, but the two axes are flipped, i.e., the
@@ -176,6 +177,7 @@ def histogram(
             Alias(bar_offset, name="bar_offset", prefix="+o"),
         ],
         G=Alias(fill, name="fill"),
+        S=Alias(stairs, name="stairs"),
         W=Alias(pen, name="pen"),
     ).add_common(
         B=frame,


### PR DESCRIPTION
This PR migrates the `stairs` parameter (option `-S`) to the new alias system.

Over the past few days, I considered whether we should adopt Matplotlib's design (https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.hist.html), which exposes a `histtype` parameter accepting values `"bars"`, `"stepfilled"`, `"step"`, and `"barstacked"` (but we already alias `histtype` to `-Z`). Matplotlib also provides an example demonstrating these histogram styles at https://matplotlib.org/stable/gallery/statistics/histogram_histtypes.html.

It turns out GMT is more flexible: it can reproduce Matplotlib’s various histogram types via different combinations of `pen`, `fill`, and `stairs`, as illustrated below. Thus, this PR is simply a routine parameter migration.
```python
import numpy as np
import pygmt
from pygmt.params import Axis, Frame

# Generate random elevation data from a normal distribution
rng = np.random.default_rng(seed=100)
mean = 100  # mean of distribution
stddev = 25  # standard deviation of distribution
data = rng.normal(loc=mean, scale=stddev, size=521)

fig = pygmt.Figure()
fig.histogram(data=data, frame=Frame(axes="WSen", title="bars"), series=5, fill="green")
fig.shift_origin(xshift="w+1")
fig.histogram(data=data, frame=Frame(axes="WSen", title="bars"), series=5, fill="green", pen="1p")

fig.shift_origin(xshift="w+1")
fig.histogram(data=data, frame=Frame(axes="WSen", title="step"), series=5, stairs=True, pen="1p")

fig.shift_origin(xshift="w+1")
fig.histogram(data=data, frame=Frame(axes="WSen", title="stepfilled"), series=5, stairs=True, pen="2p", fill="green")

fig.show()
```
<img width="7517" height="1959" alt="histogram" src="https://github.com/user-attachments/assets/47137f2e-8b66-4f98-aee9-e7f55870af98" />

_Related:_ I feel we should add this image showing different types of histograms that GMT can provide. We already have a tutorial at https://www.pygmt.org/dev/tutorials/advanced/cartesian_histograms.html, which shows several histograms, but only one is shown in the API page (https://www.pygmt.org/dev/api/generated/pygmt.Figure.histogram.html#pygmt.Figure.histogram). Maybe we should add a separate gallery example instead?