### PR TITLE
Figure.histogram: Improved syntax for filling bars by position/value

### DIFF
--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -87,15 +87,16 @@ def histogram(
         [Default is no outline].
     fill
         Set color or pattern for filling bars [Default is no fill]. Set it to one of the
-        two special values to fill bars by looking up the color from ``cmap`` instead of
-        a constant color:
+        two special values to fill bars by looking up the color from a CPT instead of a
+        constant color:
 
         - ``"position"``: look up the color using the mid-coordinate of the bin. This is
           the default when ``cmap`` is set.
         - ``"value"``: look up the color using the bin value, i.e., the bar count or
           frequency.
 
-        The special values require ``cmap``, and can't be used with ``fill``.
+        The special values require a CPT (either the current CPT or explicitely set by
+        ``cmap``), and can't be used with ``fill``.
     $cmap
     annotate : bool or str
         [**+b**][**+f**\ *font*][**+o**\ *off*][**+r**].

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -12,6 +12,7 @@ from pygmt.exceptions import GMTParameterError
 from pygmt.helpers import (
     build_arg_list,
     fmt_docstring,
+    is_given,
     kwargs_to_strings,
     use_alias,
 )
@@ -43,7 +44,7 @@ def histogram(
     bar_offset: float | str | None = None,
     cmap: str | bool = False,
     pen: str | None = None,
-    fill: str | None = None,
+    fill: str | Literal["position", "value"] | None = None,
     horizontal: bool = False,
     projection: str | None = None,
     region: Sequence[float | str] | str | None = None,
@@ -64,7 +65,7 @@ def histogram(
     $aliases
        - A = horizontal
        - B = frame
-       - C = cmap
+       - C = cmap, **+b**: fill
        - E = bar_width, **+o**: bar_offset
        - G = fill
        - J = projection
@@ -81,12 +82,21 @@ def histogram(
     data
         Pass in either a file name to an ASCII data table, a Python list, a 2-D
         $table_classes.
-    $cmap
     pen
         Draw bar outline (or stair-case curve) using the specified pen thickness
         [Default is no outline].
     fill
-         Set color or pattern for filling bars [Default is no fill].
+        Set color or pattern for filling bars [Default is no fill]. Set it to one of the
+        two special values to fill bars by looking up the color from ``cmap`` instead of
+        a constant color:
+
+        - ``"position"``: look up the color using the mid-coordinate of the bin. This is
+          the default when ``cmap`` is set.
+        - ``"value"``: look up the color using the bin value, i.e., the bar count or
+          frequency.
+
+        The special values require ``cmap``, and can't be used with ``fill``.
+    $cmap
     annotate : bool or str
         [**+b**][**+f**\ *font*][**+o**\ *off*][**+r**].
         Annotate each bar with the count it represents. Append any of the
@@ -168,14 +178,31 @@ def histogram(
             required="bar_width", reason="Required when 'bar_offset' is set."
         )
 
+    # "position" and "value" are special values that fill bars by values and cmap.
+    match fill:
+        case "position":
+            _fill_color, _fill_lookup = None, ""
+        case "value":
+            _fill_color, _fill_lookup = None, "+b"
+        case _:
+            _fill_color, _fill_lookup = fill, None
+    if _fill_color is not None and is_given(cmap):
+        raise GMTParameterError(
+            at_most_one=["cmap", "fill"],
+            reason="Cannot use 'cmap' when 'fill' is a constant color or pattern.",
+        )
+
     aliasdict = AliasSystem(
         A=Alias(horizontal, name="horizontal"),
-        C=Alias(cmap, name="cmap"),
+        C=[
+            Alias(cmap, name="cmap"),
+            Alias(_fill_lookup, name="fill"),
+        ],
         E=[
             Alias(bar_width, name="bar_width"),
             Alias(bar_offset, name="bar_offset", prefix="+o"),
         ],
-        G=Alias(fill, name="fill"),
+        G=Alias(_fill_color, name="fill"),
         W=Alias(pen, name="pen"),
     ).add_common(
         B=frame,

--- a/pygmt/src/histogram.py
+++ b/pygmt/src/histogram.py
@@ -185,7 +185,7 @@ def histogram(
         case "value":
             _fill_color, _fill_lookup = None, "+b"
         case _:
-            _fill_color, _fill_lookup = fill, None
+            _fill_color, _fill_lookup = fill, None  # type: ignore[assignment]
     if _fill_color is not None and is_given(cmap):
         raise GMTParameterError(
             at_most_one=["cmap", "fill"],

--- a/pygmt/tests/baseline/test_histogram_fill.png
+++ b/pygmt/tests/baseline/test_histogram_fill.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a82f632aba7a78db5bd880ab34fdeec8c7472b5e1257e79b61efd5ccd72aa813
+size 12900

--- a/pygmt/tests/test_histogram.py
+++ b/pygmt/tests/test_histogram.py
@@ -80,6 +80,7 @@ def test_histogram_fill(data):
     fig.colorbar(frame=True)
     return fig
 
+
 @pytest.mark.mpl_image_compare(filename="test_histogram_fill.png")
 def test_histogram_fill_old_cmap_syntax(data):
     """

--- a/pygmt/tests/test_histogram.py
+++ b/pygmt/tests/test_histogram.py
@@ -4,7 +4,7 @@ Test Figure.histogram.
 
 import pandas as pd
 import pytest
-from pygmt import Figure
+from pygmt import Figure, makecpt
 from pygmt.exceptions import GMTParameterError
 from pygmt.params import Axis
 
@@ -50,4 +50,75 @@ def test_histogram_baroffset(data):
             frame=Axis(annot=True),
             fill="green",
             bar_offset=0.25,
+        )
+
+
+@pytest.mark.mpl_image_compare(filename="test_histogram_fill.png")
+def test_histogram_fill(data):
+    """
+    Test filling bars with constant color and lookup table values.
+    """
+    kwargs = {
+        "data": data,
+        "projection": "X5c/5c",
+        "region": [0, 10, 0, 8],
+        "series": 1,
+        "frame": Axis(annot=True),
+    }
+    fig = Figure()
+    # Constant fill
+    fig.histogram(fill="green", **kwargs)
+    fig.shift_origin(xshift=6)
+    # Fill bars by bin position
+    makecpt(cmap="viridis", series=[0, 9, 1])
+    fig.histogram(fill="position", **kwargs)
+    fig.colorbar(frame=True)
+    # Fill bars by bin value
+    fig.shift_origin(xshift=6)
+    makecpt(cmap="viridis", series=[0, 6, 1])
+    fig.histogram(fill="value", **kwargs)
+    fig.colorbar(frame=True)
+    return fig
+
+@pytest.mark.mpl_image_compare(filename="test_histogram_fill.png")
+def test_histogram_fill_old_cmap_syntax(data):
+    """
+    Test filling bars with constant color and lookup table values.
+    """
+    kwargs = {
+        "data": data,
+        "projection": "X5c/5c",
+        "region": [0, 10, 0, 8],
+        "series": 1,
+        "frame": Axis(annot=True),
+    }
+    fig = Figure()
+    # Constant fill
+    fig.histogram(fill="green", **kwargs)
+    fig.shift_origin(xshift=6)
+    # Fill bars by bin position
+    makecpt(cmap="viridis", series=[0, 9, 1])
+    fig.histogram(cmap=True, **kwargs)
+    fig.colorbar(frame=True)
+    # Fill bars by bin value
+    fig.shift_origin(xshift=6)
+    makecpt(cmap="viridis", series=[0, 6, 1])
+    fig.histogram(cmap="+b", **kwargs)
+    fig.colorbar(frame=True)
+    return fig
+
+
+def test_histogram_fill_color_with_cmap(data):
+    """
+    Test that a constant fill color cannot be combined with cmap.
+    """
+    fig = Figure()
+    with pytest.raises(GMTParameterError):
+        fig.histogram(
+            data=data,
+            projection="X10c/10c",
+            region=[0, 9, 0, 8],
+            series=1,
+            cmap=True,
+            fill="green",
         )


### PR DESCRIPTION
In `histogram`, bars can be filled by a constant color/pattern, or by the bin position or value  (count, frequency). This is achieved by the `-C` option, with a syntax like `-C<cmap>+b`.

This PR implements a Pythonic syntax for such features by extending the existing parameter `fill` (alias of `-G`). In addition to color or pattern, now `fill` can accept two special values: `"position"` and `"value"`.

## GMT CLI and PyGMT comparison

Here is a comparison:

| GMT CLI | PyGMT | Notes |
|---|---|---|
| `-Gred` | `fill="red"` | Fill by a constant color | 
| `-Gp5` | `fill=Pattern(5)` | Fill by a pattern |
| `-C` | `fill="position"` | Fill based on the current CPT and the mid-coordinate of each bar |
| `-Ctest.cpt` | `fill="position", cmap="test.cpt"` | Same as above but use `test.cpt` |
| `-C+b` | `fill="value"` | Fill based on the current CPT and the bin value (count or frequency, i.e., the bin height) |
| `-Ctest.cpt+b` | `fill="value", cmap="test.cpt"` | Same as above but use `test.cpt` |

## Examples
```
import numpy as np
import pygmt
from pygmt.params import Frame, Pattern

rng = np.random.default_rng(seed=100)
mean = 100  # mean of distribution
stddev = 25  # standard deviation of distribution
data = rng.normal(loc=mean, scale=stddev, size=521)

fig = pygmt.Figure()
fig.histogram(data=data, frame=Frame(axes="WSen", title="Fill by color"), series=10, fill="green")

fig.shift_origin(xshift="w+1")
fig.histogram(data=data, frame=Frame(axes="WSen", title="Fill by pattern"), series=10, fill=Pattern(10, dpi=50))

fig.shift_origin(xshift="w+1")
pygmt.makecpt(cmap="turbo", series=(0, 200, 25))
fig.histogram(data=data, frame=Frame(axes="WSen", title="Fill by position"), series=10, pen="1p", fill="position")
fig.colorbar()

fig.shift_origin(xshift="w+4")
pygmt.makecpt(cmap="turbo", series=(0, 100, 25))
fig.histogram(data=data, frame=Frame(axes="WSen", title="Fill by value"), series=10, pen="1p", fill="value")
fig.colorbar()

fig.show()
```
<img width="7537" height="2109" alt="histogram" src="https://github.com/user-attachments/assets/78415985-acc9-4cc6-8ac5-d8a0fc918960" />

## Alternative implementation

An alternative implementation is to keep `fill` unchanged, but alias `-C` to two separate parameters, `cmap` and `fill_by_value` (or any other names). The cons are:

- User may be confused by the two similar parameters `fill` and `fill_by_value`
- `-G` can't be used with `-C`, so we need to deal with conflicts between `fill` and `cmap`/`fill_by_value` carefully

Address #4251