### PR TITLE
DOC: Fix link to style_checks.yaml in Contributors Guide

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -132,8 +132,9 @@ our tests. This way, the *main* branch is always stable.
 * How to write and submit a PR
   - Use underscores, not hyphens, in the names of all files and directories, as per
     [PEP8](https://www.python.org/dev/peps/pep-0008/) for Python (\*.py) files. A few
-    exceptions are allowed (e.g., `.pre-commit-config.yaml`) and are listed
-    in the [style checks](.github/workflows/style_checks.yaml) workflow.
+    exceptions are allowed (e.g., `.pre-commit-config.yaml`) and are listed in the
+    [style checks](https://github.com/GenericMappingTools/pygmt/blob/main/.github/workflows/style_checks.yaml)
+    workflow.
   - Describe what your PR changes and *why* this is a good thing. Be as
     specific as you can. The PR description is how we keep track of the changes
     made to the project over time.


### PR DESCRIPTION
**Description of proposed changes**

Fix the link to the `style_checks.yaml` in the Contributors Guide.

**Preview**:

**Guidelines**

- [General Guidelines for Pull Request](https://www.pygmt.org/dev/contributing.html#general-guidelines-for-making-a-pull-request-pr)
- [Guidelines for Contributing Documentation](https://www.pygmt.org/dev/contributing.html#contributing-documentation)
- [Guidelines for Contributing Code](https://www.pygmt.org/dev/contributing.html#contributing-code)

**Slash Commands**

You can write slash commands (`/command`) in the first line of a comment to perform
specific operations. Supported slash command is:

- `/format`: automatically format and lint the code
