### PR TITLE
POC: WIP: Add note regarding bug in meca ignoring a colormap set up via makecpt in GMT 6.7.0

### DIFF
--- a/examples/gallery/seismology/meca.py
+++ b/examples/gallery/seismology/meca.py
@@ -9,6 +9,11 @@ a file). The size of the beachballs can be set using the ``scale`` parameter. Th
 compressive and extensive quadrants can be filled either with a color or a pattern via
 the ``compression_fill`` and ``extension_fill`` parameters, respectively. Use the
 ``pen`` parameter to adjust the outline of the beachballs.
+
+For GMT 6.7.0, a colormap set up via ``pygmt.makecpt`` and applied as ``cmap=True``
+is ignored. For details, please see the upstream GMT
+[issue 9176](https://github.com/GenericMappingTools/gmt/issues/9176) and
+[PR 9177](https://github.com/GenericMappingTools/gmt/pull/9177).
 """
 
 # %%

--- a/examples/tutorials/advanced/focal_mechanisms.py
+++ b/examples/tutorials/advanced/focal_mechanisms.py
@@ -303,6 +303,11 @@ fig.show()
 # ``depth``, e.g., by moment magnitude or hypocentral depth, respectively. Use the
 # parameter ``cmap`` to pass the desired colormap. Now, the fills of the small circles
 # indicating the event locations are given by the colormap.
+#
+# For GMT 6.7.0, a colormap set up via ``pygmt.makecpt`` and applied as ``cmap=True``
+# is ignored. For details, please see the upstream GMT
+# [issue 9176](https://github.com/GenericMappingTools/gmt/issues/9176) and
+# [PR 9177](https://github.com/GenericMappingTools/gmt/pull/9177).
 
 fig = pygmt.Figure()
 fig.coast(region="d", projection="N10c", land="lightgray", frame=True)

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -337,6 +337,12 @@ def meca(
         automatically. The color of the compressive quadrants is determined by the
         z-value (i.e., event depth or the third column for an input file). This setting
         also applies to the fill of the circle defined via ``offset``.
+        .. note::
+           For GMT 6.7.0, a colormap set up via ``pygmt.makecpt`` and applied as
+           ``cmap=True`` is ignored. For details, please see the upstream GMT
+           [issue 9176](https://github.com/GenericMappingTools/gmt/issues/9176) and
+           [PR 9177](https://github.com/GenericMappingTools/gmt/pull/9177).
+
     no_clip
         Do **not** skip symbols that fall outside the frame boundaries [Default is
         ``False``, i.e., plot symbols inside the frame boundaries only].

--- a/pygmt/src/meca.py
+++ b/pygmt/src/meca.py
@@ -337,6 +337,7 @@ def meca(
         automatically. The color of the compressive quadrants is determined by the
         z-value (i.e., event depth or the third column for an input file). This setting
         also applies to the fill of the circle defined via ``offset``.
+
         .. note::
            For GMT 6.7.0, a colormap set up via ``pygmt.makecpt`` and applied as
            ``cmap=True`` is ignored. For details, please see the upstream GMT


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a note to point out the bug in `meca` regarding applying a colormap set up via `makecpt` in GMT 6.7.0:
- [ ] Documentation
- [ ] Tutorial
- [ ] Gallery example

Related to
- GMT forum post: https://forum.generic-mapping-tools.org/t/introduction-to-generic-mapping-tools-gmt-for-geophysics-self-paced-course-now-open/6486/10?u=yvonnefroehlich
- GMT issue (bug report): https://github.com/GenericMappingTools/gmt/issues/9176
- GMT PR (bug fix): https://github.com/GenericMappingTools/gmt/pull/9177

 **Preview**:
- https://pygmt-dev--4887.org.readthedocs.build/en/4887/tutorials/advanced/focal_mechanisms.html#using-size-coding-and-color-coding
- https://pygmt-dev--4887.org.readthedocs.build/en/4887/api/generated/pygmt.Figure.meca.html#pygmt.Figure.meca

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
